### PR TITLE
feat(RHOAIENG-80010): add bidirectional filtering between API groups and resources

### DIFF
--- a/frontend/src/components/MultiSelection.tsx
+++ b/frontend/src/components/MultiSelection.tsx
@@ -89,6 +89,9 @@ const normalizeOptionId = (optionId: number | string): string => String(optionId
 const getOptionTestId = (name: string) =>
   `select-multi-typeahead-${name.replace(/[^a-zA-Z0-9]+/g, '-')}`;
 
+/** Close function of the MultiSelection that currently has an open menu. Opening another closes it. */
+let exclusiveOpenCloseRef: React.MutableRefObject<() => void> | null = null;
+
 type MultiSelectionOptionProps = {
   option: SelectionOptions;
   children?: React.ReactNode;
@@ -150,6 +153,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
   const textInputRef = React.useRef<HTMLInputElement | null>(null);
   const focusTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
+  const closeMenuRef = React.useRef<() => void>(() => undefined);
   const generatedInstanceId = React.useId().replace(/:/g, '');
   const instanceId = id ?? `multi-select-${generatedInstanceId}`;
   const listboxId = `${instanceId}-listbox`;
@@ -284,6 +288,10 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   };
 
   const openMenu = (focusFirstOption = false) => {
+    if (exclusiveOpenCloseRef && exclusiveOpenCloseRef !== closeMenuRef) {
+      exclusiveOpenCloseRef.current();
+    }
+    exclusiveOpenCloseRef = closeMenuRef;
     setIsOpen(true);
     if (focusFirstOption) {
       const firstFocusableIndex = getNextFocusableIndex(null, 'down');
@@ -301,12 +309,19 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
     setIsOpen(false);
     setInputValue('');
     resetActiveAndFocusedItem();
+    if (exclusiveOpenCloseRef === closeMenuRef) {
+      exclusiveOpenCloseRef = null;
+    }
   };
+  closeMenuRef.current = closeMenu;
 
   React.useEffect(
     () => () => {
       if (focusTimeoutRef.current) {
         clearTimeout(focusTimeoutRef.current);
+      }
+      if (exclusiveOpenCloseRef === closeMenuRef) {
+        exclusiveOpenCloseRef = null;
       }
     },
     [],
@@ -314,7 +329,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
 
   const handleMenuArrowKeys = (key: string) => {
     if (!isOpen) {
-      setIsOpen(true);
+      openMenu();
     }
 
     const optionsLength = visibleOptions.length;
@@ -383,7 +398,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, valueOfInput: string) => {
     setInputValue(valueOfInput);
     if (valueOfInput) {
-      setIsOpen(true);
+      openMenu();
     }
     resetActiveAndFocusedItem();
   };

--- a/frontend/src/components/__tests__/MultiSelection.spec.tsx
+++ b/frontend/src/components/__tests__/MultiSelection.spec.tsx
@@ -465,4 +465,82 @@ describe('MultiSelection', () => {
       expect.arrayContaining([expect.objectContaining({ id: 1, selected: true })]),
     );
   });
+
+  it('should close an open menu when another MultiSelection opens', async () => {
+    render(
+      <>
+        <MultiSelection
+          id="select-a"
+          ariaLabel="Select A"
+          value={defaultOptions}
+          setValue={jest.fn()}
+        />
+        <MultiSelection
+          id="select-b"
+          ariaLabel="Select B"
+          value={defaultOptions}
+          setValue={jest.fn()}
+        />
+      </>,
+    );
+
+    const first = screen.getByRole('combobox', { name: 'Select A' });
+    const second = screen.getByRole('combobox', { name: 'Select B' });
+
+    await act(async () => {
+      fireEvent.keyDown(first, { key: 'ArrowDown' });
+    });
+    expect(first).toHaveAttribute('aria-expanded', 'true');
+
+    await act(async () => {
+      fireEvent.keyDown(second, { key: 'ArrowDown' });
+    });
+
+    expect(first).toHaveAttribute('aria-expanded', 'false');
+    expect(second).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('should keep selections when another MultiSelection opens', async () => {
+    const Harness: React.FC = () => {
+      const [firstValue, setFirstValue] = React.useState(defaultOptions);
+      const [secondValue, setSecondValue] = React.useState(defaultOptions);
+      return (
+        <>
+          <MultiSelection
+            id="select-a"
+            ariaLabel="Select A"
+            value={firstValue}
+            setValue={setFirstValue}
+          />
+          <MultiSelection
+            id="select-b"
+            ariaLabel="Select B"
+            value={secondValue}
+            setValue={setSecondValue}
+          />
+        </>
+      );
+    };
+
+    render(<Harness />);
+
+    const first = screen.getByRole('combobox', { name: 'Select A' });
+    const second = screen.getByRole('combobox', { name: 'Select B' });
+
+    await act(async () => {
+      fireEvent.keyDown(first, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(first, { key: 'Enter' });
+    });
+
+    expect(screen.getByRole('button', { name: 'Remove Connection 1' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.keyDown(second, { key: 'ArrowDown' });
+    });
+
+    expect(first).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('button', { name: 'Remove Connection 1' })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
@@ -8,7 +8,8 @@ import ApiGroupsTreeSelect from './ApiGroupsTreeSelect';
 import useApiResources from './useApiResources';
 import type { RuleEntry } from './types';
 import { normalizeVerbs } from './ruleModalUtils';
-import { ALL_RESOURCES_WILDCARD } from './resourceCategories';
+import { ALL_RESOURCES_WILDCARD, RESOURCE_CATEGORIES } from './resourceCategories';
+import { ALL_API_GROUPS_WILDCARD } from './apiGroupCategories';
 
 type AddRuleModalProps = {
   existingRule?: RuleEntry;
@@ -33,6 +34,81 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
 
   const [selectedVerbs, setSelectedVerbs] = React.useState<string[]>(
     () => existingRule?.verbs ?? [],
+  );
+
+  const resolvedApiResourcesData = apiResourcesLoaded
+    ? apiResourcesData
+    : { apiGroups: [], resources: [] };
+
+  const resourceToApiGroupMap = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const category of RESOURCE_CATEGORIES) {
+      for (const r of category.resources) {
+        map.set(r.name, r.apiGroup);
+      }
+    }
+    for (const r of resolvedApiResourcesData.resources) {
+      if (!map.has(r.name)) {
+        map.set(r.name, r.apiGroup);
+      }
+    }
+    return map;
+  }, [resolvedApiResourcesData.resources]);
+
+  const handleResourcesChange = React.useCallback(
+    (newResources: string[]) => {
+      setSelectedResources(newResources);
+
+      if (newResources.includes(ALL_RESOURCES_WILDCARD)) {
+        return;
+      }
+
+      const addedResources = newResources.filter((r) => !selectedResources.includes(r));
+      const groupsToAdd = new Set<string>();
+
+      for (const resource of addedResources) {
+        const apiGroup = resourceToApiGroupMap.get(resource);
+        if (apiGroup !== undefined && !selectedApiGroups.includes(apiGroup)) {
+          groupsToAdd.add(apiGroup);
+        }
+      }
+
+      if (groupsToAdd.size > 0) {
+        setSelectedApiGroups((prev) => [...prev, ...groupsToAdd]);
+      }
+    },
+    [selectedResources, selectedApiGroups, resourceToApiGroupMap],
+  );
+
+  const handleApiGroupsChange = React.useCallback(
+    (newApiGroups: string[]) => {
+      setSelectedApiGroups(newApiGroups);
+
+      if (newApiGroups.length === 0 || newApiGroups.includes(ALL_API_GROUPS_WILDCARD)) {
+        return;
+      }
+
+      if (selectedResources.includes(ALL_RESOURCES_WILDCARD)) {
+        return;
+      }
+
+      const removedGroups = selectedApiGroups.filter((g) => !newApiGroups.includes(g));
+      if (removedGroups.length === 0) {
+        return;
+      }
+
+      const allowedGroups = new Set(newApiGroups);
+      const orphanedResources = selectedResources.filter((r) => {
+        const group = resourceToApiGroupMap.get(r);
+        return group !== undefined && !allowedGroups.has(group);
+      });
+
+      if (orphanedResources.length > 0) {
+        const orphanSet = new Set(orphanedResources);
+        setSelectedResources((prev) => prev.filter((r) => !orphanSet.has(r)));
+      }
+    },
+    [selectedApiGroups, selectedResources, resourceToApiGroupMap],
   );
 
   const canSave =
@@ -93,10 +169,8 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
           >
             <ApiGroupsTreeSelect
               selectedApiGroups={selectedApiGroups}
-              onSelectedApiGroupsChange={setSelectedApiGroups}
-              apiResourcesData={
-                apiResourcesLoaded ? apiResourcesData : { apiGroups: [], resources: [] }
-              }
+              onSelectedApiGroupsChange={handleApiGroupsChange}
+              apiResourcesData={resolvedApiResourcesData}
             />
           </FormGroup>
           <FormGroup
@@ -109,10 +183,9 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
           >
             <ResourcesTreeSelect
               selectedResources={selectedResources}
-              onSelectedResourcesChange={setSelectedResources}
-              apiResourcesData={
-                apiResourcesLoaded ? apiResourcesData : { apiGroups: [], resources: [] }
-              }
+              onSelectedResourcesChange={handleResourcesChange}
+              filterByApiGroups={selectedApiGroups}
+              apiResourcesData={resolvedApiResourcesData}
             />
           </FormGroup>
           <FormGroup label="Permitted operations" fieldId="rule-verbs" isRequired>

--- a/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
@@ -10,6 +10,9 @@ import type { RuleEntry } from './types';
 import { normalizeVerbs } from './ruleModalUtils';
 import { ALL_RESOURCES_WILDCARD, RESOURCE_CATEGORIES } from './resourceCategories';
 import { ALL_API_GROUPS_WILDCARD } from './apiGroupCategories';
+import type { ApiResourcesData } from './useApiResources';
+
+const EMPTY_API_RESOURCES_DATA: ApiResourcesData = { apiGroups: [], resources: [] };
 
 type AddRuleModalProps = {
   existingRule?: RuleEntry;
@@ -36,9 +39,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
     () => existingRule?.verbs ?? [],
   );
 
-  const resolvedApiResourcesData = apiResourcesLoaded
-    ? apiResourcesData
-    : { apiGroups: [], resources: [] };
+  const resolvedApiResourcesData = apiResourcesLoaded ? apiResourcesData : EMPTY_API_RESOURCES_DATA;
 
   const resourceToApiGroupMap = React.useMemo(() => {
     const map = new Map<string, string>();
@@ -97,6 +98,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
         return;
       }
 
+      const allGroupsWereSelected = selectedApiGroups.includes(ALL_API_GROUPS_WILDCARD);
       const allowedGroups = new Set(newApiGroups);
       const orphanedResources = selectedResources.filter((r) => {
         const group = resourceToApiGroupMap.get(r);
@@ -104,7 +106,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
           return false;
         }
         if (newApiGroups.length === 0) {
-          return removedGroups.includes(group);
+          return allGroupsWereSelected || removedGroups.includes(group);
         }
         return !allowedGroups.has(group);
       });

--- a/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
@@ -5,12 +5,11 @@ import FieldGroupHelpLabelIcon from '@odh-dashboard/ui-core/components/FieldGrou
 import VerbsTreeSelect from './VerbsTreeSelect';
 import ResourcesTreeSelect from './ResourcesTreeSelect';
 import ApiGroupsTreeSelect from './ApiGroupsTreeSelect';
-import useApiResources from './useApiResources';
+import useApiResources, { type ApiResourcesData } from './useApiResources';
 import type { RuleEntry } from './types';
 import { normalizeVerbs } from './ruleModalUtils';
 import { ALL_RESOURCES_WILDCARD, RESOURCE_CATEGORIES } from './resourceCategories';
 import { ALL_API_GROUPS_WILDCARD } from './apiGroupCategories';
-import type { ApiResourcesData } from './useApiResources';
 
 const EMPTY_API_RESOURCES_DATA: ApiResourcesData = { apiGroups: [], resources: [] };
 

--- a/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
@@ -38,6 +38,12 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
     () => existingRule?.verbs ?? [],
   );
 
+  // selectedApiGroups: chips + YAML (user-selected and auto-added from resources).
+  // explicitApiGroups: groups chosen in the API groups field this session. Drives
+  // Resource types filtering. Starts empty in add and edit so loaded groups do not
+  // lock the list; auto-adding (notebooks → kubeflow.org) also must not lock it.
+  const [explicitApiGroups, setExplicitApiGroups] = React.useState<string[]>([]);
+
   const resolvedApiResourcesData = apiResourcesLoaded ? apiResourcesData : EMPTY_API_RESOURCES_DATA;
 
   const resourceToApiGroupMap = React.useMemo(
@@ -49,31 +55,70 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
     (newResources: string[]) => {
       setSelectedResources(newResources);
 
-      if (newResources.includes(ALL_RESOURCES_WILDCARD)) {
+      // Wildcards mean "all"; do not add or strip concrete API groups.
+      if (
+        newResources.includes(ALL_RESOURCES_WILDCARD) ||
+        selectedApiGroups.includes(ALL_API_GROUPS_WILDCARD)
+      ) {
         return;
       }
 
       const addedResources = newResources.filter((r) => !selectedResources.includes(r));
+      const removedResources = selectedResources.filter((r) => !newResources.includes(r));
       const groupsToAdd = new Set<string>();
+      const groupsToRemove = new Set<string>();
 
       for (const resource of addedResources) {
         const apiGroup = resourceToApiGroupMap.get(resource);
-        if (apiGroup !== undefined && !selectedApiGroups.includes(apiGroup)) {
+        if (apiGroup !== undefined) {
           groupsToAdd.add(apiGroup);
         }
       }
 
-      if (groupsToAdd.size > 0) {
-        setSelectedApiGroups((prev) => [...prev, ...groupsToAdd]);
+      // Drop a group only when no remaining mapped resource still needs it (cascade up).
+      for (const resource of removedResources) {
+        const apiGroup = resourceToApiGroupMap.get(resource);
+        if (apiGroup === undefined) {
+          continue;
+        }
+        const stillNeeded = newResources.some((r) => resourceToApiGroupMap.get(r) === apiGroup);
+        if (!stillNeeded) {
+          groupsToRemove.add(apiGroup);
+        }
+      }
+
+      // All resources → empty does not yield a mapped removal (`*` is not in the map).
+      const clearAutoAddedGroups = newResources.length === 0;
+      if (groupsToAdd.size === 0 && groupsToRemove.size === 0 && !clearAutoAddedGroups) {
+        return;
+      }
+
+      setSelectedApiGroups((prev) => {
+        let next = prev.filter((g) => !groupsToRemove.has(g));
+        for (const g of groupsToAdd) {
+          if (!next.includes(g)) {
+            next.push(g);
+          }
+        }
+        if (clearAutoAddedGroups) {
+          next = next.filter((g) => explicitApiGroups.includes(g));
+        }
+        return next;
+      });
+      if (groupsToRemove.size > 0) {
+        setExplicitApiGroups((prev) => prev.filter((g) => !groupsToRemove.has(g)));
       }
     },
-    [selectedResources, selectedApiGroups, resourceToApiGroupMap],
+    [selectedResources, selectedApiGroups, explicitApiGroups, resourceToApiGroupMap],
   );
 
   const handleApiGroupsChange = React.useCallback(
     (newApiGroups: string[]) => {
       setSelectedApiGroups(newApiGroups);
+      // Touching this field turns on resource filtering for the current group selection.
+      setExplicitApiGroups(newApiGroups);
 
+      // `*` on either field does not orphan concrete selections.
       if (newApiGroups.includes(ALL_API_GROUPS_WILDCARD)) {
         return;
       }
@@ -87,6 +132,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
         return;
       }
 
+      // Drop mapped resources that no longer have an API group (custom names stay).
       const allGroupsWereSelected = selectedApiGroups.includes(ALL_API_GROUPS_WILDCARD);
       const allowedGroups = new Set(newApiGroups);
       const orphanedResources = selectedResources.filter((r) => {
@@ -113,14 +159,18 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
   const isEdit = !!existingRule;
 
   const handleSave = React.useCallback(() => {
+    // `*` already covers every value; drop extras so YAML stays `["*"]`.
     const resources = selectedResources.includes(ALL_RESOURCES_WILDCARD)
       ? [ALL_RESOURCES_WILDCARD]
       : [...selectedResources];
+    const apiGroups = selectedApiGroups.includes(ALL_API_GROUPS_WILDCARD)
+      ? [ALL_API_GROUPS_WILDCARD]
+      : [...selectedApiGroups];
     const verbs = normalizeVerbs(selectedVerbs);
 
     onSave({
       id: existingRule?.id ?? getUniqueId('rule'),
-      apiGroups: [...selectedApiGroups],
+      apiGroups,
       resources,
       verbs,
       ...(existingRule?.resourceNames ? { resourceNames: existingRule.resourceNames } : {}),
@@ -161,7 +211,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
             fieldId="rule-api-groups"
             isRequired
             labelHelp={
-              <FieldGroupHelpLabelIcon content="API groups organize Kubernetes resources by functionality. Selecting an API group filters the Resource types list to show only resources in that group." />
+              <FieldGroupHelpLabelIcon content="Select an API group to narrow the resource types list. Choosing a resource type also adds its API group." />
             }
           >
             <ApiGroupsTreeSelect
@@ -175,13 +225,14 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
             fieldId="rule-resource-types"
             isRequired
             labelHelp={
-              <FieldGroupHelpLabelIcon content="Specify the Kubernetes resource types this rule applies to. You can select from discovered resources or type a custom resource name." />
+              <FieldGroupHelpLabelIcon content="Search or select resource types, or type a custom name. If you selected API groups, only matching resources are listed." />
             }
           >
             <ResourcesTreeSelect
               selectedResources={selectedResources}
               onSelectedResourcesChange={handleResourcesChange}
-              filterByApiGroups={selectedApiGroups}
+              // Filter only from API groups the user picked, not auto-added groups.
+              filterByApiGroups={explicitApiGroups}
               apiResourcesData={resolvedApiResourcesData}
             />
           </FormGroup>

--- a/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
@@ -8,7 +8,7 @@ import ApiGroupsTreeSelect from './ApiGroupsTreeSelect';
 import useApiResources, { type ApiResourcesData } from './useApiResources';
 import type { RuleEntry } from './types';
 import { normalizeVerbs } from './ruleModalUtils';
-import { ALL_RESOURCES_WILDCARD, RESOURCE_CATEGORIES } from './resourceCategories';
+import { ALL_RESOURCES_WILDCARD, buildResourceToApiGroupMap } from './resourceCategories';
 import { ALL_API_GROUPS_WILDCARD } from './apiGroupCategories';
 
 const EMPTY_API_RESOURCES_DATA: ApiResourcesData = { apiGroups: [], resources: [] };
@@ -40,20 +40,10 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
 
   const resolvedApiResourcesData = apiResourcesLoaded ? apiResourcesData : EMPTY_API_RESOURCES_DATA;
 
-  const resourceToApiGroupMap = React.useMemo(() => {
-    const map = new Map<string, string>();
-    for (const category of RESOURCE_CATEGORIES) {
-      for (const r of category.resources) {
-        map.set(r.name, r.apiGroup);
-      }
-    }
-    for (const r of resolvedApiResourcesData.resources) {
-      if (!map.has(r.name)) {
-        map.set(r.name, r.apiGroup);
-      }
-    }
-    return map;
-  }, [resolvedApiResourcesData.resources]);
+  const resourceToApiGroupMap = React.useMemo(
+    () => buildResourceToApiGroupMap(resolvedApiResourcesData.resources),
+    [resolvedApiResourcesData.resources],
+  );
 
   const handleResourcesChange = React.useCallback(
     (newResources: string[]) => {

--- a/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/AddRuleModal.tsx
@@ -84,7 +84,7 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
     (newApiGroups: string[]) => {
       setSelectedApiGroups(newApiGroups);
 
-      if (newApiGroups.length === 0 || newApiGroups.includes(ALL_API_GROUPS_WILDCARD)) {
+      if (newApiGroups.includes(ALL_API_GROUPS_WILDCARD)) {
         return;
       }
 
@@ -100,7 +100,13 @@ const AddRuleModal: React.FC<AddRuleModalProps> = ({ existingRule, onSave, onClo
       const allowedGroups = new Set(newApiGroups);
       const orphanedResources = selectedResources.filter((r) => {
         const group = resourceToApiGroupMap.get(r);
-        return group !== undefined && !allowedGroups.has(group);
+        if (group === undefined) {
+          return false;
+        }
+        if (newApiGroups.length === 0) {
+          return removedGroups.includes(group);
+        }
+        return !allowedGroups.has(group);
       });
 
       if (orphanedResources.length > 0) {

--- a/frontend/src/pages/projects/projectRoles/ApiGroupsTreeSelect.tsx
+++ b/frontend/src/pages/projects/projectRoles/ApiGroupsTreeSelect.tsx
@@ -49,7 +49,7 @@ const ApiGroupsTreeSelect: React.FC<ApiGroupsTreeSelectProps> = ({
       return [];
     }
     const mappedNames = new Set(API_GROUP_CATEGORIES.flatMap((c) => c.groups.map((g) => g.name)));
-    return apiResourcesData.apiGroups.filter((g) => !mappedNames.has(g));
+    return apiResourcesData.apiGroups.filter((g) => !mappedNames.has(g) && g !== '');
   }, [apiResourcesData.apiGroups, discoveredApiGroups.size]);
 
   const allCategories = React.useMemo(() => {

--- a/frontend/src/pages/projects/projectRoles/ApiGroupsTreeSelect.tsx
+++ b/frontend/src/pages/projects/projectRoles/ApiGroupsTreeSelect.tsx
@@ -49,7 +49,14 @@ const ApiGroupsTreeSelect: React.FC<ApiGroupsTreeSelectProps> = ({
       return [];
     }
     const mappedNames = new Set(API_GROUP_CATEGORIES.flatMap((c) => c.groups.map((g) => g.name)));
-    return apiResourcesData.apiGroups.filter((g) => !mappedNames.has(g) && g !== '');
+    const seen = new Set<string>();
+    return apiResourcesData.apiGroups.filter((g) => {
+      if (mappedNames.has(g) || g === '' || seen.has(g)) {
+        return false;
+      }
+      seen.add(g);
+      return true;
+    });
   }, [apiResourcesData.apiGroups, discoveredApiGroups.size]);
 
   const allCategories = React.useMemo(() => {

--- a/frontend/src/pages/projects/projectRoles/ResourcesTreeSelect.tsx
+++ b/frontend/src/pages/projects/projectRoles/ResourcesTreeSelect.tsx
@@ -9,7 +9,7 @@ import {
   ALL_RESOURCES_WILDCARD,
   buildResourceToApiGroupMap,
 } from './resourceCategories';
-import { ALL_API_GROUPS_WILDCARD } from './apiGroupCategories';
+import { ALL_API_GROUPS_WILDCARD, API_GROUP_CATEGORIES } from './apiGroupCategories';
 import {
   ALL_CATEGORY_PREFIX,
   createCategoryFilter,
@@ -23,6 +23,7 @@ type ResourcesTreeSelectProps = {
   selectedResources: string[];
   onSelectedResourcesChange: (resources: string[]) => void;
   apiResourcesData: ApiResourcesData;
+  /** User-selected API groups only. Auto-added groups must not be passed here. */
   filterByApiGroups?: string[];
 };
 
@@ -95,7 +96,19 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
     return categories;
   }, [availableCategories, otherResources, resourceToApiGroupMap]);
 
+  const knownApiGroups = React.useMemo(() => {
+    const groups = new Set(apiResourcesData.apiGroups);
+    for (const category of API_GROUP_CATEGORIES) {
+      for (const group of category.groups) {
+        groups.add(group.name);
+      }
+    }
+    return groups;
+  }, [apiResourcesData.apiGroups]);
+
   const filteredCategories = React.useMemo(() => {
+    // Empty / * show the full catalog. Known groups narrow the list. Custom typed
+    // groups have no catalog entries — ignore them so the tree is not emptied.
     if (
       !filterByApiGroups ||
       filterByApiGroups.length === 0 ||
@@ -103,14 +116,18 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
     ) {
       return allCategories;
     }
-    const allowedGroups = new Set(filterByApiGroups);
+    const knownSelectedGroups = filterByApiGroups.filter((g) => knownApiGroups.has(g));
+    if (knownSelectedGroups.length === 0) {
+      return allCategories;
+    }
+    const allowedGroups = new Set(knownSelectedGroups);
     return allCategories
       .map((category) => ({
         ...category,
         resources: category.resources.filter((r) => allowedGroups.has(r.apiGroup)),
       }))
       .filter((category) => category.resources.length > 0);
-  }, [allCategories, filterByApiGroups]);
+  }, [allCategories, filterByApiGroups, knownApiGroups]);
 
   const renderedResourceNames = React.useMemo(
     () => new Set(filteredCategories.flatMap((c) => c.resources.map((r) => r.name))),

--- a/frontend/src/pages/projects/projectRoles/ResourcesTreeSelect.tsx
+++ b/frontend/src/pages/projects/projectRoles/ResourcesTreeSelect.tsx
@@ -51,7 +51,14 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
       return [];
     }
     const mappedNames = new Set(RESOURCE_CATEGORIES.flatMap((c) => c.resources.map((r) => r.name)));
-    return apiResourcesData.resources.filter((r) => !mappedNames.has(r.name));
+    const seen = new Set<string>();
+    return apiResourcesData.resources.filter((r) => {
+      if (mappedNames.has(r.name) || seen.has(r.name)) {
+        return false;
+      }
+      seen.add(r.name);
+      return true;
+    });
   }, [apiResourcesData.resources, discoveredResourceNames.size]);
 
   const allCategories = React.useMemo(() => {

--- a/frontend/src/pages/projects/projectRoles/ResourcesTreeSelect.tsx
+++ b/frontend/src/pages/projects/projectRoles/ResourcesTreeSelect.tsx
@@ -5,6 +5,7 @@ import {
   SelectionOptions,
 } from '#~/components/MultiSelection';
 import { RESOURCE_CATEGORIES, ALL_RESOURCES_WILDCARD } from './resourceCategories';
+import { ALL_API_GROUPS_WILDCARD } from './apiGroupCategories';
 import {
   ALL_CATEGORY_PREFIX,
   createCategoryFilter,
@@ -18,12 +19,14 @@ type ResourcesTreeSelectProps = {
   selectedResources: string[];
   onSelectedResourcesChange: (resources: string[]) => void;
   apiResourcesData: ApiResourcesData;
+  filterByApiGroups?: string[];
 };
 
 const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
   selectedResources,
   onSelectedResourcesChange,
   apiResourcesData,
+  filterByApiGroups,
 }) => {
   const isAllSelected = selectedResources.includes(ALL_RESOURCES_WILDCARD);
 
@@ -67,9 +70,26 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
     return categories;
   }, [availableCategories, otherResources]);
 
+  const filteredCategories = React.useMemo(() => {
+    if (
+      !filterByApiGroups ||
+      filterByApiGroups.length === 0 ||
+      filterByApiGroups.includes(ALL_API_GROUPS_WILDCARD)
+    ) {
+      return allCategories;
+    }
+    const allowedGroups = new Set(filterByApiGroups);
+    return allCategories
+      .map((category) => ({
+        ...category,
+        resources: category.resources.filter((r) => allowedGroups.has(r.apiGroup)),
+      }))
+      .filter((category) => category.resources.length > 0);
+  }, [allCategories, filterByApiGroups]);
+
   const renderedResourceNames = React.useMemo(
-    () => new Set(allCategories.flatMap((c) => c.resources.map((r) => r.name))),
-    [allCategories],
+    () => new Set(filteredCategories.flatMap((c) => c.resources.map((r) => r.name))),
+    [filteredCategories],
   );
 
   const customEntries = React.useMemo(
@@ -94,7 +114,7 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
           selected: isAllSelected,
           className: 'odh-resource-tree__all',
         },
-        ...allCategories.flatMap((category) => {
+        ...filteredCategories.flatMap((category) => {
           const categoryResourceNames = category.resources.map((r) => r.name);
           const allInCategorySelected =
             isAllSelected || categoryResourceNames.every((r) => selectedResources.includes(r));
@@ -128,7 +148,7 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
     };
 
     return [allOptions];
-  }, [allCategories, selectedResources, isAllSelected, customEntries]);
+  }, [filteredCategories, selectedResources, isAllSelected, customEntries]);
 
   const handleSetValue = React.useCallback(
     (updatedOptions: SelectionOptions[]) => {
@@ -151,18 +171,18 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
       const realOptions = updatedOptions.filter(
         (o) =>
           String(o.id) !== ALL_RESOURCES_WILDCARD &&
-          !allCategories.some((c) => `${ALL_CATEGORY_PREFIX}${c.id}` === String(o.id)),
+          !filteredCategories.some((c) => `${ALL_CATEGORY_PREFIX}${c.id}` === String(o.id)),
       );
 
       const categoryAllOptions = updatedOptions.filter((o) =>
-        allCategories.some((c) => `${ALL_CATEGORY_PREFIX}${c.id}` === String(o.id)),
+        filteredCategories.some((c) => `${ALL_CATEGORY_PREFIX}${c.id}` === String(o.id)),
       );
 
       const selected = new Set(realOptions.filter((o) => o.selected).map((o) => String(o.id)));
 
       applyCategoryToggles(
         categoryAllOptions,
-        allCategories.map((c) => ({ id: c.id, itemNames: c.resources.map((r) => r.name) })),
+        filteredCategories.map((c) => ({ id: c.id, itemNames: c.resources.map((r) => r.name) })),
         isAllSelected,
         selectedResources,
         selected,
@@ -170,7 +190,7 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
 
       onSelectedResourcesChange([...selected]);
     },
-    [selectedResources, onSelectedResourcesChange, isAllSelected, allCategories],
+    [selectedResources, onSelectedResourcesChange, isAllSelected, filteredCategories],
   );
 
   const filterFunction = React.useMemo(() => createCategoryFilter(ALL_RESOURCES_WILDCARD), []);

--- a/frontend/src/pages/projects/projectRoles/ResourcesTreeSelect.tsx
+++ b/frontend/src/pages/projects/projectRoles/ResourcesTreeSelect.tsx
@@ -4,7 +4,11 @@ import {
   GroupSelectionOptions,
   SelectionOptions,
 } from '#~/components/MultiSelection';
-import { RESOURCE_CATEGORIES, ALL_RESOURCES_WILDCARD } from './resourceCategories';
+import {
+  RESOURCE_CATEGORIES,
+  ALL_RESOURCES_WILDCARD,
+  buildResourceToApiGroupMap,
+} from './resourceCategories';
 import { ALL_API_GROUPS_WILDCARD } from './apiGroupCategories';
 import {
   ALL_CATEGORY_PREFIX,
@@ -61,8 +65,22 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
     });
   }, [apiResourcesData.resources, discoveredResourceNames.size]);
 
+  const resourceToApiGroupMap = React.useMemo(
+    () => buildResourceToApiGroupMap(apiResourcesData.resources),
+    [apiResourcesData.resources],
+  );
+
   const allCategories = React.useMemo(() => {
-    const categories = [...availableCategories];
+    const resolveApiGroup = (name: string, fallback: string): string =>
+      resourceToApiGroupMap.get(name) ?? fallback;
+
+    const categories = availableCategories.map((category) => ({
+      ...category,
+      resources: category.resources.map((r) => ({
+        ...r,
+        apiGroup: resolveApiGroup(r.name, r.apiGroup),
+      })),
+    }));
     if (otherResources.length > 0) {
       categories.push({
         id: 'other',
@@ -70,12 +88,12 @@ const ResourcesTreeSelect: React.FC<ResourcesTreeSelectProps> = ({
         resources: otherResources.map((r) => ({
           name: r.name,
           label: r.name,
-          apiGroup: r.apiGroup,
+          apiGroup: resolveApiGroup(r.name, r.apiGroup),
         })),
       });
     }
     return categories;
-  }, [availableCategories, otherResources]);
+  }, [availableCategories, otherResources, resourceToApiGroupMap]);
 
   const filteredCategories = React.useMemo(() => {
     if (

--- a/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
@@ -1,0 +1,274 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, act } from '@testing-library/react';
+import AddRuleModal from '#~/pages/projects/projectRoles/AddRuleModal';
+import type { ApiResourcesData } from '#~/pages/projects/projectRoles/useApiResources';
+
+const mockApiResourcesData: ApiResourcesData = {
+  apiGroups: ['', 'apps', 'batch', 'kubeflow.org', 'networking.k8s.io'],
+  resources: [
+    { name: 'pods', kind: 'Pod', apiGroup: '' },
+    { name: 'services', kind: 'Service', apiGroup: '' },
+    { name: 'deployments', kind: 'Deployment', apiGroup: 'apps' },
+    { name: 'statefulsets', kind: 'StatefulSet', apiGroup: 'apps' },
+    { name: 'jobs', kind: 'Job', apiGroup: 'batch' },
+    { name: 'notebooks', kind: 'Notebook', apiGroup: 'kubeflow.org' },
+    { name: 'networkpolicies', kind: 'NetworkPolicy', apiGroup: 'networking.k8s.io' },
+  ],
+};
+
+jest.mock('#~/pages/projects/projectRoles/useApiResources', () => ({
+  __esModule: true,
+  default: () => ({
+    data: mockApiResourcesData,
+    loaded: true,
+    error: undefined,
+  }),
+}));
+
+let capturedResourcesProps: {
+  selectedResources: string[];
+  onSelectedResourcesChange: (resources: string[]) => void;
+  filterByApiGroups?: string[];
+};
+let capturedApiGroupsProps: {
+  selectedApiGroups: string[];
+  onSelectedApiGroupsChange: (groups: string[]) => void;
+};
+
+jest.mock('#~/pages/projects/projectRoles/ResourcesTreeSelect', () => {
+  const Mock: React.FC<typeof capturedResourcesProps> = (props) => {
+    capturedResourcesProps = props;
+    return (
+      <div data-testid="resources-tree-select">
+        {props.selectedResources.join(',')}
+        {props.filterByApiGroups ? ` [filter:${props.filterByApiGroups.join(',')}]` : ''}
+      </div>
+    );
+  };
+  Mock.displayName = 'MockResourcesTreeSelect';
+  return { __esModule: true, default: Mock };
+});
+
+jest.mock('#~/pages/projects/projectRoles/ApiGroupsTreeSelect', () => {
+  const Mock: React.FC<typeof capturedApiGroupsProps> = (props) => {
+    capturedApiGroupsProps = props;
+    return <div data-testid="api-groups-tree-select">{props.selectedApiGroups.join(',')}</div>;
+  };
+  Mock.displayName = 'MockApiGroupsTreeSelect';
+  return { __esModule: true, default: Mock };
+});
+
+jest.mock('#~/pages/projects/projectRoles/VerbsTreeSelect', () => {
+  const Mock = () => <div data-testid="verbs-tree-select" />;
+  Mock.displayName = 'MockVerbsTreeSelect';
+  return { __esModule: true, default: Mock };
+});
+
+describe('AddRuleModal orchestration', () => {
+  const mockOnSave = jest.fn();
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderModal = (existingRule?: Parameters<typeof AddRuleModal>[0]['existingRule']) => {
+    render(<AddRuleModal onSave={mockOnSave} onClose={mockOnClose} existingRule={existingRule} />);
+  };
+
+  describe('filterByApiGroups prop forwarding', () => {
+    it('should pass selectedApiGroups as filterByApiGroups to ResourcesTreeSelect', () => {
+      renderModal({ id: 'r1', apiGroups: ['apps'], resources: [], verbs: [] });
+
+      expect(capturedResourcesProps.filterByApiGroups).toEqual(['apps']);
+    });
+
+    it('should pass empty array when no API groups are selected', () => {
+      renderModal();
+
+      expect(capturedResourcesProps.filterByApiGroups).toEqual([]);
+    });
+  });
+
+  describe('auto-populate API groups when resource is selected', () => {
+    it('should auto-add the API group when a resource is selected', () => {
+      renderModal();
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['deployments']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toContain('apps');
+    });
+
+    it('should auto-add multiple API groups when resources from different groups are selected', () => {
+      renderModal();
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['deployments', 'notebooks']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toContain('apps');
+      expect(capturedApiGroupsProps.selectedApiGroups).toContain('kubeflow.org');
+    });
+
+    it('should not auto-add an API group that is already selected', () => {
+      renderModal({ id: 'r1', apiGroups: ['apps'], resources: ['deployments'], verbs: [] });
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['deployments', 'statefulsets']);
+      });
+
+      const appsCount = capturedApiGroupsProps.selectedApiGroups.filter((g) => g === 'apps').length;
+      expect(appsCount).toBe(1);
+    });
+
+    it('should not auto-populate when wildcard resources are selected', () => {
+      renderModal();
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['*']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual([]);
+    });
+
+    it('should not auto-populate for custom resources with unknown API group', () => {
+      renderModal();
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['mycustomresource']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual([]);
+    });
+
+    it('should auto-add core group (empty string) for core resources', () => {
+      renderModal();
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['pods']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toContain('');
+    });
+  });
+
+  describe('cascading deselection when API group is removed', () => {
+    it('should remove orphaned resources when their API group is removed', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['apps', 'batch'],
+        resources: ['deployments', 'jobs'],
+        verbs: ['get'],
+      });
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['batch']);
+      });
+
+      expect(capturedResourcesProps.selectedResources).not.toContain('deployments');
+      expect(capturedResourcesProps.selectedResources).toContain('jobs');
+    });
+
+    it('should not cascade when wildcard API group is selected', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['apps'],
+        resources: ['deployments'],
+        verbs: ['get'],
+      });
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['*']);
+      });
+
+      expect(capturedResourcesProps.selectedResources).toContain('deployments');
+    });
+
+    it('should not cascade when API groups become empty', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['apps'],
+        resources: ['deployments'],
+        verbs: ['get'],
+      });
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange([]);
+      });
+
+      expect(capturedResourcesProps.selectedResources).toContain('deployments');
+    });
+
+    it('should not cascade when resources wildcard is selected', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['apps', 'batch'],
+        resources: ['*'],
+        verbs: ['get'],
+      });
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['batch']);
+      });
+
+      expect(capturedResourcesProps.selectedResources).toContain('*');
+    });
+
+    it('should keep custom resources (unknown group) when API group is removed', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['apps'],
+        resources: ['deployments', 'mycustomresource'],
+        verbs: ['get'],
+      });
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange([]);
+      });
+
+      expect(capturedResourcesProps.selectedResources).toContain('mycustomresource');
+    });
+
+    it('should remove only resources belonging to the removed group', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['apps', 'networking.k8s.io'],
+        resources: ['deployments', 'statefulsets', 'networkpolicies'],
+        verbs: ['get'],
+      });
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['networking.k8s.io']);
+      });
+
+      expect(capturedResourcesProps.selectedResources).not.toContain('deployments');
+      expect(capturedResourcesProps.selectedResources).not.toContain('statefulsets');
+      expect(capturedResourcesProps.selectedResources).toContain('networkpolicies');
+    });
+  });
+
+  describe('edit mode', () => {
+    it('should not cascade on initial render with mismatched state', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['apps'],
+        resources: ['pods', 'deployments'],
+        verbs: ['get'],
+      });
+
+      expect(capturedResourcesProps.selectedResources).toEqual(['pods', 'deployments']);
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual(['apps']);
+    });
+  });
+
+  describe('save button', () => {
+    it('should be disabled when API groups, resources, and verbs are not all selected', () => {
+      renderModal();
+
+      expect(screen.getByTestId('modal-submit-button')).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
@@ -78,15 +78,83 @@ describe('AddRuleModal orchestration', () => {
   };
 
   describe('filterByApiGroups prop forwarding', () => {
-    it('should pass selectedApiGroups as filterByApiGroups to ResourcesTreeSelect', () => {
-      renderModal({ id: 'r1', apiGroups: ['apps'], resources: [], verbs: [] });
+    it('should not filter Resource types until the user selects an API group', () => {
+      renderModal();
+
+      expect(capturedResourcesProps.filterByApiGroups).toEqual([]);
+    });
+
+    it('should not filter when an existing rule already has API groups', () => {
+      renderModal({ id: 'r1', apiGroups: ['apps'], resources: ['deployments'], verbs: [] });
+
+      expect(capturedResourcesProps.filterByApiGroups).toEqual([]);
+    });
+
+    it('should filter Resource types when the user selects an API group', () => {
+      renderModal();
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['apps']);
+      });
 
       expect(capturedResourcesProps.filterByApiGroups).toEqual(['apps']);
     });
 
-    it('should pass empty array when no API groups are selected', () => {
+    it('should keep the API group filter after a matching resource is selected', () => {
       renderModal();
 
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['apps']);
+      });
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['deployments']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toContain('apps');
+      expect(capturedResourcesProps.filterByApiGroups).toEqual(['apps']);
+    });
+
+    it('should not filter when an API group is only auto-added from a resource', () => {
+      renderModal();
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['notebooks']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toContain('kubeflow.org');
+      expect(capturedResourcesProps.filterByApiGroups).toEqual([]);
+    });
+
+    it('should not widen the resource filter when a resource auto-adds another API group', () => {
+      renderModal();
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['apps']);
+      });
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['notebooks']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual(
+        expect.arrayContaining(['apps', 'kubeflow.org']),
+      );
+      expect(capturedResourcesProps.filterByApiGroups).toEqual(['apps']);
+    });
+
+    it('should clear the resource filter when the last resource for an explicit API group is removed', () => {
+      renderModal();
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['apps']);
+      });
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['deployments']);
+      });
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange([]);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual([]);
       expect(capturedResourcesProps.filterByApiGroups).toEqual([]);
     });
   });
