### PR TITLE
fix(RHOAIENG-79085): restore Reconfigure crumb and use Run configurat…

### DIFF
--- a/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
@@ -15,7 +15,7 @@ import classNames from 'classnames';
 import { ApplicationsPage } from 'mod-arch-shared';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import AutomlHeader from '~/app/components/common/AutomlHeader/AutomlHeader';
 import ExperimentContextBreadcrumb from '~/app/components/common/ExperimentContextBreadcrumb';
 import AutomlConfigure from '~/app/components/configure/AutomlConfigure';
@@ -52,7 +52,7 @@ type AutomlConfigurePageProps = {
   initialInputDataSecret?: SecretSelection;
   /** When reconfiguring, the run ID of the source run (used for cancel navigation). */
   sourceRunId?: string;
-  /** When reconfiguring, the display name of the source run (used in the page title). */
+  /** When reconfiguring, the display name of the source run (used in the page title and breadcrumb). */
   sourceRunName?: string;
 };
 
@@ -321,8 +321,25 @@ function AutomlConfigurePage({
             homePath={getRedirectPath(namespace)}
             onHomeNavigate={handleHomeNavigate}
           >
+            {fromResultsPage && sourceRunId && sourceRunName && (
+              <BreadcrumbItem data-testid="configure-breadcrumb-source-run">
+                <Link
+                  to={`${automlResultsPathname}/${namespace}/${sourceRunId}`}
+                  onClick={() =>
+                    fireAutomlFlowExited(
+                      'navigate',
+                      funnelStepRef.current,
+                      'otherAutoml',
+                      changedFieldsOnExitRef.current,
+                    )
+                  }
+                >
+                  <Truncate content={sourceRunName} />
+                </Link>
+              </BreadcrumbItem>
+            )}
             <BreadcrumbItem isActive data-testid="configure-breadcrumb-name">
-              Experiment configurations
+              {sourceRunId ? 'Reconfigure' : 'Run configurations'}
             </BreadcrumbItem>
           </ExperimentContextBreadcrumb>
         )

--- a/packages/automl/frontend/src/app/pages/AutomlResultsPage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlResultsPage.tsx
@@ -292,7 +292,7 @@ function AutomlResultsPage(): React.JSX.Element {
                         to={`${automlReconfigurePathname}/${namespace}/${runId}`}
                         state={{ from: 'results' }}
                       >
-                        Experiment configurations
+                        Run configurations
                       </Link>
                     </BreadcrumbItem>
                     <BreadcrumbItem isActive>Run results</BreadcrumbItem>

--- a/packages/automl/frontend/src/app/pages/__tests__/AutomlConfigurePage.spec.tsx
+++ b/packages/automl/frontend/src/app/pages/__tests__/AutomlConfigurePage.spec.tsx
@@ -457,7 +457,7 @@ describe('AutomlConfigurePage', () => {
         /Go to/,
       );
       const breadcrumbName = await screen.findByTestId('configure-breadcrumb-name');
-      expect(breadcrumbName).toHaveTextContent('Experiment configurations');
+      expect(breadcrumbName).toHaveTextContent('Run configurations');
     });
 
     it('should fire AutoML Flow Exited with trainingData and experimentsList when the breadcrumb is clicked', async () => {
@@ -1000,7 +1000,12 @@ describe('AutomlConfigurePage', () => {
         />,
       );
 
-      expect(screen.queryByTestId('configure-breadcrumb-source-run')).not.toBeInTheDocument();
+      const sourceRunBreadcrumb = await screen.findByTestId('configure-breadcrumb-source-run');
+      expect(sourceRunBreadcrumb).toHaveTextContent('Original Run');
+      expect(sourceRunBreadcrumb.querySelector('a')).toHaveAttribute(
+        'href',
+        '/develop-train/automl/results/test-namespace/prev-run-456',
+      );
       const homeBreadcrumb = await screen.findByTestId('experiment-breadcrumb-home');
       expect(homeBreadcrumb.querySelector('a')).toHaveAttribute(
         'href',
@@ -1010,10 +1015,10 @@ describe('AutomlConfigurePage', () => {
         /Go to/,
       );
       const activeBreadcrumb = await screen.findByTestId('configure-breadcrumb-name');
-      expect(activeBreadcrumb).toHaveTextContent('Experiment configurations');
+      expect(activeBreadcrumb).toHaveTextContent('Reconfigure');
     });
 
-    it('should display experiment configurations breadcrumb when reconfiguring from experiments page', async () => {
+    it('should display Reconfigure breadcrumb without source run when navigating from experiments page', async () => {
       renderWithProviders(
         <AutomlConfigurePage
           initialValues={{ display_name: 'Original Run - 1' }}
@@ -1024,7 +1029,7 @@ describe('AutomlConfigurePage', () => {
 
       expect(screen.queryByTestId('configure-breadcrumb-source-run')).not.toBeInTheDocument();
       const activeBreadcrumb = await screen.findByTestId('configure-breadcrumb-name');
-      expect(activeBreadcrumb).toHaveTextContent('Experiment configurations');
+      expect(activeBreadcrumb).toHaveTextContent('Reconfigure');
     });
 
     it('should navigate back when Cancel is clicked without sourceRunId', async () => {
@@ -1097,7 +1102,7 @@ describe('AutomlConfigurePage', () => {
       expect(descInput).toHaveValue('A reconfigured experiment');
     });
 
-    it('should show Experiment configurations in breadcrumb after navigating to configure step', async () => {
+    it('should show Reconfigure in breadcrumb after navigating to configure step', async () => {
       const user = userEvent.setup();
       renderWithProviders(
         <AutomlConfigurePage
@@ -1114,7 +1119,7 @@ describe('AutomlConfigurePage', () => {
       await user.click(nextButton);
 
       const breadcrumbName = await screen.findByTestId('configure-breadcrumb-name');
-      expect(breadcrumbName).toHaveTextContent('Experiment configurations');
+      expect(breadcrumbName).toHaveTextContent('Reconfigure');
     });
 
     describe('configure step with pre-filled values', () => {

--- a/packages/automl/frontend/src/app/pages/__tests__/AutomlResultsPage.spec.tsx
+++ b/packages/automl/frontend/src/app/pages/__tests__/AutomlResultsPage.spec.tsx
@@ -755,7 +755,7 @@ describe('AutomlResultsPage', () => {
       const experimentConfigLink = screen.getByTestId(
         'results-breadcrumb-experiment-configurations',
       );
-      expect(experimentConfigLink).toHaveTextContent('Experiment configurations');
+      expect(experimentConfigLink).toHaveTextContent('Run configurations');
       expect(experimentConfigLink.querySelector('a')).toHaveAttribute(
         'href',
         '/develop-train/automl/reconfigure/test-ns/run-123',

--- a/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
@@ -15,7 +15,7 @@ import classNames from 'classnames';
 import { ApplicationsPage } from 'mod-arch-shared';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import AutoragConfigure from '~/app/components/configure/AutoragConfigure';
 import AutoragHeader from '~/app/components/common/AutoragHeader/AutoragHeader';
 import ExperimentContextBreadcrumb from '~/app/components/common/ExperimentContextBreadcrumb';
@@ -71,7 +71,7 @@ type AutoragConfigurePageProps = {
   initialOgxSecret?: SecretSelection;
   /** When reconfiguring, the run ID of the source run (used for cancel navigation). */
   sourceRunId?: string;
-  /** When reconfiguring, the display name of the source run (used in the page title). */
+  /** When reconfiguring, the display name of the source run (used in the page title and breadcrumb). */
   sourceRunName?: string;
 };
 
@@ -431,8 +431,20 @@ function AutoragConfigurePage({
             homePath={getRedirectPath(namespace)}
             onHomeNavigate={handleHomeNavigate}
           >
+            {fromResultsPage && sourceRunId && sourceRunName && (
+              <BreadcrumbItem data-testid="configure-breadcrumb-source-run">
+                <Link
+                  to={`${autoragResultsPathname}/${namespace}/${sourceRunId}`}
+                  onClick={() =>
+                    fireAutoragFlowExited('navigate', funnelStepRef.current, 'otherGenAi')
+                  }
+                >
+                  <Truncate content={sourceRunName} />
+                </Link>
+              </BreadcrumbItem>
+            )}
             <BreadcrumbItem isActive data-testid="configure-breadcrumb-name">
-              Experiment configurations
+              {sourceRunId ? 'Reconfigure' : 'Run configurations'}
             </BreadcrumbItem>
           </ExperimentContextBreadcrumb>
         )

--- a/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
@@ -432,7 +432,7 @@ function AutoragResultsPage(): React.JSX.Element {
                         to={`${autoragReconfigurePathname}/${namespace}/${runId}`}
                         state={{ from: 'results' }}
                       >
-                        Experiment configurations
+                        Run configurations
                       </Link>
                     </BreadcrumbItem>
                     <BreadcrumbItem isActive>Run results</BreadcrumbItem>

--- a/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
+++ b/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
@@ -609,7 +609,7 @@ describe('AutoragConfigurePage', () => {
         /Go to/,
       );
       const breadcrumbName = await screen.findByTestId('configure-breadcrumb-name');
-      expect(breadcrumbName).toHaveTextContent('Experiment configurations');
+      expect(breadcrumbName).toHaveTextContent('Run configurations');
     });
 
     it('should render "Create run" button', async () => {
@@ -1744,7 +1744,8 @@ describe('AutoragConfigurePage', () => {
       expect(mockNavigate).toHaveBeenCalledWith(-1);
     });
 
-    it('should display experiment configurations breadcrumb when reconfiguring from results', async () => {
+    it('should display breadcrumb with source run link when navigating from results page', async () => {
+      mockLocationState = { from: 'results' };
       renderWithProviders(
         <AutoragConfigurePage
           initialValues={{ display_name: 'Original Run - 1' }}
@@ -1753,7 +1754,12 @@ describe('AutoragConfigurePage', () => {
         />,
       );
 
-      expect(screen.queryByTestId('configure-breadcrumb-source-run')).not.toBeInTheDocument();
+      const sourceRunBreadcrumb = await screen.findByTestId('configure-breadcrumb-source-run');
+      expect(sourceRunBreadcrumb).toHaveTextContent('Original Run');
+      expect(sourceRunBreadcrumb.querySelector('a')).toHaveAttribute(
+        'href',
+        '/gen-ai-studio/autorag/results/test-namespace/prev-run-456',
+      );
       const homeBreadcrumb = await screen.findByTestId('experiment-breadcrumb-home');
       expect(homeBreadcrumb.querySelector('a')).toHaveAttribute(
         'href',
@@ -1763,10 +1769,10 @@ describe('AutoragConfigurePage', () => {
         /Go to/,
       );
       const activeBreadcrumb = await screen.findByTestId('configure-breadcrumb-name');
-      expect(activeBreadcrumb).toHaveTextContent('Experiment configurations');
+      expect(activeBreadcrumb).toHaveTextContent('Reconfigure');
     });
 
-    it('should display experiment configurations breadcrumb when reconfiguring from experiments page', async () => {
+    it('should display Reconfigure breadcrumb without source run when navigating from experiments page', async () => {
       renderWithProviders(
         <AutoragConfigurePage
           initialValues={{ display_name: 'Original Run - 1' }}
@@ -1777,7 +1783,7 @@ describe('AutoragConfigurePage', () => {
 
       expect(screen.queryByTestId('configure-breadcrumb-source-run')).not.toBeInTheDocument();
       const activeBreadcrumb = await screen.findByTestId('configure-breadcrumb-name');
-      expect(activeBreadcrumb).toHaveTextContent('Experiment configurations');
+      expect(activeBreadcrumb).toHaveTextContent('Reconfigure');
     });
 
     it('should navigate back when Cancel is clicked without sourceRunId', async () => {
@@ -1868,7 +1874,7 @@ describe('AutoragConfigurePage', () => {
       expect(descInput).toHaveValue('A reconfigured experiment');
     });
 
-    it('should show the pre-filled name in breadcrumb after navigating to configure step', async () => {
+    it('should show Reconfigure in breadcrumb after navigating to configure step', async () => {
       const user = userEvent.setup();
       renderWithProviders(
         <AutoragConfigurePage
@@ -1900,7 +1906,7 @@ describe('AutoragConfigurePage', () => {
       await user.click(nextButton);
 
       const breadcrumbName = await screen.findByTestId('configure-breadcrumb-name');
-      expect(breadcrumbName).toHaveTextContent('Experiment configurations');
+      expect(breadcrumbName).toHaveTextContent('Reconfigure');
     });
 
     describe('configure step with pre-filled values', () => {

--- a/packages/autorag/frontend/src/app/pages/__tests__/AutoragResultsPage.spec.tsx
+++ b/packages/autorag/frontend/src/app/pages/__tests__/AutoragResultsPage.spec.tsx
@@ -719,7 +719,7 @@ describe('AutoragResultsPage', () => {
       const experimentConfigLink = screen.getByTestId(
         'results-breadcrumb-experiment-configurations',
       );
-      expect(experimentConfigLink).toHaveTextContent('Experiment configurations');
+      expect(experimentConfigLink).toHaveTextContent('Run configurations');
       expect(experimentConfigLink.querySelector('a')).toHaveAttribute(
         'href',
         '/gen-ai-studio/autorag/reconfigure/test-ns/run-123',


### PR DESCRIPTION
Follow-up to [#9101](https://github.com/opendatahub-io/odh-dashboard/pull/9101#issuecomment-5345627986)

Rename Experiment configurations to Run configurations so AutoML/AutoRAG do not collide with pipeline experiments, and restore the source-run plus Reconfigure trail when editing an existing job.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
- Renames Experiment configurations to Run configurations to avoid confusion with pipeline Experiments.
- Restores the Reconfigure crumb (and the source-run parent crumb when entered from results) so the new job is clearly a child of the old one.

cc UX @mdenisco

  Before | After
-- | --
<img width="1381" height="665" alt="before1" src="https://github.com/user-attachments/assets/66fa37c4-3115-4d96-a989-ecd8527a7215" />|  <img width="1312" height="641" alt="Screenshot 2026-08-19 at 1 00 17 PM" src="https://github.com/user-attachments/assets/163b2f6a-76b5-4177-a1e7-3ca81699cc0d" />


  Before | After
-- | --
<img width="1392" height="873" alt="Before2" src="https://github.com/user-attachments/assets/3ee34892-9c4a-480d-885f-bd5f557b5e89" />|   <img width="1386" height="876" alt="After2" src="https://github.com/user-attachments/assets/bd173c70-ed9b-45e4-b842-57eab9bf28ba" />



  Before | After
-- | --
<img width="1337" height="813" alt="Before3" src="https://github.com/user-attachments/assets/42fbde3f-f515-4ed6-bd27-2959a931e313" /> |   <img width="1337" height="814" alt="After3" src="https://github.com/user-attachments/assets/7774e289-c965-40d6-9094-48a6bf293a43" />


## How Has This Been Tested?
Lint, type-check, and unit tests passed for AutoML and AutoRAG configure/results pages.
1. Create flow configure step shows Run configurations.
2. Reconfigure from results shows {source run} > Reconfigure.
3. Reconfigure from the experiments list shows Reconfigure only.
4. Results page Run configurations links to reconfigure.

## Test Impact
Updated Jest tests for AutoML and AutoRAG configure and results breadcrumbs. No Cypress coverage; breadcrumb behavior is covered by unit tests.

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clarified navigation labels by distinguishing “Run configurations” from “Reconfigure.”
  * Reconfiguration pages now show the originating run’s name and provide a link back to its results.
  * Breadcrumbs now reflect whether configuration was started from an experiment or an existing run.
* **Tests**
  * Added coverage for breadcrumb labels and source-run navigation across AutoML and AutoRAG.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->