### PR TITLE
feat(RHOAIENG-84636): add segment tracking to model deployment settings tabs

### DIFF
--- a/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeAddTemplate.tsx
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeAddTemplate.tsx
@@ -226,6 +226,22 @@ const CustomServingRuntimeAddTemplate: React.FC<CustomServingRuntimeAddTemplateP
                     if (e instanceof Error) {
                       setError(e);
                     }
+                    if (isEdit) {
+                      fireServingRuntimeTemplateUpdated({
+                        outcome: TrackingOutcome.submit,
+                        success: false,
+                        apiProtocol: selectedAPIProtocol,
+                        modelTypes: selectedModelTypes.join(','),
+                      });
+                    } else {
+                      fireServingRuntimeTemplateCreated({
+                        outcome: TrackingOutcome.submit,
+                        success: false,
+                        mode: isDuplicate ? 'duplicate' : 'create',
+                        apiProtocol: selectedAPIProtocol,
+                        modelTypes: selectedModelTypes.join(','),
+                      });
+                    }
                     return;
                   }
                   setIsLoading(true);
@@ -272,7 +288,6 @@ const CustomServingRuntimeAddTemplate: React.FC<CustomServingRuntimeAddTemplateP
                         fireServingRuntimeTemplateUpdated({
                           outcome: TrackingOutcome.submit,
                           success: false,
-                          error: err instanceof Error ? err.message : 'unknown',
                           apiProtocol: selectedAPIProtocol,
                           modelTypes: selectedModelTypesStr,
                         });