@@ -134,6 +202,16 @@ describe('AddRuleModal orchestration', () => {
       expect(capturedApiGroupsProps.selectedApiGroups).toEqual([]);
     });
 
+    it('should not auto-add a concrete API group when All API groups is selected', () => {
+      renderModal({ id: 'r1', apiGroups: ['*'], resources: [], verbs: [] });
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['pods']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual(['*']);
+    });
+
     it('should not auto-populate for custom resources with unknown API group', () => {
       renderModal();
 
@@ -152,6 +230,84 @@ describe('AddRuleModal orchestration', () => {
       });
 
       expect(capturedApiGroupsProps.selectedApiGroups).toContain('');
+    });
+
+    it('should remove an API group when its last mapped resource is removed', () => {
+      renderModal({ id: 'r1', apiGroups: [''], resources: ['pods'], verbs: [] });
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange([]);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual([]);
+    });
+
+    it('should keep an API group when another resource from that group remains', () => {
+      renderModal({ id: 'r1', apiGroups: [''], resources: ['pods', 'services'], verbs: [] });
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['services']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual(['']);
+    });
+
+    it('should replace the API group when the last resource is swapped to another group', () => {
+      renderModal({ id: 'r1', apiGroups: [''], resources: ['pods'], verbs: [] });
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['jobs']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual(['batch']);
+    });
+
+    it('should keep a custom-typed API group when only a custom resource is selected', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['custom.example.io'],
+        resources: [],
+        verbs: [],
+      });
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['mywidgets']);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual(['custom.example.io']);
+    });
+
+    it('should drop auto-added API groups when All resources is cleared', () => {
+      renderModal();
+
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['notebooks']);
+      });
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['*']);
+      });
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange([]);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual([]);
+    });
+
+    it('should keep an explicit API group filter when All resources is cleared', () => {
+      renderModal();
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['apps']);
+      });
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange(['*']);
+      });
+      act(() => {
+        capturedResourcesProps.onSelectedResourcesChange([]);
+      });
+
+      expect(capturedApiGroupsProps.selectedApiGroups).toEqual(['apps']);
+      expect(capturedResourcesProps.filterByApiGroups).toEqual(['apps']);
     });
   });
 
