### PR TITLE
fix(cypress): add Feature Store auth and S3 registry setup for 3.5

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/featureStoreResources/testFeatureStoreResources.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/featureStoreResources/testFeatureStoreResources.yaml
@@ -3,6 +3,8 @@ projectName: "test-fs-ui-proj"
 feastInstanceName: "test-s3"
 feastCreditScoringProject: "credit_scoring_local"
 feastDriverRankingProject: "driver_ranking"
+datasetName: "credit_scoring_dataset"
+featureServiceName: "driver_activity_v1"
 # Workbench connection test data
 dspProjectName: "dsp-fs-wb-connect"
 workbenchName: "fs-connected-workbench"

--- a/packages/cypress/cypress/fixtures/resources/yaml/feast.yaml
+++ b/packages/cypress/cypress/fixtures/resources/yaml/feast.yaml
@@ -42,7 +42,7 @@ spec:
       local:
         persistence:
           file:
-            path: s3://${awsBucketName}/feast-test/credit_scoring_local/registry.pb
+            path: s3://${awsBucketName}/feast-test/${namespace}/credit_scoring_local/registry.pb
         server:
           envFrom:
           - secretRef:

--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
@@ -2,12 +2,14 @@ import * as yaml from 'js-yaml';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
 import { featureStoreGlobal } from '../../../pages/featureStore/featureStoreGlobal';
 import { shouldHaveTotalCount } from '../../../utils/featureStoreUtils';
-import { deleteOpenShiftProject } from '../../../utils/oc_commands/project';
+import { addUserToProject, deleteOpenShiftProject } from '../../../utils/oc_commands/project';
 import { createCleanProject } from '../../../utils/projectChecker';
 import type { FeatureStoreTestData } from '../../../types';
 import {
+  applyFeastPermissionViaSdk,
   createFeatureStoreCR,
   createRouteAndGetUrl,
+  createSavedDatasetViaSdk,
 } from '../../../utils/oc_commands/featureStoreResources';
 import { retryableBefore } from '../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../utils/uuidGenerator';
@@ -17,6 +19,8 @@ import {
 } from '../../../utils/api/featureStoreRest';
 import { featureMetricsOverview } from '../../../pages/featureStore/featureMetrics';
 import { getCustomResource } from '../../../utils/oc_commands/customResources';
