### PR TITLE
Cherry-pick #9142: harden register-and-store transfer job toast asserts

### DIFF
--- a/packages/cypress/cypress/pages/components/ToastNotifications.ts
+++ b/packages/cypress/cypress/pages/components/ToastNotifications.ts
@@ -1,6 +1,9 @@
 export class ToastNotifications {
-  findToastNotificationList(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('toast-notification-group');
+  findToastNotificationList(timeout?: number): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(
+      'toast-notification-group',
+      timeout !== undefined ? { timeout } : undefined,
+    );
   }
 
   // gets the list of notifications, each entry has an Alert with data-testid=toast-notification-alert

--- a/packages/cypress/cypress/tests/e2e/modelRegistry/testRegisterModel.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelRegistry/testRegisterModel.cy.ts
@@ -341,15 +341,21 @@ describe('Verify models can be registered in a model registry', () => {
       registerModelPage.findSubmitButton().should('be.enabled');
 
       cy.step('Submit the register and store form');
+      cy.intercept('POST', '**/model_transfer_jobs*').as('createTransferJob');
       registerModelPage.findSubmitButton().click();
 
+      cy.step('Wait for transfer job create API to succeed');
+      cy.wait('@createTransferJob', { timeout: 60000 })
+        .its('response.statusCode')
+        .should('be.oneOf', [200, 201]);
+
       cy.step('Verify transfer job started notification appears');
-      cy.contains(testData.ociTransferJobStartedNotification, { timeout: 15000 }).should(
-        'be.visible',
-      );
+      toastNotifications
+        .findToastNotificationList()
+        .should('contain.text', testData.ociTransferJobStartedNotification);
 
       cy.step('Verify navigation away from the registration form');
-      cy.url().should('include', '/registered-models/');
+      cy.url({ timeout: 30000 }).should('include', '/registered-models/');
 
       // Terminal state of the transfer job (success/failure) is environment-dependent
       // and not validated here. A dedicated test with a controlled backend is more appropriate.
@@ -441,7 +447,13 @@ describe('Verify models can be registered in a model registry', () => {
       registerModelPage.findSubmitButton().should('be.enabled');
 
       cy.step('Submit the register and store form');
+      cy.intercept('POST', '**/model_transfer_jobs*').as('createTransferJobUri');
       registerModelPage.findSubmitButton().click();
+
+      cy.step('Wait for transfer job create API to succeed');
+      cy.wait('@createTransferJobUri', { timeout: 60000 })
+        .its('response.statusCode')
+        .should('be.oneOf', [200, 201]);
 
       cy.step('Verify transfer job started notification appears');
       toastNotifications
@@ -452,7 +464,7 @@ describe('Verify models can be registered in a model registry', () => {
       checkModelTransferJobPodStarted(testData.ociUriJobName, projectName).should('be.true');
 
       cy.step('Verify navigation away from the registration form');
-      cy.url().should('include', '/registered-models/');
+      cy.url({ timeout: 30000 }).should('include', '/registered-models/');
     },
   );
 

--- a/packages/cypress/cypress/tests/e2e/modelRegistry/testRegisterModel.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelRegistry/testRegisterModel.cy.ts
@@ -37,6 +37,8 @@ describe('Verify models can be registered in a model registry', () => {
   let objectStorageModelName: string;
   let ociModelName: string;
   let ociUriModelName: string;
+  let ociJobName: string;
+  let ociUriJobName: string;
   let deploymentName: string;
   let projectName: string;
   const uuid = generateTestUUID();
@@ -50,6 +52,8 @@ describe('Verify models can be registered in a model registry', () => {
       objectStorageModelName = `${testData.objectStorageModelName}-${uuid}`;
       ociModelName = `${testData.ociModelName}-${uuid}`;
       ociUriModelName = `${testData.ociUriModelName}-${uuid}`;
+      ociJobName = `${testData.ociJobName}-${uuid}`;
+      ociUriJobName = `${testData.ociUriJobName}-${uuid}`;
       deploymentName = testData.operatorDeploymentName;
 
       // ensure operator has optimal memory
@@ -298,7 +302,7 @@ describe('Verify models can be registered in a model registry', () => {
         .type(testData.ociModelFormatVersion);
 
       cy.step('Fill in transfer job name');
-      registerModelPage.findFormField(FormFieldSelector.JOB_NAME).type(testData.ociJobName);
+      registerModelPage.findFormField(FormFieldSelector.JOB_NAME).type(ociJobName);
 
       cy.step('Fill in origin S3 location and credentials');
       registerModelPage.findFormField(FormFieldSelector.LOCATION_TYPE_OBJECT_STORAGE).click();
@@ -341,18 +345,15 @@ describe('Verify models can be registered in a model registry', () => {
       registerModelPage.findSubmitButton().should('be.enabled');
 
       cy.step('Submit the register and store form');
-      cy.intercept('POST', '**/model_transfer_jobs*').as('createTransferJob');
       registerModelPage.findSubmitButton().click();
-
-      cy.step('Wait for transfer job create API to succeed');
-      cy.wait('@createTransferJob', { timeout: 60000 })
-        .its('response.statusCode')
-        .should('be.oneOf', [200, 201]);
 
       cy.step('Verify transfer job started notification appears');
       toastNotifications
-        .findToastNotificationList()
+        .findToastNotificationList(60000)
         .should('contain.text', testData.ociTransferJobStartedNotification);
+
+      cy.step('Verify transfer job and pod started in the backend');
+      checkModelTransferJobPodStarted(ociJobName, projectName).should('be.true');
 
       cy.step('Verify navigation away from the registration form');
       cy.url({ timeout: 30000 }).should('include', '/registered-models/');
@@ -420,7 +421,7 @@ describe('Verify models can be registered in a model registry', () => {
         .type(testData.ociModelFormatVersion);
 
       cy.step('Fill in transfer job name');
-      registerModelPage.findFormField(FormFieldSelector.JOB_NAME).type(testData.ociUriJobName);
+      registerModelPage.findFormField(FormFieldSelector.JOB_NAME).type(ociUriJobName);
 
       cy.step('Select URI as origin location type and fill in URI');
       registerModelPage.findFormField(FormFieldSelector.LOCATION_TYPE_URI).click();
@@ -447,21 +448,15 @@ describe('Verify models can be registered in a model registry', () => {
       registerModelPage.findSubmitButton().should('be.enabled');
 
       cy.step('Submit the register and store form');
-      cy.intercept('POST', '**/model_transfer_jobs*').as('createTransferJobUri');
       registerModelPage.findSubmitButton().click();
-
-      cy.step('Wait for transfer job create API to succeed');
-      cy.wait('@createTransferJobUri', { timeout: 60000 })
-        .its('response.statusCode')
-        .should('be.oneOf', [200, 201]);
 
       cy.step('Verify transfer job started notification appears');
       toastNotifications
-        .findToastNotificationList()
+        .findToastNotificationList(60000)
         .should('contain.text', testData.ociTransferJobStartedNotification);
 
       cy.step('Verify transfer job and pod started in the backend');
-      checkModelTransferJobPodStarted(testData.ociUriJobName, projectName).should('be.true');
+      checkModelTransferJobPodStarted(ociUriJobName, projectName).should('be.true');
 
       cy.step('Verify navigation away from the registration form');
       cy.url({ timeout: 30000 }).should('include', '/registered-models/');


### PR DESCRIPTION
Cherry-pick of https://github.com/opendatahub-io/odh-dashboard/pull/9142 onto `v3.5.0-fixes`.

## Description

Hardens OCI register-and-store Cypress asserts in `testRegisterModel.cy.ts` after Jenkins Smoke flakes on the "Model transfer job started" toast.

**Changes (same intent as #9142):**
* UUID-suffixed transfer job names to avoid collisions
* Toast assert via `toastNotifications.findToastNotificationList(60000)`
* Poll transfer Job pods with `checkModelTransferJobPodStarted` (no `cy.intercept` / `cy.wait`)
* Optional timeout on the toast page-object helper

**Conflict note:** `v3.5.0-fixes` still navigates to `/registered-models/` after submit, while `main` asserts the `ai-hub` registry URL. Kept the release-branch URL assert and only backported the toast/OC hardening.

## How Has This Been Tested?

* Cherry-picked both commits from #9142 onto `upstream/v3.5.0-fixes`
* Resolved URL assert conflicts to keep `/registered-models/`
* Source PR #9142 passed Jenkins Smoke

## Test Impact

Updates existing E2E asserts only; no product code changes.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)