### PR TITLE
Cherry-pick: preserve user-configured replicas and resources (v3.5.0-fixes)

### DIFF
--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -60,6 +60,12 @@ var persesdashboardGVK = schema.GroupVersionKind{
 	Kind:    "PersesDashboardList",
 }
 
+var deploymentGVK = schema.GroupVersionKind{
+	Group:   "apps",
+	Version: "v1",
+	Kind:    "Deployment",
+}
+
 // Version is set at build time via -ldflags.
 var Version = "unknown"
 
@@ -306,6 +312,7 @@ func (r *DashboardReconciler) reconcileSidecar(
 		deploy.WithFieldOwner("dashboard-operator"),
 		deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
 		deploy.WithApplyOrder(),
+		deploy.WithMergeStrategy(deploymentGVK, deploy.MergeDeployments),
 	)
 
 	if err := deployer.Deploy(ctx, deploy.DeployInput{
@@ -425,6 +432,7 @@ func (r *DashboardReconciler) reconcileStandalone(
 		deploy.WithFieldOwner("dashboard-operator"),
 		deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
 		deploy.WithApplyOrder(),
+		deploy.WithMergeStrategy(deploymentGVK, deploy.MergeDeployments),
 	)
 
 	if err := deployer.Deploy(ctx, deploy.DeployInput{

--- a/dashboard-operator/internal/controller/merge_deployments_test.go
+++ b/dashboard-operator/internal/controller/merge_deployments_test.go
@@ -1,0 +1,373 @@
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+)
+
+func TestDeploymentGVK(t *testing.T) {
+	expected := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	if deploymentGVK != expected {
+		t.Errorf("deploymentGVK = %v, want %v", deploymentGVK, expected)
+	}
+}
+
+func TestMergeDeployments_PreservesReplicas(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "test-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(3),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "main",
+								"image": "old-image:v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "test-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "main",
+								"image": "new-image:v2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := deploy.MergeDeployments(existing, desired); err != nil {
+		t.Fatalf("MergeDeployments returned error: %v", err)
+	}
+
+	replicas, found, err := unstructured.NestedInt64(desired.Object, "spec", "replicas")
+	if err != nil {
+		t.Fatalf("failed to get replicas: %v", err)
+	}
+	if !found {
+		t.Fatal("replicas field not found after merge")
+	}
+	if replicas != 3 {
+		t.Errorf("replicas = %d, want 3 (user-configured value should be preserved)", replicas)
+	}
+}
+
+func TestMergeDeployments_PreservesContainerResources(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "test-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "odh-dashboard",
+								"image": "dashboard:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "512Mi",
+										"cpu":    "500m",
+									},
+									"limits": map[string]interface{}{
+										"memory": "2Gi",
+									},
+								},
+							},
+							map[string]interface{}{
+								"name":  "kube-rbac-proxy",
+								"image": "rbac-proxy:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "64Mi",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "test-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "odh-dashboard",
+								"image": "dashboard:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "256Mi",
+										"cpu":    "200m",
+									},
+								},
+							},
+							map[string]interface{}{
+								"name":  "kube-rbac-proxy",
+								"image": "rbac-proxy:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "32Mi",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := deploy.MergeDeployments(existing, desired); err != nil {
+		t.Fatalf("MergeDeployments returned error: %v", err)
+	}
+
+	containers, found, err := unstructured.NestedSlice(desired.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found {
+		t.Fatalf("failed to get containers: found=%v, err=%v", found, err)
+	}
+
+	for _, c := range containers {
+		cMap := c.(map[string]interface{})
+		name := cMap["name"].(string)
+		resources, ok := cMap["resources"].(map[string]interface{})
+
+		switch name {
+		case "odh-dashboard":
+			if !ok {
+				t.Fatal("odh-dashboard container should have resources after merge")
+			}
+			requests := resources["requests"].(map[string]interface{})
+			if requests["memory"] != "512Mi" {
+				t.Errorf("odh-dashboard memory request = %v, want 512Mi (user value)", requests["memory"])
+			}
+			if requests["cpu"] != "500m" {
+				t.Errorf("odh-dashboard cpu request = %v, want 500m (user value)", requests["cpu"])
+			}
+			limits, ok := resources["limits"].(map[string]interface{})
+			if !ok {
+				t.Fatal("odh-dashboard should have limits preserved from existing")
+			}
+			if limits["memory"] != "2Gi" {
+				t.Errorf("odh-dashboard memory limit = %v, want 2Gi (user value)", limits["memory"])
+			}
+
+		case "kube-rbac-proxy":
+			if !ok {
+				t.Fatal("kube-rbac-proxy container should have resources after merge")
+			}
+			requests := resources["requests"].(map[string]interface{})
+			if requests["memory"] != "64Mi" {
+				t.Errorf("kube-rbac-proxy memory request = %v, want 64Mi (user value)", requests["memory"])
+			}
+		}
+	}
+}
+
+func TestMergeDeployments_MatchesByContainerName(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "sidecar-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(2),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "odh-dashboard",
+								"image": "dashboard:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "1Gi"},
+								},
+							},
+							map[string]interface{}{
+								"name":  "model-registry-bff",
+								"image": "mr-bff:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "256Mi"},
+								},
+							},
+							map[string]interface{}{
+								"name":  "gen-ai-bff",
+								"image": "genai-bff:v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "sidecar-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "odh-dashboard",
+								"image": "dashboard:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "512Mi"},
+								},
+							},
+							map[string]interface{}{
+								"name":  "model-registry-bff",
+								"image": "mr-bff:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "128Mi"},
+								},
+							},
+							map[string]interface{}{
+								"name":  "gen-ai-bff",
+								"image": "genai-bff:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "64Mi"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := deploy.MergeDeployments(existing, desired); err != nil {
+		t.Fatalf("MergeDeployments returned error: %v", err)
+	}
+
+	replicas, _, _ := unstructured.NestedInt64(desired.Object, "spec", "replicas")
+	if replicas != 2 {
+		t.Errorf("replicas = %d, want 2", replicas)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(desired.Object, "spec", "template", "spec", "containers")
+
+	for _, c := range containers {
+		cMap := c.(map[string]interface{})
+		name := cMap["name"].(string)
+
+		switch name {
+		case "odh-dashboard":
+			res := cMap["resources"].(map[string]interface{})
+			req := res["requests"].(map[string]interface{})
+			if req["memory"] != "1Gi" {
+				t.Errorf("odh-dashboard memory = %v, want 1Gi", req["memory"])
+			}
+
+		case "model-registry-bff":
+			res := cMap["resources"].(map[string]interface{})
+			req := res["requests"].(map[string]interface{})
+			if req["memory"] != "256Mi" {
+				t.Errorf("model-registry-bff memory = %v, want 256Mi", req["memory"])
+			}
+
+		case "gen-ai-bff":
+			if _, ok := cMap["resources"]; ok {
+				t.Error("gen-ai-bff should have no resources (existing had none)")
+			}
+		}
+	}
+}
+
+func TestMergeDeployments_DefaultsAppliedOnFirstDeploy(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "new-deploy"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "main",
+								"image": "image:v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "new-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(2),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "main",
+								"image": "image:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "256Mi",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := deploy.MergeDeployments(existing, desired); err != nil {
+		t.Fatalf("MergeDeployments returned error: %v", err)
+	}
+
+	_, found, _ := unstructured.NestedInt64(desired.Object, "spec", "replicas")
+	if found {
+		t.Error("replicas should be removed when existing has no replicas set (K8s default)")
+	}
+
+	containers, _, _ := unstructured.NestedSlice(desired.Object, "spec", "template", "spec", "containers")
+	cMap := containers[0].(map[string]interface{})
+	if _, ok := cMap["resources"]; ok {
+		t.Error("resources should be removed when existing container had no resources (first deploy scenario)")
+	}
+}

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -221,6 +221,7 @@ func (r *DashboardReconciler) deployModuleManifests(
 			deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
 			deploy.WithLabel(moduleComponentLabel, mod.ManifestSlug),
 			deploy.WithApplyOrder(),
+			deploy.WithMergeStrategy(deploymentGVK, deploy.MergeDeployments),
 		)
 
 		if err := deployer.Deploy(ctx, deploy.DeployInput{


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-87038


## Description

Cherry-pick of #8846 into `v3.5.0-fixes`.

Without this change, the dashboard-operator's SSA reconcile loop overwrites any user-configured `spec.replicas` and container `resources` (CPU/memory requests and limits) with manifest defaults on every reconcile cycle. This was reported during RC2 Platform product sign-off testing — resource limits set by tests were being reverted.

The fix wires `deploy.WithMergeStrategy(deploymentGVK, deploy.MergeDeployments)` into all three `deploy.NewDeployer` calls so that user modifications to replicas and resources are preserved across reconcile cycles.

This is the same class of issue as [RHOAIENG-82720](https://issues.redhat.com/browse/RHOAIENG-82720) (Workbenches-operator SSA with ForceOwnership overwrites user-customized controller deployment resources).

## How Has This Been Tested?

This is a clean cherry-pick of #8846 (commit `9ac998dbe356`) with no conflicts. The original PR includes 5 unit tests in `merge_deployments_test.go` covering the merge strategy logic.

## Test Impact

Unit tests for `MergeDeployments` are included in the cherry-pick (`merge_deployments_test.go`). No additional tests needed — this is an exact cherry-pick.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-82720]: https://redhat.atlassian.net/browse/RHOAIENG-82720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