+import { createRegistryStep, deleteFeastRegistryFiles } from '../../../utils/oc_commands/s3Cleanup';
+import { AWS_BUCKETS } from '../../../utils/s3Buckets';
 
 describe('Feature Store Page Validation', () => {
   let testData: FeatureStoreTestData;
@@ -69,36 +73,73 @@ describe('Feature Store Page Validation', () => {
         .then(() => {
           cy.log(`Creating Namespace: ${projectName}`);
           createCleanProject(projectName);
+
+          // Feast NamespaceBasedPolicy only authorizes users with admin RoleBindings
+          // in the permitted namespace. Grant both the oc CLI user (REST count calls)
+          // and the dashboard login user (UI) admin on this project.
+          return cy.exec('oc whoami', { failOnNonZeroExit: false }).then((whoami) => {
+            const ocUser = whoami.stdout.trim();
+            if (ocUser) {
+              return addUserToProject(projectName, ocUser, 'admin').then(() =>
+                addUserToProject(projectName, HTPASSWD_CLUSTER_ADMIN_USER.USERNAME, 'admin'),
+              );
+            }
+            return addUserToProject(projectName, HTPASSWD_CLUSTER_ADMIN_USER.USERNAME, 'admin');
+          });
+        })
+        .then(() => {
+          createRegistryStep(projectName);
           createFeatureStoreCR(projectName, testData.feastInstanceName);
         })
         .then(() => {
-          // Create route and fetch counts for the Feast instance
           return createRouteAndGetUrl(projectName, testData.feastInstanceName).then((routeUrl) => {
-            return getMetricsResourceCounts(routeUrl, testData.feastCreditScoringProject).then(
-              (metricsCounts) => {
-                metricsFeatureCount = metricsCounts.featureCount;
-                metricsEntityCount = metricsCounts.entityCount;
-                metricsDatasetCount = metricsCounts.datasetCount;
-                metricsDataSourceCount = metricsCounts.dataSourceCount;
-                metricsFeatureViewCount = metricsCounts.featureViewCount;
-                metricsFeatureServiceCount = metricsCounts.featureServiceCount;
+            const buckets =
+              (Cypress.env('AWS_PIPELINES') as typeof AWS_BUCKETS | undefined) ?? AWS_BUCKETS;
+            const { NAME: awsBucketName } = buckets.BUCKET_1;
+            if (!awsBucketName) {
+              throw new Error(
+                'AWS_PIPELINES.BUCKET_1.NAME is empty. Export CY_TEST_CONFIG to packages/cypress/test-variables.yml before running E2E.',
+              );
+            }
 
-                return getAllFeatureStoreCounts(routeUrl, testData.feastCreditScoringProject).then(
-                  (listCounts) => {
-                    featureCount = listCounts.featureCount;
-                    entityCount = listCounts.entityCount;
-                    datasetCount = listCounts.datasetCount;
-                    dataSourceCount = listCounts.dataSourceCount;
-                    featureViewCount = listCounts.featureViewCount;
-                    featureServiceCount = listCounts.featureServiceCount;
+            return applyFeastPermissionViaSdk(projectName, testData.feastInstanceName, {
+              name: 'feast-auth',
+              namespaces: [projectName],
+            }).then(() => {
+              return createSavedDatasetViaSdk(projectName, testData.feastInstanceName, {
+                name: testData.datasetName,
+                project: testData.feastCreditScoringProject,
+                storagePath: `s3://${awsBucketName}/feast-test/${projectName}/credit_scoring_local/datasets/${testData.datasetName}.parquet`,
+                featureServiceName: testData.featureServiceName,
+              }).then(() => {
+                return getMetricsResourceCounts(routeUrl, testData.feastCreditScoringProject).then(
+                  (metricsCounts) => {
+                    metricsFeatureCount = metricsCounts.featureCount;
+                    metricsEntityCount = metricsCounts.entityCount;
+                    metricsDatasetCount = metricsCounts.datasetCount;
+                    metricsDataSourceCount = metricsCounts.dataSourceCount;
+                    metricsFeatureViewCount = metricsCounts.featureViewCount;
+                    metricsFeatureServiceCount = metricsCounts.featureServiceCount;
 
-                    cy.log(`Metrics counts: ${JSON.stringify(metricsCounts)}`);
-                    cy.log(`List counts: ${JSON.stringify(listCounts)}`);
-                    return cy.wrap({ metricsCounts, listCounts });
+                    return getAllFeatureStoreCounts(
+                      routeUrl,
+                      testData.feastCreditScoringProject,
+                    ).then((listCounts) => {
+                      featureCount = listCounts.featureCount;
+                      entityCount = listCounts.entityCount;
+                      datasetCount = listCounts.datasetCount;
+                      dataSourceCount = listCounts.dataSourceCount;
+                      featureViewCount = listCounts.featureViewCount;
+                      featureServiceCount = listCounts.featureServiceCount;
+
+                      cy.log(`Metrics counts: ${JSON.stringify(metricsCounts)}`);
+                      cy.log(`List counts: ${JSON.stringify(listCounts)}`);
+                      return cy.wrap({ metricsCounts, listCounts });
+                    });
                   },
                 );
-              },
-            );
+              });
+            });
           });
         });
     });
@@ -109,6 +150,9 @@ describe('Feature Store Page Validation', () => {
       cy.log('Skipping cleanup: Tests were skipped');
       return;
     }
+
+    cy.log(`Removing S3 registry files for: ${projectName}`);
+    deleteFeastRegistryFiles(projectName);
 
     cy.log(`Deleting Namespace: ${projectName}`);
     deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });

--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreRbac.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreRbac.cy.ts
@@ -1,14 +1,18 @@
 import * as yaml from 'js-yaml';
 import { LDAP_ADMIN_USER, LDAP_CONTRIBUTOR_USER } from '../../../utils/e2eUsers';
 import { featureStoreGlobal } from '../../../pages/featureStore/featureStoreGlobal';
-import { deleteOpenShiftProject } from '../../../utils/oc_commands/project';
+import { addUserToProject, deleteOpenShiftProject } from '../../../utils/oc_commands/project';
 import { createCleanProject } from '../../../utils/projectChecker';
 import type { FeatureStoreTestData } from '../../../types';
-import { createFeatureStoreCR } from '../../../utils/oc_commands/featureStoreResources';
+import {
+  applyFeastPermissionViaSdk,
+  createFeatureStoreCR,
+} from '../../../utils/oc_commands/featureStoreResources';
 import { retryableBefore, wasSetupPerformed } from '../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../utils/uuidGenerator';
 import { isRHOAI } from '../../../utils/oc_commands/applications';
 import { ensureAdminOcSession } from '../../../utils/oc_commands/baseCommands';
+import { createRegistryStep, deleteFeastRegistryFiles } from '../../../utils/oc_commands/s3Cleanup';
 
 describe('Verify RBAC scoped Feature Store discovery by namespace access', () => {
   let testData: FeatureStoreTestData;
@@ -49,10 +53,27 @@ describe('Verify RBAC scoped Feature Store discovery by namespace access', () =>
         .then(() => {
           cy.step(`Create namespace: ${projectName}`);
           createCleanProject(projectName);
+
+          return cy.exec('oc whoami', { failOnNonZeroExit: false }).then((whoami) => {
+            const ocUser = whoami.stdout.trim();
+            if (ocUser) {
+              return addUserToProject(projectName, ocUser, 'admin').then(() =>
+                addUserToProject(projectName, LDAP_ADMIN_USER.USERNAME, 'admin'),
+              );
+            }
+            return addUserToProject(projectName, LDAP_ADMIN_USER.USERNAME, 'admin');
+          });
         })
         .then(() => {
           cy.step(`Apply FeatureStore CR in namespace: ${projectName}`);
+          createRegistryStep(projectName);
           createFeatureStoreCR(projectName, testData.feastInstanceName);
+        })
+        .then(() => {
+          return applyFeastPermissionViaSdk(projectName, testData.feastInstanceName, {
+            name: 'feast-auth',
+            namespaces: [projectName],
+          });
         });
     });
   });
@@ -64,6 +85,9 @@ describe('Verify RBAC scoped Feature Store discovery by namespace access', () =>
     }
     cy.step('Restore admin oc session for cleanup');
     ensureAdminOcSession();
+
+    cy.step(`Removing S3 registry files for: ${projectName}`);
+    deleteFeastRegistryFiles(projectName);
 
     cy.step(`Delete namespace: ${projectName}`);
     deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });

--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreWorkbenchConnect.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreWorkbenchConnect.cy.ts
@@ -1,14 +1,22 @@
 import * as yaml from 'js-yaml';
 import { LDAP_ADMIN_USER } from '../../../utils/e2eUsers';
 import { featureStoreGlobal } from '../../../pages/featureStore/featureStoreGlobal';
-import { deleteOpenShiftProject, createOpenShiftProject } from '../../../utils/oc_commands/project';
+import {
+  addUserToProject,
+  deleteOpenShiftProject,
+  createOpenShiftProject,
+} from '../../../utils/oc_commands/project';
 import { createCleanProject } from '../../../utils/projectChecker';
 import type { FeatureStoreTestData } from '../../../types';
-import { createFeatureStoreCR } from '../../../utils/oc_commands/featureStoreResources';
+import {
+  applyFeastPermissionViaSdk,
+  createFeatureStoreCR,
+} from '../../../utils/oc_commands/featureStoreResources';
 import { retryableBefore, wasSetupPerformed } from '../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../utils/uuidGenerator';
 import { isRHOAI } from '../../../utils/oc_commands/applications';
 import { ensureAdminOcSession } from '../../../utils/oc_commands/baseCommands';
