### PR TITLE
fix(RHOAIENG-85369): rename "Legacy deployment" and clarify deployment method descriptions

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/modelRegistry/testModelRegistry.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/modelRegistry/testModelRegistry.yaml
@@ -21,7 +21,7 @@ modelFormat: 'openvino_ir - opset13'
 servingRuntime: 'vLLM CPU (ppc64le/s390x) ServingRuntime for KServe'
 servingRuntimeS390x: 'vLLM CPU (ppc64le/s390x) ServingRuntime for KServe'
 servingRuntimeX86: 'vLLM CPU (x86) ServingRuntime for KServe'
-deploymentType: 'Legacy deployment'
+deploymentType: 'Inference service'
 
 # Second model (URI)
 uriModelName: "test-uri-model"

--- a/packages/cypress/cypress/utils/modelServingConstants.ts
+++ b/packages/cypress/cypress/utils/modelServingConstants.ts
@@ -36,5 +36,5 @@ export const YAMLViewerToggleOption = {
 
 export const ModelDeploymentType = {
   TYPE1: 'LLM inference service with llm-d',
-  TYPE2: 'Legacy deployment',
+  TYPE2: 'Inference service',
 };

--- a/packages/kserve/src/wizardFields/deploymentMethodField.ts
+++ b/packages/kserve/src/wizardFields/deploymentMethodField.ts
@@ -4,9 +4,9 @@ export const LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY = 'legacy';
 
 const LEGACY_OPTION = {
   key: LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY,
-  label: 'Legacy deployment',
+  label: 'Inference service',
   description:
-    'Deploy using a serving runtime template. Use this option for non-LLM models or for compatibility with previous deployments. This method does not support Models as a Service.',
+    'Deploy a model using a serving runtime template. Best for custom runtimes. Not compatible with Models as a Service.',
   order: 3,
 };
 

--- a/packages/llmd-serving/src/wizardFields/deploymentMethodField.ts
+++ b/packages/llmd-serving/src/wizardFields/deploymentMethodField.ts
@@ -10,7 +10,7 @@ export const LLMD_DEPLOYMENT_METHOD_KEY = 'llm-inference-service-llmd';
 const SIMPLE_VLLM_OPTION = {
   key: SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY,
   label: 'LLM inference service',
-  description: 'Deploy a large language model using the standard LLM inference service.',
+  description: 'Deploy a large language model. Compatible with Models as a Service.',
   order: 1,
 };
 
@@ -29,7 +29,7 @@ const LLMD_OPTION = {
   key: LLMD_DEPLOYMENT_METHOD_KEY,
   label: 'LLM inference service with llm-d',
   description:
-    'Deploy a large language model with llm-d for additional scheduling and routing capabilities.',
+    'Same as LLM inference service, but with distributed serving and advanced routing techniques such as cache-aware routing and disaggregated prefill and decode.',
   order: 2,
 };
 


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/RHOAIENG-85369

The **"Legacy deployment"** deployment-method option on the 2nd page of the deploy-model wizard was read by the field as an intent to deprecate the ServingRuntime + InferenceService path. That impression is inaccurate — this path supports any model type (predictive *and* generative), is not going away, and differs from the LLMInferenceService path only in that it does not support Models as a Service.

This PR:
- Renames the option **"Legacy deployment" → "Inference service"**.
- Rewrites **all three** deployment-method descriptions for a consistent structure and accurate, non-deprecating wording (removes "non-LLM models" and "compatibility with previous deployments").

Final option copy:

<img width="948" height="271" alt="image" src="https://github.com/user-attachments/assets/9ec6d140-e662-42ab-8c1e-dbc834ab2a09" />

## How Has This Been Tested?

Ran `npm run type-check` (30/30 pass), `npm run lint` (0 errors), and unit tests for the affected packages (`kserve` 87, `llmd-serving` 361, `model-serving`) — all pass. Screenshots of the wizard section were captured and reviewed by UX in the internal thread.

## Test Impact

No new tests added — this is a microcopy change with no new logic. Updated the two existing test spots that hardcode the display label (`ModelDeploymentType.TYPE2` in `modelServingConstants.ts` and `deploymentType` in the E2E fixture `testModelRegistry.yaml`). The rewritten description text is not asserted by any test; the deployment-method radios are targeted by their stable `legacy` key/testid, not the label.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
