### PR TITLE
test(e2e): Move model-serving validation to Model deployment settings spec

### DIFF
--- a/packages/cypress/cypress/tests/e2e/settings/clusterSettings/testAdminClusterSettings.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/clusterSettings/testAdminClusterSettings.cy.ts
@@ -18,7 +18,6 @@ import type {
   NotebookControllerCullerConfig,
 } from '../../../../types';
 import {
-  validateModelServingPlatforms,
   validatePVCSize,
   validateStopIdleNotebooks,
   checkUserNotInRHODSUserGroups,
@@ -181,10 +180,6 @@ describe('Verify that only the Cluster Admin can access Cluster Settings', () =>
 
       cy.step('Navigate to Cluster Settings');
       clusterSettings.visit();
-
-      // Validate model serving displays based on OpenShift command to 'get OdhDashboardConfig' to validate configuration
-      cy.step('Validate Model Serving Platforms display and are checked');
-      validateModelServingPlatforms(dashboardConfig);
 
       // Validate pvc size based on OpenShift command to 'get OdhDashboardConfig' to validate configuration
       cy.step('Validate PVC Size displays and default displays');

--- a/packages/cypress/cypress/tests/e2e/settings/modelDeploymentSettings/testDeploymentGeneralSettings.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/modelDeploymentSettings/testDeploymentGeneralSettings.cy.ts
@@ -1,0 +1,70 @@
+import { LDAP_CONTRIBUTOR_USER, LDAP_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
+import { generalSettingsPage } from '../../../../pages/modelDeploymentSettings/generalSettings';
+import { pageNotfound } from '../../../../pages/pageNotFound';
+import type { DashboardConfig } from '../../../../types';
+import { validateModelServingPlatforms } from '../../../../utils/modelDeploymentSettingsUtils';
+import { retryableBefore } from '../../../../utils/retryableHooks';
+
+describe('Verify Model Deployment General Settings access and model-serving controls', () => {
+  let dashboardConfig: DashboardConfig;
+
+  retryableBefore(() => {
+    // Retrieve the dashboard configuration to validate the model-serving switch against
+    return cy.getDashboardConfig().then((config) => {
+      dashboardConfig = config as DashboardConfig;
+      cy.log('Dashboard Config:', JSON.stringify(dashboardConfig, null, 2));
+    });
+  });
+
+  it(
+    'Admin should access Model Deployment General Settings and see the model-serving switch matching OpenShift configuration',
+    {
+      tags: [
+        '@Smoke',
+        '@SmokeSet2',
+        '@ODS-1216',
+        '@Dashboard',
+        '@ci-dashboard-regression-tags',
+        '@SettingsCI',
+      ],
+    },
+    () => {
+      cy.step('Log into the application as admin');
+      cy.visitWithLogin('/', LDAP_CLUSTER_ADMIN_USER);
+
+      // Validate the model-serving platform switch on the General settings tab based on the
+      // OpenShift 'get OdhDashboardConfig' configuration. validateModelServingPlatforms
+      // navigates to the tab itself before asserting.
+      cy.step('Validate Model Serving Platforms display and are checked');
+      validateModelServingPlatforms(dashboardConfig);
+    },
+  );
+
+  it(
+    'Test User - should not have access rights to view the Model Deployment Settings tab',
+    {
+      tags: [
+        '@Smoke',
+        '@SmokeSet2',
+        '@ODS-1216',
+        '@Dashboard',
+        '@ci-dashboard-regression-tags',
+        '@SettingsCI',
+      ],
+    },
+    () => {
+      cy.step('Log into the application');
+      cy.visitWithLogin('/', LDAP_CONTRIBUTOR_USER);
+
+      cy.step('Navigate to the Model Deployment General Settings tab');
+      cy.visitWithLogin(
+        '/settings/model-resources-operations/model-deployment-settings/general-settings',
+        LDAP_CONTRIBUTOR_USER,
+      );
+
+      pageNotfound.findPage().should('exist');
+
+      generalSettingsPage.findNavItem().should('not.exist');
+    },
+  );
+});

--- a/packages/cypress/cypress/utils/clusterSettingsUtils.ts
+++ b/packages/cypress/cypress/utils/clusterSettingsUtils.ts
@@ -1,47 +1,6 @@
 import { getOdhDashboardConfigGroupsConfig } from './oc_commands/project';
 import type { CommandLineResult, DashboardConfig, NotebookControllerCullerConfig } from '../types';
 import { pvcSizeSettings, cullerSettings } from '../pages/clusterSettings';
-// TODO: validateModelServingPlatforms still checks the model-serving switch that used
-// to live on the Cluster Settings page; those controls moved to the General settings
-// tab, so this validation (and its e2e caller) needs to be repointed to that tab.
-// Tracked as a follow-up.
-import { generalSettingsPage } from '../pages/modelDeploymentSettings/generalSettings';
-
-/**
- * Validates the visibility and state of Model Serving Platform checkboxes
- * in the Cluster Settings based on the provided dashboard configuration.
- *
- * This function checks whether the Model Serving feature is enabled or disabled,
- * and subsequently verifies the state of the Single-Platform checkbox.
- *
- * - If Model Serving is disabled, the checkbox should not be visible.
- * - If Model Serving is enabled:
- *   - The Single-Platform Checkbox will be checked if KServe is enabled;
- *     otherwise, it will not be checked.
- *
- * @param dashboardConfig The Model Serving Platform configuration object containing
- *                        settings related to model serving and KServe.
- */
-export const validateModelServingPlatforms = (dashboardConfig: DashboardConfig): void => {
-  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-  const isModelServingEnabled = dashboardConfig.dashboardConfig?.disableModelServing;
-  const isKServeEnabled = dashboardConfig.dashboardConfig?.disableKServe;
-  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
-
-  cy.log(`Value of isModelServingEnabled: ${String(isModelServingEnabled)}`);
-  cy.log(`Value of isKServeEnabled: ${String(isKServeEnabled)}`);
-
-  if (isModelServingEnabled) {
-    generalSettingsPage.findSinglePlatformSwitch().should('not.exist');
-    cy.log('Model Serving is disabled, checkboxes should not be visible');
-  } else if (isKServeEnabled) {
-    generalSettingsPage.findSinglePlatformSwitch().should('not.be.checked');
-    cy.log('Single-Platform Checkbox is disabled, it should not be checked');
-  } else {
-    generalSettingsPage.findSinglePlatformSwitch().should('be.checked');
-    cy.log('Single-Platform Checkbox is enabled, it should be checked');
-  }
-};
 
 /**
  * Validates the PVC Size displays in the Cluster Settings.

--- a/packages/cypress/cypress/utils/modelDeploymentSettingsUtils.ts
+++ b/packages/cypress/cypress/utils/modelDeploymentSettingsUtils.ts
@@ -1,0 +1,44 @@
+import type { DashboardConfig } from '../types';
+import { generalSettingsPage } from '../pages/modelDeploymentSettings/generalSettings';
+
+/**
+ * Validates the visibility and state of the Model Serving Platform switch
+ * on the Model deployment settings General settings tab, based on the provided
+ * dashboard configuration.
+ *
+ * These controls used to live on the Cluster Settings page but moved to the
+ * General settings tab, so this navigates to that tab before asserting.
+ *
+ * This function checks whether the Model Serving feature is enabled or disabled,
+ * and subsequently verifies the state of the Single-Platform switch.
+ *
+ * - If Model Serving is disabled, the switch should not be visible.
+ * - If Model Serving is enabled:
+ *   - The Single-Platform switch will be checked if KServe is enabled;
+ *     otherwise, it will not be checked.
+ *
+ * @param dashboardConfig The Model Serving Platform configuration object containing
+ *                        settings related to model serving and KServe.
+ */
+export const validateModelServingPlatforms = (dashboardConfig: DashboardConfig): void => {
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+  const isModelServingEnabled = dashboardConfig.dashboardConfig?.disableModelServing;
+  const isKServeEnabled = dashboardConfig.dashboardConfig?.disableKServe;
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+
+  cy.log(`Value of isModelServingEnabled: ${String(isModelServingEnabled)}`);
+  cy.log(`Value of isKServeEnabled: ${String(isKServeEnabled)}`);
+
+  generalSettingsPage.visit();
+
+  if (isModelServingEnabled) {
+    generalSettingsPage.findSinglePlatformSwitch().should('not.exist');
+    cy.log('Model Serving is disabled, the switch should not be visible');
+  } else if (isKServeEnabled) {
+    generalSettingsPage.findSinglePlatformSwitch().should('not.be.checked');
+    cy.log('KServe is disabled, the Single-Platform switch should not be checked');
+  } else {
+    generalSettingsPage.findSinglePlatformSwitch().should('be.checked');
+    cy.log('KServe is enabled, the Single-Platform switch should be checked');
+  }
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-85391

## Description

`testAdminClusterSettings.cy.ts` (`Admin should access Cluster Settings and see UI fields matching OpenShift configurations`) failed on every `@ci-dashboard-regression-tags` e2e run. The single-model-serving-platform switch was removed from the **Cluster Settings** page (`/settings/cluster/general`) and now lives only on the **Model deployment settings → General settings** tab (`/settings/model-resources-operations/model-deployment-settings/general-settings`), but the spec still visited Cluster Settings before asserting the switch — so it looked for a control that no longer exists there.

Rather than fix it in place, this moves the model-serving validation to its own feature-area spec so the assertion lives with the page it targets:

- **New** `packages/cypress/cypress/tests/e2e/settings/modelDeploymentSettings/testDeploymentGeneralSettings.cy.ts`:
  - Admin test validating the single-platform switch on the General settings tab against the `OdhDashboardConfig` (the moved assertion).
  - New contributor no-access test: `Test User - should not have access rights to view the Model Deployment Settings tab`.
  - Both `it` blocks keep `@ci-dashboard-regression-tags` / `@SettingsCI`, so the regression suite that surfaced this still covers the assertion — now against the correct page.
- **New** `packages/cypress/cypress/utils/modelDeploymentSettingsUtils.ts`: `validateModelServingPlatforms` moved here from `clusterSettingsUtils.ts`, now navigating to the General settings tab before asserting.
- **Updated** `testAdminClusterSettings.cy.ts`: dropped the stale model-serving validation (still validates PVC size and idle-notebook settings on Cluster Settings).
- **Updated** `clusterSettingsUtils.ts`: removed `validateModelServingPlatforms` and the stale `TODO`.

The new `modelDeploymentSettings/` e2e folder and `modelDeploymentSettingsUtils.ts` also lay the groundwork for moving/creating more Model deployment settings e2e tests as part of [RHOAIENG-69029](https://issues.redhat.com/browse/RHOAIENG-69029) (Admin Setup - e2e tests).

## How Has This Been Tested?

- `npm run type-check` from the repo root — passes (30/30 tasks, including `@odh-dashboard/cypress`).
- `npm run lint` in `packages/cypress` — 0 errors (2 warnings are pre-existing in unrelated files).
- The moved/new e2e tests have not yet been run against a live cluster; they carry `@ci-dashboard-regression-tags` and will run in the regression suite against a PR image.

## Test Impact

This is a test-only change (stale e2e test repointed to the page the controls moved to). No product code changes. The failing regression assertion is preserved and moved to the correct feature-area spec, and a new contributor no-access test was added for the Model deployment settings tab.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-69029]: https://redhat.atlassian.net/browse/RHOAIENG-69029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Model Deployment General Settings.
  * Verified administrators can access settings and see model-serving controls matching configuration.
  * Verified contributors are denied access and redirected appropriately.
  * Moved model-serving validation coverage to the Model Deployment settings tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->