### PR TITLE
fix(gen-ai): Remove port restrictions from cross-namespace egress to support MCP servers

### DIFF
--- a/manifests/modules/gen-ai/networkpolicy.yaml
+++ b/manifests/modules/gen-ai/networkpolicy.yaml
@@ -43,11 +43,6 @@ spec:
           protocol: TCP
     - to:
         - namespaceSelector: {}
-      ports:
-        - port: 8321
-          protocol: TCP
-        - port: 8443
-          protocol: TCP
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-85502

## Description

MCP servers can run on any port in any cluster namespace. The previous `gen-ai-allow-ports` NetworkPolicy restricted cross-namespace egress to only ports 8321 and 8443, which blocked connectivity to MCP servers on other ports.

This removes the port restriction from the `namespaceSelector: {}` egress rule, restoring the original open-namespace behaviour that existed before the OGX/NemoGuardrails port additions narrowed it.

## How Has This Been Tested?

Verified locally on a cluster — gen-ai-ui pod can now reach MCP servers in arbitrary namespaces on arbitrary ports.

## Test Impact

No test changes required — this is a manifest-only change.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules to allow outbound traffic on all ports across namespaces.
  * Preserved existing DNS, application-specific, and external HTTPS/HTTP access rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->