@@ -288,6 +444,27 @@ describe('AddRuleModal orchestration', () => {
       renderModal();
 
       expect(screen.getByTestId('modal-submit-button')).toBeDisabled();
+    });
+
+    it('should save only the API groups wildcard when extra groups are also selected', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['*', ''],
+        resources: ['pods'],
+        verbs: ['get'],
+      });
+
+      act(() => {
+        screen.getByTestId('modal-submit-button').click();
+      });
+
+      expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiGroups: ['*'],
+          resources: ['pods'],
+          verbs: ['get'],
+        }),
+      );
     });
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
@@ -250,6 +250,23 @@ describe('AddRuleModal orchestration', () => {
       expect(capturedResourcesProps.selectedResources).not.toContain('statefulsets');
       expect(capturedResourcesProps.selectedResources).toContain('networkpolicies');
     });
+
+    it('should cascade all resources when wildcard API group is cleared', () => {
+      renderModal({
+        id: 'r1',
+        apiGroups: ['*'],
+        resources: ['deployments', 'pods', 'mycustomresource'],
+        verbs: ['get'],
+      });
+
+      act(() => {
+        capturedApiGroupsProps.onSelectedApiGroupsChange([]);
+      });
+
+      expect(capturedResourcesProps.selectedResources).not.toContain('deployments');
+      expect(capturedResourcesProps.selectedResources).not.toContain('pods');
+      expect(capturedResourcesProps.selectedResources).toContain('mycustomresource');
+    });
   });
 
   describe('edit mode', () => {

--- a/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
@@ -187,7 +187,7 @@ describe('AddRuleModal orchestration', () => {
       expect(capturedResourcesProps.selectedResources).toContain('deployments');
     });
 
-    it('should not cascade when API groups become empty', () => {
+    it('should cascade resources when API groups become empty', () => {
       renderModal({
         id: 'r1',
         apiGroups: ['apps'],
@@ -199,7 +199,7 @@ describe('AddRuleModal orchestration', () => {
         capturedApiGroupsProps.onSelectedApiGroupsChange([]);
       });
 
-      expect(capturedResourcesProps.selectedResources).toContain('deployments');
+      expect(capturedResourcesProps.selectedResources).not.toContain('deployments');
     });
 
     it('should not cascade when resources wildcard is selected', () => {

--- a/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/AddRuleModal.spec.tsx
@@ -220,15 +220,17 @@ describe('AddRuleModal orchestration', () => {
     it('should keep custom resources (unknown group) when API group is removed', () => {
       renderModal({
         id: 'r1',
-        apiGroups: ['apps'],
-        resources: ['deployments', 'mycustomresource'],
+        apiGroups: ['apps', ''],
+        resources: ['deployments', 'pods', 'mycustomresource'],
         verbs: ['get'],
       });
 
       act(() => {
-        capturedApiGroupsProps.onSelectedApiGroupsChange([]);
+        capturedApiGroupsProps.onSelectedApiGroupsChange(['']);
       });
 
+      expect(capturedResourcesProps.selectedResources).not.toContain('deployments');
+      expect(capturedResourcesProps.selectedResources).toContain('pods');
       expect(capturedResourcesProps.selectedResources).toContain('mycustomresource');
     });
 

--- a/frontend/src/pages/projects/projectRoles/__tests__/ApiGroupsTreeSelect.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/ApiGroupsTreeSelect.spec.tsx
@@ -79,7 +79,9 @@ describe('ApiGroupsTreeSelect', () => {
     await openDropdown();
 
     expect(screen.getByText('core')).toBeInTheDocument();
-    expect(screen.getByText('Pods, services, configmaps, namespaces, events')).toBeInTheDocument();
+    expect(
+      screen.getByText('Pods, services, configmaps, PVCs, namespaces, events'),
+    ).toBeInTheDocument();
     expect(screen.getByText('apps')).toBeInTheDocument();
     expect(screen.getByText('Deployments, StatefulSets, DaemonSets')).toBeInTheDocument();
   });

--- a/frontend/src/pages/projects/projectRoles/__tests__/ResourcesTreeSelect.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/ResourcesTreeSelect.spec.tsx
@@ -554,4 +554,161 @@ describe('ResourcesTreeSelect', () => {
     const result = mockOnChange.mock.calls[0][0] as string[];
     expect(result).not.toContain('__all_category__core');
   });
+
+  describe('filterByApiGroups', () => {
+    it('should show all resources when filterByApiGroups is undefined', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('Core')).toBeInTheDocument();
+      expect(screen.getByText('Applications')).toBeInTheDocument();
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+      expect(screen.getByText('Networking')).toBeInTheDocument();
+      expect(screen.getByText('RBAC')).toBeInTheDocument();
+    });
+
+    it('should show all resources when filterByApiGroups is empty', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={[]}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('Core')).toBeInTheDocument();
+      expect(screen.getByText('Applications')).toBeInTheDocument();
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+      expect(screen.getByText('Networking')).toBeInTheDocument();
+      expect(screen.getByText('RBAC')).toBeInTheDocument();
+    });
+
+    it('should show all resources when filterByApiGroups contains wildcard', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={['*']}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('Core')).toBeInTheDocument();
+      expect(screen.getByText('Applications')).toBeInTheDocument();
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+      expect(screen.getByText('Networking')).toBeInTheDocument();
+      expect(screen.getByText('RBAC')).toBeInTheDocument();
+    });
+
+    it('should filter resources to only show those in selected API groups', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={['apps']}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('Deployments')).toBeInTheDocument();
+      expect(screen.getByText('StatefulSets')).toBeInTheDocument();
+      expect(screen.getByText('DaemonSets')).toBeInTheDocument();
+      expect(screen.queryByText('Pods')).not.toBeInTheDocument();
+      expect(screen.queryByText('Network policies')).not.toBeInTheDocument();
+      expect(screen.queryByText('Roles')).not.toBeInTheDocument();
+    });
+
+    it('should hide empty categories when all their resources are filtered out', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={['networking.k8s.io']}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('Networking')).toBeInTheDocument();
+      expect(screen.getByText('Network policies')).toBeInTheDocument();
+      expect(screen.getByText('Ingresses')).toBeInTheDocument();
+      expect(screen.queryByText('Core')).not.toBeInTheDocument();
+      expect(screen.queryByText('Applications')).not.toBeInTheDocument();
+      expect(screen.queryByText('Storage')).not.toBeInTheDocument();
+      expect(screen.queryByText('RBAC')).not.toBeInTheDocument();
+    });
+
+    it('should filter core group resources using empty string', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={['']}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('Core')).toBeInTheDocument();
+      expect(screen.getByText('Pods')).toBeInTheDocument();
+      expect(screen.getByText('Services')).toBeInTheDocument();
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+      expect(screen.getByText('Persistent volumes')).toBeInTheDocument();
+      expect(screen.queryByText('Deployments')).not.toBeInTheDocument();
+      expect(screen.queryByText('Networking')).not.toBeInTheDocument();
+      expect(screen.queryByText('RBAC')).not.toBeInTheDocument();
+    });
+
+    it('should show resources from multiple selected API groups', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={['apps', 'batch']}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('Applications')).toBeInTheDocument();
+      expect(screen.getByText('Deployments')).toBeInTheDocument();
+      expect(screen.getByText('Jobs')).toBeInTheDocument();
+      expect(screen.getByText('CronJobs')).toBeInTheDocument();
+      expect(screen.queryByText('Core')).not.toBeInTheDocument();
+      expect(screen.queryByText('Pods')).not.toBeInTheDocument();
+    });
+
+    it('should always show the "All resources" wildcard option regardless of filter', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={['apps']}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('All resources')).toBeInTheDocument();
+    });
+  
+  });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/ResourcesTreeSelect.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/ResourcesTreeSelect.spec.tsx
@@ -719,6 +719,40 @@ describe('ResourcesTreeSelect', () => {
       expect(screen.queryByText('Pods')).not.toBeInTheDocument();
     });
 
