### PR TITLE
Hide 'Single-model serving enabled' label when 1 platform

### DIFF
--- a/packages/model-serving/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -294,7 +294,8 @@ describe('Serving Runtime List', () => {
       initModelServingIntercepts({ isEmpty: true });
       projectDetails.visit('test-project');
       projectDetails.shouldBeEmptyState('Deployments', 'model-server', true);
-      projectDetails.findServingPlatformLabel().should('have.text', 'Single-model serving enabled');
+      // When only the model serving refactor is enabled and the only platform, don't show the platform label
+      projectDetails.findServingPlatformLabel().should('not.exist');
     });
 
     it('Shows KServe metrics only when available', () => {

--- a/packages/model-serving/src/components/global/GlobalDeploymentsTable.tsx
+++ b/packages/model-serving/src/components/global/GlobalDeploymentsTable.tsx
@@ -26,12 +26,14 @@ const ProjectCell: React.FC<{ deployment: Deployment; projects: ProjectKind[] }>
   deployment,
   projects,
 }) => {
-  const platformLabel = useExtensions(isModelServingPlatformExtension);
-  const platform = platformLabel.find((p) => p.properties.id === deployment.modelServingPlatformId);
+  const platformLabels = useExtensions(isModelServingPlatformExtension);
+  const platform = platformLabels.find(
+    (p) => p.properties.id === deployment.modelServingPlatformId,
+  );
   return (
     <>
       {namespaceToProjectDisplayName(deployment.model.metadata.namespace, projects)}{' '}
-      {platform && (
+      {platform && platformLabels.length > 1 && (
         <Label data-testid="serving-platform-label" isCompact>
           {platform.properties.enableCardText.enabledText}
         </Label>

--- a/packages/model-serving/src/components/global/GlobalDeploymentsTable.tsx
+++ b/packages/model-serving/src/components/global/GlobalDeploymentsTable.tsx
@@ -5,9 +5,8 @@ import {
 } from '@odh-dashboard/k8s-core';
 import type { ProjectKind } from '@odh-dashboard/k8s-core';
 import { DashboardEmptyTableView } from '@odh-dashboard/ui-core';
-import { Label } from '@patternfly/react-core';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
-import { useExtensions, useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import GlobalModelsToolbar from './GlobalModelsToolbar';
 import {
   initialModelServingFilterData,
@@ -17,30 +16,9 @@ import {
 import DeploymentsTable from '../deployments/DeploymentsTable';
 import {
   isModelServingDeploymentsTableExtension,
-  isModelServingPlatformExtension,
   type Deployment,
   type DeploymentsTableColumn,
 } from '../../../extension-points';
-
-const ProjectCell: React.FC<{ deployment: Deployment; projects: ProjectKind[] }> = ({
-  deployment,
-  projects,
-}) => {
-  const platformLabels = useExtensions(isModelServingPlatformExtension);
-  const platform = platformLabels.find(
-    (p) => p.properties.id === deployment.modelServingPlatformId,
-  );
-  return (
-    <>
-      {namespaceToProjectDisplayName(deployment.model.metadata.namespace, projects)}{' '}
-      {platform && platformLabels.length > 1 && (
-        <Label data-testid="serving-platform-label" isCompact>
-          {platform.properties.enableCardText.enabledText}
-        </Label>
-      )}
-    </>
-  );
-};
 
 const projectColumn = (projects: ProjectKind[]): DeploymentsTableColumn => ({
   field: 'project',
@@ -49,9 +27,8 @@ const projectColumn = (projects: ProjectKind[]): DeploymentsTableColumn => ({
     namespaceToProjectDisplayName(deploymentA.model.metadata.namespace, projects).localeCompare(
       namespaceToProjectDisplayName(deploymentB.model.metadata.namespace, projects),
     ),
-  cellRenderer: (deployment: Deployment) => (
-    <ProjectCell deployment={deployment} projects={projects} />
-  ),
+  cellRenderer: (deployment: Deployment) =>
+    namespaceToProjectDisplayName(deployment.model.metadata.namespace, projects),
 });
 
 // Removed model registry-specific logic - should be passed as customColumns prop

--- a/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
+++ b/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
@@ -276,9 +276,11 @@ const DeployedModelsSection: React.FC<{ platforms: ModelServingPlatform[] }> = (
                 />
               </ToggleGroup>
             </FlexItem>
-            <FlexItem flex={{ default: 'flex_1' }}>
-              <Label style={{ float: 'right' }}>{platformLabel}</Label>
-            </FlexItem>
+            {platforms.length > 1 && (
+              <FlexItem flex={{ default: 'flex_1' }}>
+                <Label style={{ float: 'right' }}>{platformLabel}</Label>
+              </FlexItem>
+            )}
           </Flex>
         </CardHeader>
         <CardBody>

--- a/packages/model-serving/src/components/overview/ModelPlatformSection.tsx
+++ b/packages/model-serving/src/components/overview/ModelPlatformSection.tsx
@@ -99,17 +99,21 @@ const ModelPlatformSection: React.FC<{ platforms: ModelServingPlatform[] }> = ({
         objectType={ProjectObjectType.deployedModels}
         sectionType={SectionType.serving}
         title={startHintTitle}
-        headerInfo={
-          <Flex gap={{ default: 'gapSm' }}>
-            <Label>{enabledText}</Label>
-            <ResetPlatformButton
-              platforms={platforms}
-              hasDeployments={false}
-              isLoading={loadingState.type === 'reset'}
-              onReset={resetProjectPlatform}
-            />
-          </Flex>
-        }
+        {...(platforms.length > 1
+          ? {
+              headerInfo: (
+                <Flex gap={{ default: 'gapSm' }}>
+                  <Label>{enabledText}</Label>
+                  <ResetPlatformButton
+                    platforms={platforms}
+                    hasDeployments={false}
+                    isLoading={loadingState.type === 'reset'}
+                    onReset={resetProjectPlatform}
+                  />
+                </Flex>
+              ),
+            }
+          : {})}
       >
         <CardBody>
           <Stack hasGutter>

--- a/packages/model-serving/src/components/projectDetails/ModelsProjectDetailsView.tsx
+++ b/packages/model-serving/src/components/projectDetails/ModelsProjectDetailsView.tsx
@@ -64,23 +64,26 @@ const ModelsProjectDetailsView: React.FC<{
           ? [<DeployButton key="deploy-button" project={project} variant="secondary" />]
           : undefined
       }
-      labels={[
-        [
-          <Flex gap={{ default: 'gapSm' }} key="serving-platform-label">
-            <Label data-testid="serving-platform-label">
-              {activePlatform?.properties.enableCardText.enabledText}
-            </Label>
-            {projectPlatform && ( // projectPlatform gets the actual saved value in the project labels
-              <ResetPlatformButton
-                platforms={platforms}
-                hasDeployments={hasModels}
-                isLoading={loadingState.type === 'reset'}
-                onReset={resetProjectPlatform}
-              />
-            )}
-          </Flex>,
-        ],
-      ]}
+      {...(platforms.length > 1
+        ? {
+            labels: [
+              <Flex gap={{ default: 'gapSm' }} key="serving-platform-label">
+                <Label data-testid="serving-platform-label">
+                  {activePlatform?.properties.enableCardText.enabledText}
+                </Label>
+
+                {projectPlatform && ( // projectPlatform gets the actual saved value in the project labels
+                  <ResetPlatformButton
+                    platforms={platforms}
+                    hasDeployments={hasModels}
+                    isLoading={loadingState.type === 'reset'}
+                    onReset={resetProjectPlatform}
+                  />
+                )}
+              </Flex>,
+            ],
+          }
+        : {})}
       isEmpty={!activePlatform}
       emptyState={
         !isLoading && (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-84350

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When there is only 1 platform (when NIM wizard flag is enabled, or there is no NIM at all) hide the "Single mode serving enabled" labels. This is because the concept of projects being restricted to certain platforms is outdated. 

For the global models page, I ended up removing it entirely. Here, it's never used to enable or reset platforms, so it's safe to remove completely without worrying about legacy NIM stuff

<img width="1115" height="850" alt="image" src="https://github.com/user-attachments/assets/6c004e3d-35aa-46bc-8773-7ebb2e0f4624" />
<img width="1239" height="852" alt="image" src="https://github.com/user-attachments/assets/56312493-b78c-4bc2-969c-4be213b005ec" />
<img width="1162" height="645" alt="image" src="https://github.com/user-attachments/assets/5f777bc6-a275-420c-b39e-97aab0fe623c" />
<img width="1155" height="667" alt="image" src="https://github.com/user-attachments/assets/01ca5a91-5379-4fdb-bc7f-633ff9ff9959" />
<img width="1180" height="566" alt="image" src="https://github.com/user-attachments/assets/b0586746-1b62-45a0-8c97-bad277df75f2" />
<img width="1199" height="576" alt="image" src="https://github.com/user-attachments/assets/92e4634c-ab94-4efe-9a1d-f26500797651" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
2 paths
NIM on the cluster
- Enable the global NIM account 
- select the single model serving platform - you'll see the label
- Enable the nimWizard flag - it will dissapear because the old nim platform won't exist

No NIM on the cluster
- Explore the different pages and make sure the label doesn't appear
  - Global models page, in the project cell
  - Project details Overview section (the top right)
  - Project details models tab (the top right next the the deploy button)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
cypress updated

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

fyi @JustinXHale 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Simplified model serving views when only one serving platform is configured by hiding redundant platform labels and reset controls.
  * Updated deployed model cards, project details, and platform sections for a cleaner single-platform experience.
  * Removed unnecessary serving-platform labels from project listings in single-platform configurations.

* **Bug Fixes**
  * Updated serving platform display behavior to consistently omit labels when only one platform is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->