@@ -280,7 +295,6 @@ const CustomServingRuntimeAddTemplate: React.FC<CustomServingRuntimeAddTemplateP
                         fireServingRuntimeTemplateCreated({
                           outcome: TrackingOutcome.submit,
                           success: false,
-                          error: err instanceof Error ? err.message : 'unknown',
                           mode: isDuplicate ? 'duplicate' : 'create',
                           apiProtocol: selectedAPIProtocol,
                           modelTypes: selectedModelTypesStr,

--- a/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeAddTemplate.tsx
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeAddTemplate.tsx
@@ -30,7 +30,7 @@ import {
   getServingRuntimeNameFromTemplate,
   isServingRuntimeKind,
 } from '@odh-dashboard/model-serving/shared';
-import { ApplicationsPage } from '@odh-dashboard/ui-core';
+import { ApplicationsPage, TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import DashboardCodeEditor from '@odh-dashboard/internal/concepts/dashboard/codeEditor/DashboardCodeEditor';
 import {
@@ -41,6 +41,10 @@ import { CustomServingRuntimeContext } from './CustomServingRuntimeContext';
 import CustomServingRuntimeAPIProtocolSelector from './CustomServingRuntimeAPIProtocolSelector';
 import CustomServingRuntimeModelTypeSelector from './CustomServingRuntimeModelTypeSelector';
 import { SERVING_RUNTIME_TEMPLATES_TAB_PATH } from './paths';
+import {
+  fireServingRuntimeTemplateCreated,
+  fireServingRuntimeTemplateUpdated,
+} from './tracking/servingRuntimeTemplateTracking';
 
 type CustomServingRuntimeAddTemplateProps = {
   mode: 'add' | 'edit' | 'duplicate';
@@ -241,12 +245,47 @@ const CustomServingRuntimeAddTemplate: React.FC<CustomServingRuntimeAddTemplateP
                           selectedAPIProtocol,
                           selectedModelTypes,
                         );
+                  const selectedModelTypesStr = selectedModelTypes.join(',');
                   onClickFunc
                     .then(() => {
+                      if (isEdit) {
+                        fireServingRuntimeTemplateUpdated({
+                          outcome: TrackingOutcome.submit,
+                          success: true,
+                          apiProtocol: selectedAPIProtocol,
+                          modelTypes: selectedModelTypesStr,
+                        });
+                      } else {
+                        fireServingRuntimeTemplateCreated({
+                          outcome: TrackingOutcome.submit,
+                          success: true,
+                          mode: isDuplicate ? 'duplicate' : 'create',
+                          apiProtocol: selectedAPIProtocol,
+                          modelTypes: selectedModelTypesStr,
+                        });
+                      }
                       refreshData();
                       navigate(listPath);
                     })
                     .catch((err) => {
+                      if (isEdit) {
+                        fireServingRuntimeTemplateUpdated({
+                          outcome: TrackingOutcome.submit,
+                          success: false,
+                          error: err instanceof Error ? err.message : 'unknown',
+                          apiProtocol: selectedAPIProtocol,
+                          modelTypes: selectedModelTypesStr,
+                        });
+                      } else {
+                        fireServingRuntimeTemplateCreated({
+                          outcome: TrackingOutcome.submit,
+                          success: false,
+                          error: err instanceof Error ? err.message : 'unknown',
+                          mode: isDuplicate ? 'duplicate' : 'create',
+                          apiProtocol: selectedAPIProtocol,
+                          modelTypes: selectedModelTypesStr,
+                        });
+                      }
                       setError(err);
                     })
                     .finally(() => {
@@ -260,7 +299,17 @@ const CustomServingRuntimeAddTemplate: React.FC<CustomServingRuntimeAddTemplateP
                 isDisabled={loading}
                 variant="link"
                 id="cancel-button"
-                onClick={() => navigate(listPath)}
+                onClick={() => {
+                  if (isEdit) {
+                    fireServingRuntimeTemplateUpdated({ outcome: TrackingOutcome.cancel });
+                  } else {
+                    fireServingRuntimeTemplateCreated({
+                      outcome: TrackingOutcome.cancel,
+                      mode: isDuplicate ? 'duplicate' : 'create',
+                    });
+                  }
+                  navigate(listPath);
+                }}
               >
                 Cancel
               </Button>

--- a/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeEnabledToggle.tsx
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeEnabledToggle.tsx
@@ -88,7 +88,8 @@ const CustomServingRuntimeEnabledToggle: React.FC<CustomServingRuntimeEnabledTog
             outcome: TrackingOutcome.submit,
             success: false,
             error: e instanceof Error ? e.message : 'unknown',
-            enabled: checked,
+            // The patch failed, so the state reverts — report the actual state, not the intended one.
+            enabled: !checked,
           });
           setEnabled(!checked);
         })

--- a/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeEnabledToggle.tsx
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeEnabledToggle.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Switch } from '@patternfly/react-core';
 import type { TemplateKind } from '@odh-dashboard/k8s-core';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   getTemplateEnabled,
   setListDisabled,
@@ -24,6 +25,7 @@ import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analytic
 import { patchDashboardConfigTemplateDisablementBackend } from '@odh-dashboard/internal/services/dashboardService';
 import { patchTemplateAcceptedAnnotationBackend } from '@odh-dashboard/internal/services/templateService';
 import { CustomServingRuntimeContext } from './CustomServingRuntimeContext';
+import { fireServingRuntimeTemplateEnablementChanged } from './tracking/servingRuntimeTemplateTracking';
 
 type CustomServingRuntimeEnabledToggleProps = {
   template: TemplateKind;
@@ -70,6 +72,11 @@ const CustomServingRuntimeEnabledToggle: React.FC<CustomServingRuntimeEnabledTog
       patchDashboardConfigTemplateDisablementBackend(templateDisablementUpdated, dashboardNamespace)
         .then(() => {
           setEnabled(checked);
+          fireServingRuntimeTemplateEnablementChanged({
+            outcome: TrackingOutcome.submit,
+            success: true,
+            enabled: checked,
+          });
           refreshDisablement();
         })
         .catch((e) => {
@@ -77,6 +84,12 @@ const CustomServingRuntimeEnabledToggle: React.FC<CustomServingRuntimeEnabledTog
             `Error ${checked ? 'enabling' : 'disabling'} the serving runtime`,
             e.message,
           );
+          fireServingRuntimeTemplateEnablementChanged({
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: e instanceof Error ? e.message : 'unknown',
+            enabled: checked,
+          });
           setEnabled(!checked);
         })
         .finally(() => {

--- a/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeEnabledToggle.tsx
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/CustomServingRuntimeEnabledToggle.tsx
@@ -87,7 +87,6 @@ const CustomServingRuntimeEnabledToggle: React.FC<CustomServingRuntimeEnabledTog
           fireServingRuntimeTemplateEnablementChanged({
             outcome: TrackingOutcome.submit,
             success: false,
-            error: e instanceof Error ? e.message : 'unknown',
             // The patch failed, so the state reverts — report the actual state, not the intended one.
             enabled: !checked,
           });

--- a/packages/kserve/src/settings/servingRuntimeTemplates/DeleteCustomServingRuntimeModal.tsx
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/DeleteCustomServingRuntimeModal.tsx
@@ -44,7 +44,10 @@ const DeleteCustomServingRuntimeModal: React.FC<DeleteCustomServingRuntimeModalP
   return (
     <DeleteModal
       title="Delete serving runtime?"
-      onClose={() => onBeforeClose(false)}
+      onClose={() => {
+        fireServingRuntimeTemplateDeleted({ outcome: TrackingOutcome.cancel });
+        onBeforeClose(false);
+      }}
       submitButtonLabel="Delete serving runtime"
       onDelete={() => {
         setIsDeleting(true);

--- a/packages/kserve/src/settings/servingRuntimeTemplates/DeleteCustomServingRuntimeModal.tsx
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/DeleteCustomServingRuntimeModal.tsx
@@ -77,7 +77,6 @@ const DeleteCustomServingRuntimeModal: React.FC<DeleteCustomServingRuntimeModalP
             fireServingRuntimeTemplateDeleted({
               outcome: TrackingOutcome.submit,
               success: false,
-              error: e instanceof Error ? e.message : 'unknown',
             });
             setError(e);
             setIsDeleting(false);

--- a/packages/kserve/src/settings/servingRuntimeTemplates/DeleteCustomServingRuntimeModal.tsx
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/DeleteCustomServingRuntimeModal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { TemplateKind } from '@odh-dashboard/k8s-core';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   getServingRuntimeDisplayNameFromTemplate,
   getTemplateEnabled,
@@ -11,6 +12,7 @@ import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/p
 import { deleteTemplateBackend } from '@odh-dashboard/internal/services/templateService';
 import { patchDashboardConfigTemplateDisablementBackend } from '@odh-dashboard/internal/services/dashboardService';
 import { CustomServingRuntimeContext } from './CustomServingRuntimeContext';
+import { fireServingRuntimeTemplateDeleted } from './tracking/servingRuntimeTemplateTracking';
 
 type DeleteCustomServingRuntimeModalProps = {
   template: TemplateKind;
@@ -65,9 +67,15 @@ const DeleteCustomServingRuntimeModal: React.FC<DeleteCustomServingRuntimeModalP
           deleteTemplateBackend(template.metadata.name, template.metadata.namespace),
         ])
           .then(() => {
+            fireServingRuntimeTemplateDeleted({ outcome: TrackingOutcome.submit, success: true });
             onBeforeClose(true);
           })
           .catch((e) => {
+            fireServingRuntimeTemplateDeleted({
+              outcome: TrackingOutcome.submit,
+              success: false,
+              error: e instanceof Error ? e.message : 'unknown',
+            });
             setError(e);
             setIsDeleting(false);
           });

--- a/packages/kserve/src/settings/servingRuntimeTemplates/__tests__/CustomServingRuntimeEnabledToggle.spec.tsx
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/__tests__/CustomServingRuntimeEnabledToggle.spec.tsx
@@ -28,6 +28,7 @@ jest.mock('@odh-dashboard/internal/services/templateService', () => ({
 
 jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
   fireMiscTrackingEvent: jest.fn(),
+  fireFormTrackingEvent: jest.fn(),
 }));
 
 jest.mock('@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking', () => ({

--- a/packages/kserve/src/settings/servingRuntimeTemplates/tracking/__tests__/servingRuntimeTemplateTracking.spec.ts
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/tracking/__tests__/servingRuntimeTemplateTracking.spec.ts
@@ -1,0 +1,157 @@
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { ServingRuntimeAPIProtocol } from '@odh-dashboard/model-serving/shared';
+import {
+  ServingRuntimeTemplateTrackingEvent,
+  fireServingRuntimeTemplateCreated,
+  fireServingRuntimeTemplateUpdated,
+  fireServingRuntimeTemplateDeleted,
+  fireServingRuntimeTemplateEnablementChanged,
+} from '../servingRuntimeTemplateTracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
+
+describe('fireServingRuntimeTemplateCreated', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the Created event with mode and categorical properties on success', () => {
+    fireServingRuntimeTemplateCreated({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: 'create',
+      apiProtocol: ServingRuntimeAPIProtocol.REST,
+      modelTypes: 'predictive,generative',
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      ServingRuntimeTemplateTrackingEvent.CREATED,
+      {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        mode: 'create',
+        apiProtocol: ServingRuntimeAPIProtocol.REST,
+        modelTypes: 'predictive,generative',
+      },
+    );
+  });
+
+  it('should fire the Created event with mode duplicate', () => {
+    fireServingRuntimeTemplateCreated({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: 'duplicate',
+      apiProtocol: ServingRuntimeAPIProtocol.GRPC,
+      modelTypes: 'predictive',
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      ServingRuntimeTemplateTrackingEvent.CREATED,
+      expect.objectContaining({ mode: 'duplicate', apiProtocol: ServingRuntimeAPIProtocol.GRPC }),
+    );
+  });
+
+  it('should fire the Created event with success false and error on failure', () => {
+    fireServingRuntimeTemplateCreated({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: 'boom',
+      mode: 'create',
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      ServingRuntimeTemplateTrackingEvent.CREATED,
+      expect.objectContaining({ success: false, error: 'boom' }),
+    );
+  });
+
+  it('should fire the Created event with cancel outcome', () => {
+    fireServingRuntimeTemplateCreated({ outcome: TrackingOutcome.cancel, mode: 'create' });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      ServingRuntimeTemplateTrackingEvent.CREATED,
+      { outcome: TrackingOutcome.cancel, mode: 'create' },
+    );
+  });
+});
+
+describe('fireServingRuntimeTemplateUpdated', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the Updated event on success', () => {
+    fireServingRuntimeTemplateUpdated({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      apiProtocol: ServingRuntimeAPIProtocol.GRPC,
+      modelTypes: 'generative',
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      ServingRuntimeTemplateTrackingEvent.UPDATED,
+      expect.objectContaining({
+        success: true,
+        apiProtocol: ServingRuntimeAPIProtocol.GRPC,
+        modelTypes: 'generative',
+      }),
+    );
+  });
+
+  it('should fire the Updated event with cancel outcome', () => {
+    fireServingRuntimeTemplateUpdated({ outcome: TrackingOutcome.cancel });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      ServingRuntimeTemplateTrackingEvent.UPDATED,
+      { outcome: TrackingOutcome.cancel },
+    );
+  });
+});
+
+describe('fireServingRuntimeTemplateDeleted', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the Deleted event on success', () => {
+    fireServingRuntimeTemplateDeleted({ outcome: TrackingOutcome.submit, success: true });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      ServingRuntimeTemplateTrackingEvent.DELETED,
+      { outcome: TrackingOutcome.submit, success: true },
+    );
+  });
+
+  it('should fire the Deleted event with cancel outcome when the dialog is dismissed', () => {
+    fireServingRuntimeTemplateDeleted({ outcome: TrackingOutcome.cancel });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      ServingRuntimeTemplateTrackingEvent.DELETED,
+      { outcome: TrackingOutcome.cancel },
+    );
+  });
+});
+
+describe('fireServingRuntimeTemplateEnablementChanged', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the Enablement Changed event with the new enabled state', () => {
+    fireServingRuntimeTemplateEnablementChanged({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      enabled: false,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      ServingRuntimeTemplateTrackingEvent.ENABLEMENT_CHANGED,
+      { outcome: TrackingOutcome.submit, success: true, enabled: false },
+    );
+  });
+});

--- a/packages/kserve/src/settings/servingRuntimeTemplates/tracking/__tests__/servingRuntimeTemplateTracking.spec.ts
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/tracking/__tests__/servingRuntimeTemplateTracking.spec.ts
@@ -56,17 +56,16 @@ describe('fireServingRuntimeTemplateCreated', () => {
     );
   });
 
