### PR TITLE
fix(RHOAIENG-85200): correct gateway URL extraction for LLMInferenceService in GenAI Playground

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1140,9 +1140,11 @@ func ExtractStatusFromInferenceService(isvc *kservev1beta1.InferenceService) str
 	return "Stop"
 }
 
-// EnsureV1Suffix ensures that the URL ends with /v1 suffix
-// This function is exported for testing purposes
+// EnsureV1Suffix ensures that the URL ends with /v1 suffix.
+// Trailing slashes are stripped before checking/appending to avoid double-slash URLs.
+// This function is exported for testing purposes.
 func EnsureV1Suffix(url string) string {
+	url = strings.TrimRight(url, "/")
 	if !strings.HasSuffix(url, "/v1") {
 		return url + "/v1"
 	}
@@ -2552,18 +2554,54 @@ func (kc *TokenKubernetesClient) findLLMInferenceServiceByModelName(ctx context.
 	return nil, fmt.Errorf("LLMInferenceService with model name '%s' not found in namespace %s", modelName, namespace)
 }
 
+// gatewayInternalName is the address name used for internal gateway URLs with
+// path-based routing (e.g. /<namespace>/<model>/v1/...).
+const gatewayInternalName = "gateway-internal"
+
 // extractEndpointFromLLMInferenceService extracts the internal endpoint URL from LLMInferenceService
-// using the standard KServe status.addresses field. This replaces the previous workaround that
-// manually discovered K8s services and constructed URLs, which bypassed llm-d gateway routing.
+// using the standard KServe status.addresses field. It prefers "gateway-internal" named addresses
+// with path-based routing over "gateway-internal-model-routing" (root-only, header-based) entries.
+// Among gateway-internal addresses, it prefers the short /<namespace>/<model> path over the
+// /publishers/... form, since HTTPRoute rules match the short path for path-based routing.
 func (kc *TokenKubernetesClient) extractEndpointFromLLMInferenceService(_ context.Context, llmSvc *kservev1alpha1.LLMInferenceService) (string, error) {
+	var gatewayCandidate, anyInternalCandidate string
+
 	for _, addr := range llmSvc.Status.Addresses {
-		if addr.URL != nil && isInternalClusterHost(addr.URL.Host) {
-			u := addr.URL.String()
-			kc.Logger.Debug("extracted internal URL from LLMInferenceService status.addresses",
-				"llmServiceName", llmSvc.Name,
-				"endpoint", EnsureV1Suffix(u))
-			return EnsureV1Suffix(u), nil
+		if addr.URL == nil || !isInternalClusterHost(addr.URL.Host) {
+			continue
 		}
+
+		u := addr.URL.String()
+
+		if addr.Name != nil && *addr.Name == gatewayInternalName {
+			if !strings.HasPrefix(addr.URL.Path, "/publishers/") {
+				kc.Logger.Debug("extracted gateway-internal URL from LLMInferenceService status.addresses",
+					"llmServiceName", llmSvc.Name,
+					"endpoint", EnsureV1Suffix(u))
+				return EnsureV1Suffix(u), nil
+			}
+			if gatewayCandidate == "" {
+				gatewayCandidate = u
+			}
+		}
+
+		if anyInternalCandidate == "" {
+			anyInternalCandidate = u
+		}
+	}
+
+	if gatewayCandidate != "" {
+		kc.Logger.Debug("extracted gateway-internal (publishers path) URL from LLMInferenceService status.addresses",
+			"llmServiceName", llmSvc.Name,
+			"endpoint", EnsureV1Suffix(gatewayCandidate))
+		return EnsureV1Suffix(gatewayCandidate), nil
+	}
+
+	if anyInternalCandidate != "" {
+		kc.Logger.Debug("extracted internal URL from LLMInferenceService status.addresses (no gateway-internal name match)",
+			"llmServiceName", llmSvc.Name,
+			"endpoint", EnsureV1Suffix(anyInternalCandidate))
+		return EnsureV1Suffix(anyInternalCandidate), nil
 	}
 
 	if llmSvc.Status.Address != nil && llmSvc.Status.Address.URL != nil && isInternalClusterHost(llmSvc.Status.Address.URL.Host) {

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -2558,6 +2558,18 @@ func (kc *TokenKubernetesClient) findLLMInferenceServiceByModelName(ctx context.
 // path-based routing (e.g. /<namespace>/<model>/v1/...).
 const gatewayInternalName = "gateway-internal"
 
+// isShortModelPath returns true when the URL path has exactly two non-empty
+// segments: /<namespace>/<model>. Root-only ("/"), single-segment, and deeper
+// paths like /publishers/... are rejected, so only the expected path-based
+// routing form is selected as a first-choice candidate.
+func isShortModelPath(urlPath string) bool {
+	trimmed := strings.Trim(urlPath, "/")
+	if trimmed == "" {
+		return false
+	}
+	return len(strings.Split(trimmed, "/")) == 2
+}
+
 // extractEndpointFromLLMInferenceService extracts the internal endpoint URL from LLMInferenceService
 // using the standard KServe status.addresses field. It prefers "gateway-internal" named addresses
 // with path-based routing over "gateway-internal-model-routing" (root-only, header-based) entries.
@@ -2574,7 +2586,7 @@ func (kc *TokenKubernetesClient) extractEndpointFromLLMInferenceService(_ contex
 		u := addr.URL.String()
 
 		if addr.Name != nil && *addr.Name == gatewayInternalName {
-			if !strings.HasPrefix(addr.URL.Path, "/publishers/") {
+			if isShortModelPath(addr.URL.Path) {
 				kc.Logger.Debug("extracted gateway-internal URL from LLMInferenceService status.addresses",
 					"llmServiceName", llmSvc.Name,
 					"endpoint", EnsureV1Suffix(u))

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -2554,29 +2554,23 @@ func (kc *TokenKubernetesClient) findLLMInferenceServiceByModelName(ctx context.
 	return nil, fmt.Errorf("LLMInferenceService with model name '%s' not found in namespace %s", modelName, namespace)
 }
 
-// gatewayInternalName is the address name used for internal gateway URLs with
-// path-based routing (e.g. /<namespace>/<model>/v1/...).
-const gatewayInternalName = "gateway-internal"
-
-// isShortModelPath returns true when the URL path has exactly two non-empty
-// segments: /<namespace>/<model>. Root-only ("/"), single-segment, and deeper
-// paths like /publishers/... are rejected, so only the expected path-based
-// routing form is selected as a first-choice candidate.
-func isShortModelPath(urlPath string) bool {
-	trimmed := strings.Trim(urlPath, "/")
-	if trimmed == "" {
-		return false
-	}
-	return len(strings.Split(trimmed, "/")) == 2
-}
+// Address name types from the KServe LLMInferenceService status contract.
+// See: https://kserve.github.io/website/docs/next/model-serving/generative-inference/llmisvc/llmisvc-status#statusaddresses
+const (
+	addressNameGatewayInternal = "gateway-internal"
+	addressNameInternal        = "internal"
+)
 
 // extractEndpointFromLLMInferenceService extracts the internal endpoint URL from LLMInferenceService
-// using the standard KServe status.addresses field. It prefers "gateway-internal" named addresses
-// with path-based routing over "gateway-internal-model-routing" (root-only, header-based) entries.
-// Among gateway-internal addresses, it prefers the short /<namespace>/<model> path over the
-// /publishers/... form, since HTTPRoute rules match the short path for path-based routing.
+// using the standard KServe status.addresses field.
+//
+// Selection priority (per KServe status contract):
+//  1. First "gateway-internal" address (path-based routing, cluster-local gateway URL)
+//  2. First "internal" address (private IP / internal hostname, no gateway)
+//  3. First address with an internal cluster host (unnamed fallback)
+//  4. Singular status.address as last resort
 func (kc *TokenKubernetesClient) extractEndpointFromLLMInferenceService(_ context.Context, llmSvc *kservev1alpha1.LLMInferenceService) (string, error) {
-	var gatewayCandidate, anyInternalCandidate string
+	var internalCandidate, anyInternalCandidate string
 
 	for _, addr := range llmSvc.Status.Addresses {
 		if addr.URL == nil || !isInternalClusterHost(addr.URL.Host) {
@@ -2585,16 +2579,15 @@ func (kc *TokenKubernetesClient) extractEndpointFromLLMInferenceService(_ contex
 
 		u := addr.URL.String()
 
-		if addr.Name != nil && *addr.Name == gatewayInternalName {
-			if isShortModelPath(addr.URL.Path) {
-				kc.Logger.Debug("extracted gateway-internal URL from LLMInferenceService status.addresses",
-					"llmServiceName", llmSvc.Name,
-					"endpoint", EnsureV1Suffix(u))
-				return EnsureV1Suffix(u), nil
-			}
-			if gatewayCandidate == "" {
-				gatewayCandidate = u
-			}
+		if addr.Name != nil && *addr.Name == addressNameGatewayInternal {
+			kc.Logger.Debug("extracted gateway-internal URL from LLMInferenceService status.addresses",
+				"llmServiceName", llmSvc.Name,
+				"endpoint", EnsureV1Suffix(u))
+			return EnsureV1Suffix(u), nil
+		}
+
+		if addr.Name != nil && *addr.Name == addressNameInternal && internalCandidate == "" {
+			internalCandidate = u
 		}
 
 		if anyInternalCandidate == "" {
@@ -2602,15 +2595,15 @@ func (kc *TokenKubernetesClient) extractEndpointFromLLMInferenceService(_ contex
 		}
 	}
 
-	if gatewayCandidate != "" {
-		kc.Logger.Debug("extracted gateway-internal (publishers path) URL from LLMInferenceService status.addresses",
+	if internalCandidate != "" {
+		kc.Logger.Debug("extracted internal URL from LLMInferenceService status.addresses",
 			"llmServiceName", llmSvc.Name,
-			"endpoint", EnsureV1Suffix(gatewayCandidate))
-		return EnsureV1Suffix(gatewayCandidate), nil
+			"endpoint", EnsureV1Suffix(internalCandidate))
+		return EnsureV1Suffix(internalCandidate), nil
 	}
 
 	if anyInternalCandidate != "" {
-		kc.Logger.Debug("extracted internal URL from LLMInferenceService status.addresses (no gateway-internal name match)",
+		kc.Logger.Debug("extracted internal URL from LLMInferenceService status.addresses (fallback)",
 			"llmServiceName", llmSvc.Name,
 			"endpoint", EnsureV1Suffix(anyInternalCandidate))
 		return EnsureV1Suffix(anyInternalCandidate), nil

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -586,6 +586,42 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 		assert.Equal(t, "https://gw.openshift-ingress.svc.cluster.local/publishers/ns/models/model/v1", endpoint)
 	})
 
+	t.Run("root-only gateway-internal before valid short-path gateway-internal skips root", func(t *testing.T) {
+		gwInternal := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &gwInternal, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/")},
+						{Name: &gwInternal, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/myns/mymodel")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://gw.openshift-ingress.svc.cluster.local/myns/mymodel/v1", endpoint,
+			"root-only gateway-internal must not be selected; should pick the /<ns>/<model> address")
+	})
+
+	t.Run("single-segment gateway-internal path is not treated as short model path", func(t *testing.T) {
+		gwInternal := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &gwInternal, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/something")},
+						{Name: &gwInternal, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/myns/mymodel")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://gw.openshift-ingress.svc.cluster.local/myns/mymodel/v1", endpoint,
+			"single-segment path should not be treated as /<ns>/<model>")
+	})
+
 	t.Run("falls back to any internal address when no gateway-internal name match", func(t *testing.T) {
 		llmSvc := &kservev1alpha1.LLMInferenceService{
 			Status: kservev1alpha1.LLMInferenceServiceStatus{
@@ -601,6 +637,26 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 		assert.Equal(t, "https://tinyllama-kserve-workload-svc.kserve-test.svc.cluster.local/v1", endpoint,
 			"backward-compatible: addresses without Name field still work")
 	})
+}
+
+func TestIsShortModelPath(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{"/", false},
+		{"", false},
+		{"/ns", false},
+		{"/ns/model", true},
+		{"/ns/model/", true},
+		{"/ns/model/extra", false},
+		{"/publishers/ns/models/m", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isShortModelPath(tt.path))
+		})
+	}
 }
 
 // TestInferenceServiceURLSuffixConstruction tests that InferenceService URLs

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -490,6 +490,117 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "has no internal URL")
 	})
+
+	t.Run("prefers gateway-internal over gateway-internal-model-routing", func(t *testing.T) {
+		modelRoutingName := "gateway-internal-model-routing"
+		gatewayInternalName := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &modelRoutingName, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/")},
+						{Name: &gatewayInternalName, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/myns/mymodel")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/myns/mymodel/v1", endpoint,
+			"should pick gateway-internal with path, not gateway-internal-model-routing root URL")
+	})
+
+	t.Run("prefers short path over publishers path among gateway-internal addresses", func(t *testing.T) {
+		gatewayInternalName := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &gatewayInternalName, URL: mustParseURL("https://gw.openshift-ingress.svc.cluster.local/publishers/myns/models/mymodel")},
+						{Name: &gatewayInternalName, URL: mustParseURL("https://gw.openshift-ingress.svc.cluster.local/myns/mymodel")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://gw.openshift-ingress.svc.cluster.local/myns/mymodel/v1", endpoint,
+			"should prefer the short /<ns>/<model> path over /publishers/... path")
+	})
+
+	t.Run("realistic openshift-ai-inference gateway addresses", func(t *testing.T) {
+		externalModelRouting := "gateway-external-model-routing"
+		externalName := "gateway-external"
+		internalModelRouting := "gateway-internal-model-routing"
+		internalName := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &externalModelRouting, URL: mustParseURL("http://a7aba.elb.amazonaws.com/")},
+						{Name: &externalName, URL: mustParseURL("http://a7aba.elb.amazonaws.com/publishers/repro-85200/models/llama-32-1b-instruct")},
+						{Name: &externalName, URL: mustParseURL("http://a7aba.elb.amazonaws.com/repro-85200/llama-32-1b-instruct")},
+						{Name: &internalModelRouting, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/")},
+						{Name: &internalName, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/publishers/repro-85200/models/llama-32-1b-instruct")},
+						{Name: &internalName, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/repro-85200/llama-32-1b-instruct")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/repro-85200/llama-32-1b-instruct/v1", endpoint,
+			"should select the gateway-internal address with /<ns>/<model> path, not root or publishers")
+	})
+
+	t.Run("trailing slash on gateway root URL does not produce double-slash", func(t *testing.T) {
+		modelRoutingName := "gateway-internal-model-routing"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &modelRoutingName, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://gw.openshift-ingress.svc.cluster.local/v1", endpoint,
+			"should not produce //v1 from trailing slash")
+	})
+
+	t.Run("falls back to publishers path when no short path available", func(t *testing.T) {
+		gatewayInternalName := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &gatewayInternalName, URL: mustParseURL("https://gw.openshift-ingress.svc.cluster.local/publishers/ns/models/model")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://gw.openshift-ingress.svc.cluster.local/publishers/ns/models/model/v1", endpoint)
+	})
+
+	t.Run("falls back to any internal address when no gateway-internal name match", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: mustParseURL("https://tinyllama-kserve-workload-svc.kserve-test.svc.cluster.local")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://tinyllama-kserve-workload-svc.kserve-test.svc.cluster.local/v1", endpoint,
+			"backward-compatible: addresses without Name field still work")
+	})
 }
 
 // TestInferenceServiceURLSuffixConstruction tests that InferenceService URLs
@@ -520,11 +631,25 @@ func TestInferenceServiceURLSuffixConstruction(t *testing.T) {
 			inputURL: "https://my-service.namespace.svc.cluster.local:8443/v1",
 			expected: "https://my-service.namespace.svc.cluster.local:8443/v1",
 		},
+		{
+			name:     "URL with trailing slash gets slash trimmed then /v1 added",
+			inputURL: "http://gateway.openshift-ingress.svc.cluster.local/",
+			expected: "http://gateway.openshift-ingress.svc.cluster.local/v1",
+		},
+		{
+			name:     "URL with path and trailing slash gets slash trimmed then /v1 added",
+			inputURL: "http://gateway.openshift-ingress.svc.cluster.local/ns/model/",
+			expected: "http://gateway.openshift-ingress.svc.cluster.local/ns/model/v1",
+		},
+		{
+			name:     "URL with multiple trailing slashes gets all trimmed",
+			inputURL: "http://gateway.openshift-ingress.svc.cluster.local///",
+			expected: "http://gateway.openshift-ingress.svc.cluster.local/v1",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Call the actual function used for InferenceService URLs
 			actual := EnsureV1Suffix(tt.inputURL)
 
 			assert.Equal(t, tt.expected, actual,

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -510,7 +510,7 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 			"should pick gateway-internal with path, not gateway-internal-model-routing root URL")
 	})
 
-	t.Run("prefers short path over publishers path among gateway-internal addresses", func(t *testing.T) {
+	t.Run("picks first gateway-internal address", func(t *testing.T) {
 		gatewayInternalName := "gateway-internal"
 		llmSvc := &kservev1alpha1.LLMInferenceService{
 			Status: kservev1alpha1.LLMInferenceServiceStatus{
@@ -524,8 +524,8 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 		}
 		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://gw.openshift-ingress.svc.cluster.local/myns/mymodel/v1", endpoint,
-			"should prefer the short /<ns>/<model> path over /publishers/... path")
+		assert.Equal(t, "https://gw.openshift-ingress.svc.cluster.local/publishers/myns/models/mymodel/v1", endpoint,
+			"should pick the first gateway-internal address")
 	})
 
 	t.Run("realistic openshift-ai-inference gateway addresses", func(t *testing.T) {
@@ -549,8 +549,8 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 		}
 		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
 		assert.NoError(t, err)
-		assert.Equal(t, "http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/repro-85200/llama-32-1b-instruct/v1", endpoint,
-			"should select the gateway-internal address with /<ns>/<model> path, not root or publishers")
+		assert.Equal(t, "http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/publishers/repro-85200/models/llama-32-1b-instruct/v1", endpoint,
+			"should select the first gateway-internal address, not model-routing or external")
 	})
 
 	t.Run("trailing slash on gateway root URL does not produce double-slash", func(t *testing.T) {
@@ -570,7 +570,7 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 			"should not produce //v1 from trailing slash")
 	})
 
-	t.Run("falls back to publishers path when no short path available", func(t *testing.T) {
+	t.Run("gateway-internal with publishers path works", func(t *testing.T) {
 		gatewayInternalName := "gateway-internal"
 		llmSvc := &kservev1alpha1.LLMInferenceService{
 			Status: kservev1alpha1.LLMInferenceServiceStatus{
@@ -586,14 +586,15 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 		assert.Equal(t, "https://gw.openshift-ingress.svc.cluster.local/publishers/ns/models/model/v1", endpoint)
 	})
 
-	t.Run("root-only gateway-internal before valid short-path gateway-internal skips root", func(t *testing.T) {
-		gwInternal := "gateway-internal"
+	t.Run("prefers gateway-internal over internal name type", func(t *testing.T) {
+		internalName := "internal"
+		gwInternalName := "gateway-internal"
 		llmSvc := &kservev1alpha1.LLMInferenceService{
 			Status: kservev1alpha1.LLMInferenceServiceStatus{
 				AddressStatus: duckv1.AddressStatus{
 					Addresses: []duckv1.Addressable{
-						{Name: &gwInternal, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/")},
-						{Name: &gwInternal, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/myns/mymodel")},
+						{Name: &internalName, URL: mustParseURL("http://my-model-svc.myns.svc.cluster.local:8080")},
+						{Name: &gwInternalName, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/myns/mymodel")},
 					},
 				},
 			},
@@ -601,25 +602,26 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
 		assert.NoError(t, err)
 		assert.Equal(t, "http://gw.openshift-ingress.svc.cluster.local/myns/mymodel/v1", endpoint,
-			"root-only gateway-internal must not be selected; should pick the /<ns>/<model> address")
+			"gateway-internal should be preferred over internal")
 	})
 
-	t.Run("single-segment gateway-internal path is not treated as short model path", func(t *testing.T) {
-		gwInternal := "gateway-internal"
+	t.Run("falls back to internal name type when no gateway-internal", func(t *testing.T) {
+		internalName := "internal"
+		modelRoutingName := "internal-model-routing"
 		llmSvc := &kservev1alpha1.LLMInferenceService{
 			Status: kservev1alpha1.LLMInferenceServiceStatus{
 				AddressStatus: duckv1.AddressStatus{
 					Addresses: []duckv1.Addressable{
-						{Name: &gwInternal, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/something")},
-						{Name: &gwInternal, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/myns/mymodel")},
+						{Name: &modelRoutingName, URL: mustParseURL("http://my-model-svc.myns.svc.cluster.local/")},
+						{Name: &internalName, URL: mustParseURL("http://my-model-svc.myns.svc.cluster.local/myns/mymodel")},
 					},
 				},
 			},
 		}
 		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
 		assert.NoError(t, err)
-		assert.Equal(t, "http://gw.openshift-ingress.svc.cluster.local/myns/mymodel/v1", endpoint,
-			"single-segment path should not be treated as /<ns>/<model>")
+		assert.Equal(t, "http://my-model-svc.myns.svc.cluster.local/myns/mymodel/v1", endpoint,
+			"should pick internal address, not internal-model-routing")
 	})
 
 	t.Run("falls back to any internal address when no gateway-internal name match", func(t *testing.T) {
@@ -637,26 +639,6 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 		assert.Equal(t, "https://tinyllama-kserve-workload-svc.kserve-test.svc.cluster.local/v1", endpoint,
 			"backward-compatible: addresses without Name field still work")
 	})
-}
-
-func TestIsShortModelPath(t *testing.T) {
-	tests := []struct {
-		path     string
-		expected bool
-	}{
-		{"/", false},
-		{"", false},
-		{"/ns", false},
-		{"/ns/model", true},
-		{"/ns/model/", true},
-		{"/ns/model/extra", false},
-		{"/publishers/ns/models/m", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isShortModelPath(tt.path))
-		})
-	}
 }
 
 // TestInferenceServiceURLSuffixConstruction tests that InferenceService URLs


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-85200

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
fix([RHOAIENG-85200](https://redhat.atlassian.net/browse/RHOAIENG-85200)): correct gateway URL extraction for LLMInferenceService in GenAI Playground
The GenAI Playground was generating a malformed base_url (e.g. `...//v1`) in the llama-stack config for LLMInferenceService deployments. Two issues caused this:

1. `EnsureV1Suffix` did not trim trailing slashes before appending `/v1`, producing double-slash URLs.
2. `extractEndpointFromLLMInferenceService` picked the first internal address regardless of its name, often selecting the root-only `gateway-internal-model-routing` URL instead of the `gateway-internal` URL that includes the `/<namespace>/<model>` path.

The fix trims trailing slashes in `EnsureV1Suffix` and prioritizes `gateway-internal` addresses with the correct path pattern, aligning with how the Cypress E2E helpers already select `gateway-external` URLs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Unit tests — Added 10 new test cases covering:
- EnsureV1Suffix: trailing slash trimming (http://host/ → http://host/v1), double-slash prevention, and idempotency when /v1 is already present.
- extractEndpointFromLLMInferenceService: preference for gateway-internal over gateway-internal-model-routing, preference for short /<ns>/<model> paths over /publishers/... paths, realistic openshift-ai-inference gateway address layouts, and backward compatibility with pre-gateway address structures.
- All existing tests continue to pass.
- Manual cluster verification — Deployed llama-32-1b-instruct as an LLMInferenceService on a live OpenShift cluster with the openshift-ai-inference gateway enabled:

- Created a GenAI Playground via the local dev UI connected to the cluster.
Inspected the generated llama-stack-config ConfigMap and confirmed the base_url is now correctly formed:
`base_url: http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/test-85200/llama-32-1b-instruct/v1`
Previously this would produce `http://...svc.cluster.local//v1` (double-slash, missing namespace/model path).

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- added unit tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-85200]: https://redhat.atlassian.net/browse/RHOAIENG-85200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes endpoint selection for inference services.
  * Prioritized gateway-internal addresses and preferred shorter service paths.
  * Added reliable fallbacks when preferred endpoint addresses are unavailable.
  * Improved URL handling by removing trailing slashes before applying the `/v1` suffix.
  * Improved connectivity reliability when services expose multiple internal endpoint addresses.
* **Tests**
  * Added coverage for endpoint prioritization, fallback behavior, path selection, and trailing-slash handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->