### PR TITLE
Edit nim wizard

### DIFF
--- a/frontend/src/api/k8s/pvcs.ts
+++ b/frontend/src/api/k8s/pvcs.ts
@@ -6,6 +6,7 @@ import {
   k8sListResourceItems,
   K8sStatus,
   k8sUpdateResource,
+  QueryParams,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import { KnownLabels, translateDisplayNameForK8s } from '@odh-dashboard/k8s-core';
@@ -78,12 +79,15 @@ export const assemblePvc = (
   };
 };
 
-export const getDashboardPvcs = (projectName: string): Promise<PersistentVolumeClaimKind[]> =>
+export const getDashboardPvcs = (
+  projectName: string,
+  queryParams: null | QueryParams = { labelSelector: LABEL_SELECTOR_DASHBOARD_RESOURCE },
+): Promise<PersistentVolumeClaimKind[]> =>
   k8sListResourceItems<PersistentVolumeClaimKind>({
     model: PVCModel,
     queryOptions: {
       ns: projectName,
-      queryParams: { labelSelector: LABEL_SELECTOR_DASHBOARD_RESOURCE },
+      queryParams: queryParams ?? undefined,
     },
   });
 

--- a/packages/cypress/cypress/pages/modelServing/NIMWizardFields.ts
+++ b/packages/cypress/cypress/pages/modelServing/NIMWizardFields.ts
@@ -13,6 +13,10 @@ export class NIMWizardFields extends SubComponentBase {
     cy.findByRole('option', { name: new RegExp(escapedName) }).click();
   }
 
+  findImageNotFoundWarning(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findScope().findByTestId('nim-image-not-found-warning');
+  }
+
   findStorageModeSelect(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findScope().findByTestId('nim-storage-mode-select');
   }

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/legacyModelServingNim.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/legacyModelServingNim.cy.ts
@@ -174,11 +174,11 @@ describe('NIM Model Serving', () => {
       projectDetails
         .getKserveTableRow('Test Name')
         .findInfoValueFor('Model server size')
-        .should('contain.text', '8 CPUs, 32GiB Memory requested');
+        .should('contain.text', '2 CPUs, 6GiB Memory requested');
       projectDetails
         .getKserveTableRow('Test Name')
         .findInfoValueFor('Model server size')
-        .should('contain.text', '16 CPUs, 64GiB Memory limit');
+        .should('contain.text', '4 CPUs, 8GiB Memory limit');
       projectDetails
         .getKserveTableRow('Test Name')
         .findInfoValueFor('Hardware profile')

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -120,6 +120,41 @@ const deploymentMethodExtractorExtension: WizardFieldExtractorExtension<
   },
 };
 
+export const kserveFormDataExtension: ModelServingDeploymentFormDataExtension<KServeDeployment> = {
+  type: 'model-serving.deployment/form-data',
+  properties: {
+    platform: KSERVE_ID,
+    isActive: true,
+    priority: 0,
+    extractHardwareProfileConfig: () =>
+      import('./src/hardware').then((m) => (deployment) => ({
+        data: m.extractHardwareProfileConfig(deployment),
+      })),
+    extractModelType: () => import('./src/deployUtils').then((m) => m.extractModelType),
+    extractModelFormat: () => import('./src/modelFormat').then((m) => m.extractKServeModelFormat),
+    extractReplicas: () =>
+      import('./src/hardware').then((m) => (deployment) => ({
+        data: m.extractReplicas(deployment),
+      })),
+    extractRuntimeArgs: () => import('./src/hardware').then((m) => m.extractRuntimeArgs),
+    extractEnvironmentVariables: () =>
+      import('./src/hardware').then((m) => m.extractEnvironmentVariables),
+    extractModelAvailabilityData: () =>
+      import('./src/aiAssets').then((m) => m.extractModelAvailabilityData),
+    extractModelLocationData: () =>
+      import('./src/modelLocationData').then((m) => m.extractKServeModelLocationData),
+    extractDeploymentStrategy: () =>
+      import('./src/deployUtils').then((m) => m.extractDeploymentStrategy),
+    extractModelServerTemplate: () =>
+      import('./src/deployServer').then((m) => m.extractModelServerTemplate),
+    hardwareProfilePaths: () =>
+      import('./src/hardware').then((m) => m.INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS),
+  },
+  flags: {
+    required: [SupportedArea.K_SERVE],
+  },
+};
+
 const extensions: (
   | AreaExtension
   | ModelServingPlatformExtension<KServeDeployment>
@@ -249,38 +284,7 @@ const extensions: (
       required: [SupportedArea.K_SERVE],
     },
   },