+import { createRegistryStep, deleteFeastRegistryFiles } from '../../../utils/oc_commands/s3Cleanup';
 import { projectDetails, projectListPage } from '../../../pages/projects';
 import { workbenchPage, createSpawnerPage } from '../../../pages/workbench';
 import { NotebookStatusLabel } from '../../../types';
@@ -57,10 +65,27 @@ describe('Verify user can connect Feature Stores to Workbenches', () => {
         .then(() => {
           cy.step(`Create Feature Store namespace: ${fsProjectName}`);
           createCleanProject(fsProjectName);
+
+          return cy.exec('oc whoami', { failOnNonZeroExit: false }).then((whoami) => {
+            const ocUser = whoami.stdout.trim();
+            if (ocUser) {
+              return addUserToProject(fsProjectName, ocUser, 'admin').then(() =>
+                addUserToProject(fsProjectName, LDAP_ADMIN_USER.USERNAME, 'admin'),
+              );
+            }
+            return addUserToProject(fsProjectName, LDAP_ADMIN_USER.USERNAME, 'admin');
+          });
         })
         .then(() => {
           cy.step(`Apply FeatureStore CR in namespace: ${fsProjectName}`);
+          createRegistryStep(fsProjectName);
           createFeatureStoreCR(fsProjectName, testData.feastInstanceName);
+        })
+        .then(() => {
+          return applyFeastPermissionViaSdk(fsProjectName, testData.feastInstanceName, {
+            name: 'feast-auth',
+            namespaces: [fsProjectName],
+          });
         })
         .then(() => {
           cy.step(`Create Data Science Project namespace: ${dspProjectName}`);
@@ -79,6 +104,9 @@ describe('Verify user can connect Feature Stores to Workbenches', () => {
     }
     cy.step('Restore admin oc session for cleanup');
     ensureAdminOcSession();
+
+    cy.step(`Removing S3 registry files for: ${fsProjectName}`);
+    deleteFeastRegistryFiles(fsProjectName);
 
     cy.step(`Delete Data Science Project: ${dspProjectName}`);
     deleteOpenShiftProject(dspProjectName, { wait: false, ignoreNotFound: true });

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -629,6 +629,8 @@ export type FeatureStoreTestData = {
   feastInstanceName: string;
   feastCreditScoringProject: string;
   feastDriverRankingProject: string;
+  datasetName: string;
+  featureServiceName: string;
   dspProjectName: string;
   workbenchName: string;
   sectionTab: string;

--- a/packages/cypress/cypress/utils/api/featureStoreRest.ts
+++ b/packages/cypress/cypress/utils/api/featureStoreRest.ts
@@ -1,18 +1,46 @@
 /**
+ * Gets the OpenShift Bearer token from the current oc session.
+ * Required for Feast REST API calls when Kubernetes auth is enabled.
+ *
+ * @returns {Cypress.Chainable<string>} The Bearer token
+ */
+export const getOCToken = (): Cypress.Chainable<string> => {
+  return cy.exec('oc whoami -t', { failOnNonZeroExit: false, log: false }).then((result) => {
+    if (!result.stdout.trim()) {
+      throw new Error(`Failed to get OC token: ${result.stderr}`);
+    }
+    return cy.wrap(result.stdout.trim(), { log: false });
+  });
+};
+
+/**
+ * Builds the authorization headers for Feast REST API requests.
+ */
+const authHeaders = (token: string): Record<string, string> => ({
+  accept: 'application/json',
+  Authorization: `Bearer ${token}`,
+});
+
+/**
  * Gets entity count and returns it
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The entity count
  */
-export const getEntityCount = (routeUrl: string, project: string): Cypress.Chainable<number> => {
+export const getEntityCount = (
+  routeUrl: string,
+  project: string,
+  token: string,
+): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/entities?project=${project}&allow_cache=true&include_relationships=false`;
 
   return cy
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -21,25 +49,30 @@ export const getEntityCount = (routeUrl: string, project: string): Cypress.Chain
       }
       const count = response.body.entities.length;
       cy.log(`Entity count: ${count}`);
-      return cy.wrap<number>(count); // Wrap the return value with proper typing
+      return cy.wrap<number>(count);
     });
 };
 
 /**
- * Gets feature count  and returns it
+ * Gets feature count and returns it
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The feature count
  */
-export const getFeatureCount = (routeUrl: string, project: string): Cypress.Chainable<number> => {
+export const getFeatureCount = (
+  routeUrl: string,
+  project: string,
+  token: string,
+): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/features?project=${project}&include_relationships=false&allow_cache=true`;
 
   return cy
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -48,7 +81,7 @@ export const getFeatureCount = (routeUrl: string, project: string): Cypress.Chai
       }
       const count = response.body.features.length;
       cy.log(`Feature count: ${count}`);
-      return cy.wrap<number>(count); // Wrap the return value with proper typing
+      return cy.wrap<number>(count);
     });
 };
 
@@ -57,11 +90,13 @@ export const getFeatureCount = (routeUrl: string, project: string): Cypress.Chai
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The feature view count
  */
 export const getFeatureViewCount = (
   routeUrl: string,
   project: string,
+  token: string,
 ): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/feature_views?project=${project}&allow_cache=true&include_relationships=false`;
 
@@ -69,7 +104,7 @@ export const getFeatureViewCount = (
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -87,11 +122,13 @@ export const getFeatureViewCount = (
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The feature service count
  */
 export const getFeatureServicesCount = (
   routeUrl: string,
   project: string,
+  token: string,
 ): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/feature_services?project=${project}&include_relationships=false&allow_cache=true`;
 
@@ -99,7 +136,7 @@ export const getFeatureServicesCount = (
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -117,11 +154,13 @@ export const getFeatureServicesCount = (
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The data source count
  */
 export const getDataSourceCount = (
   routeUrl: string,
   project: string,
+  token: string,
 ): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/data_sources?project=${project}&include_relationships=false&allow_cache=true`;
 
@@ -129,7 +168,7 @@ export const getDataSourceCount = (
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -147,16 +186,21 @@ export const getDataSourceCount = (
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The saved dataset count
  */
-export const getDatasetsCount = (routeUrl: string, project: string): Cypress.Chainable<number> => {
+export const getDatasetsCount = (
+  routeUrl: string,
+  project: string,
+  token: string,
+): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/saved_datasets?project=${project}&allow_cache=true&include_relationships=false`;
 
   return cy
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -169,55 +213,109 @@ export const getDatasetsCount = (routeUrl: string, project: string): Cypress.Cha
     });
 };
 
-/**
- * Fetches resource counts from the metrics endpoint (same source the dashboard overview cards use)
- *
- * @param {string} routeUrl - The Feature Store route URL
- * @param {string} project - The project name
- * @returns {Cypress.Chainable<object>} Object containing all counts from the metrics endpoint
- */
-export const getMetricsResourceCounts = (
-  routeUrl: string,
-  project: string,
-): Cypress.Chainable<{
+type MetricsCounts = {
   featureCount: number;
   entityCount: number;
   datasetCount: number;
   dataSourceCount: number;
   featureViewCount: number;
   featureServiceCount: number;
-}> => {
+};
+
+/**
+ * Fetches resource counts from the metrics endpoint (same source the dashboard overview cards use).
+ * Retries when entity count is zero to allow the registry cache to propagate after feast apply.
+ *
+ * @param {string} routeUrl - The Feature Store route URL
+ * @param {string} project - The project name
+ * @returns {Cypress.Chainable<MetricsCounts>} Object containing all counts from the metrics endpoint
+ */
+export const getMetricsResourceCounts = (
+  routeUrl: string,
+  project: string,
+): Cypress.Chainable<MetricsCounts> => {
   const apiUrl = `${routeUrl}/api/v1/metrics/resource_counts?project=${encodeURIComponent(
     project,
   )}`;
 
-  return cy
-    .request({
-      method: 'GET',
-      url: apiUrl,
-      headers: { accept: 'application/json' },
-      failOnStatusCode: false,
-    })
-    .then((response) => {
-      if (response.status !== 200 || !response.body || !('counts' in response.body)) {
-        throw new Error(`Failed to get metrics resource counts: ${response.status}`);
-      }
-      const { counts } = response.body;
-      if (typeof counts.features !== 'number' || typeof counts.entities !== 'number') {
-        throw new Error(`Unexpected metrics response shape: ${JSON.stringify(counts)}`);
-      }
-      const allCounts = {
-        featureCount: counts.features,
-        entityCount: counts.entities,
-        datasetCount: counts.savedDatasets,
-        dataSourceCount: counts.dataSources,
-        featureViewCount: counts.featureViews,
-        featureServiceCount: counts.featureServices,
-      };
+  const fetchOnce = (token: string): Cypress.Chainable<MetricsCounts> =>
+    cy
+      .request({
+        method: 'GET',
+        url: apiUrl,
+        headers: authHeaders(token),
+        failOnStatusCode: false,
+      })
+      .then((response) => {
+        if (response.status !== 200 || !response.body || !('counts' in response.body)) {
+          throw new Error(`Failed to get metrics resource counts: ${response.status}`);
+        }
+        const { counts } = response.body;
+        if (typeof counts.features !== 'number' || typeof counts.entities !== 'number') {
+          throw new Error(`Unexpected metrics response shape: ${JSON.stringify(counts)}`);
+        }
+        return cy.wrap<MetricsCounts>({
+          featureCount: counts.features,
+          entityCount: counts.entities,
+          datasetCount: counts.savedDatasets,
+          dataSourceCount: counts.dataSources,
+          featureViewCount: counts.featureViews,
+          featureServiceCount: counts.featureServices,
+        });
+      });
 
-      cy.log(`Metrics resource counts fetched: ${JSON.stringify(allCounts)}`);
-      return cy.wrap(allCounts);
-    });
+  return getOCToken().then((token) => {
+    const poll = (attempt: number, maxAttempts: number): Cypress.Chainable<MetricsCounts> =>
+      fetchOnce(token).then((counts) => {
+        if (counts.entityCount === 0 && attempt < maxAttempts) {
+          cy.log(
+            `Metrics entity count still 0; retry ${attempt}/${maxAttempts} (cache propagation)`,
+          );
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          return cy.wait(2000).then(() => poll(attempt + 1, maxAttempts));
+        }
+        cy.log(`Metrics resource counts fetched: ${JSON.stringify(counts)}`);
+        return cy.wrap(counts);
+      });
+
+    return poll(1, 5);
+  });
+};
+
+/**
+ * Features are derived from feature views. Right after registry apply the
+ * registry-rest cache can return feature views without schemas, so /features is
+ * empty while /feature_views is not. Retry until the two agree or attempts run out.
+ */
+const fetchFeatureCountWithRetry = (
+  routeUrl: string,
+  project: string,
+  token: string,
+  featureViewCount: number,
+  attempt = 1,
+  maxAttempts = 5,
+): Cypress.Chainable<number> => {
+  return getFeatureCount(routeUrl, project, token).then((featuresCount) => {
+    if (featuresCount === 0 && featureViewCount > 0 && attempt < maxAttempts) {
+      cy.log(
+        `Feature count still 0 with ${featureViewCount} feature views; retry ${attempt}/${maxAttempts}`,
+      );
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      return cy
+        .wait(1000)
+        .then(() =>
+          fetchFeatureCountWithRetry(
+            routeUrl,
+            project,
+            token,
+            featureViewCount,
+            attempt + 1,
+            maxAttempts,
+          ),
+        );
+    }
+    return cy.wrap(featuresCount);
+  });
 };
 
 /**
@@ -237,27 +335,33 @@ export const getAllFeatureStoreCounts = (
   featureViewCount: number;
   featureServiceCount: number;
 }> => {
-  return getFeatureCount(routeUrl, project).then((featuresCount) => {
-    return getEntityCount(routeUrl, project).then((entitiesCount) => {
-      return getDatasetsCount(routeUrl, project).then((datasetsCount) => {
-        return getDataSourceCount(routeUrl, project).then((dataSourcesCount) => {
-          return getFeatureViewCount(routeUrl, project).then((featureViewsCount) => {
-            return getFeatureServicesCount(routeUrl, project).then((featureServicesCount) => {
-              const allCounts = {
-                featureCount: featuresCount,
-                entityCount: entitiesCount,
-                datasetCount: datasetsCount,
-                dataSourceCount: dataSourcesCount,
-                featureViewCount: featureViewsCount,
-                featureServiceCount: featureServicesCount,
-              };
+  return getOCToken().then((token) => {
+    return getFeatureViewCount(routeUrl, project, token).then((featureViewsCount) => {
+      return fetchFeatureCountWithRetry(routeUrl, project, token, featureViewsCount).then(
+        (featuresCount) => {
+          return getEntityCount(routeUrl, project, token).then((entitiesCount) => {
+            return getDatasetsCount(routeUrl, project, token).then((datasetsCount) => {
+              return getDataSourceCount(routeUrl, project, token).then((dataSourcesCount) => {
+                return getFeatureServicesCount(routeUrl, project, token).then(
+                  (featureServicesCount) => {
+                    const allCounts = {
+                      featureCount: featuresCount,
+                      entityCount: entitiesCount,
+                      datasetCount: datasetsCount,
+                      dataSourceCount: dataSourcesCount,
+                      featureViewCount: featureViewsCount,
+                      featureServiceCount: featureServicesCount,
+                    };
 
-              cy.log('All Feature Store counts fetched:', allCounts);
-              return cy.wrap(allCounts);
+                    cy.log('All Feature Store counts fetched:', allCounts);
+                    return cy.wrap(allCounts);
+                  },
+                );
+              });
             });
           });
-        });
-      });
+        },
+      );
     });
   });
 };

--- a/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
+++ b/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
@@ -3,6 +3,322 @@ import { AWS_BUCKETS } from '../s3Buckets';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
 
 /**
+ * Resolves the Feast Deployment name in the namespace for a given FeatureStore instance.
+ * Prefers `feast-<instance>` then `feast-<instance>-registry`.
+ */
+const resolveFeastDeployment = (
+  namespace: string,
+  feastInstanceName: string,
+): Cypress.Chainable<string> => {
+  const labelCmd = `oc get deploy -n ${namespace} -l app.kubernetes.io/managed-by=feast,app.kubernetes.io/instance=${feastInstanceName} -o jsonpath='{.items[0].metadata.name}'`;
+  return cy.exec(labelCmd, { failOnNonZeroExit: false, timeout: 30000 }).then((labelResult) => {
+    const labelName = labelResult.stdout.trim().replace(/^'|'$/g, '');
+    if (labelName) {
+      return cy.wrap(labelName);
+    }
+
+    const grepCmd = `oc get deploy -n ${namespace} -o custom-columns="NAME:.metadata.name" --no-headers | grep -i "${feastInstanceName}"`;
+    return cy.exec(grepCmd, { failOnNonZeroExit: false, timeout: 30000 }).then((grepResult) => {
+      const deploys = grepResult.stdout.trim().split('\n').filter(Boolean);
+      const registryDeploy = deploys.find((d) => d.includes('registry')) ?? deploys[0];
+      if (!registryDeploy) {
+        throw new Error(
+          `No Feast deployment found for instance=${feastInstanceName} in ${namespace}. ` +
+            `Label query returned: ${labelResult.stderr}`,
+        );
+      }
+      return cy.wrap(registryDeploy);
+    });
+  });
+};
+
+/**
+ * Resolves a container on the Feast Deployment. Prefers `registry`, then `online`, else first.
+ */
+const resolveFeastContainer = (
+  namespace: string,
+  deployName: string,
+): Cypress.Chainable<string> => {
+  const cmd = `oc get deploy/${deployName} -n ${namespace} -o jsonpath='{.spec.template.spec.containers[*].name}'`;
+  return cy.exec(cmd, { failOnNonZeroExit: false, timeout: 30000 }).then((result) => {
+    const containers = result.stdout.trim().replace(/^'|'$/g, '').split(/\s+/).filter(Boolean);
+    if (containers.length === 0) {
+      throw new Error(`No containers found on deploy/${deployName} in ${namespace}`);
+    }
+    const container =
+      containers.find((c) => c.includes('registry')) ??
+      containers.find((c) => c.includes('online')) ??
+      containers[0];
+    return cy.wrap(container);
+  });
+};
+
+/**
+ * Runs a Python script inside the Feast Deployment via:
+ * `cat script.py | oc exec -i -n <ns> deploy/<name> -c <container> -- python -`
+ *
+ * @param successMarker Substring that must appear in stdout for success
+ */
+const runPythonInFeastDeploy = (
+  namespace: string,
+  feastInstanceName: string,
+  pythonScript: string,
+  successMarker: string,
+): Cypress.Chainable<string> => {
+  return resolveFeastDeployment(namespace, feastInstanceName).then((deployName) => {
+    return resolveFeastContainer(namespace, deployName).then((container) => {
+      const tmpFile = `/tmp/cypress-feast-script-${Date.now()}.py`;
+
+      return cy.writeFile(tmpFile, pythonScript).then(() => {
+        const cmd =
+          `cat ${tmpFile} | oc exec -i -n ${namespace} deploy/${deployName} -c ${container} -- ` +
+          `sh -c "cd /feast-data/credit_scoring_local/feature_repo && python -"; ` +
+          `rm -f ${tmpFile}`;
+
+        return cy.exec(cmd, { failOnNonZeroExit: false, timeout: 300000 }).then((result) => {
+          const output = `${result.stdout}\n${result.stderr}`;
+          if (result.exitCode !== 0 || !output.includes(successMarker)) {
+            throw new Error(
+              `Python script failed on deploy/${deployName}: exit=${result.exitCode}\n${output}`,
+            );
+          }
+          cy.log(`Script succeeded (marker: ${successMarker})`);
+          return cy.wrap(output);
+        });
+      });
+    });
+  });
+};
+
+export type ApplyFeastPermissionViaSdkOptions = {
+  name?: string;
+  namespaces: string[];
+};
+
+/**
+ * Writes `permission.py` into the Feast registry feature repo, then applies the feature
+ * repo to the registry without DynamoDB infra updates.
+ *
+ * Target directory (registry container):
+ *   /feast-data/credit_scoring_local/feature_repo
+ *
+ * Full `feast apply` is avoided because shared DynamoDB tables hit TagResource
+ * LimitExceededException under concurrent applies. Registry-only apply still loads
+ * entities / feature views / services / permissions into the S3 registry.
+ */
+export const applyFeastPermissionViaSdk = (
+  namespace: string,
+  feastInstanceName: string,
+  options: ApplyFeastPermissionViaSdkOptions,
+): Cypress.Chainable<string> => {
+  const permissionName = options.name ?? 'feast-auth';
+  const namespacesLiteral = JSON.stringify(options.namespaces);
+  const featureRepoDir = '/feast-data/credit_scoring_local/feature_repo';
+
+  const permissionPy = `
+from feast.permissions.permission import Permission
+from feast.permissions.action import READ, AuthzedAction
+from feast.permissions.policy import NamespaceBasedPolicy
+from feast.feast_object import ALL_RESOURCE_TYPES
+
+${permissionName.replace(/-/g, '_')} = Permission(
+    name=${JSON.stringify(permissionName)},
+    types=ALL_RESOURCE_TYPES,
+    policy=NamespaceBasedPolicy(namespaces=${namespacesLiteral}),
+    actions=[AuthzedAction.DESCRIBE] + READ,
+)
+`.trim();
+
+  // Registry-only apply: same objects as feast apply, but skip online-store TagResource
+  const applyPy = `
+from pathlib import Path
+from feast import FeatureStore
+from feast.repo_operations import parse_repo, extract_objects_for_apply_delete
+
+store = FeatureStore(repo_path=".")
+# Skip DynamoDB / online-store infra updates (avoids TagResource LimitExceededException)
+store._get_provider().update_infra = lambda *args, **kwargs: None
+if hasattr(store, "_should_use_plan"):
+    store._should_use_plan = lambda: False
+
+repo = parse_repo(Path("."))
+all_to_apply, all_to_delete, _, _ = extract_objects_for_apply_delete(
+    store.project, store.registry, repo
+)
+store.apply(
+    all_to_apply,
+    objects_to_delete=all_to_delete,
+    partial=False,
+    skip_feature_view_validation=True,
+)
+print("REGISTRY_ONLY_APPLY_OK")
+print("APPLIED_PERMISSION:${permissionName}")
+`.trim();
+
+  const permissionTmpFile = `/tmp/cypress-feast-permission-${Date.now()}.py`;
+  const applyTmpFile = `/tmp/cypress-feast-registry-apply-${Date.now()}.py`;
+
+  cy.step(
+    `Write ${featureRepoDir}/permission.py and registry-only apply (ns=${namespace}, instance=${feastInstanceName})`,
+  );
+
+  return resolveFeastDeployment(namespace, feastInstanceName).then((deployName) => {
+    return resolveFeastContainer(namespace, deployName).then((container) => {
+      return cy.writeFile(permissionTmpFile, permissionPy).then(() => {
+        return cy.writeFile(applyTmpFile, applyPy).then(() => {
+          const writeCmd =
+            `cat ${permissionTmpFile} | oc exec -i -n ${namespace} deploy/${deployName} -c ${container} -- ` +
+            `tee ${featureRepoDir}/permission.py > /dev/null && ` +
+            `oc exec -n ${namespace} deploy/${deployName} -c ${container} -- ` +
+            `ls -la ${featureRepoDir}/permission.py ${featureRepoDir}/feature_definitions.py && ` +
+            `rm -f ${permissionTmpFile}`;
+
+          return cy
+            .exec(writeCmd, { failOnNonZeroExit: false, timeout: 120000, log: false })
+            .then((writeResult) => {
+              if (writeResult.exitCode !== 0) {
+                throw new Error(
+                  `Failed to write permission.py into ${featureRepoDir}: ${
+                    writeResult.stderr || writeResult.stdout
+                  }`,
+                );
+              }
+              cy.log(`Wrote permission.py into registry feature repo:\n${writeResult.stdout}`);
+
+              // Pipe apply script into the pod (skips DynamoDB TagResource via update_infra no-op).
+              // Use `apply_rc` (not `status`) — zsh treats `status` as read-only.
+              const pipedApplyCmd =
+                `cat ${applyTmpFile} | oc exec -i -n ${namespace} deploy/${deployName} -c ${container} -- ` +
+                `sh -c "cd ${featureRepoDir} && python -"; apply_rc=$?; ` +
+                `rm -f ${applyTmpFile}; ` +
+                `if [ "$apply_rc" -eq 0 ]; then echo "REGISTRY_APPLY_OK"; fi; ` +
+                `exit "$apply_rc"`;
+
+              return cy
+                .exec(pipedApplyCmd, { failOnNonZeroExit: false, timeout: 300000 })
+                .then((applyResult) => {
+                  const output = `${applyResult.stdout}\n${applyResult.stderr}`;
+                  cy.log(output);
+
+                  const applySucceeded =
+                    applyResult.exitCode === 0 &&
+                    (output.includes('REGISTRY_APPLY_OK') ||
+                      output.includes('REGISTRY_ONLY_APPLY_OK'));
+
+                  if (applySucceeded) {
+                    cy.log(`Registry-only apply succeeded for permission ${permissionName}`);
+                    return cy.wrap(permissionName);
+                  }
+
+                  throw new Error(`Registry-only apply failed on deploy/${deployName}: ${output}`);
+                });
+            });
+        });
+      });
+    });
+  });
+};
+
+export type CreateSavedDatasetViaSdkOptions = {
+  name: string;
+  project: string;
+  storagePath: string;
+  featureServiceName?: string;
+};
+
+/**
+ * Registers a saved dataset via the Feast Python SDK inside the Feast pod.
+ * Uses `registry.apply_saved_dataset` (metadata register) — works when REST POST
+ * `/saved_datasets` is unavailable (405 on older Feast builds).
+ */
+export const createSavedDatasetViaSdk = (
+  namespace: string,
+  feastInstanceName: string,
+  options: CreateSavedDatasetViaSdkOptions,
+): Cypress.Chainable<string> => {
+  const pythonScript = `
+from feast import FeatureStore
+try:
+    from feast import SavedDataset
+except ImportError:
+    from feast.saved_dataset import SavedDataset
+from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
+import inspect
+
+store = FeatureStore(repo_path=".")
+kwargs = dict(
+    name=${JSON.stringify(options.name)},
+    features=[],
+    join_keys=[],
+    storage=SavedDatasetFileStorage(path=${JSON.stringify(options.storagePath)}),
+)
+${
+  options.featureServiceName
+    ? `if "feature_service" in inspect.signature(SavedDataset.__init__).parameters:\n    kwargs["feature_service"] = store.get_feature_service(${JSON.stringify(
+        options.featureServiceName,
+      )})`
+    : ''
+}
+ds = SavedDataset(**kwargs)
+store.registry.apply_saved_dataset(ds, ${JSON.stringify(options.project)}, commit=True)
+print("CREATED_SAVED_DATASET:" + ds.name)
+`.trim();
+
+  cy.step(
+    `Create saved dataset via SDK on Feast deploy (ns=${namespace}, instance=${feastInstanceName})`,
+  );
+
+  return runPythonInFeastDeploy(
+    namespace,
+    feastInstanceName,
+    pythonScript,
+    'CREATED_SAVED_DATASET:',
+  ).then(() => {
+    cy.log(`Created saved dataset via SDK: ${options.name}`);
+    return cy.wrap(options.name);
+  });
+};
+
+const FEAST_OPERATOR_NS = 'redhat-ods-applications';
+const FEAST_OPERATOR_DEPLOY = 'feast-operator-controller-manager';
+
+/**
+ * Fail fast when the Feast operator cannot reconcile FeatureStore CRs.
+ * Without a Ready controller, Registry never becomes True (~8 min poll).
+ */
+const assertFeastOperatorReady = (): Cypress.Chainable => {
+  cy.step('Check Feast operator is Ready');
+  return cy
+    .exec(
+      `oc get deploy/${FEAST_OPERATOR_DEPLOY} -n ${FEAST_OPERATOR_NS} -o jsonpath='{.status.readyReplicas}'`,
+      { failOnNonZeroExit: false, timeout: 30000 },
+    )
+    .then((result) => {
+      const readyReplicas = parseInt(result.stdout.trim(), 10) || 0;
+      if (readyReplicas >= 1) {
+        return;
+      }
+
+      return cy
+        .exec(
+          `oc get pods -n ${FEAST_OPERATOR_NS} -l app.kubernetes.io/name=feast-operator ` +
+            `-o jsonpath='{range .items[*]}{.metadata.name}{" phase="}{.status.phase}` +
+            `{" ready="}{.status.containerStatuses[0].ready}` +
+            `{" state="}{.status.containerStatuses[0].state}{"\\n"}{end}'`,
+          { failOnNonZeroExit: false, timeout: 30000 },
+        )
+        .then((podResult) => {
+          throw new Error(
+            `Feast operator deploy/${FEAST_OPERATOR_DEPLOY} is not Ready ` +
+              `(readyReplicas=${result.stdout.trim() || '0'}). ` +
+              `FeatureStore Registry will never become True until the operator recovers.\n` +
+              `${podResult.stdout || podResult.stderr}`,
+          );
+        });
+    });
+};
+
+/**
  * Creates Feature Store custom resource by applying a YAML template.
  * This function dynamically replaces placeholders in the template with actual values and applies it.
  *
@@ -10,11 +326,18 @@ import { maskSensitiveInfo } from '../maskSensitiveInfo';
  */
 export const createFeatureStoreCR = (namespace: string, feastInstanceName: string): void => {
   cy.fixture('resources/yaml/feast.yaml').then((yamlTemplate) => {
+    const buckets = (Cypress.env('AWS_PIPELINES') as typeof AWS_BUCKETS | undefined) ?? AWS_BUCKETS;
     const {
       AWS_ACCESS_KEY_ID: awsAccessKey,
       AWS_SECRET_ACCESS_KEY: awsSecretKey,
       BUCKET_1: { NAME: awsBucketName, REGION: awsDefaultRegion },
-    } = AWS_BUCKETS;
+    } = buckets;
+
+    if (!awsBucketName) {
+      throw new Error(
+        'AWS_PIPELINES.BUCKET_1.NAME is empty. Export CY_TEST_CONFIG to packages/cypress/test-variables.yml before running E2E.',
+      );
+    }
 
     const variables: Record<string, string> = {
       awsAccessKey,
@@ -29,6 +352,7 @@ export const createFeatureStoreCR = (namespace: string, feastInstanceName: strin
       (content, [key, value]) => content.replace(new RegExp(`\\$\\{${key}\\}`, 'g'), value),
       yamlTemplate,
     );
+    assertFeastOperatorReady();
     // Apply the modified YAML
     applyOpenShiftYaml(yamlContent);
     //wait for the feature store cr to be created

--- a/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
+++ b/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
@@ -1,3 +1,4 @@
+import type { AWSS3Buckets } from '../../types';
 import { AWS_BUCKETS } from '../s3Buckets';
 
 /** Shell-escape a value by wrapping in single quotes (handles embedded quotes). */
@@ -43,6 +44,107 @@ export const deleteS3TestFiles = (
       `-- s3 rm ${shQuote(`s3://${bucketConfig.NAME}/`)} --recursive ` +
       `--endpoint-url ${shQuote(bucketConfig.ENDPOINT)} ` +
       `--exclude '*' --include '${prefix}'`,
+    { failOnNonZeroExit: false, log: false, timeout: 120000 },
+  );
+};
+
+const assertValidNamespace = (namespace: string): void => {
+  if (!/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(namespace)) {
+    throw new Error(
+      `Invalid namespace: ${namespace}. Must be a valid DNS label (lowercase alphanumeric and hyphens).`,
+    );
+  }
+};
+
+/** Prefer live Cypress.env — module-level Cypress.env can be empty at import. */
+const getAwsPipelines = (): AWSS3Buckets =>
+  (Cypress.env('AWS_PIPELINES') as AWSS3Buckets | undefined) ?? AWS_BUCKETS;
+
+const requireBucket1 = (): AWSS3Buckets => {
+  const buckets = getAwsPipelines();
+  if (!buckets.BUCKET_1.NAME) {
+    throw new Error(
+      'AWS_PIPELINES.BUCKET_1.NAME is empty. Export CY_TEST_CONFIG to packages/cypress/test-variables.yml (S3.BUCKET_1) before running E2E.',
+    );
+  }
+  return buckets;
+};
+
+const endpointArg = (endpoint: string): string =>
+  endpoint ? `--endpoint-url ${shQuote(endpoint)}` : '';
+
+/**
+ * Creates an empty S3 prefix for the namespace-scoped Feast registry.
+ *
+ * Path: `s3://<bucket>/feast-test/<namespace>/credit_scoring_local/`
+ *
+ * Does not seed registry.pb — the FeatureStore CR (`feast.yaml`) creates the
+ * registry object, and later test steps (e.g. saved dataset) write into it.
+ *
+ * Must run after the OpenShift project exists and before `createFeatureStoreCR`.
+ *
+ * @param namespace The test namespace (S3 path segment and pod namespace)
+ */
+export const createRegistryStep = (namespace: string): void => {
+  assertValidNamespace(namespace);
+
+  const buckets = requireBucket1();
+  const bucketConfig = buckets.BUCKET_1;
+  const podName = `feast-s3-create-${Date.now()}`;
+  const prefixKey = `feast-test/${namespace}/credit_scoring_local/`;
+
+  cy.step(`Create Feast registry folder: s3://${bucketConfig.NAME}/${prefixKey}`);
+  cy.exec(
+    `oc run ${podName} -n ${namespace} ` +
+      `--image=amazon/aws-cli:latest ` +
+      `--restart=Never --rm --attach --tty=false ` +
+      `--env=AWS_ACCESS_KEY_ID=${shQuote(buckets.AWS_ACCESS_KEY_ID)} ` +
+      `--env=AWS_SECRET_ACCESS_KEY=${shQuote(buckets.AWS_SECRET_ACCESS_KEY)} ` +
+      `--env=AWS_DEFAULT_REGION=${shQuote(bucketConfig.REGION)} ` +
+      `-- s3api put-object --bucket ${shQuote(bucketConfig.NAME)} --key ${shQuote(prefixKey)} ` +
+      `${endpointArg(bucketConfig.ENDPOINT)}`,
+    { failOnNonZeroExit: false, log: false, timeout: 120000 },
+  ).then((result) => {
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to create Feast registry folder s3://${bucketConfig.NAME}/${prefixKey}: ${
+          result.stderr || result.stdout
+        }`,
+      );
+    }
+    cy.log(`Created Feast registry folder s3://${bucketConfig.NAME}/${prefixKey}`);
+  });
+};
+
+/**
+ * Delete the Feast registry files for a given test namespace from S3.
+ *
+ * Removes `feast-test/<namespace>/` recursively from BUCKET_1.
+ * Must be called before `deleteOpenShiftProject` (pod runs in that namespace).
+ *
+ * @param namespace The test namespace (also used as the S3 path segment)
+ */
+export const deleteFeastRegistryFiles = (namespace: string): void => {
+  assertValidNamespace(namespace);
+
+  const buckets = getAwsPipelines();
+  if (!buckets.BUCKET_1.NAME) {
+    cy.log('Skipping Feast S3 cleanup: AWS_PIPELINES.BUCKET_1.NAME is empty');
+    return;
+  }
+  const bucketConfig = buckets.BUCKET_1;
+
+  const podName = `feast-s3-cleanup-${Date.now()}`;
+  const s3Path = `s3://${bucketConfig.NAME}/feast-test/${namespace}/`;
+
+  cy.exec(
+    `oc run ${podName} -n ${namespace} ` +
+      `--image=amazon/aws-cli:latest ` +
+      `--restart=Never --rm --attach --tty=false ` +
+      `--env=AWS_ACCESS_KEY_ID=${shQuote(buckets.AWS_ACCESS_KEY_ID)} ` +
+      `--env=AWS_SECRET_ACCESS_KEY=${shQuote(buckets.AWS_SECRET_ACCESS_KEY)} ` +
+      `--env=AWS_DEFAULT_REGION=${shQuote(bucketConfig.REGION)} ` +
+      `-- s3 rm ${shQuote(s3Path)} --recursive ${endpointArg(bucketConfig.ENDPOINT)}`,
     { failOnNonZeroExit: false, log: false, timeout: 120000 },
   );
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-84568


## Description

Ports the Feature Store Cypress E2E fix from 3.4 ([#9351](https://github.com/opendatahub-io/odh-dashboard/pull/9351)) into 3.5.

Feast now uses namespace-based auth, so the test needs proper setup before the UI can load counts. This PR adds:

- Admin RoleBindings for the `oc` user and dashboard login user
- Namespace-scoped S3 registry folder create/cleanup
- Permission + saved dataset setup via Feast SDK in-pod (registry-only apply)
- Bearer token auth on Feast REST count calls, with retry for cache propagation

3.5 still uses the metrics endpoint for overview cards, so we keep separate expected counts for metrics vs list pages.


## How Has This Been Tested?

Ran `testFeatureStoreFeatures.cy.ts` on RHOAI E2E cluster (`dash-e2e-rhoai`). Full flow passes: namespace setup, Feast CR, permission apply, saved dataset, overview metrics cards, and list page count checks.

## Test Impact

Changes are the tests themselves (Cypress E2E helpers + `testFeatureStoreFeatures.cy.ts`). No new unit tests — this is E2E infrastructure, same as the 3.4 PR.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)



After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