+    it('should not hide the resource tree when only a custom API group is selected', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={['custom.example.io']}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('All resources')).toBeInTheDocument();
+      expect(screen.getByText('Core')).toBeInTheDocument();
+      expect(screen.getByText('Pods')).toBeInTheDocument();
+      expect(screen.getByText('Applications')).toBeInTheDocument();
+    });
+
+    it('should still filter to known groups when mixed with a custom API group', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={['apps', 'custom.example.io']}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('Deployments')).toBeInTheDocument();
+      expect(screen.queryByText('Pods')).not.toBeInTheDocument();
+    });
+
     it('should always show the "All resources" wildcard option regardless of filter', async () => {
       render(
         <ResourcesTreeSelect

--- a/frontend/src/pages/projects/projectRoles/__tests__/ResourcesTreeSelect.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/ResourcesTreeSelect.spec.tsx
@@ -668,11 +668,35 @@ describe('ResourcesTreeSelect', () => {
       expect(screen.getByText('Core')).toBeInTheDocument();
       expect(screen.getByText('Pods')).toBeInTheDocument();
       expect(screen.getByText('Services')).toBeInTheDocument();
-      expect(screen.getByText('Storage')).toBeInTheDocument();
       expect(screen.getByText('Persistent volumes')).toBeInTheDocument();
+      expect(screen.getByText('Cluster storage (persistentvolumeclaims)')).toBeInTheDocument();
+      expect(screen.queryByText('Storage')).not.toBeInTheDocument();
+      expect(screen.queryByText('Storage classes')).not.toBeInTheDocument();
       expect(screen.queryByText('Deployments')).not.toBeInTheDocument();
       expect(screen.queryByText('Networking')).not.toBeInTheDocument();
       expect(screen.queryByText('RBAC')).not.toBeInTheDocument();
+    });
+
+    it('should show only storage.k8s.io resources when that API group is selected', async () => {
+      render(
+        <ResourcesTreeSelect
+          selectedResources={[]}
+          onSelectedResourcesChange={mockOnChange}
+          apiResourcesData={mockApiResourcesData}
+          filterByApiGroups={['storage.k8s.io']}
+        />,
+      );
+
+      await openDropdown();
+
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+      expect(screen.getByText('Storage classes')).toBeInTheDocument();
+      expect(screen.queryByText('Persistent volumes')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Cluster storage (persistentvolumeclaims)'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Core')).not.toBeInTheDocument();
+      expect(screen.queryByText('Pods')).not.toBeInTheDocument();
     });
 
     it('should show resources from multiple selected API groups', async () => {

--- a/frontend/src/pages/projects/projectRoles/__tests__/ResourcesTreeSelect.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/ResourcesTreeSelect.spec.tsx
@@ -709,6 +709,5 @@ describe('ResourcesTreeSelect', () => {
 
       expect(screen.getByText('All resources')).toBeInTheDocument();
     });
-  
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/resourceCategories.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/resourceCategories.spec.ts
@@ -1,0 +1,32 @@
+import {
+  RESOURCE_CATEGORIES,
+  buildResourceToApiGroupMap,
+} from '#~/pages/projects/projectRoles/resourceCategories';
+
+describe('buildResourceToApiGroupMap', () => {
+  it('should use static categories when discovery is empty', () => {
+    const map = buildResourceToApiGroupMap([]);
+
+    expect(map.get('pods')).toBe('');
+    expect(map.get('deployments')).toBe('apps');
+    expect(map.get('persistentvolumeclaims')).toBe('');
+    expect(map.get('storageclasses')).toBe('storage.k8s.io');
+    expect(map.size).toBe(RESOURCE_CATEGORIES.flatMap((c) => c.resources).length);
+  });
+
+  it('should prefer the first discovered API group over static', () => {
+    const map = buildResourceToApiGroupMap([
+      { name: 'pods', apiGroup: '' },
+      { name: 'pods', apiGroup: 'metrics.k8s.io' },
+    ]);
+
+    expect(map.get('pods')).toBe('');
+  });
+
+  it('should fill names missing from discovery from static categories', () => {
+    const map = buildResourceToApiGroupMap([{ name: 'widgets', apiGroup: 'example.io' }]);
+
+    expect(map.get('widgets')).toBe('example.io');
+    expect(map.get('notebooks')).toBe('kubeflow.org');
+  });
+});

--- a/frontend/src/pages/projects/projectRoles/apiGroupCategories.ts
+++ b/frontend/src/pages/projects/projectRoles/apiGroupCategories.ts
@@ -78,6 +78,16 @@ export const API_GROUP_CATEGORIES: ApiGroupCategory[] = [
         label: 'rbac.authorization.k8s.io',
         description: 'Roles, role bindings, cluster roles',
       },
+      {
+        name: 'authorization.k8s.io',
+        label: 'authorization.k8s.io',
+        description: 'Subject access reviews',
+      },
+      {
+        name: 'authentication.k8s.io',
+        label: 'authentication.k8s.io',
+        description: 'Token reviews',
+      },
     ],
   },
 ];

--- a/frontend/src/pages/projects/projectRoles/apiGroupCategories.ts
+++ b/frontend/src/pages/projects/projectRoles/apiGroupCategories.ts
@@ -15,7 +15,11 @@ export const API_GROUP_CATEGORIES: ApiGroupCategory[] = [
     id: 'core',
     label: 'Core',
     groups: [
-      { name: '', label: 'core', description: 'Pods, services, configmaps, namespaces, events' },
+      {
+        name: '',
+        label: 'core',
+        description: 'Pods, services, configmaps, PVCs, namespaces, events',
+      },
     ],
   },
   {

--- a/frontend/src/pages/projects/projectRoles/resourceCategories.ts
+++ b/frontend/src/pages/projects/projectRoles/resourceCategories.ts
@@ -23,6 +23,12 @@ export const RESOURCE_CATEGORIES: ResourceCategory[] = [
       { name: 'nodes', label: 'Nodes', apiGroup: '' },
       { name: 'namespaces', label: 'Projects (namespaces)', apiGroup: '' },
       { name: 'events', label: 'Events', apiGroup: '' },
+      { name: 'persistentvolumes', label: 'Persistent volumes', apiGroup: '' },
+      {
+        name: 'persistentvolumeclaims',
+        label: 'Cluster storage (persistentvolumeclaims)',
+        apiGroup: '',
+      },
     ],
   },
   {
@@ -47,13 +53,13 @@ export const RESOURCE_CATEGORIES: ResourceCategory[] = [
     id: 'storage',
     label: 'Storage',
     resources: [
-      { name: 'persistentvolumes', label: 'Persistent volumes', apiGroup: '' },
-      {
-        name: 'persistentvolumeclaims',
-        label: 'Cluster storage (persistentvolumeclaims)',
-        apiGroup: '',
-      },
       { name: 'storageclasses', label: 'Storage classes', apiGroup: 'storage.k8s.io' },
+      { name: 'volumeattachments', label: 'Volume attachments', apiGroup: 'storage.k8s.io' },
+      {
+        name: 'volumesnapshots',
+        label: 'Volume snapshots',
+        apiGroup: 'snapshot.storage.k8s.io',
+      },
     ],
   },
   {
@@ -102,3 +108,31 @@ export const RESOURCE_CATEGORIES: ResourceCategory[] = [
 ];
 
 export const ALL_RESOURCES_WILDCARD = '*';
+
+type ResourceApiGroupRef = {
+  name: string;
+  apiGroup: string;
+};
+
+/**
+ * Resource name → API group. Discovery is the source of truth (first occurrence wins).
+ * Static categories fill names that discovery did not return (empty/failed discovery, or not on cluster).
+ */
+export const buildResourceToApiGroupMap = (
+  discoveredResources: ResourceApiGroupRef[],
+): Map<string, string> => {
+  const map = new Map<string, string>();
+  for (const r of discoveredResources) {
+    if (!map.has(r.name)) {
+      map.set(r.name, r.apiGroup);
+    }
+  }
+  for (const category of RESOURCE_CATEGORIES) {
+    for (const r of category.resources) {
+      if (!map.has(r.name)) {
+        map.set(r.name, r.apiGroup);
+      }
+    }
+  }
+  return map;
+};

--- a/frontend/src/pages/projects/projectRoles/resourceCategories.ts
+++ b/frontend/src/pages/projects/projectRoles/resourceCategories.ts
@@ -18,6 +18,9 @@ export const RESOURCE_CATEGORIES: ResourceCategory[] = [
       { name: 'pods', label: 'Pods', apiGroup: '' },
       { name: 'services', label: 'Services', apiGroup: '' },
       { name: 'configmaps', label: 'ConfigMaps', apiGroup: '' },
+      { name: 'secrets', label: 'Secrets', apiGroup: '' },
+      { name: 'serviceaccounts', label: 'Service accounts', apiGroup: '' },
+      { name: 'nodes', label: 'Nodes', apiGroup: '' },
       { name: 'namespaces', label: 'Projects (namespaces)', apiGroup: '' },
       { name: 'events', label: 'Events', apiGroup: '' },
     ],
@@ -73,6 +76,28 @@ export const RESOURCE_CATEGORIES: ResourceCategory[] = [
         label: 'Cluster role bindings',
         apiGroup: 'rbac.authorization.k8s.io',
       },
+      {
+        name: 'subjectaccessreviews',
+        label: 'Subject access reviews',
+        apiGroup: 'authorization.k8s.io',
+      },
+      {
+        name: 'localsubjectaccessreviews',
+        label: 'Local subject access reviews',
+        apiGroup: 'authorization.k8s.io',
+      },
+      {
+        name: 'selfsubjectaccessreviews',
+        label: 'Self subject access reviews',
+        apiGroup: 'authorization.k8s.io',
+      },
+      {
+        name: 'selfsubjectrulesreviews',
+        label: 'Self subject rules reviews',
+        apiGroup: 'authorization.k8s.io',
+      },
+      { name: 'tokenreviews', label: 'Token reviews', apiGroup: 'authentication.k8s.io' },
+      { name: 'tokenrequests', label: 'Token requests', apiGroup: 'authentication.k8s.io' },
     ],
   },
 ];

