### PR TITLE
fix(e2e): prevent MLflow test failures on re-runs from stale name collisions

### DIFF
--- a/packages/cypress/cypress/pages/mlflowExperiments.ts
+++ b/packages/cypress/cypress/pages/mlflowExperiments.ts
@@ -143,20 +143,22 @@ class MlflowExperiments {
     return cy.findByTestId('overflow-menu-trigger');
   }
 
-  findRenameAction() {
-    return cy.findByTestId('rename');
+  findEditExperimentAction() {
+    return cy.findByTestId('mlflow.experiment_page.managementMenu.edit-experiment');
   }
 
   findDeleteAction() {
-    return cy.findByTestId('delete');
+    return cy.findByTestId('mlflow.experiment_page.managementMenu.delete');
   }
 
-  findRenameInput() {
-    return this.findCreateExperimentModal().find('input').first();
+  findEditExperimentNameInput() {
+    return cy.findByRole('dialog', { name: 'Edit experiment' }).find('input').first();
   }
 
-  findRenameSubmitButton() {
-    return this.findCreateExperimentModal().findByRole('button', { name: 'Save' });
+  findEditExperimentSubmitButton() {
+    return cy
+      .findByRole('dialog', { name: 'Edit experiment' })
+      .findByRole('button', { name: 'Save' });
   }
 
   findDeleteConfirmModal() {

--- a/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
@@ -201,7 +201,7 @@ describe('Verify MLflow Experiments page', () => {
       mlflowExperiments.findExperimentInTable(experimentName).should('be.visible');
 
       // =======================================================================
-      // Rename experiment
+      // Edit experiment (rename)
       // =======================================================================
 
       cy.step('Click experiment to open detail page');
@@ -210,14 +210,18 @@ describe('Verify MLflow Experiments page', () => {
       cy.step('Open overflow menu on detail page');
       mlflowExperiments.findOverflowMenuTrigger().click();
 
-      cy.step('Click rename action');
-      mlflowExperiments.findRenameAction().click();
+      cy.step('Click edit experiment action');
+      mlflowExperiments.findEditExperimentAction().click();
 
       cy.step('Clear and type new name');
-      mlflowExperiments.findRenameInput().should('be.visible').clear().type(renamedExperimentName);
+      mlflowExperiments
+        .findEditExperimentNameInput()
+        .should('be.visible')
+        .clear()
+        .type(renamedExperimentName);
 
-      cy.step('Submit rename');
-      mlflowExperiments.findRenameSubmitButton().click();
+      cy.step('Submit edit experiment');
+      mlflowExperiments.findEditExperimentSubmitButton().click();
       mlflowExperiments.findExperimentDetailHeading(renamedExperimentName).should('be.visible');
       uiExperimentName = renamedExperimentName;
 

--- a/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
@@ -5,6 +5,7 @@ import {
   doesMlflowCRExist,
   createMlflowExperimentViaAPI,
   deleteMlflowExperimentViaAPI,
+  findAvailableExperimentSuffix,
   getMlflowExperimentIdByName,
   logMlflowRunsViaAPI,
 } from '../../../utils/oc_commands/mlflow';
@@ -19,6 +20,7 @@ import type { MlflowExperimentsTestData } from '../../../types';
 describe('Verify MLflow Experiments page', () => {
   let testData: MlflowExperimentsTestData;
   let projectName: string;
+  let testSuffix: string;
   let crExisted: boolean | undefined;
   let runsExperimentId: string | undefined;
   let uiExperimentName: string | undefined;
@@ -46,6 +48,20 @@ describe('Verify MLflow Experiments page', () => {
       .then(() => {
         cy.step('Enable all features required for MLflow Experiments');
         return enableMlflowFeatures();
+      })
+      .then(() => {
+        cy.step('Find available experiment suffix to avoid stale name collisions');
+        const allBaseNames = [
+          testData.experiments[0].name,
+          testData.experiments[0].renamedName,
+          testData.experiments[1].name,
+        ];
+        return findAvailableExperimentSuffix(projectName, allBaseNames, uuid).then((suffix) => {
+          testSuffix = suffix;
+          if (suffix !== uuid) {
+            cy.log(`UUID ${uuid} had collisions, using suffix ${suffix} instead`);
+          }
+        });
       });
   });
 
@@ -71,10 +87,10 @@ describe('Verify MLflow Experiments page', () => {
     },
     () => {
       const experiment = testData.experiments[0];
-      const experimentName = `${experiment.name}-${uuid}`;
+      const experimentName = `${experiment.name}-${testSuffix}`;
       uiExperimentName = experimentName;
-      const renamedExperimentName = `${experiment.renamedName}-${uuid}`;
-      const runsExperimentName = `${testData.experiments[1].name}-${uuid}`;
+      const renamedExperimentName = `${experiment.renamedName}-${testSuffix}`;
+      const runsExperimentName = `${testData.experiments[1].name}-${testSuffix}`;
       const [run1, run2] = testData.runs;
 
       // =======================================================================

--- a/packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts
@@ -3,6 +3,8 @@ import {
   enablePromptManagementFeatures,
   disablePromptManagementFeatures,
   doesMlflowCRExist,
+  deleteStalePromptByName,
+  findAvailablePromptSuffix,
 } from '../../../utils/oc_commands/mlflow';
 import { deleteOpenShiftProject, createOpenShiftProject } from '../../../utils/oc_commands/project';
 import { retryableBefore } from '../../../utils/retryableHooks';
@@ -16,6 +18,7 @@ describe('Verify Prompt Management page', () => {
   let testData: PromptManagementTestData;
   let projectName: string;
   let crExisted: boolean | undefined;
+  let testSuffix: string;
   const uuid = generateTestUUID();
 
   retryableBefore(() => {
@@ -39,11 +42,27 @@ describe('Verify Prompt Management page', () => {
       .then(() => {
         cy.step('Enable all features required for Prompt Management');
         return enablePromptManagementFeatures();
+      })
+      .then(() => {
+        cy.step('Clean up stale prompts from prior runs');
+        return deleteStalePromptByName(projectName, `${testData.prompts[0].name}-${uuid}`);
+      })
+      .then(() => {
+        cy.step('Find available prompt suffix to avoid stale name collisions');
+        const allBaseNames = [testData.prompts[0].name];
+        return findAvailablePromptSuffix(projectName, allBaseNames, uuid).then((suffix) => {
+          testSuffix = suffix;
+          if (suffix !== uuid) {
+            cy.log(`UUID ${uuid} had collisions, using suffix ${suffix} instead`);
+          }
+        });
       });
   });
 
   after(() => {
     disablePromptManagementFeatures(crExisted ?? false);
+    deleteStalePromptByName(projectName, `${testData.prompts[0].name}-${testSuffix}`);
+    disablePromptManagementFeatures();
     deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
   });
 
@@ -54,6 +73,7 @@ describe('Verify Prompt Management page', () => {
     },
     () => {
       const prompt = testData.prompts[0];
+      const promptName = `${prompt.name}-${testSuffix}`;
 
       cy.step('Log into the application');
       cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
@@ -75,7 +95,7 @@ describe('Verify Prompt Management page', () => {
       promptManagement.findCreatePromptButton().click();
 
       cy.step('Fill in prompt name');
-      promptManagement.findPromptNameInput().should('be.visible').type(prompt.name);
+      promptManagement.findPromptNameInput().should('be.visible').type(promptName);
 
       cy.step('Fill in prompt template');
       promptManagement
@@ -90,7 +110,7 @@ describe('Verify Prompt Management page', () => {
       promptManagement.findCreateDialogSubmitButton().click();
 
       cy.step('Verify the prompt detail page is shown');
-      promptManagement.findPromptDetailHeading(prompt.name).should('be.visible');
+      promptManagement.findPromptDetailHeading(promptName).should('be.visible');
       promptManagement.findCreatePromptVersionButton().should('be.visible');
 
       cy.step('Verify Version 1 appears in the versions table');
@@ -130,7 +150,7 @@ describe('Verify Prompt Management page', () => {
       promptManagement.visit(projectName);
 
       cy.step('Verify the prompt persists after navigation');
-      promptManagement.findPromptInTable(prompt.name).should('be.visible');
+      promptManagement.findPromptInTable(promptName).should('be.visible');
     },
   );
 });

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -656,6 +656,7 @@ const execCurlInMlflowPod = (
   endpoint: string,
   body: object,
   workspace: string,
+  method: 'POST' | 'DELETE' = 'POST',
 ): Cypress.Chainable<string> => {
   const namespace = getApplicationsNamespace();
   const bodyJson = JSON.stringify(body);
@@ -666,11 +667,36 @@ const execCurlInMlflowPod = (
       `printf '%s' '${escapedBody}'`,
       '|',
       `oc exec -n ${namespace} -i ${podName} -c mlflow --`,
-      `curl -sk -X POST 'https://localhost:8443/mlflow${endpoint}'`,
+      `curl -sk -X ${method} 'https://localhost:8443/mlflow${endpoint}'`,
       `-H 'Content-Type: application/json'`,
       `-H "Authorization: Bearer $(oc whoami -t)"`,
       `-H 'X-MLFLOW-WORKSPACE: ${ns}'`,
       `--data-binary @-`,
+    ].join(' ');
+    return cy.exec(cmd, { timeout: 30000, log: false }).then((result) => result.stdout.trim());
+  });
+};
+
+/**
+ * Execute a GET request inside the MLflow pod against the tracking server.
+ */
+const execGetInMlflowPod = (
+  endpoint: string,
+  queryParams: Record<string, string>,
+  workspace: string,
+): Cypress.Chainable<string> => {
+  const namespace = getApplicationsNamespace();
+  const qs = Object.entries(queryParams)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+  const url = `https://localhost:8443/mlflow${endpoint}${qs ? `?${qs}` : ''}`;
+  return getMlflowPodName().then((podName) => {
+    const ns = assertNamespace(workspace);
+    const cmd = [
+      `oc exec -n ${namespace} -i ${podName} -c mlflow --`,
+      `curl -sk '${url}'`,
+      `-H "Authorization: Bearer $(oc whoami -t)"`,
+      `-H 'X-MLFLOW-WORKSPACE: ${ns}'`,
     ].join(' ');
     return cy.exec(cmd, { timeout: 30000, log: false }).then((result) => result.stdout.trim());
   });
@@ -771,6 +797,144 @@ export const getMlflowExperimentIdByName = (
   });
 
 /**
+ * Check whether an MLflow experiment name is taken, including soft-deleted
+ * experiments. MLflow's standard get-by-name only returns active experiments,
+ * but a soft-deleted experiment still reserves the name.
+ */
+export const doesMlflowExperimentNameExist = (
+  workspace: string,
+  experimentName: string,
+): Cypress.Chainable<boolean> =>
+  execCurlInMlflowPod(
+    '/api/2.0/mlflow/experiments/search',
+    // eslint-disable-next-line camelcase
+    { filter: `name = '${experimentName}'`, view_type: 'ALL', max_results: 10 },
+    workspace,
+  ).then((response) => {
+    try {
+      const experiments = JSON.parse(response)?.experiments ?? [];
+      return experiments.length > 0;
+    } catch {
+      return false;
+    }
+  });
+
+/**
+ * Find a test suffix that does not collide with any existing (active or
+ * soft-deleted) MLflow experiment. Checks every name in `baseNames` for a
+ * given suffix and increments until all names are available.
+ */
+export const findAvailableExperimentSuffix = (
+  workspace: string,
+  baseNames: string[],
+  startSuffix: string,
+  attempt = 0,
+): Cypress.Chainable<string> => {
+  if (attempt >= 20) {
+    throw new Error(
+      `Could not find available experiment suffix after ${attempt} attempts ` +
+        `(last tried: ${startSuffix})`,
+    );
+  }
+  const results: boolean[] = [];
+  return baseNames
+    .reduce<Cypress.Chainable<boolean>>(
+      (prev, name) =>
+        prev.then(() =>
+          doesMlflowExperimentNameExist(workspace, `${name}-${startSuffix}`).then(
+            (exists: boolean) => {
+              results.push(exists);
+              return exists;
+            },
+          ),
+        ),
+      cy.wrap(false),
+    )
+    .then(() => {
+      if (!results.some(Boolean)) {
+        return cy.wrap(startSuffix);
+      }
+      const taken = baseNames.filter((_, i) => results[i]);
+      cy.log(`Suffix ${startSuffix} collides on: ${taken.join(', ')}. Trying next suffix.`);
+      const next = String(Number(startSuffix) + 1).padStart(startSuffix.length, '0');
+      return findAvailableExperimentSuffix(workspace, baseNames, next, attempt + 1);
+    });
+};
+
+/**
+ * Delete an MLflow prompt (registered model) by name if it exists.
+ * Silently succeeds when the prompt is not found.
+ * Uses DELETE method — POST to this endpoint returns ENDPOINT_NOT_FOUND.
+ */
+export const deleteStalePromptByName = (
+  workspace: string,
+  promptName: string,
+): Cypress.Chainable<string> =>
+  execCurlInMlflowPod(
+    '/api/2.0/mlflow/registered-models/delete',
+    { name: promptName },
+    workspace,
+    'DELETE',
+  );
+
+/**
+ * Check whether an MLflow prompt (registered model) with the given name exists.
+ * Uses GET — the POST search endpoint returns ENDPOINT_NOT_FOUND on this server.
+ */
+export const doesMlflowPromptNameExist = (
+  workspace: string,
+  promptName: string,
+): Cypress.Chainable<boolean> =>
+  execGetInMlflowPod('/api/2.0/mlflow/registered-models/get', { name: promptName }, workspace).then(
+    (response) => {
+      try {
+        return !!JSON.parse(response)?.registered_model;
+      } catch {
+        return false;
+      }
+    },
+  );
+
+/**
+ * Find a test suffix that does not collide with any existing MLflow prompt
+ * (registered model). Same approach as findAvailableExperimentSuffix.
+ */
+export const findAvailablePromptSuffix = (
+  workspace: string,
+  baseNames: string[],
+  startSuffix: string,
+  attempt = 0,
+): Cypress.Chainable<string> => {
+  if (attempt >= 20) {
+    throw new Error(
+      `Could not find available prompt suffix after ${attempt} attempts ` +
+        `(last tried: ${startSuffix})`,
+    );
+  }
+  const results: boolean[] = [];
+  return baseNames
+    .reduce<Cypress.Chainable<boolean>>(
+      (prev, name) =>
+        prev.then(() =>
+          doesMlflowPromptNameExist(workspace, `${name}-${startSuffix}`).then((exists: boolean) => {
+            results.push(exists);
+            return exists;
+          }),
+        ),
+      cy.wrap(false),
+    )
+    .then(() => {
+      if (!results.some(Boolean)) {
+        return cy.wrap(startSuffix);
+      }
+      const taken = baseNames.filter((_, i) => results[i]);
+      cy.log(`Suffix ${startSuffix} collides on: ${taken.join(', ')}. Trying next suffix.`);
+      const next = String(Number(startSuffix) + 1).padStart(startSuffix.length, '0');
+      return findAvailablePromptSuffix(workspace, baseNames, next, attempt + 1);
+    });
+};
+
+/**
  * Log multiple runs sequentially under a single experiment.
  *
  * @param workspace - Namespace to scope the runs to.
@@ -791,7 +955,7 @@ export const logMlflowRunsViaAPI = (
       return cy.wrap(collected);
     }
     const [run, ...rest] = remaining;
-    return logMlflowRunViaAPI(workspace, experimentId, run).then((runId) =>
+    return logMlflowRunViaAPI(workspace, experimentId, run).then((runId: string) =>
       logNext(rest, [...collected, runId]),
     );
   };


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://redhat.atlassian.net/browse/RHOAIENG-85196

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a UX change -->
Cherry-picks two post-3.4 e2e fixes onto `v3.4.0-fixes` so `testMlflowExperiments` can pass on 3.4 clusters:

- https://github.com/opendatahub-io/odh-dashboard/pull/8870 — suffix incrementing to avoid stale MLflow experiment/prompt name collisions on retry (`RESOURCE_ALREADY_EXISTS` after soft-delete).
- https://github.com/opendatahub-io/odh-dashboard/pull/8255 — Cypress selectors for upstream MLflow v3.13.0, which renamed the overflow action from `data-testid="rename"` to `mlflow.experiment_page.managementMenu.edit-experiment`. Without this, the first run dies at "Click rename action" even when name collision is avoided.

The #8255 cherry-pick was previously attempted for 3.4 in https://github.com/opendatahub-io/odh-dashboard/pull/8307 and went stale.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
#8870 was previously exercised on 3.4. #8255 still needs a re-run of `testMlflowExperiments` on a 3.4 cluster with MLflow v3.13 UI (e.g. ag-gcp-34-pool-k6spq) to confirm the overflow menu / edit experiment flow.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
E2E test infrastructure only. No product code changes. Updates `testMlflowExperiments` and `testPromptManagement` plus MLflow Cypress helpers/selectors.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`