-  {
-    type: 'model-serving.deployment/form-data',
-    properties: {
-      platform: KSERVE_ID,
-      extractHardwareProfileConfig: () =>
-        import('./src/hardware').then((m) => (deployment) => ({
-          data: m.extractHardwareProfileConfig(deployment),
-        })),
-      extractModelType: () => import('./src/deployUtils').then((m) => m.extractModelType),
-      extractModelFormat: () => import('./src/modelFormat').then((m) => m.extractKServeModelFormat),
-      extractReplicas: () =>
-        import('./src/hardware').then((m) => (deployment) => ({
-          data: m.extractReplicas(deployment),
-        })),
-      extractRuntimeArgs: () => import('./src/hardware').then((m) => m.extractRuntimeArgs),
-      extractEnvironmentVariables: () =>
-        import('./src/hardware').then((m) => m.extractEnvironmentVariables),
-      extractModelAvailabilityData: () =>
-        import('./src/aiAssets').then((m) => m.extractModelAvailabilityData),
-      extractModelLocationData: () =>
-        import('./src/modelLocationData').then((m) => m.extractKServeModelLocationData),
-      extractDeploymentStrategy: () =>
-        import('./src/deployUtils').then((m) => m.extractDeploymentStrategy),
-      extractModelServerTemplate: () =>
-        import('./src/deployServer').then((m) => m.extractModelServerTemplate),
-      hardwareProfilePaths: () =>
-        import('./src/hardware').then((m) => m.INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS),
-    },
-    flags: {
-      required: [SupportedArea.K_SERVE],
-    },
-  },
+  kserveFormDataExtension,
   {
     type: 'model-serving.deployment/deploy',
     properties: {

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -397,6 +397,8 @@ const extensions: (
     type: 'model-serving.deployment/form-data',
     properties: {
       platform: LLMD_SERVING_ID,
+      isActive: true,
+      priority: 0,
       extractHardwareProfileConfig: () =>
         import('../src/deployments/hardware').then((m) => m.extractHardwareProfileConfig),
       extractModelType: () => import('../src/deployments/model').then((m) => m.extractModelType),

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -5,12 +5,14 @@ import {
 import type { Volume } from '@odh-dashboard/k8s-core';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { mockCustomSecretK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockSecretK8sResource';
+import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
 import {
   initInterceptsToDeployNimInWizard,
   initInterceptsToEnableNim,
 } from '@odh-dashboard/cypress/cypress/utils/legacyNimUtils';
 import {
   InferenceServiceModel,
+  PVCModel,
   SecretModel,
   ServingRuntimeModel,
 } from '@odh-dashboard/cypress/cypress/utils/models';
@@ -378,10 +380,20 @@ describe('NIM Models Deployments', () => {
     cy.interceptK8sList(
       ServingRuntimeModel,
       // The runtime carries the NIM image on its `kserve-container` so edit-detection recognizes
-      // it and prefills the found image (arctic-embed-l 1.0.1 exists in mockNimImages -> happy path)
+      // it and prefills the found image (arctic-embed-l 1.0.1 exists in mockNimImages -> happy path).
+      // It also carries a PVC cache volume so the PVC field prefills the existing storage selection.
       mockK8sResourceList([
-        mockNimServingRuntime({ image: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1' }),
+        mockNimServingRuntime({
+          image: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',
+          pvcName: 'my-nim-wizard-pvc',
+          subPath: 'arctic-embed-l',
+        }),
       ]),
+    );
+    // The PVC must be in the fetched list for the existing-storage select to render its name
+    cy.interceptK8sList(
+      { model: PVCModel, ns: 'test-project' },
+      mockK8sResourceList([mockPVCK8sResource({ name: 'my-nim-wizard-pvc' })]),
     );
 
     modelServingGlobal.visit('test-project');
@@ -411,6 +423,13 @@ describe('NIM Models Deployments', () => {
     // The saved hardware profile prefills (only one profile exists, so the selector is disabled)
     modelServingWizardEdit.selectPotentiallyDisabledProfile('default-profile');
     modelServingWizardEdit.findModelFormatSelect().should('not.exist');
-    // Stop before the PVC caching fields - editing them is not supported yet
+
+    // PVC caching prefills from the existing runtime's cache volume: existing-storage mode,
+    // the mounted PVC preselected, and its subpath loaded from the volumeMount
+    modelServingWizardEdit.nim
+      .findStorageModeSelect()
+      .should('contain.text', 'Deploy the NIM image from an existing cluster storage');
+    modelServingWizardEdit.nim.findExistingPVCSelect().should('contain.text', 'my-nim-wizard-pvc');
+    modelServingWizardEdit.nim.findSubPathInput().should('have.value', 'arctic-embed-l');
   });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -107,11 +107,11 @@ describe('NIM Models Deployments', () => {
     row
       .findDescriptionListItem('Model server size')
       .next('dd')
-      .should('contain.text', '8 CPUs, 32GiB Memory requested');
+      .should('contain.text', '2 CPUs, 6GiB Memory requested');
     row
       .findDescriptionListItem('Model server size')
       .next('dd')
-      .should('contain.text', '16 CPUs, 64GiB Memory limit');
+      .should('contain.text', '4 CPUs, 8GiB Memory limit');
     row
       .findDescriptionListItem('Hardware profile')
       .next('dd')
@@ -374,6 +374,10 @@ describe('NIM Models Deployments', () => {
           hardwareProfileName: 'default-profile',
           hardwareProfileNamespace: 'opendatahub',
           hardwareProfileResourceVersion: '1309350',
+          hasExternalRoute: true,
+          // Advanced settings prefill from the deployment on edit
+          args: ['--verbose', '--log-level=debug'],
+          env: [{ name: 'CUSTOM_VAR', value: 'custom-value' }],
         }),
       ]),
     );
@@ -394,6 +398,24 @@ describe('NIM Models Deployments', () => {
     cy.interceptK8sList(
       { model: PVCModel, ns: 'test-project' },
       mockK8sResourceList([mockPVCK8sResource({ name: 'my-nim-wizard-pvc' })]),
+    );
+    // Auth is enabled by default on the NIM deployment (no enable-auth=false annotation), so the
+    // token auth field reads the deployment's service-account token secret ("<deployment-name>-sa")
+    // and prefills the existing service account name from the secret's display name.
+    cy.interceptK8sList(
+      { model: SecretModel, ns: 'test-project' },
+      mockK8sResourceList([
+        mockCustomSecretK8sResource({
+          name: 'my-existing-sa-test-name-sa',
+          namespace: 'test-project',
+          annotations: {
+            'openshift.io/display-name': 'my-existing-sa',
+            'kubernetes.io/service-account.name': 'test-name-sa',
+          },
+          type: 'kubernetes.io/service-account-token',
+          data: { token: btoa('test-token') },
+        }),
+      ]),
     );
 
     modelServingGlobal.visit('test-project');
@@ -431,5 +453,22 @@ describe('NIM Models Deployments', () => {
       .should('contain.text', 'Deploy the NIM image from an existing cluster storage');
     modelServingWizardEdit.nim.findExistingPVCSelect().should('contain.text', 'my-nim-wizard-pvc');
     modelServingWizardEdit.nim.findSubPathInput().should('have.value', 'arctic-embed-l');
+
+    modelServingWizardEdit.findNextButton().should('be.enabled').click();
+
+    // Step 3: Advanced settings - external route, token auth, the existing service account, runtime
+    // args, and custom env variables all prefill from the deployment on edit
+    modelServingWizardEdit.findAdvancedOptionsStep().should('be.enabled');
+    modelServingWizardEdit.findExternalRouteCheckbox().should('be.checked');
+    modelServingWizardEdit.findTokenAuthenticationCheckbox().should('be.checked');
+    modelServingWizardEdit.findServiceAccountNameInput().should('have.value', 'my-existing-sa');
+    modelServingWizardEdit.findRuntimeArgsCheckbox().should('be.checked');
+    modelServingWizardEdit
+      .findRuntimeArgsTextBox()
+      .should('have.value', '--verbose\n--log-level=debug');
+    modelServingWizardEdit.findEnvVariablesCheckbox().should('be.checked');
+    modelServingWizardEdit.findEnvVariableName('0').should('have.value', 'CUSTOM_VAR');
+    modelServingWizardEdit.findEnvVariableValue('0').should('have.value', 'custom-value');
+    modelServingWizardEdit.findNextButton().should('be.enabled').click();
   });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -4,18 +4,21 @@ import {
 } from '@odh-dashboard/model-serving/__mocks__/mockLegacyNimResource';
 import type { Volume } from '@odh-dashboard/k8s-core';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { mockCustomSecretK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockSecretK8sResource';
 import {
   initInterceptsToDeployNimInWizard,
   initInterceptsToEnableNim,
 } from '@odh-dashboard/cypress/cypress/utils/legacyNimUtils';
 import {
   InferenceServiceModel,
+  SecretModel,
   ServingRuntimeModel,
 } from '@odh-dashboard/cypress/cypress/utils/models';
 import {
   modelServingGlobal,
   modelServingSection,
   modelServingWizard,
+  modelServingWizardEdit,
 } from '@odh-dashboard/cypress/cypress/pages/modelServing';
 import {
   ModelLocationSelectOption,
@@ -57,6 +60,73 @@ describe('NIM Models Deployments', () => {
     modelServingGlobal.visit('test-project');
     modelServingGlobal.getModelRow('Test Name').findKebabAction('Edit').should('exist');
     modelServingGlobal.getModelRow('Test Name').findKebabAction('Delete').should('exist');
+  });
+
+  it('should show the NIM deployment details in the expanded row on the project Models tab', () => {
+    initInterceptsToEnableNim({ nimWizard: true });
+    cy.interceptK8sList(
+      InferenceServiceModel,
+      // Carry the hardware profile annotations so the expanded row resolves the saved profile
+      mockK8sResourceList([
+        mockNimInferenceService({
+          hardwareProfileName: 'default-profile',
+          hardwareProfileNamespace: 'opendatahub',
+          hardwareProfileResourceVersion: '1309350',
+        }),
+      ]),
+    );
+    cy.interceptK8sList(ServingRuntimeModel, mockK8sResourceList([mockNimServingRuntime()]));
+    // Auth is enabled by default on the NIM deployment (no enable-auth=false annotation), so the
+    // token table reads the deployment's service-account token secret ("<deployment-name>-sa").
+    cy.interceptK8sList(
+      { model: SecretModel, ns: 'test-project' },
+      mockK8sResourceList([
+        mockCustomSecretK8sResource({
+          name: 'default-name2-test-name-sa',
+          namespace: 'test-project',
+          annotations: {
+            'openshift.io/display-name': 'default-name2',
+            'kubernetes.io/service-account.name': 'test-name-sa',
+          },
+          type: 'kubernetes.io/service-account-token',
+          // Decodes to 48 chars so the masked value renders the full 40-bullet cap
+          data: { token: btoa('x'.repeat(48)) },
+        }),
+      ]),
+    );
+
+    modelServingSection.visit('test-project');
+
+    const row = modelServingSection.getKServeRow('Test Name');
+    row.findToggleButton().click();
+
+    row.findDescriptionListItem('Framework').next('dd').should('have.text', 'arctic-embed-l');
+    row.findDescriptionListItem('Model server replicas').next('dd').should('have.text', '1');
+    row
+      .findDescriptionListItem('Model server size')
+      .next('dd')
+      .should('contain.text', '8 CPUs, 32GiB Memory requested');
+    row
+      .findDescriptionListItem('Model server size')
+      .next('dd')
+      .should('contain.text', '16 CPUs, 64GiB Memory limit');
+    row
+      .findDescriptionListItem('Hardware profile')
+      .next('dd')
+      .should('have.text', 'default-profile');
+    row
+      .findDescriptionListItem('Model availability')
+      .next('dd')
+      .should('have.text', 'No model availability');
+    row
+      .findDescriptionListItem('Token authentication')
+      .next('dd')
+      .should('contain.text', 'default-name2');
+    row
+      .findDescriptionListItem('Token authentication')
+      .next('dd')
+      .findByTestId('token-secret')
+      .should('contain.text', '•'.repeat(40));
   });
 
   it('should deploy a NIM model through the wizard', () => {
@@ -289,5 +359,58 @@ describe('NIM Models Deployments', () => {
       });
       expect(interception.request.body.type).to.equal('kubernetes.io/service-account-token');
     });
+  });
+
+  it('should edit a NIM deployment through the wizard', () => {
+    initInterceptsToEnableNim({ nimWizard: true });
+    initInterceptsToDeployNimInWizard();
+    cy.interceptK8sList(
+      InferenceServiceModel,
+      // Carry the hardware profile annotations so the wizard prefills the saved profile on edit
+      mockK8sResourceList([
+        mockNimInferenceService({
+          hardwareProfileName: 'default-profile',
+          hardwareProfileNamespace: 'opendatahub',
+          hardwareProfileResourceVersion: '1309350',
+        }),
+      ]),
+    );
+    cy.interceptK8sList(
+      ServingRuntimeModel,
+      // The runtime carries the NIM image on its `kserve-container` so edit-detection recognizes
+      // it and prefills the found image (arctic-embed-l 1.0.1 exists in mockNimImages -> happy path)
+      mockK8sResourceList([
+        mockNimServingRuntime({ image: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1' }),
+      ]),
+    );
+
+    modelServingGlobal.visit('test-project');
+
+    // The NIM deployment is listed in the model deployments table
+    modelServingSection.findDeploymentsTable().should('have.length', 1);
+    modelServingGlobal.getModelRow('Test Name').findKebabAction('Edit').click();
+
+    // Step 1: Model source - location is NVIDIA NIM and the existing image is found (no warning)
+    modelServingWizardEdit.findModelSourceStep().should('be.enabled');
+    modelServingWizardEdit
+      .findModelLocationSelect()
+      .should('contain.text', ModelLocationSelectOption.NIM);
+    modelServingWizardEdit.nim
+      .findImageSelect()
+      .find('input')
+      .should('have.value', 'Snowflake Arctic Embed Large Embedding - 1.0.1');
+    modelServingWizardEdit.nim.findImageNotFoundWarning().should('not.exist');
+    // NIM forces the model type - it cannot be changed
+    modelServingWizardEdit.findModelTypeSelect().should('contain.text', ModelTypeLabel.NIM);
+    modelServingWizardEdit.findModelTypeSelect().should('be.disabled');
+    modelServingWizardEdit.findNextButton().should('be.enabled').click();
+
+    // Step 2: Model deployment - name prefilled, no model format select (NIM is legacy KServe)
+    modelServingWizardEdit.findModelDeploymentStep().should('be.enabled');
+    modelServingWizardEdit.findModelDeploymentNameInput().should('have.value', 'Test Name');
+    // The saved hardware profile prefills (only one profile exists, so the selector is disabled)
+    modelServingWizardEdit.selectPotentiallyDisabledProfile('default-profile');
+    modelServingWizardEdit.findModelFormatSelect().should('not.exist');
+    // Stop before the PVC caching fields - editing them is not supported yet
   });
 });

--- a/packages/model-serving/extension-points/deployment-wizard.ts
+++ b/packages/model-serving/extension-points/deployment-wizard.ts
@@ -19,6 +19,16 @@ export type ModelServingDeploymentFormDataExtension<D extends Deployment = Deplo
   'model-serving.deployment/form-data',
   {
     platform: D['modelServingPlatformId'];
+    /**
+     * Whether this extension is active for the given deployment. When multiple form-data
+     * extensions share a `platform`, the active one with the highest `priority` wins.
+     * Evaluated at extraction time from an existing deployment, so it must not rely on wizard state.
+     */
+    isActive: CodeRef<(deployment: D) => boolean> | true;
+    /**
+     * Priority among active extensions WITH the same `platform`. Higher number wins.
+     */
+    priority: number | 0;
     hardwareProfilePaths: CodeRef<CrPathConfig>;
     extractHardwareProfileConfig: CodeRef<
       (deployment: D) => ExtractionResult<Parameters<typeof useHardwareProfileConfig> | null>

--- a/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
+++ b/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
@@ -69,6 +69,9 @@ export const mockNimInferenceService = ({
     limits: { cpu: '16', memory: '64Gi' },
     requests: { cpu: '8', memory: '32Gi' },
   },
+  hardwareProfileName,
+  hardwareProfileNamespace,
+  hardwareProfileResourceVersion,
 }: NimInferenceService = {}): InferenceServiceKind => {
   const inferenceService = mockInferenceServiceK8sResource({
     name: 'test-name',
@@ -76,6 +79,9 @@ export const mockNimInferenceService = ({
     displayName,
     namespace,
     resources,
+    hardwareProfileName,
+    hardwareProfileNamespace,
+    hardwareProfileResourceVersion,
   });
 
   delete inferenceService.metadata.labels?.name;
@@ -93,7 +99,13 @@ export const mockNimInferenceService = ({
   return inferenceService;
 };
 
-export const mockNimServingRuntime = (): ServingRuntimeKind => {
+export const mockNimServingRuntime = ({
+  image,
+}: {
+  // When set, the runtime carries a `kserve-container` with this image so edit-detection
+  // (isNIMKServeDeployment) recognizes it and the image field prefills on edit.
+  image?: string;
+} = {}): ServingRuntimeKind => {
   const servingRuntime = mockServingRuntimeK8sResource({
     name: 'test-name',
     displayName: 'Test Name',
@@ -101,6 +113,11 @@ export const mockNimServingRuntime = (): ServingRuntimeKind => {
   if (servingRuntime.metadata.annotations) {
     servingRuntime.metadata.annotations['opendatahub.io/template-display-name'] = 'NVIDIA NIM';
     servingRuntime.metadata.annotations['opendatahub.io/template-name'] = 'nvidia-nim-runtime';
+  }
+  if (image) {
+    servingRuntime.spec.containers = [
+      { ...servingRuntime.spec.containers[0], name: 'kserve-container', image },
+    ];
   }
 
   return servingRuntime;

--- a/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
+++ b/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
@@ -100,11 +100,17 @@ export const mockNimInferenceService = ({
 };
 
 export const mockNimServingRuntime = ({
-  image,
+  image = 'nvcr.io/nim/nvidia/my-nim-container:mytag',
+  pvcName = 'my-nim-pvc',
+  subPath,
 }: {
   // When set, the runtime carries a `kserve-container` with this image so edit-detection
   // (isNIMKServeDeployment) recognizes it and the image field prefills on edit.
   image?: string;
+  // When set, the runtime carries a PVC cache volume + `kserve-container` volumeMount at the NIM
+  // cache path so the PVC field prefills the existing storage selection on edit.
+  pvcName?: string;
+  subPath?: string;
 } = {}): ServingRuntimeKind => {
   const servingRuntime = mockServingRuntimeK8sResource({
     name: 'test-name',
@@ -118,6 +124,23 @@ export const mockNimServingRuntime = ({
     servingRuntime.spec.containers = [
       { ...servingRuntime.spec.containers[0], name: 'kserve-container', image },
     ];
+  }
+  if (pvcName) {
+    servingRuntime.spec.volumes = [
+      ...(servingRuntime.spec.volumes ?? []),
+      { name: pvcName, persistentVolumeClaim: { claimName: pvcName } },
+    ];
+    servingRuntime.spec.containers = servingRuntime.spec.containers.map((container) =>
+      container.name === 'kserve-container'
+        ? {
+            ...container,
+            volumeMounts: [
+              ...(container.volumeMounts ?? []),
+              { name: pvcName, mountPath: '/mnt/models/cache', ...(subPath ? { subPath } : {}) },
+            ],
+          }
+        : container,
+    );
   }
 
   return servingRuntime;

--- a/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
+++ b/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
@@ -60,18 +60,24 @@ type NimInferenceService = {
   hardwareProfileName?: string;
   hardwareProfileNamespace?: string;
   hardwareProfileResourceVersion?: string;
+  hasExternalRoute?: boolean;
+  args?: string[];
+  env?: Array<{ name: string; value?: string }>;
 };
 
 export const mockNimInferenceService = ({
   displayName = 'Test Name',
   namespace = 'test-project',
   resources = {
-    limits: { cpu: '16', memory: '64Gi' },
-    requests: { cpu: '8', memory: '32Gi' },
+    limits: { cpu: '4', memory: '8Gi' },
+    requests: { cpu: '2', memory: '6Gi' },
   },
   hardwareProfileName,
   hardwareProfileNamespace,
   hardwareProfileResourceVersion,
+  hasExternalRoute,
+  args,
+  env,
 }: NimInferenceService = {}): InferenceServiceKind => {
   const inferenceService = mockInferenceServiceK8sResource({
     name: 'test-name',
@@ -82,6 +88,9 @@ export const mockNimInferenceService = ({
     hardwareProfileName,
     hardwareProfileNamespace,
     hardwareProfileResourceVersion,
+    hasExternalRoute,
+    args,
+    env,
   });
 
   delete inferenceService.metadata.labels?.name;

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -9,7 +9,6 @@ import {
   StateActionToggle,
 } from '@odh-dashboard/ui-core';
 import { getDisplayNameFromK8sResource, SchedulingType } from '@odh-dashboard/k8s-core';
-import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import { useKueueConfiguration } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
 import {
   useHardwareProfileBindingState,
@@ -33,7 +32,10 @@ import DeploymentStatus from '../DeploymentStatus';
 import DeployedModelsVersion from '../DeployedModelsVersion';
 import ModelServingStopModal from '../ModelServingStopModal';
 import DeploymentStatusModal from '../DeploymentStatusModal';
-import { useDeploymentExtension } from '../../../concepts/extensionUtils';
+import {
+  useDeploymentExtension,
+  useResolvedDeploymentExtension,
+} from '../../../concepts/extensionUtils';
 import {
   Deployment,
   DeploymentsTableColumn,
@@ -105,15 +107,9 @@ export const DeploymentRow: React.FC<{
   const navigateToDeploymentWizard = useNavigateToDeploymentWizard(deployment);
   const statusSubtitle = getDeploymentStatusSubtitle(deployment.status);
 
-  const [formDataExtensions, formDataResolved] = useResolvedExtensions(
+  const [formDataExtension, formDataResolved] = useResolvedDeploymentExtension(
     isModelServingDeploymentFormDataExtension,
-  );
-  const formDataExtension = React.useMemo(
-    () =>
-      formDataExtensions.find(
-        (ext) => ext.properties.platform === deployment.modelServingPlatformId,
-      ) ?? null,
-    [formDataExtensions, deployment.modelServingPlatformId],
+    deployment,
   );
   const hardwareProfilePaths = formDataExtension?.properties.hardwareProfilePaths;
   const pathsLoaded = formDataResolved && !!hardwareProfilePaths;

--- a/packages/model-serving/src/concepts/extensionUtils.ts
+++ b/packages/model-serving/src/concepts/extensionUtils.ts
@@ -1,6 +1,11 @@
 import React from 'react';
 import { useResolvedExtensions, useExtensions } from '@odh-dashboard/plugin-core';
-import { Extension, ExtensionPredicate, ResolvedExtension } from '@openshift/dynamic-plugin-sdk';
+import {
+  AnyObject,
+  Extension,
+  ExtensionPredicate,
+  ResolvedExtension,
+} from '@openshift/dynamic-plugin-sdk';
 import { ModelServingPlatform } from './useProjectServingPlatform';
 import { type Deployment } from '../../extension-points';
 
@@ -50,6 +55,24 @@ export const useDeploymentExtension = <T extends PlatformExtension>(
   );
 };
 
+const getExtensionPriority = (properties: AnyObject): number =>
+  typeof properties.priority === 'number' ? properties.priority : 0;
+
+const isExtensionActiveForDeployment = (
+  properties: AnyObject,
+  deployment?: Deployment | null,
+): boolean => {
+  const { isActive } = properties;
+  if (typeof isActive === 'function') {
+    return !!deployment && isActive(deployment) === true;
+  }
+  // Absent or `true` means active; only an explicit `false` disables.
+  return isActive !== false;
+};
+
+// Selects the extension for a deployment's platform. When several extensions share a platform,
+// only those whose optional `isActive(deployment)` passes are eligible, and the highest `priority`
+// wins. Extensions without isActive/priority (auth, delete, fetch-status) behave as before.
 export const useResolvedDeploymentExtension = <T extends PlatformExtension>(
   extensionPredicate: ExtensionPredicate<T>,
   deployment?: Deployment | null,
@@ -58,12 +81,15 @@ export const useResolvedDeploymentExtension = <T extends PlatformExtension>(
 
   return React.useMemo(
     () => [
-      resolvedExtensions.find(
-        (ext) => ext.properties.platform === deployment?.modelServingPlatformId,
-      ) ?? null,
+      resolvedExtensions
+        .filter((ext) => ext.properties.platform === deployment?.modelServingPlatformId)
+        .filter((ext) => isExtensionActiveForDeployment(ext.properties, deployment))
+        .toSorted(
+          (a, b) => getExtensionPriority(b.properties) - getExtensionPriority(a.properties),
+        )[0] ?? null,
       loaded,
       errors.map((error) => (error instanceof Error ? error : new Error(String(error)))),
     ],
-    [resolvedExtensions, deployment?.modelServingPlatformId, loaded, errors],
+    [resolvedExtensions, deployment, loaded, errors],
   );
 };

--- a/packages/nim-serving/extensions/nim-kserve.ts
+++ b/packages/nim-serving/extensions/nim-kserve.ts
@@ -33,7 +33,7 @@ const nimPVCExtractorExtension: WizardFieldExtractorExtension<NIMPVCFieldValue, 
     type: 'model-serving.deployment/wizard-field-extractor',
     properties: {
       fieldId: 'nim-serving/pvcStorage',
-      platform: NIM_LEGACY_ID,
+      platform: KSERVE_ID,
       extract: () =>
         import('../src/nimKServe/fields/nimPVCApplyExtract').then((m) => m.extractNIMPVCFieldData),
     },

--- a/packages/nim-serving/extensions/nim-kserve.ts
+++ b/packages/nim-serving/extensions/nim-kserve.ts
@@ -72,6 +72,27 @@ const nimImageApplyExtension: WizardFieldApplyExtension<NIMImageFieldValue, KSer
   },
 };
 
+const nimImageExtractExtension: WizardFieldExtractorExtension<
+  NIMImageFieldValue,
+  KServeDeployment
+> = {
+  // Prefills the image field on edit. Matches the shared KServe platform (a legacy NIM
+  // InferenceService reports modelServingPlatformId === KSERVE_ID); the extractor returns
+  // undefined for non-NIM deployments so plain KServe edits are unaffected.
+  type: 'model-serving.deployment/wizard-field-extractor',
+  properties: {
+    fieldId: 'nim-serving/nimImage',
+    platform: KSERVE_ID,
+    extract: () =>
+      import('../src/nimKServe/fields/nimImageApplyExtract').then(
+        (m) => m.extractNIMKServeImageFieldData,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
+
 // Legacy NIM reuses KServe's form-data extension (same KSERVE_ID platform) and overrides only
 // what differs: isActive detects the NIM image on the runtime, priority beats plain KServe (0),
 // and the model location resolves to NIM instead of KServe.
@@ -116,23 +137,7 @@ const extensions: (
   nimPVCApplyExtension,
   nimPVCExtractorExtension,
   nimPVCDeployFunctionsExtension,
-  {
-    // Prefills the image field on edit. Matches the shared KServe platform (a legacy NIM
-    // InferenceService reports modelServingPlatformId === KSERVE_ID); the extractor returns
-    // undefined for non-NIM deployments so plain KServe edits are unaffected.
-    type: 'model-serving.deployment/wizard-field-extractor',
-    properties: {
-      fieldId: 'nim-serving/nimImage',
-      platform: KSERVE_ID,
-      extract: () =>
-        import('../src/nimKServe/fields/nimImageApplyExtract').then(
-          (m) => m.extractNIMKServeImageFieldData,
-        ),
-    },
-    flags: {
-      required: [SupportedArea.NIM_WIZARD],
-    },
-  },
+  nimImageExtractExtension,
 ];
 
 export default extensions;

--- a/packages/nim-serving/extensions/nim-kserve.ts
+++ b/packages/nim-serving/extensions/nim-kserve.ts
@@ -1,6 +1,9 @@
 import type { KServeDeployment } from '@odh-dashboard/kserve/types';
+// eslint-disable-next-line no-restricted-syntax
+import { KSERVE_ID, kserveFormDataExtension } from '@odh-dashboard/kserve/extensions';
 import type {
   ModelServingDeploy,
+  ModelServingDeploymentFormDataExtension,
   WizardFieldApplyExtension,
   WizardFieldDeploymentFunctionsExtension,
   WizardFieldExtractorExtension,
@@ -69,14 +72,33 @@ const nimImageApplyExtension: WizardFieldApplyExtension<NIMImageFieldValue, KSer
   },
 };
 
+// Legacy NIM reuses KServe's form-data extension (same KSERVE_ID platform) and overrides only
+// what differs: isActive detects the NIM image on the runtime, priority beats plain KServe (0),
+// and the model location resolves to NIM instead of KServe.
+const nimKServeFormDataExtension: ModelServingDeploymentFormDataExtension<KServeDeployment> = {
+  ...kserveFormDataExtension,
+  properties: {
+    ...kserveFormDataExtension.properties,
+    isActive: () => import('../src/nimKServe/extractFormData').then((m) => m.isNIMKServeDeployment),
+    priority: 50,
+    extractModelLocationData: () =>
+      import('../src/nimKServe/extractFormData').then((m) => m.extractNIMKServeModelLocationData),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
+
 const extensions: (
   | ModelServingDeploy<KServeDeployment>
+  | ModelServingDeploymentFormDataExtension<KServeDeployment>
   | WizardFieldExtractorExtension<NIMImageFieldValue, KServeDeployment>
   | WizardFieldExtractorExtension<NIMPVCFieldValue, KServeDeployment>
   | WizardFieldApplyExtension<NIMImageFieldValue, KServeDeployment>
   | WizardFieldApplyExtension<NIMPVCFieldValue, KServeDeployment>
   | WizardFieldDeploymentFunctionsExtension<NIMPVCFieldValue, KServeDeployment>
 )[] = [
+  nimKServeFormDataExtension,
   {
     type: 'model-serving.deployment/deploy',
     properties: {
@@ -94,6 +116,23 @@ const extensions: (
   nimPVCApplyExtension,
   nimPVCExtractorExtension,
   nimPVCDeployFunctionsExtension,
+  {
+    // Prefills the image field on edit. Matches the shared KServe platform (a legacy NIM
+    // InferenceService reports modelServingPlatformId === KSERVE_ID); the extractor returns
+    // undefined for non-NIM deployments so plain KServe edits are unaffected.
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'nim-serving/nimImage',
+      platform: KSERVE_ID,
+      extract: () =>
+        import('../src/nimKServe/fields/nimImageApplyExtract').then(
+          (m) => m.extractNIMKServeImageFieldData,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
 ];
 
 export default extensions;

--- a/packages/nim-serving/extensions/nim-service.ts
+++ b/packages/nim-serving/extensions/nim-service.ts
@@ -196,6 +196,8 @@ const extensions: (
     type: 'model-serving.deployment/form-data',
     properties: {
       platform: NIM_SERVICE_ID,
+      isActive: true,
+      priority: 0,
       hardwareProfilePaths: () =>
         import('../src/pages/deploymentWizard/extractNIMFormData').then(
           (m) => m.NIM_SERVICE_HARDWARE_PROFILE_PATHS,

--- a/packages/nim-serving/src/api/images/__tests__/utils.spec.ts
+++ b/packages/nim-serving/src/api/images/__tests__/utils.spec.ts
@@ -1,4 +1,9 @@
-import { normalizeVersion, getImageRepository } from '../utils';
+import {
+  normalizeVersion,
+  getImageRepository,
+  parseImageString,
+  formatImageString,
+} from '../utils';
 
 describe('normalizeVersion', () => {
   it('should pad single number to three parts', () => {
@@ -29,5 +34,74 @@ describe('normalizeVersion', () => {
 describe('getImageRepository', () => {
   it('should construct repository from namespace and model name', () => {
     expect(getImageRepository('nim/test', 'my-model')).toBe('nvcr.io/nim/test/my-model');
+  });
+});
+
+describe('parseImageString', () => {
+  it('should split host, namespace, name, and tag', () => {
+    expect(parseImageString('nvcr.io/nim/snowflake/arctic-embed-l:1.0.1')).toEqual([
+      'nvcr.io',
+      'nim/snowflake',
+      'arctic-embed-l',
+      '1.0.1',
+    ]);
+  });
+
+  it('should return an empty tag when none is present', () => {
+    expect(parseImageString('nvcr.io/nim/meta/llama-3-8b-instruct')).toEqual([
+      'nvcr.io',
+      'nim/meta',
+      'llama-3-8b-instruct',
+      '',
+    ]);
+  });
+
+  it('should keep a host port and not mistake it for a tag', () => {
+    expect(parseImageString('mirror.local:5000/nim/arctic-embed-l')).toEqual([
+      'mirror.local:5000',
+      'nim',
+      'arctic-embed-l',
+      '',
+    ]);
+  });
+
+  it('should read the tag alongside a host port', () => {
+    expect(parseImageString('mirror.local:5000/nim/arctic-embed-l:1.0.1')).toEqual([
+      'mirror.local:5000',
+      'nim',
+      'arctic-embed-l',
+      '1.0.1',
+    ]);
+  });
+
+  it('should treat a bare name with a tag as name and tag only', () => {
+    expect(parseImageString('arctic-embed-l:1.0.1')).toEqual(['', '', 'arctic-embed-l', '1.0.1']);
+  });
+
+  it('should not treat a plain first segment as a host', () => {
+    expect(parseImageString('nim/arctic-embed-l')).toEqual(['', 'nim', 'arctic-embed-l', '']);
+  });
+});
+
+describe('formatImageString', () => {
+  it('should join all parts into a full reference', () => {
+    expect(formatImageString(['nvcr.io', 'nim/snowflake', 'arctic-embed-l', '1.0.1'])).toBe(
+      'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',
+    );
+  });
+
+  it('should omit the tag when it is empty', () => {
+    expect(formatImageString(['nvcr.io', 'nim/snowflake', 'arctic-embed-l', ''])).toBe(
+      'nvcr.io/nim/snowflake/arctic-embed-l',
+    );
+  });
+
+  it('should drop empty host and namespace without leaving stray slashes', () => {
+    expect(formatImageString(['', '', 'arctic-embed-l', '1.0.1'])).toBe('arctic-embed-l:1.0.1');
+  });
+
+  it('should round-trip a parsed reference', () => {
+    const image = 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1';
+    expect(formatImageString(parseImageString(image))).toBe(image);
   });
 });

--- a/packages/nim-serving/src/api/images/utils.ts
+++ b/packages/nim-serving/src/api/images/utils.ts
@@ -14,6 +14,35 @@ export const normalizeVersion = (tag: string): string => {
 export const getImageRepository = (modelNamespace: string, modelName: string): string =>
   `${NIM_IMAGE_REGISTRY}/${modelNamespace}/${modelName}`;
 
-/** `nvcr.io/nim/meta/llama-3-8b-instruct` -> `llama-3-8b-instruct` */
-export const getModelNameFromRepository = (repository: string): string =>
-  repository.split('/').pop() || repository;
+/**
+ * The parts of an image reference `[HOST[:PORT]/]NAMESPACE/NAME[:TAG]`.
+ * Absent parts are '' (e.g. a bare `model:1.0` yields `['', '', 'model', '1.0']`).
+ */
+export type NIMImageParts = [host: string, namespace: string, name: string, tag: string];
+
+// The standard OCI rule: a first path segment is a registry host (not part of the namespace) only
+// if it carries a dot, a port colon, or is localhost.
+const isRegistryHost = (segment: string): boolean =>
+  segment.includes('.') || segment.includes(':') || segment === 'localhost';
+
+/**
+ * Parses `[HOST[:PORT]/]NAMESPACE/NAME[:TAG]` into its parts. The tag is only read from the
+ * final path segment, so a `HOST:PORT` colon is never mistaken for a tag.
+ */
+export const parseImageString = (image: string): NIMImageParts => {
+  const lastSlash = image.lastIndexOf('/');
+  const tagColon = image.indexOf(':', lastSlash + 1);
+  const tag = tagColon === -1 ? '' : image.slice(tagColon + 1);
+  const path = tagColon === -1 ? image : image.slice(0, tagColon);
+
+  const segments = path.split('/');
+  const host = segments.length > 1 && isRegistryHost(segments[0]) ? segments.shift() ?? '' : '';
+  const name = segments.pop() ?? '';
+  return [host, segments.join('/'), name, tag];
+};
+
+/** Inverse of {@link parseImageString}; empty parts are dropped so no stray `/` or `:` remains. */
+export const formatImageString = ([host, namespace, name, tag]: NIMImageParts): string => {
+  const path = [host, namespace, name].filter(Boolean).join('/');
+  return tag ? `${path}:${tag}` : path;
+};

--- a/packages/nim-serving/src/api/servingruntime/consts.ts
+++ b/packages/nim-serving/src/api/servingruntime/consts.ts
@@ -1,0 +1,6 @@
+//
+/**
+ * The NIM Template copies this annotation into the ServingRuntime at deploy time.
+ * The Template has it in Template.spec[0] -> ServingRuntime.metadata.annotations
+ */
+export const NIM_RUNTIME_TEMPLATE_ANNOTATION = 'runtimes.opendatahub.io/nvidia-nim';

--- a/packages/nim-serving/src/api/servingruntime/consts.ts
+++ b/packages/nim-serving/src/api/servingruntime/consts.ts
@@ -1,6 +1,5 @@
-//
 /**
  * The NIM Template copies this annotation into the ServingRuntime at deploy time.
  * The Template has it in Template.spec[0] -> ServingRuntime.metadata.annotations
  */
-export const NIM_RUNTIME_TEMPLATE_ANNOTATION = 'runtimes.opendatahub.io/nvidia-nim';
+export const NIM_RUNTIME_STAMP_ANNOTATION = 'runtimes.opendatahub.io/nvidia-nim';

--- a/packages/nim-serving/src/api/servingruntime/useFetchNIMTemplate.ts
+++ b/packages/nim-serving/src/api/servingruntime/useFetchNIMTemplate.ts
@@ -1,19 +1,19 @@
 import React from 'react';
 import { getTemplate } from '@odh-dashboard/internal/api/index';
 import { NIMAccountKind, TemplateKind } from '@odh-dashboard/k8s-core';
-import useFetch, { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import useFetch, { FetchStateObject, NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetch';
 
 export const useFetchNIMTemplate = (
   account?: NIMAccountKind | null,
 ): FetchStateObject<TemplateKind | undefined> => {
   const callback = React.useCallback(async () => {
     if (!account) {
-      return Promise.reject(new Error('NIM Account unavailable'));
+      return Promise.reject(new NotReadyError('NIM Account unavailable'));
     }
 
     const templateName = account.status?.runtimeTemplate?.name;
     if (!templateName) {
-      return Promise.reject(new Error('status.runtimeTemplate unavailable on NIM Account'));
+      return Promise.reject(new NotReadyError('status.runtimeTemplate unavailable on NIM Account'));
     }
     const { namespace } = account.metadata;
 

--- a/packages/nim-serving/src/nimKServe/__tests__/extractFormData.spec.ts
+++ b/packages/nim-serving/src/nimKServe/__tests__/extractFormData.spec.ts
@@ -47,6 +47,14 @@ describe('isNIMKServeDeployment', () => {
     ).toBe(false);
   });
 
+  it('should return false for a non-NIM nvcr.io image (not under the nim/ namespace)', () => {
+    expect(
+      isNIMKServeDeployment(
+        makeDeployment(makeServingRuntime('nvcr.io/nvidia/tritonserver:24.01')),
+      ),
+    ).toBe(false);
+  });
+
   it('should return false when there is no server', () => {
     expect(isNIMKServeDeployment(makeDeployment())).toBe(false);
   });

--- a/packages/nim-serving/src/nimKServe/__tests__/extractFormData.spec.ts
+++ b/packages/nim-serving/src/nimKServe/__tests__/extractFormData.spec.ts
@@ -29,12 +29,12 @@ describe('isNIMKServeDeployment', () => {
     ).toBe(true);
   });
 
-  it('should detect NIM from the runtime template annotation when the image is a mirror registry', () => {
+  it('should detect NIM from the runtime stamp annotation when the image is a mirror registry', () => {
     expect(
       isNIMKServeDeployment(
         makeDeployment(
           makeServingRuntime('mirror.local/nim/test:1.0.0', {
-            'opendatahub.io/template-name': 'nvidia-nim-runtime',
+            'runtimes.opendatahub.io/nvidia-nim': 'true',
           }),
         ),
       ),

--- a/packages/nim-serving/src/nimKServe/__tests__/extractFormData.spec.ts
+++ b/packages/nim-serving/src/nimKServe/__tests__/extractFormData.spec.ts
@@ -1,0 +1,53 @@
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
+import type { KServeDeployment } from '@odh-dashboard/kserve/types';
+import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
+import { isNIMKServeDeployment } from '../extractFormData';
+
+const makeServingRuntime = (
+  kserveContainerImage?: string,
+  annotations?: Record<string, string>,
+): ServingRuntimeKind => ({
+  apiVersion: 'serving.kserve.io/v1alpha1',
+  kind: 'ServingRuntime',
+  metadata: { name: 'test-model', namespace: 'test-project', annotations },
+  spec: {
+    containers: [{ name: 'kserve-container', image: kserveContainerImage }],
+    supportedModelFormats: [{ name: 'placeholder', version: '1' }],
+  },
+});
+
+const makeDeployment = (server?: ServingRuntimeKind): KServeDeployment => ({
+  modelServingPlatformId: 'kserve',
+  model: mockInferenceServiceK8sResource({ name: 'test-model' }),
+  server,
+});
+
+describe('isNIMKServeDeployment', () => {
+  it('should detect NIM from an nvcr.io container image', () => {
+    expect(
+      isNIMKServeDeployment(makeDeployment(makeServingRuntime('nvcr.io/nim/test:1.0.0'))),
+    ).toBe(true);
+  });
+
+  it('should detect NIM from the runtime template annotation when the image is a mirror registry', () => {
+    expect(
+      isNIMKServeDeployment(
+        makeDeployment(
+          makeServingRuntime('mirror.local/nim/test:1.0.0', {
+            'opendatahub.io/template-name': 'nvidia-nim-runtime',
+          }),
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('should return false for a plain KServe deployment (no NIM image or annotation)', () => {
+    expect(
+      isNIMKServeDeployment(makeDeployment(makeServingRuntime('quay.io/some/image:1.0'))),
+    ).toBe(false);
+  });
+
+  it('should return false when there is no server', () => {
+    expect(isNIMKServeDeployment(makeDeployment())).toBe(false);
+  });
+});

--- a/packages/nim-serving/src/nimKServe/extractFormData.ts
+++ b/packages/nim-serving/src/nimKServe/extractFormData.ts
@@ -5,7 +5,7 @@ import {
 } from '@odh-dashboard/model-serving/shared/types/form-data';
 import { getNIMKServeContainerImage } from './fields/nimImageApplyExtract';
 import { NIM_IMAGE_REGISTRY } from '../api/images/constants';
-import { NIM_RUNTIME_TEMPLATE_ANNOTATION } from '../api/servingruntime/consts';
+import { NIM_RUNTIME_STAMP_ANNOTATION } from '../api/servingruntime/consts';
 
 // Legacy NIM deploys as a plain KServe InferenceService (modelServingPlatformId === KSERVE_ID),
 // so it shares KServe's form-data extension. We detect NIM by the nvcr.io image on the runtime
@@ -13,7 +13,7 @@ import { NIM_RUNTIME_TEMPLATE_ANNOTATION } from '../api/servingruntime/consts';
 // where the image prefix differs. Either match lets this extension win over KServe's via priority.
 export const isNIMKServeDeployment = (deployment: KServeDeployment): boolean =>
   (getNIMKServeContainerImage(deployment)?.startsWith(NIM_IMAGE_REGISTRY) ?? false) ||
-  !!deployment.server?.metadata.annotations?.[NIM_RUNTIME_TEMPLATE_ANNOTATION];
+  !!deployment.server?.metadata.annotations?.[NIM_RUNTIME_STAMP_ANNOTATION];
 
 // Only reached when isActive already confirmed this is a NIM deployment, so it always marks NIM.
 // The image itself is prefilled by the nimImage wizard-field-extractor, not here.

--- a/packages/nim-serving/src/nimKServe/extractFormData.ts
+++ b/packages/nim-serving/src/nimKServe/extractFormData.ts
@@ -7,12 +7,16 @@ import { getNIMKServeContainerImage } from './fields/nimImageApplyExtract';
 import { NIM_IMAGE_REGISTRY } from '../api/images/constants';
 import { NIM_RUNTIME_STAMP_ANNOTATION } from '../api/servingruntime/consts';
 
+// NIM containers live under the `nim/` org namespace on the registry (e.g. `nvcr.io/nim/...`).
+// Matching the registry host alone would also claim non-NIM images (e.g. `nvcr.io/nvidia/...`).
+const NIM_IMAGE_REPOSITORY_PREFIX = `${NIM_IMAGE_REGISTRY}/nim/`;
+
 // Legacy NIM deploys as a plain KServe InferenceService (modelServingPlatformId === KSERVE_ID),
-// so it shares KServe's form-data extension. We detect NIM by the nvcr.io image on the runtime
+// so it shares KServe's form-data extension. We detect NIM by the nvcr.io/nim/ image on the runtime
 // container, falling back to the NIM runtime template annotation for mirror/air-gapped registries
 // where the image prefix differs. Either match lets this extension win over KServe's via priority.
 export const isNIMKServeDeployment = (deployment: KServeDeployment): boolean =>
-  (getNIMKServeContainerImage(deployment)?.startsWith(NIM_IMAGE_REGISTRY) ?? false) ||
+  (getNIMKServeContainerImage(deployment)?.startsWith(NIM_IMAGE_REPOSITORY_PREFIX) ?? false) ||
   !!deployment.server?.metadata.annotations?.[NIM_RUNTIME_STAMP_ANNOTATION];
 
 // Only reached when isActive already confirmed this is a NIM deployment, so it always marks NIM.

--- a/packages/nim-serving/src/nimKServe/extractFormData.ts
+++ b/packages/nim-serving/src/nimKServe/extractFormData.ts
@@ -1,0 +1,24 @@
+import type { KServeDeployment } from '@odh-dashboard/kserve/types';
+import {
+  type ModelLocationData,
+  ModelLocationType,
+} from '@odh-dashboard/model-serving/shared/types/form-data';
+import { getNIMKServeContainerImage } from './fields/nimImageApplyExtract';
+import { NIM_IMAGE_REGISTRY } from '../api/images/constants';
+import { NIM_RUNTIME_TEMPLATE_ANNOTATION } from '../api/servingruntime/consts';
+
+// Legacy NIM deploys as a plain KServe InferenceService (modelServingPlatformId === KSERVE_ID),
+// so it shares KServe's form-data extension. We detect NIM by the nvcr.io image on the runtime
+// container, falling back to the NIM runtime template annotation for mirror/air-gapped registries
+// where the image prefix differs. Either match lets this extension win over KServe's via priority.
+export const isNIMKServeDeployment = (deployment: KServeDeployment): boolean =>
+  (getNIMKServeContainerImage(deployment)?.startsWith(NIM_IMAGE_REGISTRY) ?? false) ||
+  !!deployment.server?.metadata.annotations?.[NIM_RUNTIME_TEMPLATE_ANNOTATION];
+
+// Only reached when isActive already confirmed this is a NIM deployment, so it always marks NIM.
+// The image itself is prefilled by the nimImage wizard-field-extractor, not here.
+export const extractNIMKServeModelLocationData = (): ModelLocationData => ({
+  type: ModelLocationType.NIM,
+  fieldValues: {},
+  additionalFields: {},
+});

--- a/packages/nim-serving/src/nimKServe/fields/__tests__/nimImageApplyExtract.spec.ts
+++ b/packages/nim-serving/src/nimKServe/fields/__tests__/nimImageApplyExtract.spec.ts
@@ -1,16 +1,19 @@
 import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
 import type { KServeDeployment } from '@odh-dashboard/kserve/types';
 import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
-import { applyNIMImageFieldData } from '../nimImageApplyExtract';
+import { applyNIMImageFieldData, extractNIMKServeImageFieldData } from '../nimImageApplyExtract';
 
 const NIM_IMAGE = { repository: 'nvcr.io/nim/snowflake/arctic-embed-l', tag: '1.0.1' };
 
-const makeServingRuntime = (): ServingRuntimeKind => ({
+const makeServingRuntime = (kserveContainerImage?: string): ServingRuntimeKind => ({
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'ServingRuntime',
   metadata: { name: 'test-model', namespace: 'test-project' },
   spec: {
-    containers: [{ name: 'transformer-container' }, { name: 'kserve-container' }],
+    containers: [
+      { name: 'transformer-container' },
+      { name: 'kserve-container', image: kserveContainerImage },
+    ],
     supportedModelFormats: [{ name: 'placeholder', version: '1' }],
   },
 });
@@ -70,5 +73,40 @@ describe('applyNIMImageFieldData', () => {
     });
 
     expect(result.model.spec.predictor.model?.modelFormat).toEqual({ name: 'arctic-embed-l' });
+  });
+});
+
+describe('extractNIMKServeImageFieldData', () => {
+  it('should split the kserve-container image into repository and tag', () => {
+    const deployment = makeDeployment(
+      makeServingRuntime('nvcr.io/nim/snowflake/arctic-embed-l:1.0.1'),
+    );
+
+    expect(extractNIMKServeImageFieldData(deployment)).toEqual(NIM_IMAGE);
+  });
+
+  it('should return an empty tag when the image has no tag', () => {
+    const deployment = makeDeployment(makeServingRuntime('nvcr.io/nim/snowflake/arctic-embed-l'));
+
+    expect(extractNIMKServeImageFieldData(deployment)).toEqual({
+      repository: 'nvcr.io/nim/snowflake/arctic-embed-l',
+      tag: '',
+    });
+  });
+
+  it('should return undefined for a non-NIM (non-nvcr.io) image', () => {
+    const deployment = makeDeployment(makeServingRuntime('quay.io/some/image:1.0'));
+
+    expect(extractNIMKServeImageFieldData(deployment)).toBeUndefined();
+  });
+
+  it('should return undefined when the kserve-container has no image', () => {
+    const deployment = makeDeployment(makeServingRuntime());
+
+    expect(extractNIMKServeImageFieldData(deployment)).toBeUndefined();
+  });
+
+  it('should return undefined when the deployment has no server', () => {
+    expect(extractNIMKServeImageFieldData(makeDeployment())).toBeUndefined();
   });
 });

--- a/packages/nim-serving/src/nimKServe/fields/__tests__/nimImageApplyExtract.spec.ts
+++ b/packages/nim-serving/src/nimKServe/fields/__tests__/nimImageApplyExtract.spec.ts
@@ -5,10 +5,13 @@ import { applyNIMImageFieldData, extractNIMKServeImageFieldData } from '../nimIm
 
 const NIM_IMAGE = { repository: 'nvcr.io/nim/snowflake/arctic-embed-l', tag: '1.0.1' };
 
-const makeServingRuntime = (kserveContainerImage?: string): ServingRuntimeKind => ({
+const makeServingRuntime = (
+  kserveContainerImage?: string,
+  annotations?: Record<string, string>,
+): ServingRuntimeKind => ({
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'ServingRuntime',
-  metadata: { name: 'test-model', namespace: 'test-project' },
+  metadata: { name: 'test-model', namespace: 'test-project', annotations },
   spec: {
     containers: [
       { name: 'transformer-container' },
@@ -94,7 +97,20 @@ describe('extractNIMKServeImageFieldData', () => {
     });
   });
 
-  it('should return undefined for a non-NIM (non-nvcr.io) image', () => {
+  it('should prefill a mirror-registry image when the NIM runtime stamp annotation is present', () => {
+    const deployment = makeDeployment(
+      makeServingRuntime('mirror.local/nim/snowflake/arctic-embed-l:1.0.1', {
+        'runtimes.opendatahub.io/nvidia-nim': 'true',
+      }),
+    );
+
+    expect(extractNIMKServeImageFieldData(deployment)).toEqual({
+      repository: 'mirror.local/nim/snowflake/arctic-embed-l',
+      tag: '1.0.1',
+    });
+  });
+
+  it('should return undefined for a non-NIM (non-nvcr.io) image without the annotation', () => {
     const deployment = makeDeployment(makeServingRuntime('quay.io/some/image:1.0'));
 
     expect(extractNIMKServeImageFieldData(deployment)).toBeUndefined();

--- a/packages/nim-serving/src/nimKServe/fields/nimImageApplyExtract.ts
+++ b/packages/nim-serving/src/nimKServe/fields/nimImageApplyExtract.ts
@@ -1,12 +1,12 @@
 import { KServeDeployment } from '@odh-dashboard/kserve/types';
 import { parseImageString } from '../../api/images/utils';
 import { KSERVE_CONTAINER_NAME } from '../../constants';
-import { NIM_IMAGE_REGISTRY } from '../../api/images/constants';
 import {
   getImageOptionKey,
   NIMImageFieldValue,
   toNIMImageFieldValue,
 } from '../../pages/deploymentWizard/fields/NIMImageField';
+import { isNIMKServeDeployment } from '../extractFormData';
 
 const setNIMDeploymentModelFormat = (
   deployment: KServeDeployment,
@@ -105,7 +105,7 @@ export const extractNIMKServeImageFieldData = (
   deployment: KServeDeployment,
 ): NIMImageFieldValue | undefined => {
   const image = getNIMKServeContainerImage(deployment);
-  if (!image?.startsWith(NIM_IMAGE_REGISTRY)) {
+  if (!image || !isNIMKServeDeployment(deployment)) {
     return undefined;
   }
   return toNIMImageFieldValue(image);

--- a/packages/nim-serving/src/nimKServe/fields/nimImageApplyExtract.ts
+++ b/packages/nim-serving/src/nimKServe/fields/nimImageApplyExtract.ts
@@ -1,43 +1,51 @@
 import { KServeDeployment } from '@odh-dashboard/kserve/types';
-import type { NIMImageFieldValue } from '../../pages/deploymentWizard/fields/NIMImageField';
-import { getModelNameFromRepository } from '../../api/images/utils';
+import { parseImageString } from '../../api/images/utils';
 import { KSERVE_CONTAINER_NAME } from '../../constants';
+import { NIM_IMAGE_REGISTRY } from '../../api/images/constants';
+import {
+  getImageOptionKey,
+  NIMImageFieldValue,
+  toNIMImageFieldValue,
+} from '../../pages/deploymentWizard/fields/NIMImageField';
 
 const setNIMDeploymentModelFormat = (
   deployment: KServeDeployment,
   nimImage: NIMImageFieldValue,
-): KServeDeployment => ({
-  ...deployment,
-  model: {
-    ...deployment.model,
-    spec: {
-      ...deployment.model.spec,
-      predictor: {
-        ...deployment.model.spec.predictor,
-        model: {
-          ...deployment.model.spec.predictor.model,
-          modelFormat: { name: getModelNameFromRepository(nimImage.repository) },
+): KServeDeployment => {
+  const [, , imageName] = parseImageString(nimImage.repository);
+  return {
+    ...deployment,
+    model: {
+      ...deployment.model,
+      spec: {
+        ...deployment.model.spec,
+        predictor: {
+          ...deployment.model.spec.predictor,
+          model: {
+            ...deployment.model.spec.predictor.model,
+            modelFormat: { name: imageName },
+          },
         },
       },
     },
-  },
-  server: deployment.server
-    ? {
-        ...deployment.server,
-        spec: {
-          ...deployment.server.spec,
-          supportedModelFormats: [
-            {
-              autoSelect: false,
-              name: getModelNameFromRepository(nimImage.repository),
-              priority: 1,
-              version: nimImage.tag,
-            },
-          ],
-        },
-      }
-    : undefined,
-});
+    server: deployment.server
+      ? {
+          ...deployment.server,
+          spec: {
+            ...deployment.server.spec,
+            supportedModelFormats: [
+              {
+                autoSelect: false,
+                name: imageName,
+                priority: 1,
+                version: nimImage.tag,
+              },
+            ],
+          },
+        }
+      : undefined,
+  };
+};
 
 const setNIMDeploymentImage = (
   deployment: KServeDeployment,
@@ -51,7 +59,7 @@ const setNIMDeploymentImage = (
     if (c.name === KSERVE_CONTAINER_NAME) {
       return {
         ...c,
-        image: `${nimImage.repository}:${nimImage.tag}`,
+        image: getImageOptionKey(nimImage),
       };
     }
     return c;
@@ -83,4 +91,22 @@ export const applyNIMImageFieldData = (
   assembledDeployment = setNIMDeploymentImage(assembledDeployment, fieldData);
 
   return assembledDeployment;
+};
+
+export const getNIMKServeContainerImage = (deployment: KServeDeployment): string | undefined =>
+  deployment.server?.spec.containers.find((c) => c.name === KSERVE_CONTAINER_NAME)?.image;
+
+/**
+ * Reads the NIM image back off the ServingRuntime container to prefill the image field on edit.
+ * Returns undefined for non-NIM KServe deployments so it doesn't fire on plain KServe edits
+ * (the extractor matches on the shared KServe platform).
+ */
+export const extractNIMKServeImageFieldData = (
+  deployment: KServeDeployment,
+): NIMImageFieldValue | undefined => {
+  const image = getNIMKServeContainerImage(deployment);
+  if (!image?.startsWith(NIM_IMAGE_REGISTRY)) {
+    return undefined;
+  }
+  return toNIMImageFieldValue(image);
 };

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -12,7 +12,12 @@ import useNIMAccountStatus, { NIMAccountStatus } from '../../../api/accounts/hoo
 import NIMSettingsLink from '../../projectSettings/NIMSettingsLink';
 import { useNIMImages, type NIMImagesData } from '../../../api/images/hooks';
 import type { NIMImage } from '../../../api/images/types';
-import { getImageRepository, normalizeVersion } from '../../../api/images/utils';
+import {
+  formatImageString,
+  getImageRepository,
+  normalizeVersion,
+  parseImageString,
+} from '../../../api/images/utils';
 import { useFetchNIMTemplate } from '../../../api/servingruntime/useFetchNIMTemplate';
 
 export const isNIMImageFieldExternalData = (data: unknown): data is NIMImageFieldExternalData =>
@@ -86,7 +91,13 @@ const nimImageFieldSchema = z.object({
 
 type NIMImageOption = TypeaheadSelectOption & NIMImageFieldValue;
 
-const getImageOptionKey = (image: NIMImageFieldValue): string => `${image.repository}:${image.tag}`;
+export const getImageOptionKey = (image: NIMImageFieldValue): string =>
+  `${image.repository}:${image.tag}`;
+
+export const toNIMImageFieldValue = (image: string): NIMImageFieldValue => {
+  const [host, namespace, name, tag] = parseImageString(image);
+  return { repository: formatImageString([host, namespace, name, '']), tag };
+};
 
 const getNIMImageOptions = (images: NIMImage[]): NIMImageOption[] => {
   const seen = new Set<string | number>();

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -99,9 +99,12 @@ export const toNIMImageFieldValue = (image: string): NIMImageFieldValue => {
   return { repository: formatImageString([host, namespace, name, '']), tag };
 };
 
-const getNIMImageOptions = (images: NIMImage[]): NIMImageOption[] => {
-  const seen = new Set<string | number>();
-  return images.flatMap((image) => {
+const getNIMImageOptions = (
+  images: NIMImage[],
+  existingSelection?: NIMImageFieldValue,
+): { options: NIMImageOption[]; existingOptionNotFound: boolean } => {
+  const seen = new Set<string>();
+  const result = images.flatMap((image) => {
     if (!image.namespace) {
       return [];
     }
@@ -121,6 +124,19 @@ const getNIMImageOptions = (images: NIMImage[]): NIMImageOption[] => {
       return acc;
     }, []);
   });
+
+  let existingOptionNotFound = false;
+  // Add the existing value if it's not found in the list
+  if (existingSelection && !seen.has(getImageOptionKey(existingSelection))) {
+    existingOptionNotFound = true;
+    result.unshift({
+      value: getImageOptionKey(existingSelection),
+      content: getImageOptionKey(existingSelection),
+      repository: existingSelection.repository,
+      tag: existingSelection.tag,
+    });
+  }
+  return { options: result, existingOptionNotFound };
 };
 
 type NIMImageFieldComponentProps = {
@@ -143,16 +159,12 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
     [externalData?.data.nimImages.images],
   );
 
-  const options: NIMImageOption[] = React.useMemo(() => getNIMImageOptions(images), [images]);
+  const { options, existingOptionNotFound } = React.useMemo(
+    () => getNIMImageOptions(images, value),
+    [images, value],
+  );
 
-  const selectedKey = React.useMemo(() => {
-    if (!value?.repository) {
-      return '';
-    }
-    const currentKey = getImageOptionKey(value);
-    const matched = options.find((opt) => String(opt.value) === currentKey);
-    return matched ? String(matched.value) : currentKey;
-  }, [value, options]);
+  const selectedKey = value ? getImageOptionKey(value) : undefined;
 
   const onSelect = React.useCallback(
     (_event: React.MouseEvent | React.KeyboardEvent | undefined, key: string | number) => {
@@ -230,6 +242,13 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
         <HelperText>
           <HelperTextItem variant="error">
             There was a problem fetching the NIM models. Please try again later.
+          </HelperTextItem>
+        </HelperText>
+      )}
+      {existingOptionNotFound && (
+        <HelperText>
+          <HelperTextItem variant="warning">
+            The existing NIM image was not found. The deployment may not work as expected.
           </HelperTextItem>
         </HelperText>
       )}

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -127,7 +127,11 @@ const getNIMImageOptions = (
 
   let existingOptionNotFound = false;
   // Add the existing value if it's not found in the list
-  if (existingSelection && !seen.has(getImageOptionKey(existingSelection))) {
+  if (
+    existingSelection?.repository &&
+    existingSelection.tag &&
+    !seen.has(getImageOptionKey(existingSelection))
+  ) {
     existingOptionNotFound = true;
     result.unshift({
       value: getImageOptionKey(existingSelection),
@@ -164,7 +168,7 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
     [images, value],
   );
 
-  const selectedKey = value ? getImageOptionKey(value) : undefined;
+  const selectedKey = value?.repository && value.tag ? getImageOptionKey(value) : undefined;
 
   const onSelect = React.useCallback(
     (_event: React.MouseEvent | React.KeyboardEvent | undefined, key: string | number) => {
@@ -247,7 +251,7 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
       )}
       {existingOptionNotFound && (
         <HelperText>
-          <HelperTextItem variant="warning">
+          <HelperTextItem variant="warning" data-testid="nim-image-not-found-warning">
             The existing NIM image was not found. The deployment may not work as expected.
           </HelperTextItem>
         </HelperText>

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -249,7 +249,7 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
           </HelperTextItem>
         </HelperText>
       )}
-      {existingOptionNotFound && (
+      {existingOptionNotFound && !externalData.loadError && (
         <HelperText>
           <HelperTextItem variant="warning" data-testid="nim-image-not-found-warning">
             The existing NIM image was not found. The deployment may not work as expected.

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -131,7 +131,8 @@ const useNIMPVCExternalData = (dependencies?: {
     }
     const [scList, pvcList] = await Promise.all([
       getStorageClasses(),
-      getDashboardPvcs(projectName),
+      // Don't filter out PVCs without a `opendatahub.io/dashboard=true`, old modal NIMs didn't add it
+      getDashboardPvcs(projectName, null),
     ]);
 
     return {
@@ -185,19 +186,13 @@ type SubPathFieldProps = {
   subPath: string;
   onSubPathChange: (val: string) => void;
   isDisabled?: boolean;
-  idSuffix?: string;
 };
 
-const SubPathField: React.FC<SubPathFieldProps> = ({
-  subPath,
-  onSubPathChange,
-  isDisabled,
-  idSuffix = '',
-}) => (
-  <FormGroup label="Subpath" fieldId={`nim-subpath${idSuffix}`}>
+const SubPathField: React.FC<SubPathFieldProps> = ({ subPath, onSubPathChange, isDisabled }) => (
+  <FormGroup label="Subpath" fieldId="nim-subpath">
     <TextInput
-      id={`nim-subpath${idSuffix}`}
-      data-testid={`nim-subpath${idSuffix}-input`}
+      id="nim-subpath"
+      data-testid="nim-subpath-input"
       value={subPath}
       onChange={(_event, val) => onSubPathChange(val)}
       placeholder="/"
@@ -389,7 +384,6 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
             subPath={fieldValue.subPath}
             onSubPathChange={(val) => updateField({ subPath: val })}
             isDisabled={isDisabled}
-            idSuffix="-existing"
           />
         </>
       )}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79810

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
NIM Kserve reuses the kserve deployment-to-form parser and overwrites the model selection + a extract function for the NIM location field that sets it.
I also made it so if a NIM image isn't found in the list, it still shows up. This would happen if the list shifts, versions are lost, or NIM gets disabled 

PVC extraction might be captured in https://redhat.atlassian.net/browse/RHOAIENG-79807

<img width="1123" height="863" alt="image" src="https://github.com/user-attachments/assets/65062012-3806-491d-9fb2-51523878db91" />

<img width="597" height="451" alt="image" src="https://github.com/user-attachments/assets/937feeaf-b8c4-4bca-9dc3-00b78a0fcbf7" />

The PVC data loads on edit too now
<img width="773" height="802" alt="image" src="https://github.com/user-attachments/assets/4d0de33d-cd8f-453b-8912-fc2348292c9a" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
2 scenarios
1. Have the `nimWizard` flag set to false
2. Deploy a NIM model from the old modal
3. Turn the `nimWizard` to true
4. Find the deployed model and edit it, should show everything correctly

New nim models
1. Turn the `nimWizard` to true
2. Deploy a NIM model using the wizard
3. Find the deployed model and edit it, should show everything correctly

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
cypress test added to test the "Edit" scenario. It goes up until the PVC to check the data

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for managing legacy NIM deployments through KServe-based workflows.
  - Existing NIM images, hardware profiles, and PVC cache settings are now detected and prefilled during editing.
  - Improved handling of NIM image references, including mirrored registries, tags, and untagged images.
  - Deployment details now display hardware profiles, authentication settings, and masked service-account tokens.
  - Older NIM storage volumes are now available for selection.

- **Bug Fixes**
  - Added a warning when an existing NIM image is no longer available.
  - Improved deployment configuration selection for active model-serving workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->