-  it('should fire the Created event with success false and error on failure', () => {
+  it('should fire the Created event with success false on failure (no free-form error/PII)', () => {
     fireServingRuntimeTemplateCreated({
       outcome: TrackingOutcome.submit,
       success: false,
-      error: 'boom',
       mode: 'create',
     });
 
     expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
       ServingRuntimeTemplateTrackingEvent.CREATED,
-      expect.objectContaining({ success: false, error: 'boom' }),
+      { outcome: TrackingOutcome.submit, success: false, mode: 'create' },
     );
   });
 

--- a/packages/kserve/src/settings/servingRuntimeTemplates/tracking/servingRuntimeTemplateTracking.ts
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/tracking/servingRuntimeTemplateTracking.ts
@@ -1,0 +1,55 @@
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { type FormTrackingEventProperties } from '@odh-dashboard/ui-core';
+import type { ServingRuntimeAPIProtocol } from '@odh-dashboard/model-serving/shared';
+
+export enum ServingRuntimeTemplateTrackingEvent {
+  CREATED = 'Model Serving Serving Runtime Template Created',
+  UPDATED = 'Model Serving Serving Runtime Template Updated',
+  DELETED = 'Model Serving Serving Runtime Template Deleted',
+  ENABLEMENT_CHANGED = 'Model Serving Serving Runtime Template Enablement Changed',
+}
+
+export type ServingRuntimeTemplateCreatedProperties = FormTrackingEventProperties & {
+  /** Whether the template was created from scratch or duplicated from an existing one. */
+  mode: 'create' | 'duplicate';
+  apiProtocol?: ServingRuntimeAPIProtocol;
+  /** Comma-separated list of selected model type enum values (no free text). */
+  modelTypes?: string;
+};
+
+export type ServingRuntimeTemplateUpdatedProperties = FormTrackingEventProperties & {
+  apiProtocol?: ServingRuntimeAPIProtocol;
+  /** Comma-separated list of selected model type enum values (no free text). */
+  modelTypes?: string;
+};
+
+export type ServingRuntimeTemplateDeletedProperties = FormTrackingEventProperties;
+
+export type ServingRuntimeTemplateEnablementChangedProperties = FormTrackingEventProperties & {
+  /** The new enabled state after the toggle is applied. */
+  enabled: boolean;
+};
+
+export const fireServingRuntimeTemplateCreated = (
+  properties: ServingRuntimeTemplateCreatedProperties,
+): void => {
+  fireFormTrackingEvent(ServingRuntimeTemplateTrackingEvent.CREATED, properties);
+};
+
+export const fireServingRuntimeTemplateUpdated = (
+  properties: ServingRuntimeTemplateUpdatedProperties,
+): void => {
+  fireFormTrackingEvent(ServingRuntimeTemplateTrackingEvent.UPDATED, properties);
+};
+
+export const fireServingRuntimeTemplateDeleted = (
+  properties: ServingRuntimeTemplateDeletedProperties,
+): void => {
+  fireFormTrackingEvent(ServingRuntimeTemplateTrackingEvent.DELETED, properties);
+};
+
+export const fireServingRuntimeTemplateEnablementChanged = (
+  properties: ServingRuntimeTemplateEnablementChangedProperties,
+): void => {
+  fireFormTrackingEvent(ServingRuntimeTemplateTrackingEvent.ENABLEMENT_CHANGED, properties);
+};

--- a/packages/kserve/src/settings/servingRuntimeTemplates/tracking/servingRuntimeTemplateTracking.ts
+++ b/packages/kserve/src/settings/servingRuntimeTemplates/tracking/servingRuntimeTemplateTracking.ts
@@ -26,7 +26,7 @@ export type ServingRuntimeTemplateUpdatedProperties = FormTrackingEventPropertie
 export type ServingRuntimeTemplateDeletedProperties = FormTrackingEventProperties;
 
 export type ServingRuntimeTemplateEnablementChangedProperties = FormTrackingEventProperties & {
-  /** The new enabled state after the toggle is applied. */
+  /** The actual enabled state after the toggle attempt (reverts to the prior state on failure). */
   enabled: boolean;
 };
 

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/DeleteLlmAcceleratorConfigModal.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/DeleteLlmAcceleratorConfigModal.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard delete confirmation wrapper
 import DeleteModal from '@odh-dashboard/internal/pages/projects/components/DeleteModal';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import type { LLMInferenceServiceConfigKind } from '../../types';
 import { deleteLLMInferenceServiceConfig } from '../../api/LLMInferenceServiceConfigs';
+import { fireLlmAcceleratorConfigDeleted } from '../../tracking/llmdTrackingConstants';
 
 type DeleteLlmAcceleratorConfigModalProps = {
   config: LLMInferenceServiceConfigKind;
@@ -27,9 +29,15 @@ const DeleteLlmAcceleratorConfigModal: React.FC<DeleteLlmAcceleratorConfigModalP
         setError(undefined);
         deleteLLMInferenceServiceConfig(config.metadata.name, config.metadata.namespace)
           .then(() => {
+            fireLlmAcceleratorConfigDeleted({ outcome: TrackingOutcome.submit, success: true });
             onClose(true);
           })
           .catch((e) => {
+            fireLlmAcceleratorConfigDeleted({
+              outcome: TrackingOutcome.submit,
+              success: false,
+              error: e instanceof Error ? e.message : 'unknown',
+            });
             setError(e);
             setIsDeleting(false);
           });

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/DeleteLlmAcceleratorConfigModal.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/DeleteLlmAcceleratorConfigModal.tsx
@@ -22,7 +22,10 @@ const DeleteLlmAcceleratorConfigModal: React.FC<DeleteLlmAcceleratorConfigModalP
   return (
     <DeleteModal
       title="Delete LLM accelerator configuration?"
-      onClose={() => onClose(false)}
+      onClose={() => {
+        fireLlmAcceleratorConfigDeleted({ outcome: TrackingOutcome.cancel });
+        onClose(false);
+      }}
       submitButtonLabel="Delete LLM accelerator configuration"
       onDelete={() => {
         setIsDeleting(true);

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/DeleteLlmAcceleratorConfigModal.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/DeleteLlmAcceleratorConfigModal.tsx
@@ -39,7 +39,6 @@ const DeleteLlmAcceleratorConfigModal: React.FC<DeleteLlmAcceleratorConfigModalP
             fireLlmAcceleratorConfigDeleted({
               outcome: TrackingOutcome.submit,
               success: false,
-              error: e instanceof Error ? e.message : 'unknown',
             });
             setError(e);
             setIsDeleting(false);

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
@@ -142,10 +142,28 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
       parsed = YAML.parse(yamlCode);
     } catch (e) {
       setError(e instanceof Error ? e : new Error(String(e)));
+      if (isEdit) {
+        fireLlmAcceleratorConfigUpdated({ outcome: TrackingOutcome.submit, success: false });
+      } else {
+        fireLlmAcceleratorConfigCreated({
+          outcome: TrackingOutcome.submit,
+          success: false,
+          mode: isDuplicate ? 'duplicate' : 'create',
+        });
+      }
       return;
     }
     if (!isConfigObject(parsed)) {
       setError(new Error('YAML must represent a valid kubernetes resource object'));
+      if (isEdit) {
+        fireLlmAcceleratorConfigUpdated({ outcome: TrackingOutcome.submit, success: false });
+      } else {
+        fireLlmAcceleratorConfigCreated({
+          outcome: TrackingOutcome.submit,
+          success: false,
+          mode: isDuplicate ? 'duplicate' : 'create',
+        });
+      }
       return;
     }
     const config = overrideLlmConfigFields(parsed, {
@@ -178,13 +196,11 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
           fireLlmAcceleratorConfigUpdated({
             outcome: TrackingOutcome.submit,
             success: false,
-            error: err instanceof Error ? err.message : 'unknown',
           });
         } else {
           fireLlmAcceleratorConfigCreated({
             outcome: TrackingOutcome.submit,
             success: false,
-            error: err instanceof Error ? err.message : 'unknown',
             mode: isDuplicate ? 'duplicate' : 'create',
           });
         }

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
@@ -18,7 +18,7 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import YAML from 'yaml';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
-import { ApplicationsPage } from '@odh-dashboard/ui-core';
+import { ApplicationsPage, TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
@@ -40,6 +40,10 @@ import {
 } from '../../utils';
 import { ConfigType, CONFIG_TYPE_LABEL } from '../../types';
 import type { LLMInferenceServiceConfigKind } from '../../types';
+import {
+  fireLlmAcceleratorConfigCreated,
+  fireLlmAcceleratorConfigUpdated,
+} from '../../tracking/llmdTrackingConstants';
 
 type FormMode = 'add' | 'edit' | 'duplicate';
 
@@ -157,10 +161,33 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
       : createLLMInferenceServiceConfig(config);
     submitFn
       .then(() => {
+        if (isEdit) {
+          fireLlmAcceleratorConfigUpdated({ outcome: TrackingOutcome.submit, success: true });
+        } else {
+          fireLlmAcceleratorConfigCreated({
+            outcome: TrackingOutcome.submit,
+            success: true,
+            mode: isDuplicate ? 'duplicate' : 'create',
+          });
+        }
         navigate(listPath);
       })
       .catch((err: unknown) => {
         setError(err instanceof Error ? err : new Error(String(err)));
+        if (isEdit) {
+          fireLlmAcceleratorConfigUpdated({
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: err instanceof Error ? err.message : 'unknown',
+          });
+        } else {
+          fireLlmAcceleratorConfigCreated({
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: err instanceof Error ? err.message : 'unknown',
+            mode: isDuplicate ? 'duplicate' : 'create',
+          });
+        }
       })
       .finally(() => {
         setLoading(false);
@@ -168,6 +195,7 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
   }, [
     yamlCode,
     isEdit,
+    isDuplicate,
     sourceConfig?.metadata.name,
     nameDescData,
     version,
@@ -244,7 +272,17 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
             isDisabled={loading}
             variant="link"
             data-testid="cancel-button"
-            onClick={() => navigate(listPath)}
+            onClick={() => {
+              if (isEdit) {
+                fireLlmAcceleratorConfigUpdated({ outcome: TrackingOutcome.cancel });
+              } else {
+                fireLlmAcceleratorConfigCreated({
+                  outcome: TrackingOutcome.cancel,
+                  mode: isDuplicate ? 'duplicate' : 'create',
+                });
+              }
+              navigate(listPath);
+            }}
           >
             Cancel
           </Button>

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigEnabledToggle.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigEnabledToggle.tsx
@@ -69,12 +69,13 @@ const LlmAcceleratorConfigEnabledToggle: React.FC<LlmAcceleratorConfigEnabledTog
   );
 
   const handleToggle = React.useCallback(async () => {
+    // The actual resulting state: the intended state on success, unchanged (reverted) on failure.
     if (effectiveEnabled) {
       const success = await patchConfigAnnotations({ [DISABLED_ANNOTATION]: 'true' });
       fireLlmAcceleratorConfigEnablementChanged({
         outcome: TrackingOutcome.submit,
         success,
-        enabled: false,
+        enabled: success ? false : effectiveEnabled,
       });
     } else if (unsupportedUnaccepted) {
       setShowAcceptanceModal(true);
@@ -83,7 +84,7 @@ const LlmAcceleratorConfigEnabledToggle: React.FC<LlmAcceleratorConfigEnabledTog
       fireLlmAcceleratorConfigEnablementChanged({
         outcome: TrackingOutcome.submit,
         success,
-        enabled: true,
+        enabled: success ? true : effectiveEnabled,
       });
     }
   }, [effectiveEnabled, unsupportedUnaccepted, patchConfigAnnotations]);
@@ -97,7 +98,8 @@ const LlmAcceleratorConfigEnabledToggle: React.FC<LlmAcceleratorConfigEnabledTog
     fireLlmAcceleratorConfigEnablementChanged({
       outcome: TrackingOutcome.submit,
       success,
-      enabled: true,
+      // Accept enables from a disabled state; on failure it stays disabled.
+      enabled: success,
     });
     if (success) {
       fireRiskAccepted(fireMiscTrackingEvent, {

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigEnabledToggle.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigEnabledToggle.tsx
@@ -16,10 +16,12 @@ import {
   fireRiskDismissed,
   getResourceVersions,
 } from '@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import type { LLMInferenceServiceConfigKind } from '../../types';
 import { DISABLED_ANNOTATION } from '../../const';
 import { isConfigEnabled } from '../../utils';
 import { patchLLMInferenceServiceConfig } from '../../api/LLMInferenceServiceConfigs';
+import { fireLlmAcceleratorConfigEnablementChanged } from '../../tracking/llmdTrackingConstants';
 
 type LlmAcceleratorConfigEnabledToggleProps = {
   config: LLMInferenceServiceConfigKind;
@@ -66,13 +68,23 @@ const LlmAcceleratorConfigEnabledToggle: React.FC<LlmAcceleratorConfigEnabledTog
     [config, notification],
   );
 
-  const handleToggle = React.useCallback(() => {
+  const handleToggle = React.useCallback(async () => {
     if (effectiveEnabled) {
-      patchConfigAnnotations({ [DISABLED_ANNOTATION]: 'true' });
+      const success = await patchConfigAnnotations({ [DISABLED_ANNOTATION]: 'true' });
+      fireLlmAcceleratorConfigEnablementChanged({
+        outcome: TrackingOutcome.submit,
+        success,
+        enabled: false,
+      });
     } else if (unsupportedUnaccepted) {
       setShowAcceptanceModal(true);
     } else {
-      patchConfigAnnotations({ [DISABLED_ANNOTATION]: 'false' });
+      const success = await patchConfigAnnotations({ [DISABLED_ANNOTATION]: 'false' });
+      fireLlmAcceleratorConfigEnablementChanged({
+        outcome: TrackingOutcome.submit,
+        success,
+        enabled: true,
+      });
     }
   }, [effectiveEnabled, unsupportedUnaccepted, patchConfigAnnotations]);
 
@@ -81,6 +93,11 @@ const LlmAcceleratorConfigEnabledToggle: React.FC<LlmAcceleratorConfigEnabledTog
     const success = await patchConfigAnnotations({
       [UNSUPPORTED_STATUS_ACCEPTED_ANNOTATION]: 'true',
       [DISABLED_ANNOTATION]: 'false',
+    });
+    fireLlmAcceleratorConfigEnablementChanged({
+      outcome: TrackingOutcome.submit,
+      success,
+      enabled: true,
     });
     if (success) {
       fireRiskAccepted(fireMiscTrackingEvent, {

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/__tests__/LlmAcceleratorConfigEnabledToggle.spec.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/__tests__/LlmAcceleratorConfigEnabledToggle.spec.tsx
@@ -19,6 +19,7 @@ jest.mock('../../../api/LLMInferenceServiceConfigs', () => ({
 
 jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
   fireMiscTrackingEvent: jest.fn(),
+  fireFormTrackingEvent: jest.fn(),
 }));
 
 jest.mock('@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking', () => ({

--- a/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationCreateEdit.tsx
@@ -20,7 +20,7 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Link, useNavigate, useParams } from 'react-router';
 import YAML from 'yaml';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
-import { ApplicationsPage } from '@odh-dashboard/ui-core';
+import { ApplicationsPage, TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import {
   getDisplayNameFromK8sResource,
@@ -54,6 +54,10 @@ import {
   createLLMInferenceServiceConfig,
   patchLLMInferenceServiceConfig,
 } from '../../api/LLMInferenceServiceConfigs';
+import {
+  fireRoutingConfigCreated,
+  fireRoutingConfigUpdated,
+} from '../../tracking/llmdTrackingConstants';
 
 const SAMPLE_DISPLAY_NAME_ANNOTATION = 'openshift.io/display-name';
 const SAMPLE_DESCRIPTION_ANNOTATION = 'description';
@@ -318,8 +322,20 @@ const RoutingConfigurationCreateEditInner: React.FC<{
 
       if (isEditMode && existingConfig) {
         await patchLLMInferenceServiceConfig(existingConfig, newConfig);
+        fireRoutingConfigUpdated({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          topologyType: selectedTopology,
+        });
       } else {
         await createLLMInferenceServiceConfig(newConfig);
+        fireRoutingConfigCreated({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          mode: isDuplicate ? 'duplicate' : 'create',
+          configSource,
+          topologyType: selectedTopology,
+        });
       }
       navigate(listPath);
     } catch (e) {
@@ -329,6 +345,23 @@ const RoutingConfigurationCreateEditInner: React.FC<{
         `Error ${isEditMode ? 'updating' : 'creating'} configuration`,
         err.message,
       );
+      if (isEditMode) {
+        fireRoutingConfigUpdated({
+          outcome: TrackingOutcome.submit,
+          success: false,
+          error: err.message,
+          topologyType: selectedTopology,
+        });
+      } else {
+        fireRoutingConfigCreated({
+          outcome: TrackingOutcome.submit,
+          success: false,
+          error: err.message,
+          mode: isDuplicate ? 'duplicate' : 'create',
+          configSource,
+          topologyType: selectedTopology,
+        });
+      }
     } finally {
       setLoading(false);
     }
@@ -431,7 +464,17 @@ const RoutingConfigurationCreateEditInner: React.FC<{
             variant="link"
             data-testid="cancel-routing-config-button"
             isDisabled={loading}
-            onClick={() => navigate(listPath)}
+            onClick={() => {
+              if (isEditMode) {
+                fireRoutingConfigUpdated({ outcome: TrackingOutcome.cancel });
+              } else {
+                fireRoutingConfigCreated({
+                  outcome: TrackingOutcome.cancel,
+                  mode: isDuplicate ? 'duplicate' : 'create',
+                });
+              }
+              navigate(listPath);
+            }}
           >
             Cancel
           </Button>

--- a/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationCreateEdit.tsx
@@ -349,14 +349,12 @@ const RoutingConfigurationCreateEditInner: React.FC<{
         fireRoutingConfigUpdated({
           outcome: TrackingOutcome.submit,
           success: false,
-          error: err.message,
           topologyType: selectedTopology,
         });
       } else {
         fireRoutingConfigCreated({
           outcome: TrackingOutcome.submit,
           success: false,
-          error: err.message,
           mode: isDuplicate ? 'duplicate' : 'create',
           configSource,
           topologyType: selectedTopology,

--- a/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationsTable.tsx
@@ -107,7 +107,6 @@ const RoutingConfigurationsTable: React.FC<RoutingConfigurationsTableProps> = ({
       fireRoutingConfigDeleted({
         outcome: TrackingOutcome.submit,
         success: false,
-        error: e instanceof Error ? e.message : 'unknown',
       });
     } finally {
       setIsDeleting(false);

--- a/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationsTable.tsx
@@ -3,7 +3,7 @@ import { Button, EmptyState, EmptyStateBody, ToolbarItem } from '@patternfly/rea
 import { CubesIcon } from '@patternfly/react-icons';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard delete confirmation wrapper
 import DeleteModal from '@odh-dashboard/internal/pages/projects/components/DeleteModal';
-import { Table, SortableData } from '@odh-dashboard/ui-core';
+import { Table, SortableData, TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useNavigate } from 'react-router';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { k8sDeleteResource, K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
@@ -13,6 +13,7 @@ import RoutingConfigurationRow, { getSupportedTopologiesLabel } from './RoutingC
 import { type LLMInferenceServiceConfigKind, LLMInferenceServiceConfigModel } from '../../types';
 import { isConfigEnabled, isConfigEffectivelyEnabled } from '../../utils';
 import { patchLLMInferenceServiceConfig } from '../../api/LLMInferenceServiceConfigs';
+import { fireRoutingConfigDeleted } from '../../tracking/llmdTrackingConstants';
 
 export const columns: SortableData<LLMInferenceServiceConfigKind>[] = [
   {
@@ -96,12 +97,18 @@ const RoutingConfigurationsTable: React.FC<RoutingConfigurationsTableProps> = ({
           ns: dashboardNamespace,
         },
       });
+      fireRoutingConfigDeleted({ outcome: TrackingOutcome.submit, success: true });
       setDeleteConfig(undefined);
     } catch (e) {
       notification.error(
         'Error deleting configuration',
         e instanceof Error ? e.message : 'Unknown error',
       );
+      fireRoutingConfigDeleted({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: e instanceof Error ? e.message : 'unknown',
+      });
     } finally {
       setIsDeleting(false);
     }

--- a/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationsTable.tsx
@@ -160,6 +160,7 @@ const RoutingConfigurationsTable: React.FC<RoutingConfigurationsTableProps> = ({
         <DeleteModal
           title="Delete llm-d routing configuration?"
           onClose={() => {
+            fireRoutingConfigDeleted({ outcome: TrackingOutcome.cancel });
             setDeleteConfig(undefined);
             setIsDeleting(false);
           }}

--- a/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationCreateEdit.tsx
@@ -20,7 +20,7 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Link, Navigate, useNavigate, useParams } from 'react-router';
 import YAML from 'yaml';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
-import { ApplicationsPage } from '@odh-dashboard/ui-core';
+import { ApplicationsPage, TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import {
   getDisplayNameFromK8sResource,
@@ -52,6 +52,10 @@ import {
   createLLMInferenceServiceConfig,
   patchLLMInferenceServiceConfig,
 } from '../../api/LLMInferenceServiceConfigs';
+import {
+  fireTopologyConfigCreated,
+  fireTopologyConfigUpdated,
+} from '../../tracking/llmdTrackingConstants';
 
 const TopologyConfigurationCreateEditInner: React.FC<{
   sourceConfig?: LLMInferenceServiceConfigKind;
@@ -260,8 +264,20 @@ const TopologyConfigurationCreateEditInner: React.FC<{
 
       if (isEditMode && existingConfig) {
         await patchLLMInferenceServiceConfig(existingConfig, newConfig);
+        fireTopologyConfigUpdated({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          topologyType: resolvedTopologyType,
+        });
       } else {
         await createLLMInferenceServiceConfig(newConfig);
+        fireTopologyConfigCreated({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          mode: isDuplicate ? 'duplicate' : 'create',
+          configSource,
+          topologyType: resolvedTopologyType,
+        });
       }
       navigate(listPath);
     } catch (e) {
@@ -271,6 +287,23 @@ const TopologyConfigurationCreateEditInner: React.FC<{
         `Error ${isEditMode ? 'updating' : 'creating'} configuration`,
         err.message,
       );
+      if (isEditMode) {
+        fireTopologyConfigUpdated({
+          outcome: TrackingOutcome.submit,
+          success: false,
+          error: err.message,
+          topologyType: resolvedTopologyType,
+        });
+      } else {
+        fireTopologyConfigCreated({
+          outcome: TrackingOutcome.submit,
+          success: false,
+          error: err.message,
+          mode: isDuplicate ? 'duplicate' : 'create',
+          configSource,
+          topologyType: resolvedTopologyType,
+        });
+      }
     } finally {
       setLoading(false);
     }
@@ -356,7 +389,17 @@ const TopologyConfigurationCreateEditInner: React.FC<{
             variant="link"
             data-testid="cancel-topology-config-button"
             isDisabled={loading}
-            onClick={() => navigate(listPath)}
+            onClick={() => {
+              if (isEditMode) {
+                fireTopologyConfigUpdated({ outcome: TrackingOutcome.cancel });
+              } else {
+                fireTopologyConfigCreated({
+                  outcome: TrackingOutcome.cancel,
+                  mode: isDuplicate ? 'duplicate' : 'create',
+                });
+              }
+              navigate(listPath);
+            }}
           >
             Cancel
           </Button>

--- a/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationCreateEdit.tsx
@@ -291,14 +291,12 @@ const TopologyConfigurationCreateEditInner: React.FC<{
         fireTopologyConfigUpdated({
           outcome: TrackingOutcome.submit,
           success: false,
-          error: err.message,
           topologyType: resolvedTopologyType,
         });
       } else {
         fireTopologyConfigCreated({
           outcome: TrackingOutcome.submit,
           success: false,
-          error: err.message,
           mode: isDuplicate ? 'duplicate' : 'create',
           configSource,
           topologyType: resolvedTopologyType,

--- a/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationsTable.tsx
@@ -132,7 +132,6 @@ const TopologyConfigurationsTable: React.FC<TopologyConfigurationsTableProps> = 
         fireTopologyConfigDeleted({
           outcome: TrackingOutcome.submit,
           success: false,
-          error: e instanceof Error ? e.message : 'unknown',
         });
       })
       .finally(() => {

--- a/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationsTable.tsx
@@ -217,6 +217,7 @@ const TopologyConfigurationsTable: React.FC<TopologyConfigurationsTableProps> = 
         <DeleteModal
           title="Delete llm-d topology configuration?"
           onClose={() => {
+            fireTopologyConfigDeleted({ outcome: TrackingOutcome.cancel });
             setDeleteConfig(undefined);
             setIsDeleting(false);
           }}

--- a/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationsTable.tsx
@@ -12,7 +12,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard delete confirmation wrapper
 import DeleteModal from '@odh-dashboard/internal/pages/projects/components/DeleteModal';
-import { Table, SortableData } from '@odh-dashboard/ui-core';
+import { Table, SortableData, TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useNavigate } from 'react-router';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { k8sDeleteResource, K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
@@ -28,6 +28,7 @@ import {
 } from '../../types';
 import { isConfigEnabled, isConfigEffectivelyEnabled } from '../../utils';
 import { patchLLMInferenceServiceConfig } from '../../api/LLMInferenceServiceConfigs';
+import { fireTopologyConfigDeleted } from '../../tracking/llmdTrackingConstants';
 
 const getTopologyTypeLabel = (config: LLMInferenceServiceConfigKind): string => {
   const type = getConfigTopologyType(config);
@@ -120,6 +121,7 @@ const TopologyConfigurationsTable: React.FC<TopologyConfigurationsTableProps> = 
       },
     })
       .then(() => {
+        fireTopologyConfigDeleted({ outcome: TrackingOutcome.submit, success: true });
         setDeleteConfig(undefined);
       })
       .catch((e: unknown) => {
@@ -127,6 +129,11 @@ const TopologyConfigurationsTable: React.FC<TopologyConfigurationsTableProps> = 
           'Error deleting configuration',
           e instanceof Error ? e.message : 'Unknown error',
         );
+        fireTopologyConfigDeleted({
+          outcome: TrackingOutcome.submit,
+          success: false,
+          error: e instanceof Error ? e.message : 'unknown',
+        });
       })
       .finally(() => {
         setIsDeleting(false);

--- a/packages/llmd-serving/src/tracking/__tests__/llmdTrackingConstants.spec.ts
+++ b/packages/llmd-serving/src/tracking/__tests__/llmdTrackingConstants.spec.ts
@@ -1,0 +1,209 @@
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { TopologyType } from '../../types';
+import {
+  LlmAcceleratorConfigTrackingEvent,
+  TopologyConfigTrackingEvent,
+  RoutingConfigTrackingEvent,
+  fireLlmAcceleratorConfigCreated,
+  fireLlmAcceleratorConfigUpdated,
+  fireLlmAcceleratorConfigDeleted,
+  fireLlmAcceleratorConfigEnablementChanged,
+  fireTopologyConfigCreated,
+  fireTopologyConfigUpdated,
+  fireTopologyConfigDeleted,
+  fireRoutingConfigCreated,
+  fireRoutingConfigUpdated,
+  fireRoutingConfigDeleted,
+} from '../llmdTrackingConstants';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
+const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
+
+describe('LLM accelerator config tracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the Created event with mode via fireFormTrackingEvent', () => {
+    fireLlmAcceleratorConfigCreated({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: 'create',
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      LlmAcceleratorConfigTrackingEvent.CREATED,
+      { outcome: TrackingOutcome.submit, success: true, mode: 'create' },
+    );
+    expect(mockFireMiscTrackingEvent).not.toHaveBeenCalled();
+  });
+
+  it('should fire the Created event with cancel outcome', () => {
+    fireLlmAcceleratorConfigCreated({ outcome: TrackingOutcome.cancel, mode: 'duplicate' });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      LlmAcceleratorConfigTrackingEvent.CREATED,
+      { outcome: TrackingOutcome.cancel, mode: 'duplicate' },
+    );
+  });
+
+  it('should fire the Updated event', () => {
+    fireLlmAcceleratorConfigUpdated({ outcome: TrackingOutcome.submit, success: true });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      LlmAcceleratorConfigTrackingEvent.UPDATED,
+      { outcome: TrackingOutcome.submit, success: true },
+    );
+  });
+
+  it('should fire the Deleted event on submit and on cancel', () => {
+    fireLlmAcceleratorConfigDeleted({ outcome: TrackingOutcome.submit, success: true });
+    fireLlmAcceleratorConfigDeleted({ outcome: TrackingOutcome.cancel });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenNthCalledWith(
+      1,
+      LlmAcceleratorConfigTrackingEvent.DELETED,
+      { outcome: TrackingOutcome.submit, success: true },
+    );
+    expect(mockFireFormTrackingEvent).toHaveBeenNthCalledWith(
+      2,
+      LlmAcceleratorConfigTrackingEvent.DELETED,
+      { outcome: TrackingOutcome.cancel },
+    );
+  });
+
+  it('should fire the Enablement Changed event with the new enabled state', () => {
+    fireLlmAcceleratorConfigEnablementChanged({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      enabled: true,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      LlmAcceleratorConfigTrackingEvent.ENABLEMENT_CHANGED,
+      { outcome: TrackingOutcome.submit, success: true, enabled: true },
+    );
+  });
+});
+
+describe('llm-d topology config tracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the Created event with mode, configSource, and topologyType', () => {
+    fireTopologyConfigCreated({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: 'create',
+      configSource: 'template',
+      topologyType: TopologyType.MULTI_NODE,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(TopologyConfigTrackingEvent.CREATED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: 'create',
+      configSource: 'template',
+      topologyType: TopologyType.MULTI_NODE,
+    });
+  });
+
+  it('should fire the Updated event with topologyType', () => {
+    fireTopologyConfigUpdated({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      topologyType: TopologyType.SINGLE_NODE,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      TopologyConfigTrackingEvent.UPDATED,
+      expect.objectContaining({ topologyType: TopologyType.SINGLE_NODE }),
+    );
+  });
+
+  it('should fire the Deleted event on submit and on cancel', () => {
+    fireTopologyConfigDeleted({ outcome: TrackingOutcome.submit, success: true });
+    fireTopologyConfigDeleted({ outcome: TrackingOutcome.cancel });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenNthCalledWith(
+      1,
+      TopologyConfigTrackingEvent.DELETED,
+      { outcome: TrackingOutcome.submit, success: true },
+    );
+    expect(mockFireFormTrackingEvent).toHaveBeenNthCalledWith(
+      2,
+      TopologyConfigTrackingEvent.DELETED,
+      {
+        outcome: TrackingOutcome.cancel,
+      },
+    );
+  });
+});
+
+describe('llm-d routing config tracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the Created event with mode, configSource, and topologyType', () => {
+    fireRoutingConfigCreated({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: 'create',
+      configSource: 'editor',
+      topologyType: TopologyType.SINGLE_NODE_DISAGGREGATED,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(RoutingConfigTrackingEvent.CREATED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: 'create',
+      configSource: 'editor',
+      topologyType: TopologyType.SINGLE_NODE_DISAGGREGATED,
+    });
+  });
+
+  it('should fire the Updated event with topologyType', () => {
+    fireRoutingConfigUpdated({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      topologyType: TopologyType.MULTI_NODE_DISAGGREGATED,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      RoutingConfigTrackingEvent.UPDATED,
+      expect.objectContaining({ topologyType: TopologyType.MULTI_NODE_DISAGGREGATED }),
+    );
+  });
+
+  it('should fire the Deleted event on submit and on cancel', () => {
+    fireRoutingConfigDeleted({ outcome: TrackingOutcome.submit, success: true });
+    fireRoutingConfigDeleted({ outcome: TrackingOutcome.cancel });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenNthCalledWith(
+      1,
+      RoutingConfigTrackingEvent.DELETED,
+      {
+        outcome: TrackingOutcome.submit,
+        success: true,
+      },
+    );
+    expect(mockFireFormTrackingEvent).toHaveBeenNthCalledWith(
+      2,
+      RoutingConfigTrackingEvent.DELETED,
+      {
+        outcome: TrackingOutcome.cancel,
+      },
+    );
+  });
+});

--- a/packages/llmd-serving/src/tracking/llmdTrackingConstants.ts
+++ b/packages/llmd-serving/src/tracking/llmdTrackingConstants.ts
@@ -1,4 +1,9 @@
-import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { type FormTrackingEventProperties } from '@odh-dashboard/ui-core';
+import type { TopologyType } from '../types';
 
 export enum LlmdTrackingEvent {
   TOPOLOGY_TYPE_SELECTED = 'Model Serving LLM-D Topology Type Selected',
@@ -21,4 +26,102 @@ export const fireTopologyTypeSelected = (properties: TopologyTypeSelectedPropert
 
 export const fireRoutingSelected = (properties: RoutingSelectedProperties): void => {
   fireMiscTrackingEvent(LlmdTrackingEvent.ROUTING_SELECTED, properties);
+};
+
+// --- Admin settings CRUD tracking (Model deployment settings tabs) ---
+
+/** Where a config form was seeded from when created. */
+export type ConfigSource = 'template' | 'editor';
+
+export enum LlmAcceleratorConfigTrackingEvent {
+  CREATED = 'Model Serving LLM Accelerator Config Created',
+  UPDATED = 'Model Serving LLM Accelerator Config Updated',
+  DELETED = 'Model Serving LLM Accelerator Config Deleted',
+  ENABLEMENT_CHANGED = 'Model Serving LLM Accelerator Config Enablement Changed',
+}
+
+export type LlmAcceleratorConfigCreatedProperties = FormTrackingEventProperties & {
+  /** Whether the config was created from scratch or duplicated from an existing one. */
+  mode: 'create' | 'duplicate';
+};
+
+export type LlmAcceleratorConfigEnablementChangedProperties = FormTrackingEventProperties & {
+  /** The new enabled state after the toggle is applied. */
+  enabled: boolean;
+};
+
+export const fireLlmAcceleratorConfigCreated = (
+  properties: LlmAcceleratorConfigCreatedProperties,
+): void => {
+  fireFormTrackingEvent(LlmAcceleratorConfigTrackingEvent.CREATED, properties);
+};
+
+export const fireLlmAcceleratorConfigUpdated = (properties: FormTrackingEventProperties): void => {
+  fireFormTrackingEvent(LlmAcceleratorConfigTrackingEvent.UPDATED, properties);
+};
+
+export const fireLlmAcceleratorConfigDeleted = (properties: FormTrackingEventProperties): void => {
+  fireFormTrackingEvent(LlmAcceleratorConfigTrackingEvent.DELETED, properties);
+};
+
+export const fireLlmAcceleratorConfigEnablementChanged = (
+  properties: LlmAcceleratorConfigEnablementChangedProperties,
+): void => {
+  fireFormTrackingEvent(LlmAcceleratorConfigTrackingEvent.ENABLEMENT_CHANGED, properties);
+};
+
+export enum TopologyConfigTrackingEvent {
+  CREATED = 'Model Serving LLM-D Topology Config Created',
+  UPDATED = 'Model Serving LLM-D Topology Config Updated',
+  DELETED = 'Model Serving LLM-D Topology Config Deleted',
+}
+
+export type TopologyConfigCreatedProperties = FormTrackingEventProperties & {
+  mode: 'create' | 'duplicate';
+  configSource?: ConfigSource;
+  topologyType?: TopologyType;
+};
+
+export type TopologyConfigUpdatedProperties = FormTrackingEventProperties & {
+  topologyType?: TopologyType;
+};
+
+export const fireTopologyConfigCreated = (properties: TopologyConfigCreatedProperties): void => {
+  fireFormTrackingEvent(TopologyConfigTrackingEvent.CREATED, properties);
+};
+
+export const fireTopologyConfigUpdated = (properties: TopologyConfigUpdatedProperties): void => {
+  fireFormTrackingEvent(TopologyConfigTrackingEvent.UPDATED, properties);
+};
+
+export const fireTopologyConfigDeleted = (properties: FormTrackingEventProperties): void => {
+  fireFormTrackingEvent(TopologyConfigTrackingEvent.DELETED, properties);
+};
+
+export enum RoutingConfigTrackingEvent {
+  CREATED = 'Model Serving LLM-D Routing Config Created',
+  UPDATED = 'Model Serving LLM-D Routing Config Updated',
+  DELETED = 'Model Serving LLM-D Routing Config Deleted',
+}
+
+export type RoutingConfigCreatedProperties = FormTrackingEventProperties & {
+  mode: 'create' | 'duplicate';
+  configSource?: ConfigSource;
+  topologyType?: TopologyType;
+};
+
+export type RoutingConfigUpdatedProperties = FormTrackingEventProperties & {
+  topologyType?: TopologyType;
+};
+
+export const fireRoutingConfigCreated = (properties: RoutingConfigCreatedProperties): void => {
+  fireFormTrackingEvent(RoutingConfigTrackingEvent.CREATED, properties);
+};
+
+export const fireRoutingConfigUpdated = (properties: RoutingConfigUpdatedProperties): void => {
+  fireFormTrackingEvent(RoutingConfigTrackingEvent.UPDATED, properties);
+};
+
+export const fireRoutingConfigDeleted = (properties: FormTrackingEventProperties): void => {
+  fireFormTrackingEvent(RoutingConfigTrackingEvent.DELETED, properties);
 };

--- a/packages/llmd-serving/src/tracking/llmdTrackingConstants.ts
+++ b/packages/llmd-serving/src/tracking/llmdTrackingConstants.ts
@@ -46,7 +46,7 @@ export type LlmAcceleratorConfigCreatedProperties = FormTrackingEventProperties 
 };
 
 export type LlmAcceleratorConfigEnablementChangedProperties = FormTrackingEventProperties & {
-  /** The new enabled state after the toggle is applied. */
+  /** The actual enabled state after the toggle attempt (reverts to the prior state on failure). */
   enabled: boolean;
 };
 

--- a/packages/model-serving/src/components/settings/GeneralSettingsTab.tsx
+++ b/packages/model-serving/src/components/settings/GeneralSettingsTab.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { isEqual } from 'lodash-es';
 import { Button, Bullseye, PageSection, Spinner, Stack, StackItem } from '@patternfly/react-core';
-import { useNotification } from '@odh-dashboard/ui-core';
+import { TrackingOutcome, useNotification } from '@odh-dashboard/ui-core';
 import type {
   ClusterSettingsType,
   ModelServingPlatformEnabled,
@@ -12,6 +12,10 @@ import {
 } from '@odh-dashboard/internal/services/clusterSettingsService';
 import ModelServingPlatformSettings from './ModelServingPlatformSettings';
 import DeploymentStrategySettings, { DeploymentStrategy } from './DeploymentStrategySettings';
+import {
+  fireDeploymentStrategyChanged,
+  firePlatformSettingChanged,
+} from '../../shared/tracking/generalSettingsTracking';
 
 const DEFAULT_DISTRIBUTED_INFERENCING = true;
 const DEFAULT_ENABLED_PLATFORMS: ModelServingPlatformEnabled = { kServe: true, LLMd: true };
@@ -119,6 +123,43 @@ const GeneralSettingsTab: React.FC = () => {
 
       if (!response.success) {
         throw new Error(response.error);
+      }
+
+      // Fire a tracking event per setting that actually changed, comparing the
+      // saved payload against the pre-save baseline. No PII — booleans/enums only.
+      const previous = baselineSettings;
+      if (
+        previous?.modelServingPlatformEnabled.kServe !== payload.modelServingPlatformEnabled.kServe
+      ) {
+        firePlatformSettingChanged({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          setting: 'model_serving_enabled',
+          enabled: payload.modelServingPlatformEnabled.kServe,
+        });
+      }
+      if (previous?.modelServingPlatformEnabled.LLMd !== payload.modelServingPlatformEnabled.LLMd) {
+        firePlatformSettingChanged({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          setting: 'llmd_enabled',
+          enabled: payload.modelServingPlatformEnabled.LLMd,
+        });
+      }
+      if (previous?.isDistributedInferencingDefault !== payload.isDistributedInferencingDefault) {
+        firePlatformSettingChanged({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          setting: 'llmd_default_for_generative',
+          enabled: payload.isDistributedInferencingDefault ?? false,
+        });
+      }
+      if (previous?.defaultDeploymentStrategy !== payload.defaultDeploymentStrategy) {
+        fireDeploymentStrategyChanged({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          strategy: defaultDeploymentStrategy,
+        });
       }
 
       setBaselineSettings(payload);

--- a/packages/model-serving/src/shared/tracking/__tests__/generalSettingsTracking.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/generalSettingsTracking.spec.ts
@@ -1,0 +1,99 @@
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { DeploymentStrategy } from '../../../components/settings/DeploymentStrategySettings';
+import {
+  GeneralSettingsTrackingEvent,
+  firePlatformSettingChanged,
+  fireDeploymentStrategyChanged,
+} from '../generalSettingsTracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
+
+describe('firePlatformSettingChanged', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the Platform Setting Changed event with the setting key and new value', () => {
+    firePlatformSettingChanged({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      setting: 'llmd_enabled',
+      enabled: true,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      GeneralSettingsTrackingEvent.PLATFORM_SETTING_CHANGED,
+      {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        setting: 'llmd_enabled',
+        enabled: true,
+      },
+    );
+  });
+
+  it('should support the model_serving_enabled setting toggled off', () => {
+    firePlatformSettingChanged({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      setting: 'model_serving_enabled',
+      enabled: false,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      GeneralSettingsTrackingEvent.PLATFORM_SETTING_CHANGED,
+      expect.objectContaining({ setting: 'model_serving_enabled', enabled: false }),
+    );
+  });
+
+  it('should support the llmd_default_for_generative setting', () => {
+    firePlatformSettingChanged({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      setting: 'llmd_default_for_generative',
+      enabled: true,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      GeneralSettingsTrackingEvent.PLATFORM_SETTING_CHANGED,
+      expect.objectContaining({ setting: 'llmd_default_for_generative' }),
+    );
+  });
+});
+
+describe('fireDeploymentStrategyChanged', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the Deployment Strategy Changed event with the strategy', () => {
+    fireDeploymentStrategyChanged({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      strategy: DeploymentStrategy.ROLLING,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      GeneralSettingsTrackingEvent.DEPLOYMENT_STRATEGY_CHANGED,
+      { outcome: TrackingOutcome.submit, success: true, strategy: DeploymentStrategy.ROLLING },
+    );
+  });
+
+  it('should support the recreate strategy', () => {
+    fireDeploymentStrategyChanged({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      strategy: DeploymentStrategy.RECREATE,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      GeneralSettingsTrackingEvent.DEPLOYMENT_STRATEGY_CHANGED,
+      expect.objectContaining({ strategy: DeploymentStrategy.RECREATE }),
+    );
+  });
+});

--- a/packages/model-serving/src/shared/tracking/generalSettingsTracking.ts
+++ b/packages/model-serving/src/shared/tracking/generalSettingsTracking.ts
@@ -1,0 +1,34 @@
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { type FormTrackingEventProperties } from '@odh-dashboard/ui-core';
+import type { DeploymentStrategy } from '../../components/settings/DeploymentStrategySettings';
+
+export enum GeneralSettingsTrackingEvent {
+  PLATFORM_SETTING_CHANGED = 'Model Serving Platform Setting Changed',
+  DEPLOYMENT_STRATEGY_CHANGED = 'Model Serving Deployment Strategy Changed',
+}
+
+/** The persisted platform toggles on the General settings tab. */
+export type PlatformSetting =
+  | 'model_serving_enabled'
+  | 'llmd_enabled'
+  | 'llmd_default_for_generative';
+
+export type PlatformSettingChangedProperties = FormTrackingEventProperties & {
+  setting: PlatformSetting;
+  /** The new boolean value the setting was saved with. */
+  enabled: boolean;
+};
+
+export type DeploymentStrategyChangedProperties = FormTrackingEventProperties & {
+  strategy: DeploymentStrategy;
+};
+
+export const firePlatformSettingChanged = (properties: PlatformSettingChangedProperties): void => {
+  fireFormTrackingEvent(GeneralSettingsTrackingEvent.PLATFORM_SETTING_CHANGED, properties);
+};
+
+export const fireDeploymentStrategyChanged = (
+  properties: DeploymentStrategyChangedProperties,
+): void => {
+  fireFormTrackingEvent(GeneralSettingsTrackingEvent.DEPLOYMENT_STRATEGY_CHANGED, properties);
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-84636

## Description

Adds Segment analytics tracking to the five tabs of the **Model deployment settings** page. Before this change, these admin pages had no tracking of create/edit/delete or settings actions — the only events were the unsupported-runtime risk accept/dismiss prompts on two tabs.

This instruments the admin actions across all five tabs so Amplitude can answer questions like *which serving platforms admins enable, how many custom runtimes/configs get created, which topology types are used, and how often configs are deleted*.

**Events added (16 event types):**

| Tab | Events |
| --- | --- |
| General settings | `Model Serving Platform Setting Changed` (per changed toggle), `Model Serving Deployment Strategy Changed` |
| Serving runtime templates | `... Serving Runtime Template Created / Updated / Deleted / Enablement Changed` |
| LLM accelerator configurations | `... LLM Accelerator Config Created / Updated / Deleted / Enablement Changed` |
| llm-d topology configurations | `... LLM-D Topology Config Created / Updated / Deleted` |
| llm-d routing configurations | `... LLM-D Routing Config Created / Updated / Deleted` |

**Design notes:**
- Follows the repo's `fire*TrackingEvent` convention. Cancel is not a separate event — it is the action's own event name with `outcome: cancel` (matching `DeleteProjectModal`, `ManageProjectModal`, `CreateExperimentModal`). Cancel is wired for create, edit, and delete flows.
- General settings persists on a single Save, so tracking fires one event per **changed** setting on save (comparing the saved payload against the pre-save baseline).
- Properties are categorical/numeric/boolean only — `mode`, `apiProtocol`, `modelTypes`, `configSource`, `topologyType`, `enabled`, plus `outcome`/`success`. No names, descriptions, versions, YAML, or free-form error messages are sent (no PII); failures are conveyed by `success: false` alone.
- Event name constants live in a `tracking/` module per package (kserve, llmd-serving, model-serving).

## How Has This Been Tested?

Manually verified every event in a browser against a dev dashboard. In dev mode, tracking events are logged to the console as `Telemetry event triggered:` instead of being sent to Segment. All test resources created during verification were deleted afterward. Captured output per tab:

### General settings

```text
Telemetry event triggered: Model Serving Platform Setting Changed - {"outcome":"submit","success":true,"setting":"llmd_default_for_generative","enabled":true}
Telemetry event triggered: Model Serving Deployment Strategy Changed - {"outcome":"submit","success":true,"strategy":"rolling"}
```

### Serving runtime templates

```text
Telemetry event triggered: Model Serving Serving Runtime Template Created - {"outcome":"submit","success":true,"mode":"create","apiProtocol":"REST","modelTypes":"predictive,generative"}
Telemetry event triggered: Model Serving Serving Runtime Template Created - {"outcome":"cancel","mode":"create"}
Telemetry event triggered: Model Serving Serving Runtime Template Updated - {"outcome":"submit","success":true,"apiProtocol":"gRPC","modelTypes":"predictive,generative"}
Telemetry event triggered: Model Serving Serving Runtime Template Updated - {"outcome":"cancel"}
Telemetry event triggered: Model Serving Serving Runtime Template Enablement Changed - {"outcome":"submit","success":true,"enabled":false}
Telemetry event triggered: Model Serving Serving Runtime Template Deleted - {"outcome":"submit","success":true}
Telemetry event triggered: Model Serving Serving Runtime Template Deleted - {"outcome":"cancel"}
```

### LLM accelerator configurations

```text
Telemetry event triggered: Model Serving LLM Accelerator Config Created - {"outcome":"submit","success":true,"mode":"create"}
Telemetry event triggered: Model Serving LLM Accelerator Config Created - {"outcome":"cancel","mode":"create"}
Telemetry event triggered: Model Serving LLM Accelerator Config Updated - {"outcome":"submit","success":true}
Telemetry event triggered: Model Serving LLM Accelerator Config Updated - {"outcome":"cancel"}
Telemetry event triggered: Model Serving LLM Accelerator Config Enablement Changed - {"outcome":"submit","success":true,"enabled":false}
Telemetry event triggered: Model Serving LLM Accelerator Config Deleted - {"outcome":"submit","success":true}
Telemetry event triggered: Model Serving LLM Accelerator Config Deleted - {"outcome":"cancel"}
```

### llm-d topology configurations

```text
Telemetry event triggered: Model Serving LLM-D Topology Config Created - {"outcome":"submit","success":true,"mode":"create","configSource":"editor","topologyType":"workload-multi-node-data-parallel"}
Telemetry event triggered: Model Serving LLM-D Topology Config Created - {"outcome":"submit","success":true,"mode":"create","configSource":"template","topologyType":"workload-multi-node-data-parallel"}
Telemetry event triggered: Model Serving LLM-D Topology Config Created - {"outcome":"cancel","mode":"create"}
Telemetry event triggered: Model Serving LLM-D Topology Config Updated - {"outcome":"submit","success":true,"topologyType":"workload-multi-node-data-parallel"}
Telemetry event triggered: Model Serving LLM-D Topology Config Updated - {"outcome":"cancel"}
Telemetry event triggered: Model Serving LLM-D Topology Config Deleted - {"outcome":"submit","success":true}
Telemetry event triggered: Model Serving LLM-D Topology Config Deleted - {"outcome":"cancel"}
```

### llm-d routing configurations

```text
Telemetry event triggered: Model Serving LLM-D Routing Config Created - {"outcome":"submit","success":true,"mode":"create","configSource":"editor","topologyType":"workload-single-node-pd"}
Telemetry event triggered: Model Serving LLM-D Routing Config Created - {"outcome":"submit","success":true,"mode":"create","configSource":"template","topologyType":"workload-single-node"}
Telemetry event triggered: Model Serving LLM-D Routing Config Created - {"outcome":"cancel","mode":"create"}
Telemetry event triggered: Model Serving LLM-D Routing Config Updated - {"outcome":"submit","success":true,"topologyType":"workload-single-node-pd"}
Telemetry event triggered: Model Serving LLM-D Routing Config Updated - {"outcome":"cancel"}
Telemetry event triggered: Model Serving LLM-D Routing Config Deleted - {"outcome":"submit","success":true}
Telemetry event triggered: Model Serving LLM-D Routing Config Deleted - {"outcome":"cancel"}
```

Both `configSource: editor` and `configSource: template` were exercised. Cancel outcomes were verified for every create form, edit form, and delete dialog across all four CRUD tabs (same event name, `outcome: cancel`), with no double-firing — cancelling a delete fires only the cancel event, and confirming afterward fires only the submit event. General settings has no cancel event because it persists via a single Save (no per-form cancel affordance); it fires one event per changed setting on save.

## Test Impact

Added Jest unit tests for the three tracking constants modules (one spec per module, co-located in `__tests__/` in each owning package). Each mocks `fireFormTrackingEvent` and asserts the correct event name and property shape across submit/failure/cancel outcomes — 25 tests total, following the existing `deploymentTracking.spec.ts` precedent. Component-level form tests were not added; the new logic (event names + property construction) lives in the constants helpers, which these tests cover directly.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
