### PR TITLE
[eval-hub] Fix threshold normalization, breadcrumb chevrons, reconfigure threshold, and pass status fallback

### DIFF
--- a/packages/eval-hub/frontend/src/app/components/AboutBenchmarkResultPopover.tsx
+++ b/packages/eval-hub/frontend/src/app/components/AboutBenchmarkResultPopover.tsx
@@ -6,6 +6,7 @@ import {
   formatBenchmarkScore,
   getBenchmarkDisplayName,
   getJobBenchmarks,
+  normalizeThreshold,
 } from '~/app/utilities/evaluationUtils';
 
 type AboutBenchmarkResultPopoverProps = {
@@ -15,10 +16,7 @@ type AboutBenchmarkResultPopoverProps = {
   provider?: Provider;
 };
 
-const formatThreshold = (threshold: number): string => {
-  const value = threshold <= 1 ? Math.round(threshold * 100) : Math.round(threshold);
-  return `${value}%`;
-};
+const formatThreshold = (threshold: number): string => `${normalizeThreshold(threshold)}%`;
 
 const AboutBenchmarkResultPopover: React.FC<AboutBenchmarkResultPopoverProps> = ({
   benchmarkId,

--- a/packages/eval-hub/frontend/src/app/components/BenchmarkResultDetails.tsx
+++ b/packages/eval-hub/frontend/src/app/components/BenchmarkResultDetails.tsx
@@ -46,12 +46,7 @@ const BenchmarkResultDetails: React.FC<BenchmarkResultDetailsProps> = ({
     return null;
   }
 
-  const benchmarkStatus = job.status.benchmarks?.find(
-    (b, idx) => b.id === benchmarkId && (b.benchmark_index ?? idx) === benchmarkIndex,
-  );
-  const passStatus =
-    result.test?.pass ??
-    (benchmarkStatus?.status == null ? null : benchmarkStatus.status === 'completed');
+  const passStatus = result.test?.pass ?? null;
   const metricKeys = result.metrics ? Object.keys(result.metrics).toSorted() : [];
   const primaryMetricName =
     benchmarkConfig?.primary_score?.metric ?? (metricKeys.length > 0 ? metricKeys[0] : '-');

--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -114,6 +114,47 @@ const StartEvaluationRunPage: React.FC<StartEvaluationRunPageProps> = ({
 
   const breadcrumbFlowLabel = isCollectionFlow ? 'Select benchmark suite' : 'Select benchmark';
 
+  const getBreadcrumbItems = (): React.ReactElement[] => {
+    const items: React.ReactElement[] = [
+      <BreadcrumbItem
+        key="evaluations"
+        render={() => <Link to={evaluationsBaseRoute(namespace)}>Evaluations</Link>}
+      />,
+    ];
+    if (isReconfigure) {
+      items.push(
+        <BreadcrumbItem key="active" isActive>
+          Reconfigure evaluation
+        </BreadcrumbItem>,
+      );
+    } else {
+      items.push(
+        <BreadcrumbItem
+          key="type"
+          render={() => <Link to={evaluationCreateRoute(namespace)}>Select evaluation type</Link>}
+        />,
+        <BreadcrumbItem
+          key="suite"
+          render={() => (
+            <Link
+              to={
+                isCollectionFlow
+                  ? evaluationCollectionsRoute(namespace)
+                  : evaluationBenchmarksRoute(namespace)
+              }
+            >
+              {breadcrumbFlowLabel}
+            </Link>
+          )}
+        />,
+        <BreadcrumbItem key="active" isActive>
+          Start evaluation run
+        </BreadcrumbItem>,
+      );
+    }
+    return items;
+  };
+
   // ── Source dropdown state ────────────────────────────────────────────
 
   const [isSourceOpen, setIsSourceOpen] = React.useState(false);
@@ -188,38 +229,7 @@ const StartEvaluationRunPage: React.FC<StartEvaluationRunPageProps> = ({
   return (
     <ApplicationsPage
       noHeader
-      breadcrumb={
-        <Breadcrumb>
-          <BreadcrumbItem
-            render={() => <Link to={evaluationsBaseRoute(namespace)}>Evaluations</Link>}
-          />
-          {isReconfigure ? (
-            <BreadcrumbItem isActive>Reconfigure evaluation</BreadcrumbItem>
-          ) : (
-            <>
-              <BreadcrumbItem
-                render={() => (
-                  <Link to={evaluationCreateRoute(namespace)}>Select evaluation type</Link>
-                )}
-              />
-              <BreadcrumbItem
-                render={() => (
-                  <Link
-                    to={
-                      isCollectionFlow
-                        ? evaluationCollectionsRoute(namespace)
-                        : evaluationBenchmarksRoute(namespace)
-                    }
-                  >
-                    {breadcrumbFlowLabel}
-                  </Link>
-                )}
-              />
-              <BreadcrumbItem isActive>Start evaluation run</BreadcrumbItem>
-            </>
-          )}
-        </Breadcrumb>
-      }
+      breadcrumb={<Breadcrumb>{getBreadcrumbItems()}</Breadcrumb>}
       loaded
       empty={false}
     >

--- a/packages/eval-hub/frontend/src/app/pages/useStartEvaluationRunForm.ts
+++ b/packages/eval-hub/frontend/src/app/pages/useStartEvaluationRunForm.ts
@@ -19,6 +19,7 @@ import buildEvaluationRequest from '~/app/utils/buildEvaluationRequest';
 import type { ReconfigureFormData } from '~/app/utils/extractReconfigureData';
 import { getUrlValidationError } from '~/app/utils/validationUtils';
 import getErrorTitle from '~/app/utils/getErrorTitle';
+import { normalizeThreshold } from '~/app/utilities/evaluationUtils';
 import { evaluationsBaseRoute } from '~/app/routes';
 import { useNotification } from '~/app/hooks/useNotification';
 import { useConnectionValidation } from '~/app/hooks/useConnectionValidation';
@@ -65,13 +66,13 @@ export function useStartEvaluationRunForm({
 
   const defaultThreshold = React.useMemo(() => {
     if (collection?.pass_criteria) {
-      return Math.round(collection.pass_criteria.threshold * 100);
+      return normalizeThreshold(collection.pass_criteria.threshold);
     }
     if (collection) {
       return DEFAULT_SUITE_THRESHOLD;
     }
     if (benchmark?.pass_criteria) {
-      return Math.round(benchmark.pass_criteria.threshold * 100);
+      return normalizeThreshold(benchmark.pass_criteria.threshold);
     }
     return 0;
   }, [benchmark, collection]);

--- a/packages/eval-hub/frontend/src/app/utilities/__tests__/evaluationUtils.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utilities/__tests__/evaluationUtils.spec.ts
@@ -12,6 +12,7 @@ import {
   formatDate,
   formatDurationCompact,
   isTerminalState,
+  normalizeThreshold,
 } from '~/app/utilities/evaluationUtils';
 
 describe('getEvaluationName', () => {
@@ -524,5 +525,31 @@ describe('getFailedBenchmarkCount', () => {
 
   it('should count all when every benchmark has failed', () => {
     expect(getFailedBenchmarkCount([{ status: 'failed' }, { status: 'failed' }])).toBe(2);
+  });
+});
+
+describe('normalizeThreshold', () => {
+  it('should convert 0–1 decimal to percentage', () => {
+    expect(normalizeThreshold(0.38)).toBe(38);
+  });
+
+  it('should convert 0.5 to 50', () => {
+    expect(normalizeThreshold(0.5)).toBe(50);
+  });
+
+  it('should use value as-is when already a percentage scale', () => {
+    expect(normalizeThreshold(38)).toBe(38);
+  });
+
+  it('should use value as-is for large percentage values', () => {
+    expect(normalizeThreshold(80)).toBe(80);
+  });
+
+  it('should handle 0', () => {
+    expect(normalizeThreshold(0)).toBe(0);
+  });
+
+  it('should round fractional results', () => {
+    expect(normalizeThreshold(0.333)).toBe(33);
   });
 });

--- a/packages/eval-hub/frontend/src/app/utilities/evaluationUtils.ts
+++ b/packages/eval-hub/frontend/src/app/utilities/evaluationUtils.ts
@@ -218,3 +218,9 @@ export const isEvaluationJobComparable = (job: EvaluationJob): boolean =>
 
 export const getFailedBenchmarkCount = (benchmarks: Array<{ status: string }>): number =>
   benchmarks.filter((bm) => bm.status === 'failed').length;
+
+// Different benchmark providers use different scoring scales — most use 0–1 decimal fractions,
+// but some (e.g. Open LLM Leaderboard v2) use a 0–100 percentage scale. Thresholds > 1 are
+// already in percentage form; thresholds ≤ 1 are multiplied by 100 to match the slider range.
+export const normalizeThreshold = (threshold: number): number =>
+  threshold <= 1 ? Math.round(threshold * 100) : Math.round(threshold);

--- a/packages/eval-hub/frontend/src/app/utils/extractReconfigureData.ts
+++ b/packages/eval-hub/frontend/src/app/utils/extractReconfigureData.ts
@@ -111,7 +111,10 @@ const extractReconfigureData = (
   }
   /* eslint-enable camelcase */
 
-  const threshold = job.pass_criteria ? Math.round(job.pass_criteria.threshold * 100) : 0;
+  // Collection flow writes pass_criteria at the job level; benchmark flow writes it on the
+  // individual benchmark entry. Fall back to the first benchmark to cover the latter case.
+  const passCriteria = job.pass_criteria ?? firstBenchmark?.pass_criteria;
+  const threshold = passCriteria ? Math.round(passCriteria.threshold * 100) : 0;
 
   const primaryMetric = firstBenchmark?.primary_score?.metric;
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-85348

## Description

A set of fixes for the AI Evaluations (eval-hub) results and configuration pages.

**1. Normalize benchmark threshold display**
Different benchmark providers use different scoring scales — most use 0–1 decimal fractions, but some (e.g. Open LLM Leaderboard v2) use a 0–100 percentage scale. The form was unconditionally multiplying all thresholds by 100, causing leaderboard-v2 to display as 3800 instead of 38. Introduced `normalizeThreshold` utility in `evaluationUtils.ts` (thresholds ≤ 1 are multiplied by 100; thresholds > 1 are used as-is) and applied it consistently across the form default, the reconfigure extraction, and the "About this result" popover. Added unit tests.

**2. Fix breadcrumb chevrons on Start evaluation run page**
PatternFly's `Breadcrumb` injects dividers between direct children. Wrapping conditional items in a React Fragment caused the component to see a single child, hiding the chevrons. Replaced the inline conditional JSX with a `getBreadcrumbItems()` helper that returns a flat array, making each `BreadcrumbItem` a direct child.

**3. Fix reconfigure threshold showing 0 for standalone benchmark runs**
`buildEvaluationRequest` writes `pass_criteria` at the top-level job field for collection flow, but on the individual benchmark entry for standalone benchmark flow. `extractReconfigureData` was only reading `job.pass_criteria`, so standalone benchmark reconfigures always showed 0. Added a fallback to `firstBenchmark.pass_criteria` with a comment explaining the split.

**4. Remove incorrect pass/fail fallback for benchmark results**
When `result.test?.pass` is absent (e.g. due to a backend misconfiguration where the primary metric key doesn't match what the runner returns), the UI was falling back to `benchmarkStatus.status === 'completed'` — treating "the benchmark ran" as "the benchmark passed." This caused all benchmarks to show Pass regardless of score. Removed the fallback so missing pass data shows no badge. The upstream fix (eval-hub PR #893 / TrustyAI operator PR #876) addresses the root cause for Toxigen; this change prevents incorrect badges for any future misconfiguration.

### Before / After

| Fix | Before | After |
|-----|--------|-------|
| Threshold normalization (leaderboard-v2) |<img width="2998" height="1474" alt="image" src="https://github.com/user-attachments/assets/47659c71-0eac-4a49-a660-db1c04245713" />|<img width="1540" height="1289" alt="Screenshot 2026-08-19 at 9 29 16 AM" src="https://github.com/user-attachments/assets/f854b8c6-11b8-4fb1-afb6-2970357164a6" />|
| Breadcrumb chevrons |<img width="1208" height="1177" alt="image" src="https://github.com/user-attachments/assets/7c051e10-4ae3-4f0e-894f-1206034d7992" />|<img width="1422" height="1289" alt="Screenshot 2026-08-19 at 10 59 53 AM" src="https://github.com/user-attachments/assets/04c879b4-b9a2-4b6e-83a7-93963ddae5f7" />|
| Reconfigure threshold (standalone benchmark) |<img width="1376" height="1135" alt="image" src="https://github.com/user-attachments/assets/4b766cfa-5f0c-4af3-8cc5-c8b61677d7cc" />|<img width="1167" height="1182" alt="image" src="https://github.com/user-attachments/assets/99c3088f-7499-4509-b348-c72e401a4555" />|
| Pass/fail badge |<img width="1593" height="1063" alt="image" src="https://github.com/user-attachments/assets/6512f308-86df-4f6e-9805-b08914e91dd9" />|<img width="1784" height="1014" alt="image" src="https://github.com/user-attachments/assets/98682937-7b50-45d4-b471-7dc0ff1b3332" />|

## How Has This Been Tested?

Manually tested against a live eval-hub cluster:
- Open LLM Leaderboard v2 threshold now displays correctly instead of 3800
- Breadcrumb chevrons visible on the Start evaluation run page
- Reconfigure flow for standalone benchmark runs loads the correct threshold
- Benchmark result cards show no badge (instead of incorrect Pass) when `test.pass` is absent pending the upstream backend fix

## Test Impact

- Added 6 unit tests for `normalizeThreshold` in `evaluationUtils.spec.ts` covering 0–1 decimal, 0–100 percentage, zero, and rounding cases

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`