--- a/frontend/src/pages/projects/projectRoles/resourceCategories.ts
+++ b/frontend/src/pages/projects/projectRoles/resourceCategories.ts
@@ -97,7 +97,6 @@ export const RESOURCE_CATEGORIES: ResourceCategory[] = [
         apiGroup: 'authorization.k8s.io',
       },
       { name: 'tokenreviews', label: 'Token reviews', apiGroup: 'authentication.k8s.io' },
-      { name: 'tokenrequests', label: 'Token requests', apiGroup: 'authentication.k8s.io' },
     ],
   },
 ];


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-80010

## Description

Implements cross-field coordination in the Add Rule modal (Custom Role creation) so that API Groups and Resource Types selections are contextually linked:

- **API Group → Resources filtering**: Selecting an API group narrows the Resources dropdown to only show resources belonging to that group
- **Resource → API Group auto-population**: Selecting a resource automatically adds its corresponding API group
- **Cascading deselection**: Removing an API group removes resources that only belonged to that group
- **Wildcard handling**: `*` (all) in either field shows all options in the other
- **Custom entries**: User-typed values that don't map to known resources/groups are preserved without side effects

https://github.com/user-attachments/assets/10aaa984-b671-4214-9324-96e012e0d2f1

### Behavior Summary

| Trigger | Effect |
| --- | --- |
| Select API group | Resources dropdown filters to show only resources in selected groups |
| Select resource (no matching API group selected) | Auto-add the resource's API group |
| Remove API group | Auto-remove resources whose API group is no longer selected |
| Remove resource | Keep the API group (no cascade up) |
| No API groups selected | Show all resources (unfiltered) |
| Wildcard API group (`*`) | Show all resources (unfiltered) |
| Wildcard resources (`*`) | No auto-populate of API groups |
| Custom resource (unknown group) | No auto-populate |

## How Has This Been Tested?

- Unit tests for `AddRuleModal` orchestration logic (14 test cases covering all scenarios)
- Unit tests for `ResourcesTreeSelect` `filterByApiGroups` prop (7 test cases)
- Manual testing of the full Add Rule modal flow

## Test Impact

- Added `AddRuleModal.spec.tsx` with 14 tests covering auto-population, cascading deselection, wildcards, custom entries, and edit mode
- Added 7 tests to `ResourcesTreeSelect.spec.tsx` for the `filterByApiGroups` prop

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Resource and API group selections now stay synchronized when creating or editing project role rules.
  * Resource lists can be filtered by selected API groups while retaining wildcard and “All resources” options.
  * Expanded Core, Storage, and RBAC categories to include additional Kubernetes resources and API groups.
  * Duplicate or unnamed API groups are excluded from selection lists.
  * API group wildcard selections are normalized when rules are saved.
  * Only one selection menu remains open at a time for a cleaner experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->