### PR TITLE
test: restore Cypress mock test for NIM settings card extension

### DIFF
--- a/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
@@ -1,0 +1,83 @@
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
+import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { mockOdhApplication } from '@odh-dashboard/k8s-core/__mocks__/mockOdhApplication';
+import { mockNimServingRuntimeTemplate } from '@odh-dashboard/model-serving/__mocks__/mockLegacyNimResource';
+import { mockNimAccount } from '@odh-dashboard/internal/__mocks__/mockNimAccount';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { projectDetailsSettingsTab } from '../../../../pages/projects';
+import { NIMAccountModel, ProjectModel, TemplateModel } from '../../../../utils/models';
+import { asProjectEditUser } from '../../../../utils/mockUsers';
+
+const initIntercepts = ({
+  nimAccountExists = false,
+}: {
+  nimAccountExists?: boolean;
+} = {}) => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+      },
+    }),
+  );
+
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableKServe: false,
+      disableNIMModelServing: false,
+      nimWizard: true,
+    }),
+  );
+
+  cy.interceptOdh('GET /api/components', null, [mockOdhApplication({})]);
+
+  cy.interceptOdh(
+    'GET /api/integrations/:internalRoute',
+    { path: { internalRoute: 'nim' } },
+    {
+      isInstalled: true,
+      isEnabled: true,
+      canInstall: false,
+      error: '',
+    },
+  );
+
+  const mockProject = mockProjectK8sResource({});
+  cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProject]));
+  cy.interceptK8s(ProjectModel, mockProject);
+
+  const templateMock = mockNimServingRuntimeTemplate();
+  cy.interceptK8sList(
+    { model: TemplateModel, ns: 'opendatahub' },
+    mockK8sResourceList([templateMock]),
+  );
+  cy.interceptK8s(TemplateModel, templateMock);
+
+  cy.interceptK8sList(
+    { model: NIMAccountModel, ns: 'test-project' },
+    mockK8sResourceList(nimAccountExists ? [mockNimAccount({ namespace: 'test-project' })] : []),
+  );
+};
+
+describe('NIM Settings Card', () => {
+  beforeEach(() => {
+    asProjectEditUser();
+  });
+
+  it('should render the NIM settings card with enable button when NIMAccount does not exist', () => {
+    initIntercepts({ nimAccountExists: false });
+    projectDetailsSettingsTab.visitSettings('test-project');
+    projectDetailsSettingsTab.findNIMEnableButton().should('exist');
+  });
+
+  it('should render the NIM settings card with management buttons when NIMAccount exists', () => {
+    initIntercepts({ nimAccountExists: true });
+    projectDetailsSettingsTab.visitSettings('test-project');
+    projectDetailsSettingsTab.findNIMRemoveButton().should('exist');
+    projectDetailsSettingsTab.findNIMReplaceKeyButton().should('exist');
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
@@ -46,7 +46,7 @@ const initIntercepts = ({
     },
   );
 
-  const mockProject = mockProjectK8sResource({});
+  const mockProject = mockProjectK8sResource({ enableNIM: true });
   cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProject]));
   cy.interceptK8s(ProjectModel, mockProject);
 


### PR DESCRIPTION
## Description

The NIM project-scoped key settings Cypress mock test (`projectSettingsNim.cy.ts`) was removed in PR #8773 as part of a CI wall-time reduction effort, because Jest tests in `NIMSettingsCard.spec.tsx` covered similar RBAC button-state assertions.

However, the Cypress test uniquely validated that the **NIM settings card loads as a plugin extension** in the project Settings tab — something Jest cannot cover since it mocks the hooks (`useNIMSettingsAccessAllowed`, `useNIMAccountStatus`) directly. Specifically, Jest cannot test:

1. **Extension registration** — that the `app.project-details/settings-card` extension is discovered and rendered
2. **Feature flag gating** — that the `NIM_WIZARD` → `NIM_MODEL` → `K_SERVE` area chain resolves correctly from dashboard config + DSC status
3. **Integration with project details routing** — navigating to `/projects/test-project?section=settings` and seeing the NIM card

This restores a **slimmed-down version** (2 tests vs the original 5) that covers the extension-shows-up scenario in both NIMAccount states, without duplicating the RBAC micro-interactions already tested in Jest. The orphaned page object methods (`findNIMEnableButton`, `findNIMRemoveButton`, `findNIMReplaceKeyButton`) are now used again.

## How Has This Been Tested?

- Ran the Cypress mock test locally (headless Chrome) — passes consistently across multiple runs
- Verified lint passes via pre-commit hook

## Test Impact

This PR **is** the test — it restores Cypress mock test coverage for the NIM settings card extension rendering.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for NIM project settings.
  * Verified that projects without a NIM account display an enable option.
  * Verified that projects with an account display controls to remove the account or replace its key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->