### PR TITLE
test(e2e): Consolidate model deployment settings page objects, fix stale tests, add CRUD e2e test for topology

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/genAi/testGenAiModelDeployment.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/genAi/testGenAiModelDeployment.yaml
@@ -16,4 +16,4 @@ hardwareProfileDeploymentSize: 'cypress-gen-ai-hardware-profile Compatible CPU: 
 # Playground resources
 configMapName: 'llama-stack-config'
 playgroundServiceName: 'lsd-genai-playground-service'
-servingRuntimesPath: '/settings/model-resources-operations/serving-runtimes'
+servingRuntimesPath: '/settings/model-resources-operations/model-deployment-settings/serving-runtime-templates'

--- a/packages/cypress/cypress/fixtures/e2e/settings/llmdRoutingConfigurations/testLlmdRoutingConfigurations.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/settings/llmdRoutingConfigurations/testLlmdRoutingConfigurations.yaml
@@ -2,7 +2,7 @@
 
 routingConfigName: 'e2e-scheduler-routing'
 routingConfigFixture: 'resources/modelServing/llmd-routing-config.yaml'
-topologyTypeTestId: 'topology-type-workload-single-node'
+topologyTypeTestId: 'workload-single-node'
 topologyTypeLabel: 'Single node'
 configSourceEditorKey: 'editor'
 projectResourceName: 'routing-admin'

--- a/packages/cypress/cypress/fixtures/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurationsCrud.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurationsCrud.yaml
@@ -1,0 +1,8 @@
+# testLlmdTopologyConfigurationsCrud.cy.ts Test Data #
+
+# Base names; the spec appends a per-run UUID for concurrency safety.
+topologyConfigResourceName: 'e2e-topo-crud'
+topologyConfigDisplayName: 'E2E Topology CRUD'
+# Spec body pasted into the create form's YAML editor (name comes from the form).
+topologyConfigEditorFixture: 'resources/modelServing/llmd-topology-config-editor-body.yaml'
+configSourceEditorKey: 'editor'

--- a/packages/cypress/cypress/fixtures/resources/modelServing/llmd-topology-config-editor-body.yaml
+++ b/packages/cypress/cypress/fixtures/resources/modelServing/llmd-topology-config-editor-body.yaml
@@ -1,0 +1,23 @@
+# Minimal valid llm-d topology config spec pasted into the create form's YAML
+# editor by testLlmdTopologyConfigurationsCrud.cy.ts. The config's metadata.name
+# comes from the form's resource-name field, so this body only needs a valid spec.
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: placeholder-overridden-by-form
+  labels:
+    opendatahub.io/config-type: workload-single-node
+    opendatahub.io/dashboard: "true"
+spec:
+  replicas: 1
+  template:
+    containers:
+      - name: main
+        image: quay.io/pierdipi/vllm-cpu:latest
+        resources:
+          limits:
+            cpu: "2"
+            memory: 8Gi
+          requests:
+            cpu: "1"
+            memory: 4Gi

--- a/packages/cypress/cypress/fixtures/resources/modelServing/llmd-topology-config.yaml
+++ b/packages/cypress/cypress/fixtures/resources/modelServing/llmd-topology-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
-  name: e2e-multi-node-topology
+  name: ${TOPOLOGY_CONFIG_NAME}
   annotations:
     openshift.io/display-name: E2E Multi-Node Topology
     openshift.io/description: Test topology config for multi-node data-parallel deployments

--- a/packages/cypress/cypress/fixtures/resources/modelServing/llmd-topology-config.yaml
+++ b/packages/cypress/cypress/fixtures/resources/modelServing/llmd-topology-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
-  name: ${TOPOLOGY_CONFIG_NAME}
+  name: {{TOPOLOGY_CONFIG_NAME}}
   annotations:
     openshift.io/display-name: E2E Multi-Node Topology
     openshift.io/description: Test topology config for multi-node data-parallel deployments

--- a/packages/cypress/cypress/fixtures/resources/modelServing/singleModel/kserve_singleservingruntime.yaml
+++ b/packages/cypress/cypress/fixtures/resources/modelServing/singleModel/kserve_singleservingruntime.yaml
@@ -3,10 +3,10 @@ kind: ServingRuntime
 metadata:
   annotations:
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-    openshift.io/display-name: Cypress Single ServingRuntime for KServe
+    openshift.io/display-name: ${SERVING_RUNTIME_DISPLAY_NAME}
   labels:
     opendatahub.io/dashboard: "true"
-  name: single-cypress-vllm-runtime
+  name: ${SERVING_RUNTIME_NAME}
 spec:
   annotations:
     prometheus.io/path: /metrics

--- a/packages/cypress/cypress/fixtures/resources/modelServing/singleModel/kserve_singleservingruntime.yaml
+++ b/packages/cypress/cypress/fixtures/resources/modelServing/singleModel/kserve_singleservingruntime.yaml
@@ -3,10 +3,10 @@ kind: ServingRuntime
 metadata:
   annotations:
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-    openshift.io/display-name: ${SERVING_RUNTIME_DISPLAY_NAME}
+    openshift.io/display-name: {{SERVING_RUNTIME_DISPLAY_NAME}}
   labels:
     opendatahub.io/dashboard: "true"
-  name: ${SERVING_RUNTIME_NAME}
+  name: {{SERVING_RUNTIME_NAME}}
 spec:
   annotations:
     prometheus.io/path: /metrics

--- a/packages/cypress/cypress/pages/modelDeploymentSettings/llmAcceleratorConfigurations.ts
+++ b/packages/cypress/cypress/pages/modelDeploymentSettings/llmAcceleratorConfigurations.ts
@@ -1,5 +1,5 @@
-import { appChrome } from './appChrome';
-import { DashboardCodeEditor } from './components/DashboardCodeEditor';
+import { appChrome } from '../appChrome';
+import { DashboardCodeEditor } from '../components/DashboardCodeEditor';
 
 class LlmAcceleratorConfigRow {
   constructor(public readonly name: string) {}
@@ -80,7 +80,7 @@ class UnsupportedStatusAcceptanceModal {
   }
 }
 
-class LlmAcceleratorConfigs {
+class LlmAcceleratorConfigurations {
   visit(wait = true) {
     cy.visitWithLogin(
       '/settings/model-resources-operations/model-deployment-settings/llm-accelerator-configurations',
@@ -163,5 +163,5 @@ class LlmAcceleratorConfigs {
   }
 }
 
-export const llmAcceleratorConfigs = new LlmAcceleratorConfigs();
+export const llmAcceleratorConfigurations = new LlmAcceleratorConfigurations();
 export const unsupportedStatusAcceptanceModal = new UnsupportedStatusAcceptanceModal();

--- a/packages/cypress/cypress/pages/modelDeploymentSettings/routingConfigurations.ts
+++ b/packages/cypress/cypress/pages/modelDeploymentSettings/routingConfigurations.ts
@@ -1,6 +1,7 @@
 import { appChrome } from '../appChrome';
 import { TableRow } from '../components/table';
 import { DeleteModal } from '../components/DeleteModal';
+import { DashboardCodeEditor } from '../components/DashboardCodeEditor';
 
 class RoutingConfigRow extends TableRow {
   findEnabledSwitch() {
@@ -119,6 +120,14 @@ class LlmdRoutingCreatePage {
 
   findYamlEditor() {
     return cy.findByTestId('config-yaml-editor');
+  }
+
+  /**
+   * The config YAML field is a PatternFly Monaco CodeEditor (no <textarea>).
+   * Use this to read/write its content via the shared DashboardCodeEditor helper.
+   */
+  getYamlEditor() {
+    return new DashboardCodeEditor(() => cy.findByTestId('config-yaml-editor'));
   }
 
   findSubmitButton() {

--- a/packages/cypress/cypress/pages/modelDeploymentSettings/routingConfigurations.ts
+++ b/packages/cypress/cypress/pages/modelDeploymentSettings/routingConfigurations.ts
@@ -1,6 +1,6 @@
-import { appChrome } from './appChrome';
-import { TableRow } from './components/table';
-import { DeleteModal } from './components/DeleteModal';
+import { appChrome } from '../appChrome';
+import { TableRow } from '../components/table';
+import { DeleteModal } from '../components/DeleteModal';
 
 class RoutingConfigRow extends TableRow {
   findEnabledSwitch() {
@@ -19,7 +19,7 @@ class RoutingConfigRow extends TableRow {
   }
 }
 
-class LlmdRoutingSettingsPage {
+class RoutingConfigurations {
   visit(wait = true) {
     cy.visitWithLogin(
       '/settings/model-resources-operations/model-deployment-settings/routing-configurations',
@@ -136,6 +136,6 @@ class DeleteRouteModal extends DeleteModal {
   }
 }
 
-export const llmdRoutingSettingsPage = new LlmdRoutingSettingsPage();
+export const routingConfigurations = new RoutingConfigurations();
 export const llmdRoutingCreatePage = new LlmdRoutingCreatePage();
 export const deleteRouteModal = new DeleteRouteModal();

--- a/packages/cypress/cypress/pages/modelDeploymentSettings/routingConfigurations.ts
+++ b/packages/cypress/cypress/pages/modelDeploymentSettings/routingConfigurations.ts
@@ -41,7 +41,10 @@ class RoutingConfigurations {
   }
 
   private wait() {
-    this.findTable();
+    // The tab renders an empty state (no table) until the first config exists,
+    // so wait for the Add button, which is present in both the empty and
+    // populated states, rather than the table.
+    this.findAddButton().should('exist');
   }
 
   findNavItem() {

--- a/packages/cypress/cypress/pages/modelDeploymentSettings/servingRuntimeTemplates.ts
+++ b/packages/cypress/cypress/pages/modelDeploymentSettings/servingRuntimeTemplates.ts
@@ -1,7 +1,7 @@
 import type { ServingRuntimeAPIProtocol } from '@odh-dashboard/model-serving/shared';
-import { appChrome } from './appChrome';
-import { DashboardCodeEditor } from './components/DashboardCodeEditor';
-import type { ModelTypeLabelValue } from '../utils/modelServingConstants';
+import { appChrome } from '../appChrome';
+import { DashboardCodeEditor } from '../components/DashboardCodeEditor';
+import type { ModelTypeLabelValue } from '../../utils/modelServingConstants';
 
 class ServingRuntimeRow {
   constructor(public readonly id: string) {}
@@ -68,7 +68,7 @@ class ServingRuntimeRow {
   }
 }
 
-class ServingRuntimes {
+class ServingRuntimeTemplates {
   visit(wait = true) {
     cy.visitWithLogin(
       '/settings/model-resources-operations/model-deployment-settings/serving-runtime-templates',
@@ -104,8 +104,15 @@ class ServingRuntimes {
     });
   }
 
+  // The standalone add/edit/duplicate form pages still render 'app-page-title'.
   findAppTitle() {
     return cy.findByTestId('app-page-title');
+  }
+
+  // The serving-runtime-templates tab lives under the Model deployment settings
+  // tab-route page, whose title uses the 'app-tab-page-title' testid.
+  findTabPageTitle() {
+    return cy.findByTestId('app-tab-page-title');
   }
 
   findAddButton() {
@@ -191,4 +198,4 @@ class ServingRuntimes {
   }
 }
 
-export const servingRuntimes = new ServingRuntimes();
+export const servingRuntimeTemplates = new ServingRuntimeTemplates();

--- a/packages/cypress/cypress/pages/modelDeploymentSettings/topologyConfigurations.ts
+++ b/packages/cypress/cypress/pages/modelDeploymentSettings/topologyConfigurations.ts
@@ -1,5 +1,5 @@
-import { appChrome } from './appChrome';
-import { TableRow } from './components/table';
+import { appChrome } from '../appChrome';
+import { TableRow } from '../components/table';
 
 class TopologyConfigRow extends TableRow {
   findEnabledSwitch() {
@@ -18,7 +18,7 @@ class TopologyConfigRow extends TableRow {
   }
 }
 
-class LlmdTopologySettingsPage {
+class TopologyConfigurations {
   visit(wait = true) {
     cy.visitWithLogin(
       '/settings/model-resources-operations/model-deployment-settings/topology-configurations',
@@ -118,4 +118,4 @@ class LlmdTopologySettingsPage {
   }
 }
 
-export const llmdTopologySettingsPage = new LlmdTopologySettingsPage();
+export const topologyConfigurations = new TopologyConfigurations();

--- a/packages/cypress/cypress/pages/modelDeploymentSettings/topologyConfigurations.ts
+++ b/packages/cypress/cypress/pages/modelDeploymentSettings/topologyConfigurations.ts
@@ -40,7 +40,10 @@ class TopologyConfigurations {
   }
 
   private wait() {
-    this.findTable();
+    // The tab renders an empty state (no table) until the first config exists,
+    // so wait for the Add button, which is present in both the empty state
+    // (as the split-button primary) and the populated table header.
+    this.findAddButton().should('exist');
   }
 
   findNavItem() {

--- a/packages/cypress/cypress/pages/modelDeploymentSettings/topologyConfigurations.ts
+++ b/packages/cypress/cypress/pages/modelDeploymentSettings/topologyConfigurations.ts
@@ -1,5 +1,6 @@
 import { appChrome } from '../appChrome';
 import { TableRow } from '../components/table';
+import { DashboardCodeEditor } from '../components/DashboardCodeEditor';
 
 class TopologyConfigRow extends TableRow {
   findEnabledSwitch() {
@@ -96,12 +97,33 @@ class TopologyConfigurations {
     return cy.findByTestId('topology-config-name');
   }
 
+  findEditResourceNameLink() {
+    return cy.findByTestId('topology-config-editResourceLink');
+  }
+
   findDescriptionInput() {
     return cy.findByTestId('topology-config-description');
   }
 
   findConfigSourceSelect() {
     return cy.findByTestId('config-source-select');
+  }
+
+  selectConfigSource(optionKey: string) {
+    this.findConfigSourceSelect().click();
+    cy.findByTestId(optionKey).click();
+  }
+
+  findYamlEditor() {
+    return cy.findByTestId('config-yaml-editor');
+  }
+
+  /**
+   * The config YAML field is a PatternFly Monaco CodeEditor (no <textarea>).
+   * Use this to read/write its content via the shared DashboardCodeEditor helper.
+   */
+  getYamlEditor() {
+    return new DashboardCodeEditor(() => cy.findByTestId('config-yaml-editor'));
   }
 
   findSubmitButton() {

--- a/packages/cypress/cypress/tests/e2e/settings/clusterSettings/testAdminClusterSettings.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/clusterSettings/testAdminClusterSettings.cy.ts
@@ -9,7 +9,7 @@ import { storageClassesPage } from '../../../../pages/storageClasses';
 import { notebookImageSettings } from '../../../../pages/notebookImageSettings';
 import { hardwareProfile } from '../../../../pages/hardwareProfile';
 import { connectionTypesPage } from '../../../../pages/connectionTypes';
-import { servingRuntimes } from '../../../../pages/servingRuntimes';
+import { servingRuntimeTemplates } from '../../../../pages/modelDeploymentSettings/servingRuntimeTemplates';
 import { modelRegistrySettings } from '../../../../pages/modelRegistrySettings';
 import type {
   CommandLineResult,
@@ -222,7 +222,18 @@ describe('Verify that only the Cluster Admin can access Cluster Settings', () =>
 
   it(
     'Cluster Admin user can access all Settings pages',
-    { tags: ['@Smoke', '@SmokeSet2', '@ODS-1688', '@Dashboard', '@SettingsCI'] },
+    {
+      tags: [
+        '@Smoke',
+        '@SmokeSet2',
+        '@ODS-1688',
+        '@Dashboard',
+        '@ModelServing',
+        '@SettingsCI',
+        '@KServeCI',
+        '@ModelServingCI',
+      ],
+    },
     function testClusterAdminSettingsAccess() {
       // Skip on BYOIDC clusters - User Management page requires groups API which returns 404 on BYOIDC
       skipIfBYOIDC(
@@ -257,8 +268,8 @@ describe('Verify that only the Cluster Admin can access Cluster Settings', () =>
       connectionTypesPage.findPageTitle().should('exist');
 
       cy.step('Access Settings -> Model resources and operations -> Serving runtimes');
-      servingRuntimes.visit();
-      servingRuntimes.findAppTitle().should('exist');
+      servingRuntimeTemplates.visit();
+      servingRuntimeTemplates.findTabPageTitle().should('exist');
 
       cy.step('Access Settings -> Model resources and operations -> Model registry settings');
       modelRegistrySettings.visit();

--- a/packages/cypress/cypress/tests/e2e/settings/clusterSettings/testAdminClusterSettings.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/clusterSettings/testAdminClusterSettings.cy.ts
@@ -222,18 +222,7 @@ describe('Verify that only the Cluster Admin can access Cluster Settings', () =>
 
   it(
     'Cluster Admin user can access all Settings pages',
-    {
-      tags: [
-        '@Smoke',
-        '@SmokeSet2',
-        '@ODS-1688',
-        '@Dashboard',
-        '@ModelServing',
-        '@SettingsCI',
-        '@KServeCI',
-        '@ModelServingCI',
-      ],
-    },
+    { tags: ['@Smoke', '@SmokeSet2', '@ODS-1688', '@Dashboard', '@SettingsCI'] },
     function testClusterAdminSettingsAccess() {
       // Skip on BYOIDC clusters - User Management page requires groups API which returns 404 on BYOIDC
       skipIfBYOIDC(

--- a/packages/cypress/cypress/tests/e2e/settings/llmAcceleratorConfigs/testLlmAcceleratorConfigsUnsupported.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmAcceleratorConfigs/testLlmAcceleratorConfigsUnsupported.cy.ts
@@ -14,9 +14,9 @@ import {
   checkLLMInferenceServiceConfigState,
 } from '../../../../utils/oc_commands/llmInferenceServiceConfig';
 import {
-  llmAcceleratorConfigs,
+  llmAcceleratorConfigurations,
   unsupportedStatusAcceptanceModal,
-} from '../../../../pages/llmAcceleratorConfigs';
+} from '../../../../pages/modelDeploymentSettings/llmAcceleratorConfigurations';
 import { deleteModal } from '../../../../pages/components/DeleteModal';
 import { projectDetails, projectListPage } from '../../../../pages/projects';
 import { modelServingGlobal, modelServingWizard } from '../../../../pages/modelServing';
@@ -98,55 +98,56 @@ describe('Unsupported accelerator configs: CRUD + wizard gating', () => {
     },
     () => {
       cy.step('Log into the application as admin');
-      cy.visitWithLogin(
-        '/?devFeatureFlags=modelDeploymentSettings=true,vLLMDeploymentOnMaaS=true',
-        LDAP_ADMIN_USER,
-      );
+      cy.visitWithLogin('/?devFeatureFlags=vLLMDeploymentOnMaaS=true', LDAP_ADMIN_USER);
 
       cy.step('Create unsupported accelerator config from UI');
-      llmAcceleratorConfigs.navigate();
-      llmAcceleratorConfigs.findAddButton().should('exist').click();
-      llmAcceleratorConfigs.findNameInput().clear().type(acceleratorConfigName);
-      llmAcceleratorConfigs.findEditResourceNameLink().click();
-      llmAcceleratorConfigs.findResourceNameInput().should('be.visible').clear().type(resourceName);
+      llmAcceleratorConfigurations.navigate();
+      llmAcceleratorConfigurations.findAddButton().should('exist').click();
+      llmAcceleratorConfigurations.findNameInput().clear().type(acceleratorConfigName);
+      llmAcceleratorConfigurations.findEditResourceNameLink().click();
+      llmAcceleratorConfigurations
+        .findResourceNameInput()
+        .should('be.visible')
+        .clear()
+        .type(resourceName);
 
-      llmAcceleratorConfigs.findVersionInput().clear().type(testData.version);
+      llmAcceleratorConfigurations.findVersionInput().clear().type(testData.version);
       cy.fixture(testData.unsupportedAcceleratorConfigFixturePath).then((yamlContent) => {
-        llmAcceleratorConfigs.findYAMLCodeEditor().findStartFromScratchButton().click();
-        llmAcceleratorConfigs.findYAMLCodeEditor().setValue(yamlContent);
+        llmAcceleratorConfigurations.findYAMLCodeEditor().findStartFromScratchButton().click();
+        llmAcceleratorConfigurations.findYAMLCodeEditor().setValue(yamlContent);
       });
-      llmAcceleratorConfigs.findSubmitButton().should('be.enabled').click();
+      llmAcceleratorConfigurations.findSubmitButton().should('be.enabled').click();
       checkLLMInferenceServiceConfigState(resourceName, namespace);
 
       cy.step('Duplicate it and create the duplicate');
-      const acceleratorConfigRow = llmAcceleratorConfigs.getRowByName(resourceName);
+      const acceleratorConfigRow = llmAcceleratorConfigurations.getRowByName(resourceName);
       acceleratorConfigRow.find().should('exist');
       acceleratorConfigRow.shouldHaveUnsupportedLabel(true);
       acceleratorConfigRow.shouldBeEnabled(false);
       acceleratorConfigRow.findKebabToggle().click();
       acceleratorConfigRow.findDuplicateAction().click();
 
-      llmAcceleratorConfigs.findNameInput().clear().type(duplicateAcceleratorConfigName);
-      llmAcceleratorConfigs.findEditResourceNameLink().click();
-      llmAcceleratorConfigs
+      llmAcceleratorConfigurations.findNameInput().clear().type(duplicateAcceleratorConfigName);
+      llmAcceleratorConfigurations.findEditResourceNameLink().click();
+      llmAcceleratorConfigurations
         .findResourceNameInput()
         .should('be.visible')
         .clear()
         .type(duplicateResourceName);
-      llmAcceleratorConfigs.findVersionInput().should('have.value', testData.version);
+      llmAcceleratorConfigurations.findVersionInput().should('have.value', testData.version);
       stubClipboard('copiedYAML');
-      llmAcceleratorConfigs.findYAMLCodeEditor().copyToClipboard().click();
+      llmAcceleratorConfigurations.findYAMLCodeEditor().copyToClipboard().click();
       getClipboardContent('copiedYAML').then((copied) => {
         expect(copied).to.have.length.at.least(1);
         const yamlContent = copied[0];
         expect(yamlContent).to.include(testData.resourceApiVersion);
         expect(yamlContent).to.include(testData.resourceType);
       });
-      llmAcceleratorConfigs.findSubmitButton().should('be.enabled').click();
+      llmAcceleratorConfigurations.findSubmitButton().should('be.enabled').click();
       checkLLMInferenceServiceConfigState(duplicateResourceName, namespace);
 
       cy.step('Edit the duplicate accelerator config: mark accepted and enabled');
-      const dupRow = llmAcceleratorConfigs.getRowByName(duplicateResourceName);
+      const dupRow = llmAcceleratorConfigurations.getRowByName(duplicateResourceName);
       dupRow.find().should('exist');
       dupRow.shouldHaveUnsupportedLabel(true);
       dupRow.shouldBeEnabled(false);
@@ -156,12 +157,12 @@ describe('Unsupported accelerator configs: CRUD + wizard gating', () => {
       dupRow.findKebabToggle().click();
       dupRow.findEditButton().click();
       // update the unsupported accelerator config to supported
-      llmAcceleratorConfigs
+      llmAcceleratorConfigurations
         .findYAMLCodeEditor()
         .replaceInEditor(testData.replaceSourceString, testData.replaceTargetString);
-      llmAcceleratorConfigs.findSubmitButton().should('be.enabled').click();
+      llmAcceleratorConfigurations.findSubmitButton().should('be.enabled').click();
       checkLLMInferenceServiceConfigState(duplicateResourceName, namespace);
-      llmAcceleratorConfigs
+      llmAcceleratorConfigurations
         .getRowByName(duplicateResourceName)
         .shouldHaveUnsupportedLabel(false)
         .shouldBeEnabled(true);
@@ -172,25 +173,28 @@ describe('Unsupported accelerator configs: CRUD + wizard gating', () => {
       deleteModal.find().should('exist');
       deleteModal.findInput().clear().type(duplicateAcceleratorConfigName);
       deleteModal.findSubmitButton().should('be.enabled').click();
-      llmAcceleratorConfigs.getRowByName(duplicateResourceName).find().should('have.length', 0);
+      llmAcceleratorConfigurations
+        .getRowByName(duplicateResourceName)
+        .find()
+        .should('have.length', 0);
 
       cy.step('Verify the LLMInferenceServiceConfig for the original config exists');
       checkLLMInferenceServiceConfigState(resourceName, namespace);
 
       cy.step(' Verify the unsupported accelerator config is hidden in the wizard');
-      llmAcceleratorConfigs.getRowByName(resourceName).shouldBeEnabled(false);
+      llmAcceleratorConfigurations.getRowByName(resourceName).shouldBeEnabled(false);
       openDeployWizardToDeploymentStep();
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
       modelServingWizard.findGlobalScopedTemplateOption(acceleratorConfigName).should('not.exist');
 
       cy.step('Enable the accelerator config');
-      llmAcceleratorConfigs.visit();
-      llmAcceleratorConfigs.getRowByName(resourceName).findEnabledToggle().click();
+      llmAcceleratorConfigurations.visit();
+      llmAcceleratorConfigurations.getRowByName(resourceName).findEnabledToggle().click();
       unsupportedStatusAcceptanceModal.shouldBeOpen();
       unsupportedStatusAcceptanceModal.findAcceptButton().should('be.disabled');
       unsupportedStatusAcceptanceModal.findAcceptanceCheckbox().click();
       unsupportedStatusAcceptanceModal.findAcceptButton().click();
-      llmAcceleratorConfigs.getRowByName(resourceName).shouldBeEnabled(true);
+      llmAcceleratorConfigurations.getRowByName(resourceName).shouldBeEnabled(true);
 
       cy.step('Verify the accelerator config is visible in the wizard');
       openDeployWizardToDeploymentStep();

--- a/packages/cypress/cypress/tests/e2e/settings/llmdRoutingConfigurations/testLlmdRoutingConfigurations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdRoutingConfigurations/testLlmdRoutingConfigurations.cy.ts
@@ -44,14 +44,7 @@ describe('LLMD Routing Configurations - Admin Settings', () => {
   it(
     'Admin can create, validate, edit, duplicate, delete routing configs and verify wizard visibility',
     {
-      tags: [
-        '@Featureflagged',
-        '@Dashboard',
-        '@ModelServing',
-        '@NonConcurrent',
-        '@LLMDServingCI',
-        '@ModelServingCI',
-      ],
+      tags: ['@Featureflagged', '@Dashboard', '@ModelServing', '@LLMDServingCI', '@ModelServingCI'],
     },
     () => {
       cy.step('Log in as admin');

--- a/packages/cypress/cypress/tests/e2e/settings/llmdRoutingConfigurations/testLlmdRoutingConfigurations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdRoutingConfigurations/testLlmdRoutingConfigurations.cy.ts
@@ -1,10 +1,10 @@
 import { LDAP_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { retryableBefore } from '../../../../utils/retryableHooks';
 import {
-  llmdRoutingSettingsPage,
+  routingConfigurations,
   llmdRoutingCreatePage,
   deleteRouteModal,
-} from '../../../../pages/llmdRoutingSettings';
+} from '../../../../pages/modelDeploymentSettings/routingConfigurations';
 import { cleanupLLMInferenceServiceConfig } from '../../../../utils/oc_commands/llmInferenceServiceConfig';
 import { projectDetails, projectListPage } from '../../../../pages/projects';
 import { modelServingGlobal, modelServingWizard } from '../../../../pages/modelServing';
@@ -44,17 +44,24 @@ describe('LLMD Routing Configurations - Admin Settings', () => {
   it(
     'Admin can create, validate, edit, duplicate, delete routing configs and verify wizard visibility',
     {
-      tags: ['@Featureflagged', '@Dashboard', '@ModelServing', '@NonConcurrent', '@LLMDServingCI'],
+      tags: [
+        '@Featureflagged',
+        '@Dashboard',
+        '@ModelServing',
+        '@NonConcurrent',
+        '@LLMDServingCI',
+        '@ModelServingCI',
+      ],
     },
     () => {
       cy.step('Log in as admin');
       cy.visitWithLogin('/?devFeatureFlags=llmdTemplates=true', LDAP_ADMIN_USER);
 
       cy.step('Navigate to routing configurations settings');
-      llmdRoutingSettingsPage.navigate();
+      routingConfigurations.navigate();
 
       cy.step('Create routing config from UI');
-      llmdRoutingSettingsPage.findAddButton().click();
+      routingConfigurations.findAddButton().click();
       llmdRoutingCreatePage.findDisplayNameInput().clear().type(routingConfigName);
       llmdRoutingCreatePage.selectTopologyType(testData.topologyTypeTestId);
       llmdRoutingCreatePage.selectConfigSource(testData.configSourceEditorKey);
@@ -69,8 +76,8 @@ describe('LLMD Routing Configurations - Admin Settings', () => {
       llmdRoutingCreatePage.findSubmitButton().should('be.enabled').click();
 
       cy.step('Validate routing row: exists, enabled, topology type');
-      llmdRoutingSettingsPage.findTable().should('exist');
-      const row = llmdRoutingSettingsPage.getRow(routingConfigName);
+      routingConfigurations.findTable().should('exist');
+      const row = routingConfigurations.getRow(routingConfigName);
       row.find().should('exist');
       row.findEnabledSwitch().should('exist');
       row.find().should('contain.text', testData.topologyTypeLabel);
@@ -79,20 +86,20 @@ describe('LLMD Routing Configurations - Admin Settings', () => {
       row.findKebabAction('Edit').click();
       llmdRoutingCreatePage.findTopologyTypeSelect().should('not.be.disabled');
       llmdRoutingCreatePage.findSubmitButton().should('be.enabled').click();
-      llmdRoutingSettingsPage.findTable().should('exist');
-      llmdRoutingSettingsPage.getRow(routingConfigName).find().should('exist');
+      routingConfigurations.findTable().should('exist');
+      routingConfigurations.getRow(routingConfigName).find().should('exist');
 
       cy.step('Duplicate the routing config');
-      llmdRoutingSettingsPage.getRow(routingConfigName).findKebabAction('Duplicate').click();
+      routingConfigurations.getRow(routingConfigName).findKebabAction('Duplicate').click();
       llmdRoutingCreatePage.findSubmitButton().should('be.enabled').click();
-      llmdRoutingSettingsPage.findTable().should('exist');
-      llmdRoutingSettingsPage.getRow(`${routingConfigName}-copy`).find().should('exist');
+      routingConfigurations.findTable().should('exist');
+      routingConfigurations.getRow(`${routingConfigName}-copy`).find().should('exist');
 
       cy.step('Delete the original routing config');
-      llmdRoutingSettingsPage.getRow(routingConfigName).findKebabAction('Delete').click();
+      routingConfigurations.getRow(routingConfigName).findKebabAction('Delete').click();
       deleteRouteModal.findSubmitButton().should('be.enabled').click();
-      llmdRoutingSettingsPage.getRow(routingConfigName).find().should('not.exist');
-      llmdRoutingSettingsPage.getRow(`${routingConfigName}-copy`).find().should('exist');
+      routingConfigurations.getRow(routingConfigName).find().should('not.exist');
+      routingConfigurations.getRow(`${routingConfigName}-copy`).find().should('exist');
 
       cy.step('Navigate to project and open deploy wizard');
       projectListPage.navigate();

--- a/packages/cypress/cypress/tests/e2e/settings/llmdRoutingConfigurations/testLlmdRoutingConfigurations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdRoutingConfigurations/testLlmdRoutingConfigurations.cy.ts
@@ -10,7 +10,11 @@ import { projectDetails, projectListPage } from '../../../../pages/projects';
 import { modelServingGlobal, modelServingWizard } from '../../../../pages/modelServing';
 import { ModelLocationSelectOption, ModelTypeLabel } from '../../../../utils/modelServingConstants';
 import { createCleanProject } from '../../../../utils/projectChecker';
-import { deleteOpenShiftProject } from '../../../../utils/oc_commands/project';
+import {
+  addUserToProject,
+  deleteOpenShiftProject,
+  waitForUserProjectAccess,
+} from '../../../../utils/oc_commands/project';
 import { generateTestUUID } from '../../../../utils/uuidGenerator';
 import { loadDSPFixture } from '../../../../utils/dataLoader';
 import type { RoutingTestData, DataScienceProjectData } from '../../../../types';
@@ -19,6 +23,9 @@ let testData: RoutingTestData;
 const uuid = generateTestUUID();
 let projectName: string;
 let routingConfigName: string;
+// Duplicating a config produces display name "Copy of <name>", whose k8s
+// metadata.name (and therefore its row/option testids) is "copy-of-<name>".
+let duplicateRoutingConfigName: string;
 
 describe('LLMD Routing Configurations - Admin Settings', () => {
   retryableBefore(() => {
@@ -29,15 +36,22 @@ describe('LLMD Routing Configurations - Admin Settings', () => {
         testData = fixtureData as RoutingTestData;
         projectName = `${testData.projectResourceName}-${uuid}`;
         routingConfigName = `${testData.routingConfigName}-${uuid}`;
+        duplicateRoutingConfigName = `copy-of-${routingConfigName}`;
       })
       .then(() => {
         createCleanProject(projectName);
+      })
+      .then(() => {
+        // The project is created via oc as a cluster admin; grant the test's
+        // login user admin access so it appears in their Projects list (STEP 8).
+        addUserToProject(projectName, LDAP_ADMIN_USER.USERNAME, 'admin');
+        return waitForUserProjectAccess(projectName, LDAP_ADMIN_USER.USERNAME);
       });
   });
 
   after(() => {
     cleanupLLMInferenceServiceConfig(routingConfigName);
-    cleanupLLMInferenceServiceConfig(`${routingConfigName}-copy`);
+    cleanupLLMInferenceServiceConfig(duplicateRoutingConfigName);
     deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true, timeout: 300000 });
   });
 
@@ -60,11 +74,9 @@ describe('LLMD Routing Configurations - Admin Settings', () => {
       llmdRoutingCreatePage.selectConfigSource(testData.configSourceEditorKey);
       llmdRoutingCreatePage.findYamlEditor().should('exist');
       cy.fixture(testData.routingConfigFixture).then((yamlContent: string) => {
-        llmdRoutingCreatePage.findYamlEditor().find('textarea').clear({ force: true });
-        llmdRoutingCreatePage.findYamlEditor().find('textarea').type(yamlContent, {
-          parseSpecialCharSequences: false,
-          delay: 0,
-        });
+        // The config field is a Monaco CodeEditor (no textarea); set content via
+        // the shared helper, which uploads through the editor's file input.
+        llmdRoutingCreatePage.getYamlEditor().setValue(yamlContent);
       });
       llmdRoutingCreatePage.findSubmitButton().should('be.enabled').click();
 
@@ -86,13 +98,15 @@ describe('LLMD Routing Configurations - Admin Settings', () => {
       routingConfigurations.getRow(routingConfigName).findKebabAction('Duplicate').click();
       llmdRoutingCreatePage.findSubmitButton().should('be.enabled').click();
       routingConfigurations.findTable().should('exist');
-      routingConfigurations.getRow(`${routingConfigName}-copy`).find().should('exist');
+      routingConfigurations.getRow(duplicateRoutingConfigName).find().should('exist');
 
       cy.step('Delete the original routing config');
       routingConfigurations.getRow(routingConfigName).findKebabAction('Delete').click();
+      // The delete modal gates its danger button on typing the config name to confirm.
+      deleteRouteModal.findInput().clear().type(routingConfigName);
       deleteRouteModal.findSubmitButton().should('be.enabled').click();
       routingConfigurations.getRow(routingConfigName).find().should('not.exist');
-      routingConfigurations.getRow(`${routingConfigName}-copy`).find().should('exist');
+      routingConfigurations.getRow(duplicateRoutingConfigName).find().should('exist');
 
       cy.step('Navigate to project and open deploy wizard');
       projectListPage.navigate();
@@ -120,7 +134,7 @@ describe('LLMD Routing Configurations - Admin Settings', () => {
         .findRoutingConfigSelect()
         .should('contain.text', testData.defaultRoutingLabel);
       modelServingWizard.findRoutingConfigSelect().click();
-      modelServingWizard.findRoutingConfigOption(`${routingConfigName}-copy`).should('exist');
+      modelServingWizard.findRoutingConfigOption(duplicateRoutingConfigName).should('exist');
     },
   );
 });

--- a/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
@@ -63,7 +63,7 @@ describe('LLMD Topology Configurations - Admin Settings', () => {
   it(
     'Admin can manage topology configurations and verify wizard visibility',
     {
-      tags: ['@Smoke', '@Dashboard', '@ModelServing', '@LLMDServingCI', '@ModelServingCI'],
+      tags: ['@Featureflagged', '@Dashboard', '@ModelServing', '@LLMDServingCI', '@ModelServingCI'],
     },
     () => {
       cy.step('Log in with topology configs feature flag');

--- a/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
@@ -1,15 +1,15 @@
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { retryableBefore } from '../../../../utils/retryableHooks';
 import { topologyConfigurations } from '../../../../pages/modelDeploymentSettings/topologyConfigurations';
-import {
-  createCleanLLMInferenceServiceConfig,
-  cleanupLLMInferenceServiceConfig,
-} from '../../../../utils/oc_commands/llmInferenceServiceConfig';
+import { cleanupLLMInferenceServiceConfig } from '../../../../utils/oc_commands/llmInferenceServiceConfig';
 import { projectDetails, projectListPage } from '../../../../pages/projects';
 import { modelServingGlobal, modelServingWizard } from '../../../../pages/modelServing';
 import { ModelLocationSelectOption, ModelTypeLabel } from '../../../../utils/modelServingConstants';
 import { createCleanProject } from '../../../../utils/projectChecker';
 import { deleteOpenShiftProject } from '../../../../utils/oc_commands/project';
+import { applyOpenShiftYaml } from '../../../../utils/oc_commands/baseCommands';
+import { renderYamlFileWithReplacements } from '../../../../utils/oc_commands/templates';
+import { getFixturePath } from '../../../../utils/fileImportUtils';
 import { generateTestUUID } from '../../../../utils/uuidGenerator';
 import { loadDSPFixture } from '../../../../utils/dataLoader';
 import type { DataScienceProjectData } from '../../../../types';
@@ -22,6 +22,9 @@ type TopologyTestData = DataScienceProjectData & {
 let testData: TopologyTestData;
 const uuid = generateTestUUID();
 let projectName: string;
+// Unique per-run config name so the test is safe to run concurrently.
+let topologyConfigName: string;
+const applicationNamespace = Cypress.env('APPLICATIONS_NAMESPACE');
 
 describe('LLMD Topology Configurations - Admin Settings', () => {
   retryableBefore(() => {
@@ -30,30 +33,24 @@ describe('LLMD Topology Configurations - Admin Settings', () => {
     ).then((fixtureData: DataScienceProjectData) => {
       testData = fixtureData as TopologyTestData;
       projectName = `${testData.projectResourceName}-${uuid}`;
-      createCleanLLMInferenceServiceConfig(
-        testData.topologyConfigName,
-        testData.topologyConfigFixture,
-      );
+      topologyConfigName = `${testData.topologyConfigName}-${uuid}`;
+      // Seed a uniquely-named topology config so concurrent runs don't collide.
+      renderYamlFileWithReplacements(getFixturePath(testData.topologyConfigFixture), {
+        TOPOLOGY_CONFIG_NAME: topologyConfigName,
+      }).then((renderedYaml) => applyOpenShiftYaml(renderedYaml, applicationNamespace));
       createCleanProject(projectName);
     });
   });
 
   after(() => {
-    cleanupLLMInferenceServiceConfig(testData.topologyConfigName);
+    cleanupLLMInferenceServiceConfig(topologyConfigName);
     deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true, timeout: 300000 });
   });
 
   it(
     'Admin can manage topology configurations and verify wizard visibility',
     {
-      tags: [
-        '@Smoke',
-        '@Dashboard',
-        '@NonConcurrent',
-        '@ModelServing',
-        '@LLMDServingCI',
-        '@ModelServingCI',
-      ],
+      tags: ['@Smoke', '@Dashboard', '@ModelServing', '@LLMDServingCI', '@ModelServingCI'],
     },
     () => {
       cy.step('Log in with topology configs feature flag');
@@ -64,7 +61,7 @@ describe('LLMD Topology Configurations - Admin Settings', () => {
       topologyConfigurations.findTable().should('exist');
 
       cy.step('Verify the test topology config is listed');
-      topologyConfigurations.getRow(testData.topologyConfigName).find().should('exist');
+      topologyConfigurations.getRow(topologyConfigName).find().should('exist');
 
       cy.step('Navigate to project and open deploy wizard');
       projectListPage.navigate();

--- a/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
@@ -1,4 +1,4 @@
-import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
+import { LDAP_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { retryableBefore } from '../../../../utils/retryableHooks';
 import { topologyConfigurations } from '../../../../pages/modelDeploymentSettings/topologyConfigurations';
 import { cleanupLLMInferenceServiceConfig } from '../../../../utils/oc_commands/llmInferenceServiceConfig';
@@ -6,7 +6,11 @@ import { projectDetails, projectListPage } from '../../../../pages/projects';
 import { modelServingGlobal, modelServingWizard } from '../../../../pages/modelServing';
 import { ModelLocationSelectOption, ModelTypeLabel } from '../../../../utils/modelServingConstants';
 import { createCleanProject } from '../../../../utils/projectChecker';
-import { deleteOpenShiftProject } from '../../../../utils/oc_commands/project';
+import {
+  addUserToProject,
+  deleteOpenShiftProject,
+  waitForUserProjectAccess,
+} from '../../../../utils/oc_commands/project';
 import { applyOpenShiftYaml } from '../../../../utils/oc_commands/baseCommands';
 import { renderYamlFileWithReplacements } from '../../../../utils/oc_commands/templates';
 import { getFixturePath } from '../../../../utils/fileImportUtils';
@@ -30,16 +34,25 @@ describe('LLMD Topology Configurations - Admin Settings', () => {
   retryableBefore(() => {
     return loadDSPFixture(
       'e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.yaml',
-    ).then((fixtureData: DataScienceProjectData) => {
-      testData = fixtureData as TopologyTestData;
-      projectName = `${testData.projectResourceName}-${uuid}`;
-      topologyConfigName = `${testData.topologyConfigName}-${uuid}`;
-      // Seed a uniquely-named topology config so concurrent runs don't collide.
-      renderYamlFileWithReplacements(getFixturePath(testData.topologyConfigFixture), {
-        TOPOLOGY_CONFIG_NAME: topologyConfigName,
-      }).then((renderedYaml) => applyOpenShiftYaml(renderedYaml, applicationNamespace));
-      createCleanProject(projectName);
-    });
+    )
+      .then((fixtureData: DataScienceProjectData) => {
+        testData = fixtureData as TopologyTestData;
+        projectName = `${testData.projectResourceName}-${uuid}`;
+        topologyConfigName = `${testData.topologyConfigName}-${uuid}`;
+        // Seed a uniquely-named topology config so concurrent runs don't collide.
+        return renderYamlFileWithReplacements(getFixturePath(testData.topologyConfigFixture), {
+          TOPOLOGY_CONFIG_NAME: topologyConfigName,
+        }).then((renderedYaml) => applyOpenShiftYaml(renderedYaml, applicationNamespace));
+      })
+      .then(() => {
+        createCleanProject(projectName);
+      })
+      .then(() => {
+        // The project is created via oc as a cluster admin; grant the test's
+        // login user admin access so it appears in their Projects list.
+        addUserToProject(projectName, LDAP_ADMIN_USER.USERNAME, 'admin');
+        return waitForUserProjectAccess(projectName, LDAP_ADMIN_USER.USERNAME);
+      });
   });
 
   after(() => {
@@ -54,7 +67,7 @@ describe('LLMD Topology Configurations - Admin Settings', () => {
     },
     () => {
       cy.step('Log in with topology configs feature flag');
-      cy.visitWithLogin('/?devFeatureFlags=llmdTemplates=true', HTPASSWD_CLUSTER_ADMIN_USER);
+      cy.visitWithLogin('/?devFeatureFlags=llmdTemplates=true', LDAP_ADMIN_USER);
 
       cy.step('Navigate to topology configurations settings');
       topologyConfigurations.navigate();

--- a/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
@@ -1,6 +1,6 @@
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { retryableBefore } from '../../../../utils/retryableHooks';
-import { llmdTopologySettingsPage } from '../../../../pages/llmdTopologySettings';
+import { topologyConfigurations } from '../../../../pages/modelDeploymentSettings/topologyConfigurations';
 import {
   createCleanLLMInferenceServiceConfig,
   cleanupLLMInferenceServiceConfig,
@@ -45,17 +45,26 @@ describe('LLMD Topology Configurations - Admin Settings', () => {
 
   it(
     'Admin can manage topology configurations and verify wizard visibility',
-    { tags: ['@Smoke', '@Dashboard', '@NonConcurrent', '@LLMDServingCI'] },
+    {
+      tags: [
+        '@Smoke',
+        '@Dashboard',
+        '@NonConcurrent',
+        '@ModelServing',
+        '@LLMDServingCI',
+        '@ModelServingCI',
+      ],
+    },
     () => {
       cy.step('Log in with topology configs feature flag');
       cy.visitWithLogin('/?devFeatureFlags=llmdTemplates=true', HTPASSWD_CLUSTER_ADMIN_USER);
 
       cy.step('Navigate to topology configurations settings');
-      llmdTopologySettingsPage.navigate();
-      llmdTopologySettingsPage.findTable().should('exist');
+      topologyConfigurations.navigate();
+      topologyConfigurations.findTable().should('exist');
 
       cy.step('Verify the test topology config is listed');
-      llmdTopologySettingsPage.getRow(testData.topologyConfigName).find().should('exist');
+      topologyConfigurations.getRow(testData.topologyConfigName).find().should('exist');
 
       cy.step('Navigate to project and open deploy wizard');
       projectListPage.navigate();

--- a/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurationsCrud.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurationsCrud.cy.ts
@@ -1,0 +1,91 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
+import { retryableBefore } from '../../../../utils/retryableHooks';
+import { topologyConfigurations } from '../../../../pages/modelDeploymentSettings/topologyConfigurations';
+import { deleteModal } from '../../../../pages/components/DeleteModal';
+import {
+  cleanupLLMInferenceServiceConfig,
+  checkLLMInferenceServiceConfigState,
+} from '../../../../utils/oc_commands/llmInferenceServiceConfig';
+import { generateTestUUID } from '../../../../utils/uuidGenerator';
+import { loadDSPFixture } from '../../../../utils/dataLoader';
+import type { DataScienceProjectData } from '../../../../types';
+
+type TopologyCrudTestData = DataScienceProjectData & {
+  topologyConfigResourceName: string;
+  topologyConfigDisplayName: string;
+  topologyConfigEditorFixture: string;
+  configSourceEditorKey: string;
+};
+
+let testData: TopologyCrudTestData;
+const uuid = generateTestUUID();
+const namespace = Cypress.env('APPLICATIONS_NAMESPACE');
+// Unique per-run names so the test is safe to run concurrently.
+let resourceName: string;
+let displayName: string;
+
+describe('LLMD Topology Configurations - Admin CRUD', () => {
+  retryableBefore(() => {
+    return loadDSPFixture(
+      'e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurationsCrud.yaml',
+    ).then((fixtureData: DataScienceProjectData) => {
+      testData = fixtureData as TopologyCrudTestData;
+      resourceName = `${testData.topologyConfigResourceName}-${uuid}`;
+      displayName = `${testData.topologyConfigDisplayName} ${uuid}`;
+      // Ensure a clean start if a previous run left this config behind.
+      cleanupLLMInferenceServiceConfig(resourceName);
+    });
+  });
+
+  after(() => {
+    cleanupLLMInferenceServiceConfig(resourceName);
+  });
+
+  it(
+    'Admin creates a topology config via the UI, it persists on the cluster, and delete removes it',
+    { tags: ['@Dashboard', '@ModelServing', '@LLMDServingCI', '@ModelServingCI'] },
+    () => {
+      cy.step('Log in with the topology configs feature flag');
+      cy.visitWithLogin('/?devFeatureFlags=llmdTemplates=true', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      cy.step('Navigate to topology configurations settings');
+      topologyConfigurations.navigate();
+      topologyConfigurations.findTable().should('exist');
+
+      cy.step('Open the create form (single node topology)');
+      topologyConfigurations.findAddButton().click();
+
+      cy.step('Fill in name, resource name, and configuration');
+      topologyConfigurations.findDisplayNameInput().clear().type(displayName);
+      topologyConfigurations.findEditResourceNameLink().click();
+      topologyConfigurations.findNameInput().should('be.visible').clear().type(resourceName);
+      topologyConfigurations.selectConfigSource(testData.configSourceEditorKey);
+      topologyConfigurations.findYamlEditor().should('exist');
+      cy.fixture(testData.topologyConfigEditorFixture).then((yamlContent: string) => {
+        // The config field is a Monaco CodeEditor (no textarea); set content via
+        // the shared helper, which uploads through the editor's file input.
+        topologyConfigurations.getYamlEditor().setValue(yamlContent);
+      });
+
+      cy.step('Submit and verify the config is created');
+      topologyConfigurations.findSubmitButton().should('be.enabled').click();
+
+      cy.step('Verify the new config appears in the table');
+      topologyConfigurations.findTable().should('exist');
+      topologyConfigurations.getRow(resourceName).find().should('exist');
+
+      cy.step(
+        'Verify the config actually persisted as an LLMInferenceServiceConfig on the cluster',
+      );
+      checkLLMInferenceServiceConfigState(resourceName, namespace);
+
+      cy.step('Delete the config from the UI');
+      topologyConfigurations.getRow(resourceName).findKebabAction('Delete').click();
+      deleteModal.findInput().clear().type(displayName);
+      deleteModal.findSubmitButton().should('be.enabled').click();
+
+      cy.step('Verify the config is removed from the table');
+      topologyConfigurations.getRow(resourceName).find().should('not.exist');
+    },
+  );
+});

--- a/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurationsCrud.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurationsCrud.cy.ts
@@ -49,8 +49,11 @@ describe('LLMD Topology Configurations - Admin CRUD', () => {
       cy.visitWithLogin('/?devFeatureFlags=llmdTemplates=true', HTPASSWD_CLUSTER_ADMIN_USER);
 
       cy.step('Navigate to topology configurations settings');
+      // On a clean cluster the tab renders an empty state (no table) until the
+      // first config exists, so open the create form via the Add button (present
+      // in both the empty state and the populated table) rather than asserting
+      // the table up front.
       topologyConfigurations.navigate();
-      topologyConfigurations.findTable().should('exist');
 
       cy.step('Open the create form (single node topology)');
       topologyConfigurations.findAddButton().click();

--- a/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurationsCrud.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurationsCrud.cy.ts
@@ -43,7 +43,9 @@ describe('LLMD Topology Configurations - Admin CRUD', () => {
 
   it(
     'Admin creates a topology config via the UI, it persists on the cluster, and delete removes it',
-    { tags: ['@Dashboard', '@ModelServing', '@LLMDServingCI', '@ModelServingCI'] },
+    {
+      tags: ['@Featureflagged', '@Dashboard', '@ModelServing', '@LLMDServingCI', '@ModelServingCI'],
+    },
     () => {
       cy.step('Log in with the topology configs feature flag');
       cy.visitWithLogin('/?devFeatureFlags=llmdTemplates=true', HTPASSWD_CLUSTER_ADMIN_USER);

--- a/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testServingRuntimesUnsupported.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testServingRuntimesUnsupported.cy.ts
@@ -1,6 +1,6 @@
 import { retryableBefore } from '../../../../utils/retryableHooks';
 import { LDAP_ADMIN_USER } from '../../../../utils/e2eUsers';
-import { servingRuntimes } from '../../../../pages/servingRuntimes';
+import { servingRuntimeTemplates } from '../../../../pages/modelDeploymentSettings/servingRuntimeTemplates';
 import { loadDSPFixture } from '../../../../utils/dataLoader';
 import { createCleanProject } from '../../../../utils/projectChecker';
 import {
@@ -18,7 +18,7 @@ import { projectDetails, projectListPage } from '../../../../pages/projects';
 import { modelServingGlobal, modelServingWizard } from '../../../../pages/modelServing';
 import { ModelLocationSelectOption, ModelTypeLabel } from '../../../../utils/modelServingConstants';
 import type { DataScienceProjectData, ServingRuntimeSettingsTestData } from '../../../../types';
-import { unsupportedStatusAcceptanceModal } from '../../../../pages/llmAcceleratorConfigs';
+import { unsupportedStatusAcceptanceModal } from '../../../../pages/modelDeploymentSettings/llmAcceleratorConfigurations';
 import { deleteModal } from '../../../../pages/components/DeleteModal';
 import { generateTestUUID } from '../../../../utils/uuidGenerator';
 
@@ -83,34 +83,38 @@ describe('Serving runtimes: CRUD + wizard visibility', () => {
 
   it(
     'Admin can import/enable/disable/delete a serving runtime and verify wizard options',
-    { tags: ['@Dashboard', '@Smoke', '@SmokeSet3', '@ModelServing', '@ModelServingCI'] },
+    {
+      tags: ['@Dashboard', '@Smoke', '@SmokeSet3', '@ModelServing', '@ModelServingCI', '@KServeCI'],
+    },
     () => {
       cy.step('Log into the application');
       cy.visitWithLogin('/', LDAP_ADMIN_USER);
 
       cy.step('Navigate to Serving runtimes and import a custom runtime YAML');
-      cy.wrap(servingRuntimes.navigate());
-      servingRuntimes.findAddButton().should('exist').and('be.visible').click();
+      cy.wrap(servingRuntimeTemplates.navigate());
+      servingRuntimeTemplates.findAddButton().should('exist').and('be.visible').click();
 
       cy.step('Select API protocol and model type');
-      servingRuntimes.findSelectAPIProtocolButton().click();
-      servingRuntimes.selectAPIProtocol(testData.apiProtocol);
-      servingRuntimes.findSelectModelTypes().click();
-      servingRuntimes.findGenerativeAIModelOption().click();
+      servingRuntimeTemplates.findSelectAPIProtocolButton().click();
+      servingRuntimeTemplates.selectAPIProtocol(testData.apiProtocol);
+      servingRuntimeTemplates.findSelectModelTypes().click();
+      servingRuntimeTemplates.findGenerativeAIModelOption().click();
 
       cy.step('Upload YAML and create serving runtime');
       const yamlPath = getFixturePath(testData.unsupportedServingRuntimeYamlFixturePath);
       renderYamlFileWithReplacements(yamlPath, {
         SERVING_RUNTIME_NAME: servingRuntimeId,
         SERVING_RUNTIME_DISPLAY_NAME: servingRuntimeDisplayName,
-      }).then((renderedYaml) => servingRuntimes.getDashboardCodeEditor().setValue(renderedYaml));
+      }).then((renderedYaml) =>
+        servingRuntimeTemplates.getDashboardCodeEditor().setValue(renderedYaml),
+      );
 
       cy.step('Submit the serving runtime');
-      servingRuntimes.findSubmitButton().should('be.enabled').click();
+      servingRuntimeTemplates.findSubmitButton().should('be.enabled').click();
       waitForTemplateByServingRuntimeName(servingRuntimeId);
 
       cy.step('Verify the serving runtime is created');
-      const runtimeRow = servingRuntimes.getRowById(servingRuntimeId);
+      const runtimeRow = servingRuntimeTemplates.getRowById(servingRuntimeId);
       runtimeRow.find().should('exist');
       runtimeRow.shouldHaveUnsupportedLabel(true);
       runtimeRow.shouldBeEnabled(false);
@@ -118,15 +122,17 @@ describe('Serving runtimes: CRUD + wizard visibility', () => {
       cy.step('Duplicate the serving runtime and verify the duplicate');
       runtimeRow.findKebabToggle().click();
       runtimeRow.findDuplicateAction().click();
-      servingRuntimes.findSelectAPIProtocolButton().should('have.text', testData.apiProtocol);
-      servingRuntimes.findSelectModelTypes().click();
-      servingRuntimes.findGenerativeAIModelOption().should('be.checked');
-      servingRuntimes.getDashboardCodeEditor().containsText(testData.resourceType);
-      servingRuntimes.findSubmitButton().should('be.enabled').click();
+      servingRuntimeTemplates
+        .findSelectAPIProtocolButton()
+        .should('have.text', testData.apiProtocol);
+      servingRuntimeTemplates.findSelectModelTypes().click();
+      servingRuntimeTemplates.findGenerativeAIModelOption().should('be.checked');
+      servingRuntimeTemplates.getDashboardCodeEditor().containsText(testData.resourceType);
+      servingRuntimeTemplates.findSubmitButton().should('be.enabled').click();
       waitForTemplateByServingRuntimeName(duplicateservingRuntimeId);
 
       cy.step('Verify the duplicate serving runtime is created');
-      const duplicateRuntimeRow = servingRuntimes.getRowById(duplicateservingRuntimeId);
+      const duplicateRuntimeRow = servingRuntimeTemplates.getRowById(duplicateservingRuntimeId);
       duplicateRuntimeRow.find().should('exist');
       duplicateRuntimeRow.shouldHaveUnsupportedLabel(true);
       duplicateRuntimeRow.shouldBeEnabled(false);
@@ -135,10 +141,10 @@ describe('Serving runtimes: CRUD + wizard visibility', () => {
       duplicateRuntimeRow.findKebabToggle().click();
       duplicateRuntimeRow.findEditButton().click();
       // update the unsupported serving runtime to supported
-      servingRuntimes
+      servingRuntimeTemplates
         .getDashboardCodeEditor()
         .replaceInEditor(testData.replaceSourceString, testData.replaceTargetString);
-      servingRuntimes.findSubmitButton().should('be.enabled').click();
+      servingRuntimeTemplates.findSubmitButton().should('be.enabled').click();
       waitForTemplateByServingRuntimeName(duplicateservingRuntimeId);
       duplicateRuntimeRow.shouldHaveUnsupportedLabel(false);
       duplicateRuntimeRow.shouldBeEnabled(true);
@@ -162,8 +168,8 @@ describe('Serving runtimes: CRUD + wizard visibility', () => {
         .should('not.exist');
 
       cy.step('Enable the serving runtime and verify it is visible in the wizard');
-      servingRuntimes.visit();
-      const runtimeRowAfterVisit = servingRuntimes.getRowById(servingRuntimeId);
+      servingRuntimeTemplates.visit();
+      const runtimeRowAfterVisit = servingRuntimeTemplates.getRowById(servingRuntimeId);
       runtimeRowAfterVisit.find().should('exist');
       runtimeRowAfterVisit.findEnabledToggle().click();
       unsupportedStatusAcceptanceModal.shouldBeOpen();

--- a/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
@@ -1,5 +1,5 @@
 import { ServingRuntimeAPIProtocol } from '@odh-dashboard/model-serving/shared/types';
-import { servingRuntimes } from '../../../../pages/servingRuntimes';
+import { servingRuntimeTemplates } from '../../../../pages/modelDeploymentSettings/servingRuntimeTemplates';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { getSingleModelPath } from '../../../../utils/fileImportUtils';
 import { getSingleModelServingRuntimeInfo } from '../../../../utils/fileParserUtil';
@@ -32,7 +32,19 @@ after(() => {
 describe('Verify Admins Can Import and Delete a Custom Single-Model Serving Runtime Template By Uploading A YAML file', () => {
   it(
     'Admin should access serving runtimes, import a yaml file and then delete',
-    { tags: ['@Smoke', '@SmokeSet2', '@ODS-2276', '@Dashboard', '@NonConcurrent', '@SettingsCI'] },
+    {
+      tags: [
+        '@Smoke',
+        '@SmokeSet2',
+        '@ODS-2276',
+        '@Dashboard',
+        '@NonConcurrent',
+        '@ModelServing',
+        '@SettingsCI',
+        '@KServeCI',
+        '@ModelServingCI',
+      ],
+    },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');
@@ -43,49 +55,52 @@ describe('Verify Admins Can Import and Delete a Custom Single-Model Serving Runt
         // TODO: Remove extended timeout once '/servingruntimes' performance is optimized - RHOAIENG-15914
         // Current workaround for ODH page loading performance issues
         cy.log('⚠️ Note: RHOAIENG-15914 may cause intermittent failures at this step ⚠️');
-        return cy.wrap(servingRuntimes.navigate(), { timeout: 100000 });
+        return cy.wrap(servingRuntimeTemplates.navigate(), { timeout: 100000 });
       });
 
       cy.log('Navigation successful | Searching for Add button');
-      servingRuntimes.findAddButton().should('exist').and('be.visible').click();
+      servingRuntimeTemplates.findAddButton().should('exist').and('be.visible').click();
 
       cy.step('Select API Protocol');
-      servingRuntimes.findSelectAPIProtocolButton().click();
-      servingRuntimes.selectAPIProtocol(ServingRuntimeAPIProtocol.REST);
+      servingRuntimeTemplates.findSelectAPIProtocolButton().click();
+      servingRuntimeTemplates.selectAPIProtocol(ServingRuntimeAPIProtocol.REST);
 
       cy.step('Select Model Types');
-      servingRuntimes.findSelectModelTypes().click();
-      servingRuntimes.findPredictiveModelOption().click();
+      servingRuntimeTemplates.findSelectModelTypes().click();
+      servingRuntimeTemplates.findPredictiveModelOption().click();
 
       cy.step('Upload a Single-Model Serving runtime yaml file');
       const singleModelYaml = getSingleModelPath();
-      servingRuntimes.uploadYaml(singleModelYaml);
+      servingRuntimeTemplates.uploadYaml(singleModelYaml);
 
       cy.step('Click to save and verify that creation was successful');
-      servingRuntimes
+      servingRuntimeTemplates
         .findSubmitButton()
         .should('be.enabled')
         .click()
         .then(() => {
-          cy.url().should('match', /\/serving-runtimes$/, { timeout: 30000 });
+          cy.url().should('match', /\/serving-runtime-templates$/, { timeout: 30000 });
         });
 
       // Edit the created model serving platform and delete
       cy.step(`Verify the model ${modelServingSingleName} has been created`);
       cy.contains(metadataSingleDisplayName).should('be.visible');
-      servingRuntimes
+      servingRuntimeTemplates
         .getRowById(modelServingSingleName)
         .find()
         .within(() => {
-          servingRuntimes.findEditModel().click();
+          servingRuntimeTemplates.findEditModel().click();
         });
-      servingRuntimes.findDeleteModel().click();
+      servingRuntimeTemplates.findDeleteModel().click();
 
-      servingRuntimes.findDeleteModal().should('be.visible').type(metadataSingleDisplayName);
+      servingRuntimeTemplates
+        .findDeleteModal()
+        .should('be.visible')
+        .type(metadataSingleDisplayName);
 
       cy.step(`Delete the model ${modelServingSingleName}`);
-      servingRuntimes.findDeleteModelServingButton().click();
-      servingRuntimes.getRowById(modelServingSingleName).find().should('not.exist');
+      servingRuntimeTemplates.findDeleteModelServingButton().click();
+      servingRuntimeTemplates.getRowById(modelServingSingleName).find().should('not.exist');
     },
   );
 });

--- a/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
@@ -2,31 +2,35 @@ import { ServingRuntimeAPIProtocol } from '@odh-dashboard/model-serving/shared/t
 import { servingRuntimeTemplates } from '../../../../pages/modelDeploymentSettings/servingRuntimeTemplates';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { getSingleModelPath } from '../../../../utils/fileImportUtils';
-import { getSingleModelServingRuntimeInfo } from '../../../../utils/fileParserUtil';
-import { cleanupTemplates } from '../../../../utils/oc_commands/templates';
+import {
+  cleanupTemplates,
+  renderYamlFileWithReplacements,
+} from '../../../../utils/oc_commands/templates';
 import { retryableBefore } from '../../../../utils/retryableHooks';
+import { generateTestUUID } from '../../../../utils/uuidGenerator';
 
-let modelServingSingleName: string;
-let metadataSingleDisplayName: string;
+const uuid = generateTestUUID();
+// Unique per-run names so the test is safe to run concurrently.
+const modelServingSingleName = `single-cypress-vllm-runtime-${uuid}`;
+const metadataSingleDisplayName = `Cypress Single ServingRuntime for KServe ${uuid}`;
+// Rendered copy of the runtime YAML, written to a temp path outside the repo so the
+// test still exercises the real "pick a file from disk" upload path (selectFile with a
+// file path) without leaving stray files in the fixtures tree.
+const renderedRuntimeYamlPath = `/tmp/kserve_singleservingruntime-${uuid}.yaml`;
 
 retryableBefore(() => {
-  cy.wrap(null)
-    .then(() => getSingleModelServingRuntimeInfo())
-    .then((info) => {
-      // Load Single-Model serving runtime info before tests run
-      modelServingSingleName = info.singleModelServingName;
-      metadataSingleDisplayName = info.displayName;
-      cy.log(`Loaded Single-Model Name: ${modelServingSingleName}`);
-      cy.log(`Loaded Single-Model Metadata Name: ${metadataSingleDisplayName}`);
+  // Render the templatized runtime YAML with unique names and write it to disk.
+  renderYamlFileWithReplacements(getSingleModelPath(), {
+    SERVING_RUNTIME_NAME: modelServingSingleName,
+    SERVING_RUNTIME_DISPLAY_NAME: metadataSingleDisplayName,
+  }).then((renderedYaml) => cy.writeFile(renderedRuntimeYamlPath, renderedYaml));
 
-      // Clean up by nested ServingRuntime name (Template row id)
-      return cleanupTemplates(modelServingSingleName);
-    });
+  // Clean up by nested ServingRuntime name (Template row id).
+  cleanupTemplates(modelServingSingleName);
 });
 after(() => {
-  if (modelServingSingleName) {
-    cleanupTemplates(modelServingSingleName);
-  }
+  cleanupTemplates(modelServingSingleName);
+  cy.task('deleteFile', renderedRuntimeYamlPath);
 });
 
 describe('Verify Admins Can Import and Delete a Custom Single-Model Serving Runtime Template By Uploading A YAML file', () => {
@@ -38,7 +42,6 @@ describe('Verify Admins Can Import and Delete a Custom Single-Model Serving Runt
         '@SmokeSet2',
         '@ODS-2276',
         '@Dashboard',
-        '@NonConcurrent',
         '@ModelServing',
         '@SettingsCI',
         '@KServeCI',
@@ -70,8 +73,7 @@ describe('Verify Admins Can Import and Delete a Custom Single-Model Serving Runt
       servingRuntimeTemplates.findPredictiveModelOption().click();
 
       cy.step('Upload a Single-Model Serving runtime yaml file');
-      const singleModelYaml = getSingleModelPath();
-      servingRuntimeTemplates.uploadYaml(singleModelYaml);
+      servingRuntimeTemplates.uploadYaml(renderedRuntimeYamlPath);
 
       cy.step('Click to save and verify that creation was successful');
       servingRuntimeTemplates

--- a/packages/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
@@ -5,7 +5,7 @@ import {
 } from '@odh-dashboard/model-serving/shared';
 import { mockServingRuntimeK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockServingRuntimeK8sResource';
 import { customServingRuntimesIntercept } from './customServingRuntimesUtils';
-import { servingRuntimes } from '../../../pages/servingRuntimes';
+import { servingRuntimeTemplates } from '../../../pages/modelDeploymentSettings/servingRuntimeTemplates';
 import { deleteModal } from '../../../pages/components/DeleteModal';
 import { asProductAdminUser, asProjectAdminUser } from '../../../utils/mockUsers';
 import { pageNotfound } from '../../../pages/pageNotFound';
@@ -17,9 +17,9 @@ const editfilePath =
 
 it('Custom servingruntimes should not be available for non product admins', () => {
   asProjectAdminUser();
-  servingRuntimes.visit(false);
+  servingRuntimeTemplates.visit(false);
   pageNotfound.findPage().should('exist');
-  servingRuntimes.findNavItem().should('not.exist');
+  servingRuntimeTemplates.findNavItem().should('not.exist');
 });
 
 describe('Custom serving runtimes', () => {
@@ -27,24 +27,42 @@ describe('Custom serving runtimes', () => {
     asProductAdminUser();
     customServingRuntimesIntercept();
 
-    servingRuntimes.visit();
+    servingRuntimeTemplates.visit();
   });
 
   it('should display serving runtime version label', () => {
-    servingRuntimes.getRowById('template-1').findServingRuntimeVersionLabel().should('exist');
-    servingRuntimes.getRowById('template-2').findServingRuntimeVersionLabel().should('exist');
+    servingRuntimeTemplates
+      .getRowById('template-1')
+      .findServingRuntimeVersionLabel()
+      .should('exist');
+    servingRuntimeTemplates
+      .getRowById('template-2')
+      .findServingRuntimeVersionLabel()
+      .should('exist');
   });
 
   it('should test pre-installed label', () => {
-    servingRuntimes.getRowById('template-1').shouldHavePreInstalledLabel(false);
-    servingRuntimes.getRowById('template-1').find().findKebabAction('Delete').should('exist');
-    servingRuntimes.getRowById('template-1').find().findKebabAction('Edit').should('exist');
-    servingRuntimes.getRowById('template-1').find().findKebabAction('Duplicate').should('exist');
+    servingRuntimeTemplates.getRowById('template-1').shouldHavePreInstalledLabel(false);
+    servingRuntimeTemplates
+      .getRowById('template-1')
+      .find()
+      .findKebabAction('Delete')
+      .should('exist');
+    servingRuntimeTemplates.getRowById('template-1').find().findKebabAction('Edit').should('exist');
+    servingRuntimeTemplates
+      .getRowById('template-1')
+      .find()
+      .findKebabAction('Duplicate')
+      .should('exist');
   });
 
   it('should display api protocol in table row', () => {
-    servingRuntimes.getRowById('template-1').shouldHaveAPIProtocol(ServingRuntimeAPIProtocol.GRPC);
-    servingRuntimes.getRowById('template-2').shouldHaveAPIProtocol(ServingRuntimeAPIProtocol.REST);
+    servingRuntimeTemplates
+      .getRowById('template-1')
+      .shouldHaveAPIProtocol(ServingRuntimeAPIProtocol.GRPC);
+    servingRuntimeTemplates
+      .getRowById('template-2')
+      .shouldHaveAPIProtocol(ServingRuntimeAPIProtocol.REST);
   });
 
   // I have no idea why this isn't passing in the CI, it passes locally
@@ -59,24 +77,24 @@ describe('Custom serving runtimes', () => {
   //     'createTemplate',
   //   );
 
-  //   servingRuntimes.findAddButton().click();
-  //   servingRuntimes.findAppTitle().should('contain', 'Add serving runtime');
+  //   servingRuntimeTemplates.findAddButton().click();
+  //   servingRuntimeTemplates.findAppTitle().should('contain', 'Add serving runtime');
 
-  //   servingRuntimes.findSubmitButton().should('be.disabled');
-  //   servingRuntimes.shouldDisplayAPIProtocolValues([
+  //   servingRuntimeTemplates.findSubmitButton().should('be.disabled');
+  //   servingRuntimeTemplates.shouldDisplayAPIProtocolValues([
   //     ServingRuntimeAPIProtocol.REST,
   //     ServingRuntimeAPIProtocol.GRPC,
   //   ]);
-  //   servingRuntimes.selectAPIProtocol(ServingRuntimeAPIProtocol.REST);
-  //   servingRuntimes.findSelectModelTypeButton().click();
-  //   servingRuntimes.selectModelType('Predictive model');
-  //   servingRuntimes.findStartFromScratchButton().click();
-  //   servingRuntimes.uploadYaml(addfilePath);
-  //   servingRuntimes.getDashboardCodeEditor().findInput().should('not.be.empty');
+  //   servingRuntimeTemplates.selectAPIProtocol(ServingRuntimeAPIProtocol.REST);
+  //   servingRuntimeTemplates.findSelectModelTypeButton().click();
+  //   servingRuntimeTemplates.selectModelType('Predictive model');
+  //   servingRuntimeTemplates.findStartFromScratchButton().click();
+  //   servingRuntimeTemplates.uploadYaml(addfilePath);
+  //   servingRuntimeTemplates.getDashboardCodeEditor().findInput().should('not.be.empty');
 
   //   // Wait for form validation to complete
-  //   servingRuntimes.findSubmitButton().should('be.enabled');
-  //   servingRuntimes.findSubmitButton().click();
+  //   servingRuntimeTemplates.findSubmitButton().should('be.enabled');
+  //   servingRuntimeTemplates.findSubmitButton().click();
   //   cy.wait('@createSingleModelServingRuntime').then((interception) => {
   //     expect(interception.request.url).to.include('?dryRun=All');
   //     expect(interception.request.body).to.containSubset({
@@ -108,7 +126,7 @@ describe('Custom serving runtimes', () => {
   //     });
   //   });
 
-  //   servingRuntimes.findAppTitle().should('contain', 'Serving runtimes');
+  //   servingRuntimeTemplates.findAppTitle().should('contain', 'Serving runtimes');
 
   //   cy.wsK8s(
   //     'ADDED',
@@ -121,8 +139,8 @@ describe('Custom serving runtimes', () => {
   //     }),
   //   );
 
-  //   servingRuntimes.getRowById('template-new').find().should('exist');
-  //   servingRuntimes.getRowById('template-new').shouldBeSingleModel(true);
+  //   servingRuntimeTemplates.getRowById('template-new').find().should('exist');
+  //   servingRuntimeTemplates.getRowById('template-new').shouldBeSingleModel(true);
   // });
 
   it('should duplicate a serving runtime', () => {
@@ -136,17 +154,17 @@ describe('Custom serving runtimes', () => {
       'duplicateTemplate',
     );
 
-    servingRuntimes.getRowById('template-1').find().findKebabAction('Duplicate').click();
-    servingRuntimes.findAppTitle().should('have.text', 'Duplicate serving runtime');
+    servingRuntimeTemplates.getRowById('template-1').find().findKebabAction('Duplicate').click();
+    servingRuntimeTemplates.findAppTitle().should('have.text', 'Duplicate serving runtime');
     cy.url().should('include', '/serving-runtime-templates/duplicate/template-1');
 
-    servingRuntimes.shouldDisplayAPIProtocolValues([
+    servingRuntimeTemplates.shouldDisplayAPIProtocolValues([
       ServingRuntimeAPIProtocol.REST,
       ServingRuntimeAPIProtocol.GRPC,
     ]);
-    servingRuntimes.selectAPIProtocol(ServingRuntimeAPIProtocol.GRPC);
-    servingRuntimes.findSubmitButton().should('be.enabled');
-    servingRuntimes.findSubmitButton().click();
+    servingRuntimeTemplates.selectAPIProtocol(ServingRuntimeAPIProtocol.GRPC);
+    servingRuntimeTemplates.findSubmitButton().should('be.enabled');
+    servingRuntimeTemplates.findSubmitButton().click();
 
     cy.wait('@duplicateServingRuntime').then((interception) => {
       expect(interception.request.body.metadata).to.containSubset({
@@ -182,7 +200,7 @@ describe('Custom serving runtimes', () => {
     // Wait for the templates list itself to finish mounting after the navigation before
     // pushing the websocket ADDED event — otherwise the event can fire before the list
     // has subscribed and the new row is missed.
-    servingRuntimes.getRowById('template-1').find().should('exist');
+    servingRuntimeTemplates.getRowById('template-1').find().should('exist');
 
     cy.wsK8s(
       'ADDED',
@@ -195,8 +213,8 @@ describe('Custom serving runtimes', () => {
       }),
     );
 
-    servingRuntimes.getRowById('template-1-copy').find().should('exist');
-    servingRuntimes
+    servingRuntimeTemplates.getRowById('template-1-copy').find().should('exist');
+    servingRuntimeTemplates
       .getRowById('template-1-copy')
       .shouldHaveAPIProtocol(ServingRuntimeAPIProtocol.GRPC);
   });
@@ -213,12 +231,12 @@ describe('Custom serving runtimes', () => {
       mockServingRuntimeTemplateK8sResource({}),
     ).as('editTemplate');
 
-    servingRuntimes.getRowById('template-1').find().findKebabAction('Edit').click();
-    servingRuntimes.findAppTitle().should('contain', 'Edit Caikit');
+    servingRuntimeTemplates.getRowById('template-1').find().findKebabAction('Edit').click();
+    servingRuntimeTemplates.findAppTitle().should('contain', 'Edit Caikit');
     cy.url().should('include', '/serving-runtime-templates/edit/template-1');
-    servingRuntimes.findSubmitButton().should('be.disabled');
-    servingRuntimes.uploadYaml(editfilePath);
-    servingRuntimes.findSubmitButton().click();
+    servingRuntimeTemplates.findSubmitButton().should('be.disabled');
+    servingRuntimeTemplates.uploadYaml(editfilePath);
+    servingRuntimeTemplates.findSubmitButton().click();
 
     cy.wait('@editServingRuntime').then((interception) => {
       expect(interception.request.body).to.containSubset({
@@ -260,7 +278,7 @@ describe('Custom serving runtimes', () => {
       mockServingRuntimeTemplateK8sResource({}),
     ).as('deleteServingRuntime');
 
-    servingRuntimes.getRowById('template-1').find().findKebabAction('Delete').click();
+    servingRuntimeTemplates.getRowById('template-1').find().findKebabAction('Delete').click();
     deleteModal.findSubmitButton().should('be.disabled');
 
     // test delete form is enabled after filling out required fields
@@ -278,7 +296,7 @@ describe('Custom serving runtimes', () => {
         apiProtocol: ServingRuntimeAPIProtocol.REST,
       }),
     );
-    servingRuntimes.getRowById('template-1').find().should('not.exist');
+    servingRuntimeTemplates.getRowById('template-1').find().should('not.exist');
   });
 
   describe('redirect from old standalone routes to the tab', () => {

--- a/packages/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUnsupported.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUnsupported.cy.ts
@@ -3,8 +3,8 @@ import {
   interceptTemplatePatch,
   interceptDashboardConfigPatch,
 } from './customServingRuntimesUtils';
-import { servingRuntimes } from '../../../pages/servingRuntimes';
-import { unsupportedStatusAcceptanceModal } from '../../../pages/llmAcceleratorConfigs';
+import { servingRuntimeTemplates } from '../../../pages/modelDeploymentSettings/servingRuntimeTemplates';
+import { unsupportedStatusAcceptanceModal } from '../../../pages/modelDeploymentSettings/llmAcceleratorConfigurations';
 import { asProductAdminUser } from '../../../utils/mockUsers';
 
 describe('Custom serving runtimes — unsupported resource handling', () => {
@@ -12,18 +12,23 @@ describe('Custom serving runtimes — unsupported resource handling', () => {
     asProductAdminUser();
     customServingRuntimesIntercept();
 
-    servingRuntimes.visit();
+    servingRuntimeTemplates.visit();
   });
 
   it('should show toggle OFF for unsupported unaccepted template', () => {
-    servingRuntimes.getRowById('template-unsupported-unaccepted').shouldBeEnabled(false);
-    servingRuntimes.getRowById('template-unsupported-unaccepted').shouldHaveUnsupportedLabel(true);
+    servingRuntimeTemplates.getRowById('template-unsupported-unaccepted').shouldBeEnabled(false);
+    servingRuntimeTemplates
+      .getRowById('template-unsupported-unaccepted')
+      .shouldHaveUnsupportedLabel(true);
   });
 
   it('should show acceptance modal when toggling on an unsupported unaccepted template', () => {
     unsupportedStatusAcceptanceModal.shouldNotExist();
 
-    servingRuntimes.getRowById('template-unsupported-unaccepted').findEnabledToggle().click();
+    servingRuntimeTemplates
+      .getRowById('template-unsupported-unaccepted')
+      .findEnabledToggle()
+      .click();
 
     unsupportedStatusAcceptanceModal.shouldBeOpen();
     unsupportedStatusAcceptanceModal
@@ -32,20 +37,26 @@ describe('Custom serving runtimes — unsupported resource handling', () => {
   });
 
   it('should dismiss modal without patching when cancel is clicked', () => {
-    servingRuntimes.getRowById('template-unsupported-unaccepted').findEnabledToggle().click();
+    servingRuntimeTemplates
+      .getRowById('template-unsupported-unaccepted')
+      .findEnabledToggle()
+      .click();
     unsupportedStatusAcceptanceModal.shouldBeOpen();
 
     unsupportedStatusAcceptanceModal.findCancelButton().click();
 
     unsupportedStatusAcceptanceModal.shouldNotExist();
-    servingRuntimes.getRowById('template-unsupported-unaccepted').shouldBeEnabled(false);
+    servingRuntimeTemplates.getRowById('template-unsupported-unaccepted').shouldBeEnabled(false);
   });
 
   it('should patch template annotation and enable when accept is clicked', () => {
     interceptTemplatePatch('template-unsupported-unaccepted');
     interceptDashboardConfigPatch();
 
-    servingRuntimes.getRowById('template-unsupported-unaccepted').findEnabledToggle().click();
+    servingRuntimeTemplates
+      .getRowById('template-unsupported-unaccepted')
+      .findEnabledToggle()
+      .click();
     unsupportedStatusAcceptanceModal.shouldBeOpen();
 
     unsupportedStatusAcceptanceModal.findAcceptButton().should('be.disabled');
@@ -67,25 +78,29 @@ describe('Custom serving runtimes — unsupported resource handling', () => {
 
   it('should toggle already-accepted unsupported template normally without modal', () => {
     interceptDashboardConfigPatch();
-    servingRuntimes.getRowById('template-unsupported-accepted').shouldBeEnabled(true);
+    servingRuntimeTemplates.getRowById('template-unsupported-accepted').shouldBeEnabled(true);
 
-    servingRuntimes.getRowById('template-unsupported-accepted').findEnabledToggle().click();
+    servingRuntimeTemplates.getRowById('template-unsupported-accepted').findEnabledToggle().click();
 
     cy.wait('@patchDashboardConfig');
     unsupportedStatusAcceptanceModal.shouldNotExist();
   });
 
   it('should show limited support label on unsupported templates', () => {
-    servingRuntimes.getRowById('template-unsupported-unaccepted').shouldHaveUnsupportedLabel(true);
-    servingRuntimes.getRowById('template-unsupported-accepted').shouldHaveUnsupportedLabel(true);
+    servingRuntimeTemplates
+      .getRowById('template-unsupported-unaccepted')
+      .shouldHaveUnsupportedLabel(true);
+    servingRuntimeTemplates
+      .getRowById('template-unsupported-accepted')
+      .shouldHaveUnsupportedLabel(true);
   });
 
   it('should not show limited support label on normal templates', () => {
-    servingRuntimes.getRowById('template-1').shouldHaveUnsupportedLabel(false);
+    servingRuntimeTemplates.getRowById('template-1').shouldHaveUnsupportedLabel(false);
   });
 
   it('should show version label on templates with version annotation', () => {
-    servingRuntimes
+    servingRuntimeTemplates
       .getRowById('template-unsupported-unaccepted')
       .findServingRuntimeVersionLabel()
       .should('have.text', '0.11.0+rhai5');

--- a/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigs.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigs.cy.ts
@@ -4,28 +4,30 @@ import {
   interceptLlmAcceleratorConfigPatch,
 } from './llmAcceleratorConfigsUtils';
 import {
-  llmAcceleratorConfigs,
+  llmAcceleratorConfigurations,
   unsupportedStatusAcceptanceModal,
-} from '../../../pages/llmAcceleratorConfigs';
+} from '../../../pages/modelDeploymentSettings/llmAcceleratorConfigurations';
 import { asProductAdminUser, asProjectAdminUser } from '../../../utils/mockUsers';
 import { pageNotfound } from '../../../pages/pageNotFound';
 
 it('LLM accelerator configurations should not be available for non product admins', () => {
   asProjectAdminUser();
   cy.interceptOdh('GET /api/config', mockDashboardConfig({ vLLMDeploymentOnMaaS: true }));
-  llmAcceleratorConfigs.visit(false);
+  llmAcceleratorConfigurations.visit(false);
   pageNotfound.findPage().should('exist');
-  llmAcceleratorConfigs.findNavItem().should('not.exist');
+  llmAcceleratorConfigurations.findNavItem().should('not.exist');
 });
 
 it('LLM accelerator configurations tab should not be available when vLLMDeploymentOnMaaS is disabled', () => {
   asProductAdminUser();
   cy.interceptOdh('GET /api/config', mockDashboardConfig({ vLLMDeploymentOnMaaS: false }));
-  llmAcceleratorConfigs.visit(false);
+  llmAcceleratorConfigurations.visit(false);
   // The parent tabbed page still renders (other tabs are visible), but the accelerator
   // tab is hidden. TabRoutePage redirects to the first available tab.
-  llmAcceleratorConfigs.findTabPageTitle().should('contain.text', 'Model deployment settings');
-  llmAcceleratorConfigs.findTab().should('not.exist');
+  llmAcceleratorConfigurations
+    .findTabPageTitle()
+    .should('contain.text', 'Model deployment settings');
+  llmAcceleratorConfigurations.findTab().should('not.exist');
 });
 
 describe('LLM accelerator configurations', () => {
@@ -33,31 +35,31 @@ describe('LLM accelerator configurations', () => {
     asProductAdminUser();
     llmAcceleratorConfigsIntercept();
 
-    llmAcceleratorConfigs.visit();
+    llmAcceleratorConfigurations.visit();
   });
 
   it('should render the page with configs from the API', () => {
-    llmAcceleratorConfigs.findNavItem().should('exist');
-    llmAcceleratorConfigs.getRowByName('vllm-cuda').find().should('exist');
-    llmAcceleratorConfigs.getRowByName('vllm-rocm').find().should('exist');
-    llmAcceleratorConfigs.getRowByName('vllm-cpu').find().should('exist');
-    llmAcceleratorConfigs.getRowByName('vllm-tpu').find().should('exist');
-    llmAcceleratorConfigs.getRowByName('vllm-gaudi').find().should('exist');
+    llmAcceleratorConfigurations.findNavItem().should('exist');
+    llmAcceleratorConfigurations.getRowByName('vllm-cuda').find().should('exist');
+    llmAcceleratorConfigurations.getRowByName('vllm-rocm').find().should('exist');
+    llmAcceleratorConfigurations.getRowByName('vllm-cpu').find().should('exist');
+    llmAcceleratorConfigurations.getRowByName('vllm-tpu').find().should('exist');
+    llmAcceleratorConfigurations.getRowByName('vllm-gaudi').find().should('exist');
   });
 
   it('should show enabled toggle ON for enabled config and OFF for disabled config', () => {
-    llmAcceleratorConfigs.getRowByName('vllm-cuda').shouldBeEnabled(true);
-    llmAcceleratorConfigs.getRowByName('vllm-cpu').shouldBeEnabled(false);
+    llmAcceleratorConfigurations.getRowByName('vllm-cuda').shouldBeEnabled(true);
+    llmAcceleratorConfigurations.getRowByName('vllm-cpu').shouldBeEnabled(false);
   });
 
   it('should show toggle OFF for unsupported unaccepted config', () => {
-    llmAcceleratorConfigs.getRowByName('vllm-tpu').shouldBeEnabled(false);
-    llmAcceleratorConfigs.getRowByName('vllm-tpu').shouldHaveUnsupportedLabel(true);
+    llmAcceleratorConfigurations.getRowByName('vllm-tpu').shouldBeEnabled(false);
+    llmAcceleratorConfigurations.getRowByName('vllm-tpu').shouldHaveUnsupportedLabel(true);
   });
 
   it('should disable a config by toggling off', () => {
     interceptLlmAcceleratorConfigPatch('vllm-cuda');
-    llmAcceleratorConfigs.getRowByName('vllm-cuda').findEnabledToggle().click();
+    llmAcceleratorConfigurations.getRowByName('vllm-cuda').findEnabledToggle().click();
 
     cy.wait('@patchConfig').then((interception) => {
       const body = interception.request.body as { op: string; path: string; value: string }[];
@@ -70,7 +72,7 @@ describe('LLM accelerator configurations', () => {
   it('should show acceptance modal when toggling on an unsupported unaccepted config', () => {
     unsupportedStatusAcceptanceModal.shouldNotExist();
 
-    llmAcceleratorConfigs.getRowByName('vllm-tpu').findEnabledToggle().click();
+    llmAcceleratorConfigurations.getRowByName('vllm-tpu').findEnabledToggle().click();
 
     unsupportedStatusAcceptanceModal.shouldBeOpen();
     unsupportedStatusAcceptanceModal
@@ -79,7 +81,7 @@ describe('LLM accelerator configurations', () => {
   });
 
   it('should dismiss modal without patching when cancel is clicked', () => {
-    llmAcceleratorConfigs.getRowByName('vllm-tpu').findEnabledToggle().click();
+    llmAcceleratorConfigurations.getRowByName('vllm-tpu').findEnabledToggle().click();
     unsupportedStatusAcceptanceModal.shouldBeOpen();
 
     unsupportedStatusAcceptanceModal.findCancelButton().click();
@@ -89,7 +91,7 @@ describe('LLM accelerator configurations', () => {
 
   it('should patch config when accept is clicked on unsupported modal', () => {
     interceptLlmAcceleratorConfigPatch('vllm-tpu');
-    llmAcceleratorConfigs.getRowByName('vllm-tpu').findEnabledToggle().click();
+    llmAcceleratorConfigurations.getRowByName('vllm-tpu').findEnabledToggle().click();
     unsupportedStatusAcceptanceModal.shouldBeOpen();
 
     unsupportedStatusAcceptanceModal.findAcceptButton().should('be.disabled');
@@ -111,9 +113,9 @@ describe('LLM accelerator configurations', () => {
 
   it('should toggle already-accepted unsupported config normally without modal', () => {
     interceptLlmAcceleratorConfigPatch('vllm-gaudi');
-    llmAcceleratorConfigs.getRowByName('vllm-gaudi').shouldBeEnabled(false);
+    llmAcceleratorConfigurations.getRowByName('vllm-gaudi').shouldBeEnabled(false);
 
-    llmAcceleratorConfigs.getRowByName('vllm-gaudi').findEnabledToggle().click();
+    llmAcceleratorConfigurations.getRowByName('vllm-gaudi').findEnabledToggle().click();
 
     cy.wait('@patchConfig').then((interception) => {
       const body = interception.request.body as { op: string; path: string; value: string }[];

--- a/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigsCrud.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigsCrud.cy.ts
@@ -4,7 +4,7 @@ import {
   interceptLlmAcceleratorConfigUpdate,
   interceptLlmAcceleratorConfigDelete,
 } from './llmAcceleratorConfigsUtils';
-import { llmAcceleratorConfigs } from '../../../pages/llmAcceleratorConfigs';
+import { llmAcceleratorConfigurations } from '../../../pages/modelDeploymentSettings/llmAcceleratorConfigurations';
 import { asProductAdminUser } from '../../../utils/mockUsers';
 import { deleteModal } from '../../../pages/components/DeleteModal';
 
@@ -12,59 +12,73 @@ describe('LLM accelerator configurations CRUD operations', () => {
   beforeEach(() => {
     asProductAdminUser();
     llmAcceleratorConfigsIntercept();
-    llmAcceleratorConfigs.visit();
+    llmAcceleratorConfigurations.visit();
   });
 
   describe('Navigation flows', () => {
     it('should navigate to add form when clicking Add button', () => {
-      llmAcceleratorConfigs.findAddButton().click();
+      llmAcceleratorConfigurations.findAddButton().click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/llm-accelerator-configurations/add',
       );
-      llmAcceleratorConfigs.findAppTitle().should('have.text', 'Add LLM accelerator configuration');
+      llmAcceleratorConfigurations
+        .findAppTitle()
+        .should('have.text', 'Add LLM accelerator configuration');
       // The form is a full-page breakout route, not tab content: it must not render
       // beneath the tabbed page title and tab bar, which would give it two headings.
-      llmAcceleratorConfigs.findTabPageTitle().should('not.exist');
-      llmAcceleratorConfigs.findTab().should('not.exist');
+      llmAcceleratorConfigurations.findTabPageTitle().should('not.exist');
+      llmAcceleratorConfigurations.findTab().should('not.exist');
     });
 
     it('should navigate to edit form when clicking Edit action', () => {
-      llmAcceleratorConfigs.getRowByName('vllm-cuda').find().findKebabAction('Edit').click();
+      llmAcceleratorConfigurations.getRowByName('vllm-cuda').find().findKebabAction('Edit').click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/llm-accelerator-configurations/edit/vllm-cuda',
       );
-      llmAcceleratorConfigs.findAppTitle().should('have.text', 'Edit vLLM CUDA Accelerator');
+      llmAcceleratorConfigurations.findAppTitle().should('have.text', 'Edit vLLM CUDA Accelerator');
     });
 
     it('should navigate to duplicate form when clicking Duplicate action', () => {
-      llmAcceleratorConfigs.getRowByName('vllm-cuda').find().findKebabAction('Duplicate').click();
+      llmAcceleratorConfigurations
+        .getRowByName('vllm-cuda')
+        .find()
+        .findKebabAction('Duplicate')
+        .click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/llm-accelerator-configurations/duplicate/vllm-cuda',
       );
-      llmAcceleratorConfigs
+      llmAcceleratorConfigurations
         .findAppTitle()
         .should('have.text', 'Duplicate LLM accelerator configuration');
     });
 
     it('should reload edit form and preserve inputs', () => {
-      llmAcceleratorConfigs.getRowByName('vllm-cuda').find().findKebabAction('Edit').click();
-      llmAcceleratorConfigs.findNameInput().should('have.value', 'vLLM CUDA Accelerator');
+      llmAcceleratorConfigurations.getRowByName('vllm-cuda').find().findKebabAction('Edit').click();
+      llmAcceleratorConfigurations.findNameInput().should('have.value', 'vLLM CUDA Accelerator');
 
       cy.reload();
 
-      llmAcceleratorConfigs.findNameInput().should('have.value', 'vLLM CUDA Accelerator');
+      llmAcceleratorConfigurations.findNameInput().should('have.value', 'vLLM CUDA Accelerator');
     });
 
     it('should reload duplicate form and preserve inputs', () => {
-      llmAcceleratorConfigs.getRowByName('vllm-cuda').find().findKebabAction('Duplicate').click();
-      llmAcceleratorConfigs.findNameInput().should('have.value', 'Copy of vLLM CUDA Accelerator');
+      llmAcceleratorConfigurations
+        .getRowByName('vllm-cuda')
+        .find()
+        .findKebabAction('Duplicate')
+        .click();
+      llmAcceleratorConfigurations
+        .findNameInput()
+        .should('have.value', 'Copy of vLLM CUDA Accelerator');
 
       cy.reload();
 
-      llmAcceleratorConfigs.findNameInput().should('have.value', 'Copy of vLLM CUDA Accelerator');
+      llmAcceleratorConfigurations
+        .findNameInput()
+        .should('have.value', 'Copy of vLLM CUDA Accelerator');
     });
   });
 
@@ -72,12 +86,12 @@ describe('LLM accelerator configurations CRUD operations', () => {
     it('should create a new config', () => {
       interceptLlmAcceleratorConfigCreate();
 
-      llmAcceleratorConfigs.findAddButton().click();
-      llmAcceleratorConfigs.findNameInput().type('New Config');
-      llmAcceleratorConfigs.findVersionInput().type('v1.0.0');
-      llmAcceleratorConfigs.findYAMLCodeEditor().setValue('metadata:\n  name: placeholder');
+      llmAcceleratorConfigurations.findAddButton().click();
+      llmAcceleratorConfigurations.findNameInput().type('New Config');
+      llmAcceleratorConfigurations.findVersionInput().type('v1.0.0');
+      llmAcceleratorConfigurations.findYAMLCodeEditor().setValue('metadata:\n  name: placeholder');
 
-      llmAcceleratorConfigs.findSubmitButton().click();
+      llmAcceleratorConfigurations.findSubmitButton().click();
 
       cy.wait('@createConfig').then((interception) => {
         expect(interception.request.body.metadata).to.include({
@@ -92,9 +106,9 @@ describe('LLM accelerator configurations CRUD operations', () => {
     it('should update an existing config', () => {
       interceptLlmAcceleratorConfigUpdate('vllm-cuda');
 
-      llmAcceleratorConfigs.getRowByName('vllm-cuda').find().findKebabAction('Edit').click();
-      llmAcceleratorConfigs.findNameInput().clear().type('Updated CUDA');
-      llmAcceleratorConfigs.findSubmitButton().click();
+      llmAcceleratorConfigurations.getRowByName('vllm-cuda').find().findKebabAction('Edit').click();
+      llmAcceleratorConfigurations.findNameInput().clear().type('Updated CUDA');
+      llmAcceleratorConfigurations.findSubmitButton().click();
 
       cy.wait('@updateConfig').then((interception) => {
         expect(interception.request.body.metadata.annotations).to.include({
@@ -106,7 +120,11 @@ describe('LLM accelerator configurations CRUD operations', () => {
     it('should delete a config', () => {
       interceptLlmAcceleratorConfigDelete('vllm-cuda');
 
-      llmAcceleratorConfigs.getRowByName('vllm-cuda').find().findKebabAction('Delete').click();
+      llmAcceleratorConfigurations
+        .getRowByName('vllm-cuda')
+        .find()
+        .findKebabAction('Delete')
+        .click();
       deleteModal.find().should('exist');
       deleteModal.findInput().type('vLLM CUDA Accelerator');
       deleteModal.findSubmitButton().click();

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
@@ -8,9 +8,9 @@ import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { LLMInferenceServiceConfigModel } from '@odh-dashboard/cypress/cypress/utils/models';
 import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
 import {
-  llmdRoutingSettingsPage,
+  routingConfigurations,
   llmdRoutingCreatePage,
-} from '@odh-dashboard/cypress/cypress/pages/llmdRoutingSettings';
+} from '@odh-dashboard/cypress/cypress/pages/modelDeploymentSettings/routingConfigurations';
 
 const mockPreInstalledScheduler = mockLLMInferenceServiceConfigK8sResource({
   name: 'managed-scheduler',
@@ -87,88 +87,84 @@ describe('LLMD Routing Admin Settings', () => {
   describe('tab visibility', () => {
     it('should show routing configurations tab when flags enabled', () => {
       initIntercepts();
-      llmdRoutingSettingsPage.visit();
-      llmdRoutingSettingsPage
-        .findTabPageTitle()
-        .should('contain.text', 'Model deployment settings');
-      llmdRoutingSettingsPage.findTab().should('exist');
-      llmdRoutingSettingsPage.findTable().should('exist');
+      routingConfigurations.visit();
+      routingConfigurations.findTabPageTitle().should('contain.text', 'Model deployment settings');
+      routingConfigurations.findTab().should('exist');
+      routingConfigurations.findTable().should('exist');
     });
   });
 
   describe('empty state', () => {
     it('should show empty state when no routing configurations exist', () => {
       initIntercepts({ configs: [] });
-      llmdRoutingSettingsPage.visit(false);
-      llmdRoutingSettingsPage
-        .findTabPageTitle()
-        .should('contain.text', 'Model deployment settings');
-      llmdRoutingSettingsPage.findTab().should('exist');
-      llmdRoutingSettingsPage.findEmptyState().should('exist');
-      llmdRoutingSettingsPage
+      routingConfigurations.visit(false);
+      routingConfigurations.findTabPageTitle().should('contain.text', 'Model deployment settings');
+      routingConfigurations.findTab().should('exist');
+      routingConfigurations.findEmptyState().should('exist');
+      routingConfigurations
         .findEmptyState()
         .should('contain.text', 'No llm-d routing configurations');
-      llmdRoutingSettingsPage.findEmptyStateAddButton().should('exist');
+      routingConfigurations.findEmptyStateAddButton().should('exist');
     });
 
     it('should navigate to add page from empty state button', () => {
       initIntercepts({ configs: [] });
-      llmdRoutingSettingsPage.visit(false);
-      llmdRoutingSettingsPage.findEmptyStateAddButton().click();
+      routingConfigurations.visit(false);
+      routingConfigurations.findEmptyStateAddButton().click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/routing-configurations/add',
       );
       // The form is a full-page breakout route, not tab content: it must not render
       // beneath the tabbed page title and tab bar, which would give it two headings.
-      llmdRoutingSettingsPage.findTabPageTitle().should('not.exist');
-      llmdRoutingSettingsPage.findTab().should('not.exist');
-      llmdRoutingSettingsPage.findAppTitle().should('have.text', 'Add llm-d routing configuration');
+      routingConfigurations.findTabPageTitle().should('not.exist');
+      routingConfigurations.findTab().should('not.exist');
+      routingConfigurations.findAppTitle().should('have.text', 'Add llm-d routing configuration');
     });
   });
 
   describe('configurations table', () => {
     beforeEach(() => {
       initIntercepts();
-      llmdRoutingSettingsPage.visit();
+      routingConfigurations.visit();
     });
 
     it('should list routing configs with correct columns', () => {
-      llmdRoutingSettingsPage.getRow('managed-scheduler-httproute').find().should('exist');
-      llmdRoutingSettingsPage
+      routingConfigurations.getRow('managed-scheduler-httproute').find().should('exist');
+      routingConfigurations
         .getRow('managed-scheduler-httproute')
         .find()
         .should('contain.text', 'Managed scheduler with HTTPRoute');
 
-      llmdRoutingSettingsPage.getRow('managed-scheduler').find().should('exist');
-      llmdRoutingSettingsPage
+      routingConfigurations.getRow('managed-scheduler').find().should('exist');
+      routingConfigurations
         .getRow('managed-scheduler')
         .find()
         .should('contain.text', 'Managed scheduler');
 
-      llmdRoutingSettingsPage.getRow('lab-routing-profile').find().should('exist');
-      llmdRoutingSettingsPage
+      routingConfigurations.getRow('lab-routing-profile').find().should('exist');
+      routingConfigurations
         .getRow('lab-routing-profile')
         .find()
         .should('contain.text', 'Lab routing profile');
     });
 
     it('should show pre-installed badge on well-known configs', () => {
-      llmdRoutingSettingsPage.getRow('managed-scheduler').shouldHavePreInstalledLabel(true);
-      llmdRoutingSettingsPage.getRow('lab-routing-profile').shouldHavePreInstalledLabel(false);
+      routingConfigurations.getRow('managed-scheduler').shouldHavePreInstalledLabel(true);
+      routingConfigurations.getRow('lab-routing-profile').shouldHavePreInstalledLabel(false);
     });
 
     it('should show topology type labels', () => {
-      llmdRoutingSettingsPage
+      routingConfigurations
         .getRow('managed-scheduler-httproute')
         .findTopologyTypeCell()
         .should('have.text', 'Single node, Multi-node');
-      llmdRoutingSettingsPage
+      routingConfigurations
         .getRow('managed-scheduler')
         .findTopologyTypeCell()
         .should('have.text', 'Single node');
       // No supported topologies annotation means the config applies to all topologies
-      llmdRoutingSettingsPage
+      routingConfigurations
         .getRow('managed-httproute')
         .findTopologyTypeCell()
         .should('have.text', 'All');
@@ -192,7 +188,7 @@ describe('LLMD Routing Admin Settings', () => {
         patchedConfig,
       ).as('patchConfig');
 
-      llmdRoutingSettingsPage.getRow('lab-routing-profile').findEnabledSwitch().click();
+      routingConfigurations.getRow('lab-routing-profile').findEnabledSwitch().click();
       cy.wait('@patchConfig').then((interception) => {
         const patches: { op: string; path: string; value: string }[] = interception.request.body;
         const disabledPatch = patches.find(
@@ -203,40 +199,40 @@ describe('LLMD Routing Admin Settings', () => {
     });
 
     it('should hide delete action for pre-installed configs', () => {
-      llmdRoutingSettingsPage
+      routingConfigurations
         .getRow('managed-scheduler')
         .findKebabAction('Delete', false)
         .should('not.exist');
     });
 
     it('should show delete action for user-created configs', () => {
-      llmdRoutingSettingsPage.getRow('lab-routing-profile').findKebabAction('Delete');
+      routingConfigurations.getRow('lab-routing-profile').findKebabAction('Delete');
     });
 
     it('should navigate to edit form when clicking Edit action', () => {
-      llmdRoutingSettingsPage.getRow('lab-routing-profile').findKebabAction('Edit').click();
+      routingConfigurations.getRow('lab-routing-profile').findKebabAction('Edit').click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/routing-configurations/edit/lab-routing-profile',
       );
       // The form is a full-page breakout route, not tab content: it must not render
       // beneath the tabbed page title and tab bar, which would give it two headings.
-      llmdRoutingSettingsPage.findTabPageTitle().should('not.exist');
-      llmdRoutingSettingsPage.findTab().should('not.exist');
-      llmdRoutingSettingsPage.findAppTitle().should('have.text', 'Edit Lab routing profile');
+      routingConfigurations.findTabPageTitle().should('not.exist');
+      routingConfigurations.findTab().should('not.exist');
+      routingConfigurations.findAppTitle().should('have.text', 'Edit Lab routing profile');
     });
 
     it('should navigate to duplicate form when clicking Duplicate action', () => {
-      llmdRoutingSettingsPage.getRow('lab-routing-profile').findKebabAction('Duplicate').click();
+      routingConfigurations.getRow('lab-routing-profile').findKebabAction('Duplicate').click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/routing-configurations/duplicate/lab-routing-profile',
       );
       // The form is a full-page breakout route, not tab content: it must not render
       // beneath the tabbed page title and tab bar, which would give it two headings.
-      llmdRoutingSettingsPage.findTabPageTitle().should('not.exist');
-      llmdRoutingSettingsPage.findTab().should('not.exist');
-      llmdRoutingSettingsPage
+      routingConfigurations.findTabPageTitle().should('not.exist');
+      routingConfigurations.findTab().should('not.exist');
+      routingConfigurations
         .findAppTitle()
         .should('have.text', 'Duplicate llm-d routing configuration');
     });
@@ -245,16 +241,16 @@ describe('LLMD Routing Admin Settings', () => {
   describe('create page', () => {
     beforeEach(() => {
       initIntercepts();
-      llmdRoutingSettingsPage.visit();
-      llmdRoutingSettingsPage.findAddButton().click();
+      routingConfigurations.visit();
+      routingConfigurations.findAddButton().click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/routing-configurations/add',
       );
       // The form is a full-page breakout route, not tab content: it must not render
       // beneath the tabbed page title and tab bar, which would give it two headings.
-      llmdRoutingSettingsPage.findTabPageTitle().should('not.exist');
-      llmdRoutingSettingsPage.findTab().should('not.exist');
+      routingConfigurations.findTabPageTitle().should('not.exist');
+      routingConfigurations.findTab().should('not.exist');
       llmdRoutingCreatePage.findTitle().should('have.text', 'Add llm-d routing configuration');
     });
 
@@ -273,7 +269,7 @@ describe('LLMD Routing Admin Settings', () => {
 
     it('should navigate back on cancel', () => {
       llmdRoutingCreatePage.findCancelButton().click();
-      llmdRoutingSettingsPage.findTable().should('exist');
+      routingConfigurations.findTable().should('exist');
     });
   });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopologyAdmin.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopologyAdmin.cy.ts
@@ -7,7 +7,7 @@ import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sRe
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { LLMInferenceServiceConfigModel } from '@odh-dashboard/cypress/cypress/utils/models';
 import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
-import { llmdTopologySettingsPage } from '@odh-dashboard/cypress/cypress/pages/llmdTopologySettings';
+import { topologyConfigurations } from '@odh-dashboard/cypress/cypress/pages/modelDeploymentSettings/topologyConfigurations';
 
 const mockPreInstalledConfig = mockLLMInferenceServiceConfigK8sResource({
   name: 'preinstalled-single-node',
@@ -65,58 +65,52 @@ describe('LLMD Topology Admin Settings', () => {
   describe('tab visibility', () => {
     it('should show topology configurations tab when flags enabled', () => {
       initIntercepts();
-      llmdTopologySettingsPage.visit();
-      llmdTopologySettingsPage
-        .findTabPageTitle()
-        .should('contain.text', 'Model deployment settings');
-      llmdTopologySettingsPage.findTab().should('exist');
-      llmdTopologySettingsPage.findTable().should('exist');
+      topologyConfigurations.visit();
+      topologyConfigurations.findTabPageTitle().should('contain.text', 'Model deployment settings');
+      topologyConfigurations.findTab().should('exist');
+      topologyConfigurations.findTable().should('exist');
     });
   });
 
   describe('empty state', () => {
     it('should show empty state when no topology configurations exist', () => {
       initIntercepts({ configs: [] });
-      llmdTopologySettingsPage.visit(false);
-      llmdTopologySettingsPage
-        .findTabPageTitle()
-        .should('contain.text', 'Model deployment settings');
-      llmdTopologySettingsPage.findTab().should('exist');
-      llmdTopologySettingsPage.findEmptyState().should('exist');
-      llmdTopologySettingsPage
+      topologyConfigurations.visit(false);
+      topologyConfigurations.findTabPageTitle().should('contain.text', 'Model deployment settings');
+      topologyConfigurations.findTab().should('exist');
+      topologyConfigurations.findEmptyState().should('exist');
+      topologyConfigurations
         .findEmptyState()
         .should('contain.text', 'No llm-d topology configurations');
-      llmdTopologySettingsPage.findEmptyStateAddButton().should('exist');
-      llmdTopologySettingsPage.findEmptyStateDropdownToggle().should('exist');
+      topologyConfigurations.findEmptyStateAddButton().should('exist');
+      topologyConfigurations.findEmptyStateDropdownToggle().should('exist');
     });
 
     it('should navigate to add page from empty state button', () => {
       initIntercepts({ configs: [] });
-      llmdTopologySettingsPage.visit(false);
-      llmdTopologySettingsPage.findEmptyStateAddButton().click();
+      topologyConfigurations.visit(false);
+      topologyConfigurations.findEmptyStateAddButton().click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/topology-configurations/add/workload-single-node',
       );
       // The form actually mounted (URL + missing tab chrome alone don't prove it).
-      llmdTopologySettingsPage.findAppTitle().should('have.text', 'Add Single node configuration');
+      topologyConfigurations.findAppTitle().should('have.text', 'Add Single node configuration');
       // The form is a full-page breakout route, not tab content: it must not render
       // beneath the tabbed page title and tab bar, which would give it two headings.
-      llmdTopologySettingsPage.findTabPageTitle().should('not.exist');
-      llmdTopologySettingsPage.findTab().should('not.exist');
+      topologyConfigurations.findTabPageTitle().should('not.exist');
+      topologyConfigurations.findTab().should('not.exist');
     });
 
     it('should show dropdown with other topology types in empty state', () => {
       initIntercepts({ configs: [] });
-      llmdTopologySettingsPage.visit(false);
-      llmdTopologySettingsPage.findEmptyStateDropdownToggle().click();
-      llmdTopologySettingsPage
+      topologyConfigurations.visit(false);
+      topologyConfigurations.findEmptyStateDropdownToggle().click();
+      topologyConfigurations
         .findEmptyStateDropdownItem('workload-multi-node-data-parallel')
         .should('exist');
-      llmdTopologySettingsPage
-        .findEmptyStateDropdownItem('workload-single-node-pd')
-        .should('exist');
-      llmdTopologySettingsPage
+      topologyConfigurations.findEmptyStateDropdownItem('workload-single-node-pd').should('exist');
+      topologyConfigurations
         .findEmptyStateDropdownItem('workload-multi-node-data-parallel-pd')
         .should('exist');
     });
@@ -125,28 +119,28 @@ describe('LLMD Topology Admin Settings', () => {
   describe('configurations table', () => {
     beforeEach(() => {
       initIntercepts();
-      llmdTopologySettingsPage.visit();
+      topologyConfigurations.visit();
     });
 
     it('should list topology configs with correct columns', () => {
-      llmdTopologySettingsPage.getRow('preinstalled-single-node').find().should('exist');
-      llmdTopologySettingsPage
+      topologyConfigurations.getRow('preinstalled-single-node').find().should('exist');
+      topologyConfigurations
         .getRow('preinstalled-single-node')
         .find()
         .should('contain.text', 'Pre-installed Single Node');
 
-      llmdTopologySettingsPage.getRow('user-multi-node').find().should('exist');
-      llmdTopologySettingsPage
+      topologyConfigurations.getRow('user-multi-node').find().should('exist');
+      topologyConfigurations
         .getRow('user-multi-node')
         .find()
         .should('contain.text', 'User Multi-node Config');
 
-      llmdTopologySettingsPage.getRow('disabled-config').find().should('exist');
+      topologyConfigurations.getRow('disabled-config').find().should('exist');
     });
 
     it('should show pre-installed badge on well-known configs', () => {
-      llmdTopologySettingsPage.getRow('preinstalled-single-node').shouldHavePreInstalledLabel(true);
-      llmdTopologySettingsPage.getRow('user-multi-node').shouldHavePreInstalledLabel(false);
+      topologyConfigurations.getRow('preinstalled-single-node').shouldHavePreInstalledLabel(true);
+      topologyConfigurations.getRow('user-multi-node').shouldHavePreInstalledLabel(false);
     });
 
     it('should toggle enabled state via switch', () => {
@@ -166,49 +160,49 @@ describe('LLMD Topology Admin Settings', () => {
         patchedConfig,
       ).as('patchConfig');
 
-      llmdTopologySettingsPage.getRow('user-multi-node').findEnabledSwitch().click();
+      topologyConfigurations.getRow('user-multi-node').findEnabledSwitch().click();
       cy.wait('@patchConfig');
     });
 
     it('should hide delete action for pre-installed configs', () => {
-      llmdTopologySettingsPage
+      topologyConfigurations
         .getRow('preinstalled-single-node')
         .findKebabAction('Delete', false)
         .should('not.exist');
     });
 
     it('should show delete action for user-created configs', () => {
-      llmdTopologySettingsPage.getRow('user-multi-node').findKebabAction('Delete');
+      topologyConfigurations.getRow('user-multi-node').findKebabAction('Delete');
     });
 
     it('should navigate to edit form as a full-page breakout route', () => {
-      llmdTopologySettingsPage.getRow('user-multi-node').findKebabAction('Edit').click();
+      topologyConfigurations.getRow('user-multi-node').findKebabAction('Edit').click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/topology-configurations/edit/user-multi-node',
       );
       // The form actually mounted (URL + missing tab chrome alone don't prove it).
-      llmdTopologySettingsPage.findAppTitle().should('have.text', 'Edit User Multi-node Config');
+      topologyConfigurations.findAppTitle().should('have.text', 'Edit User Multi-node Config');
       // The form is a full-page breakout route, not tab content: it must not render
       // beneath the tabbed page title and tab bar, which would give it two headings.
-      llmdTopologySettingsPage.findTabPageTitle().should('not.exist');
-      llmdTopologySettingsPage.findTab().should('not.exist');
+      topologyConfigurations.findTabPageTitle().should('not.exist');
+      topologyConfigurations.findTab().should('not.exist');
     });
 
     it('should navigate to duplicate form as a full-page breakout route', () => {
-      llmdTopologySettingsPage.getRow('user-multi-node').findKebabAction('Duplicate').click();
+      topologyConfigurations.getRow('user-multi-node').findKebabAction('Duplicate').click();
       cy.url().should(
         'include',
         '/settings/model-resources-operations/model-deployment-settings/topology-configurations/duplicate/user-multi-node',
       );
       // The form actually mounted (URL + missing tab chrome alone don't prove it).
-      llmdTopologySettingsPage
+      topologyConfigurations
         .findAppTitle()
         .should('have.text', 'Duplicate llm-d topology configuration');
       // The form is a full-page breakout route, not tab content: it must not render
       // beneath the tabbed page title and tab bar, which would give it two headings.
-      llmdTopologySettingsPage.findTabPageTitle().should('not.exist');
-      llmdTopologySettingsPage.findTab().should('not.exist');
+      topologyConfigurations.findTabPageTitle().should('not.exist');
+      topologyConfigurations.findTab().should('not.exist');
     });
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-69029

## Description

The Model deployment settings epic ([RHOAIENG-68972](https://issues.redhat.com/browse/RHOAIENG-68972)) consolidated four standalone admin pages into tabs on `/settings/model-resources-operations/model-deployment-settings/` and removed the standalone pages ([RHOAIENG-80077](https://redhat.atlassian.net/browse/RHOAIENG-80077)). This left several E2E tests and their page objects pointing at the old locations. This PR does the E2E-side cleanup, fixes the llm-d admin specs so they pass end-to-end against the migrated tabs, makes the admin specs concurrency-safe, and adds missing live-cluster coverage.

All touched specs were **verified passing end-to-end on a live cluster**, including the deploy-wizard steps.

**1. Consolidate the tab page objects.** Moved the four Cypress page objects for the Model deployment settings tabs into `packages/cypress/cypress/pages/modelDeploymentSettings/` (alongside the already-moved `generalSettings.ts` from https://github.com/opendatahub-io/odh-dashboard/pull/9378) and renamed them to match the tab identifiers:

| From | To | Export |
| --- | --- | --- |
| `pages/servingRuntimes.ts` | `pages/modelDeploymentSettings/servingRuntimeTemplates.ts` | `servingRuntimes` → `servingRuntimeTemplates` |
| `pages/llmAcceleratorConfigs.ts` | `pages/modelDeploymentSettings/llmAcceleratorConfigurations.ts` | `llmAcceleratorConfigs` → `llmAcceleratorConfigurations` |
| `pages/llmdTopologySettings.ts` | `pages/modelDeploymentSettings/topologyConfigurations.ts` | `llmdTopologySettingsPage` → `topologyConfigurations` |
| `pages/llmdRoutingSettings.ts` | `pages/modelDeploymentSettings/routingConfigurations.ts` | `llmdRoutingSettingsPage` → `routingConfigurations` |

Secondary exports (`unsupportedStatusAcceptanceModal`, `llmdRoutingCreatePage`, `deleteRouteModal`) keep their names. All importers were updated, including the scoped `@odh-dashboard/cypress` imports in the `model-serving` mock tests. Moves are tracked as git renames (history preserved).

**2. Fix existing tests broken by the standalone-page removal.**
- `testSingleServingRuntimeCreation.cy.ts`: post-save URL assertion `/serving-runtimes$/` → `/serving-runtime-templates$/` (the form now lands on the serving-runtime-templates tab).
- `servingRuntimeTemplates.ts` + `testAdminClusterSettings.cy.ts`: the serving-runtimes list is now a tab-route page whose title uses `app-tab-page-title`. Added `findTabPageTitle()` for the tab and used it, leaving `findAppTitle()` (`app-page-title`) for the add/edit/duplicate form pages.

**3. Stale-path cleanups.**
- `testGenAiModelDeployment.yaml`: `servingRuntimesPath` → the serving-runtime-templates tab path (the standalone page now only works via a compatibility redirect).
- `testLlmAcceleratorConfigsUnsupported.cy.ts`: dropped the no-op `devFeatureFlags=modelDeploymentSettings=true` (the flag is fully removed), keeping `vLLMDeploymentOnMaaS=true`.

**4. Fix the llm-d routing spec against the migrated tab UI.** `testLlmdRoutingConfigurations.cy.ts` was `@NonConcurrent` since it was added ([#8778](https://github.com/opendatahub-io/odh-dashboard/pull/8778)), so GitHub E2E CI never ran it — and its on-disk selectors had drifted from the actual form. Each of the following was confirmed necessary by tracing the failure to the current component source:
- **Topology-type option testid** `topology-type-workload-single-node` → `workload-single-node`. The `SimpleSelect` renders each option's `data-testid` as its `key`, which is the `TopologyType` enum value (`workload-single-node`) — there was never a `topology-type-` prefix.
- **YAML editor interaction** `.find('textarea')` → a `getYamlEditor()` helper backed by `DashboardCodeEditor.setValue()`. The config field is a PatternFly Monaco `CodeEditor` (`@patternfly/react-code-editor`) with no `<textarea>`.
- **Duplicate name** `${name}-copy` → `copy-of-${name}`. Duplicating produces display name `Copy of <name>`, whose k8s `metadata.name` (and row/option testids) is `copy-of-<name>`. The `after()` cleanup targeted the wrong name too, so the duplicated config was never cleaned up — also fixed.
- **Delete confirmation**: the delete modal gates its danger button on typing the config name, so the spec now types the name before submitting.

**5. Grant the login user project access for the deploy-wizard steps.** The routing and topology admin specs create their test project via `oc` (as a cluster admin) and then drive the deploy wizard logged into the dashboard as `LDAP_ADMIN_USER` — a dashboard admin, not a cluster admin. That user was never a member of the oc-created project, so it never appeared in their Projects list and the "open deploy wizard" step failed with "No results found". Both specs now grant the login user admin access to the project after creation and wait for it to propagate (`addUserToProject` + `waitForUserProjectAccess`), matching the pattern already used by the passing serving-runtime and accelerator-config admin specs. The topology spec is switched to `LDAP_ADMIN_USER` so both llm-d admin specs use the same login user.

**6. Make the admin specs concurrency-safe (drop `@NonConcurrent`).** Three specs were tagged `@NonConcurrent` because they created shared, admin-scoped resources (serving-runtime `Template`s, `LLMInferenceServiceConfig`s) under fixed fixture-derived names, so parallel runs on the same cluster would collide — which meant CI's E2E run (it skips `@NonConcurrent`) never exercised them. Their resource names are now UUID-suffixed so they can run concurrently, and the tag is dropped:
- `testLlmdRoutingConfigurations.cy.ts` — already UUID-scoped every resource; just dropped the tag.
- `testLlmdTopologyConfigurations.cy.ts` — templated the seeded config's `metadata.name` and render+apply it with a UUID-suffixed name.
- `testSingleServingRuntimeCreation.cy.ts` — templated the runtime YAML's name/display-name, rendered with UUID values, and upload it via the real file-picker path (`selectFile` with a file path) so disk-upload coverage is preserved.

**7. Add missing live-cluster coverage: topology config UI-driven CRUD.** New spec `testLlmdTopologyConfigurationsCrud.cy.ts` covers a gap no existing test hit — an admin creating an llm-d topology config **through the UI form** and it persisting as a real `LLMInferenceServiceConfig` CR. (The existing topology e2e only seeds via `oc` and reads back; the mock tests cover form/table/navigation UI but never submit the create form against the API server.) The spec creates a single-node config via the UI (name, resource name, YAML editor), verifies it appears in the table AND persisted on the cluster, then deletes it via the UI and verifies removal. Resource names are UUID-suffixed (concurrency-safe).

**8. Enter the config tabs via the Add button, not the table.** On a clean cluster the routing and topology tabs render an empty state (no table) until the first config exists, so waiting for `*-configurations-table` on arrival timed out in CI (which starts from an empty cluster) even though it passed locally against a populated one. The page objects now wait for the Add button — which the app renders in both the empty state and the populated table header (same `data-testid`) — and the topology CRUD spec drops its up-front table assertion. Post-create table assertions are unchanged, since a config is guaranteed to exist by then.

**9. Tag the llm-d config specs consistently as `@Featureflagged`.** All four llm-d config admin tabs are gated behind the `llmdTemplates` Tech Preview feature flag, so the topology specs now carry `@Featureflagged` like the routing and accelerator specs, and the topology spec's stray `@Smoke` tag (which had no matching `@SmokeSet*` shard) is removed. This follows the established convention that feature-flagged Tech-Preview specs are categorized by the flag rather than slotted into the `@Smoke`/`@Sanity` priority suites — matching the MCP, eval-hub, autorag, and most automl feature-flagged e2e specs.

## How Has This Been Tested?

- **Live cluster (E2E):** all touched specs were run headless against a live OpenShift cluster and pass end-to-end, including the deploy-wizard steps in the routing and topology specs and the new topology CRUD create/persist/delete flow.
- `npm run type-check` from the repo root — passes (30/30 tasks, including `@odh-dashboard/cypress` and `model-serving-cypress`).
- `npm run lint` in `packages/cypress` — 0 errors.
- **E2E CI:** the touched specs carry `@ModelServing` + `@ModelServingCI` (plus their owning-package tags: `@KServeCI` / `@LLMDServingCI`). GitHub E2E auto-detection keys off *changed packages'* `e2eCiTags`, and this PR only changes the Cypress workspaces (`model-serving-cypress`, `@odh-dashboard/cypress`), so the `test:ModelServingCI` label is applied to run the model-serving specs in the GitHub E2E matrix (`testAdminClusterSettings` also runs via the always-on `@ci-dashboard-regression-tags`).

## Test Impact

Test-only change. No product code is modified. Stale E2E assertions that targeted removed standalone pages are repointed to the consolidated tabs; the E2E page objects for those tabs are relocated and renamed for consistency with the tab structure. The llm-d routing spec is fixed to match the migrated tab UI, and both llm-d admin specs now grant their login user project access so the deploy-wizard steps work. Three admin specs are made concurrency-safe (UUID-suffixed resource names) so they run in GitHub E2E CI instead of being skipped as `@NonConcurrent`. One new e2e test adds live-cluster CRUD coverage for the topology configurations tab. No existing test coverage is removed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-69029]: https://redhat.atlassian.net/browse/RHOAIENG-69029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-68972]: https://redhat.atlassian.net/browse/RHOAIENG-68972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-80077]: https://redhat.atlassian.net/browse/RHOAIENG-80077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated model deployment settings terminology and navigation for Serving Runtime Templates, Routing Configurations, Topology Configurations, and LLM Accelerator Configurations.
  - Improved configuration workflows with YAML editor access and clearer tab-specific page identification.

- **Tests**
  - Expanded coverage for configuration creation, editing, duplication, deletion, enabling, and unsupported states.
  - Added end-to-end coverage for creating and deleting topology configurations.
  - Improved test isolation with unique configuration and runtime names.
  - Updated route, tab, and model-serving test classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
