### PR TITLE
fix(e2e): stop AWS credentials leaking into Cypress CI logs

### DIFF
--- a/.github/scripts/mask-cypress-test-secrets.sh
+++ b/.github/scripts/mask-cypress-test-secrets.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Register GitHub Actions masks for credentials in Cypress test-variables.yml.
+# Usage: mask-cypress-test-secrets.sh /path/to/test-variables.yml
+set -euo pipefail
+
+FILE="${1:-}"
+if [[ -z "$FILE" || ! -f "$FILE" ]]; then
+  echo "⚠️  test-variables file not found; skipping credential masking"
+  exit 0
+fi
+
+mask_value() {
+  local value="$1"
+  if [[ -z "$value" || ${#value} -lt 3 ]]; then
+    return 0
+  fi
+  echo "::add-mask::${value}"
+  # Tests also embed these values as base64 in Secret YAML.
+  echo "::add-mask::$(printf '%s' "${value}" | base64 | tr -d '\n')"
+}
+
+extract_scalar() {
+  local key="$1"
+  grep -E "^[[:space:]]*${key}:" "$FILE" 2>/dev/null | head -1 | sed -E "s/^[[:space:]]*${key}:[[:space:]]*//; s/[[:space:]]+$//; s/^['\"]//; s/['\"]$//" || true
+}
+
+# AWS keys used by AutoML / AutoRAG / Feature Store S3 helpers
+mask_value "$(extract_scalar AWS_ACCESS_KEY_ID)"
+mask_value "$(extract_scalar AWS_SECRET_ACCESS_KEY)"
+
+# Other credentials from the same test config (same leak class if logged)
+mask_value "$(extract_scalar NGC_API_KEY)"
+mask_value "$(extract_scalar GEMINI_API_KEY)"
+mask_value "$(extract_scalar OGX_API_KEY)"
+mask_value "$(extract_scalar OCI_SECRET_VALUE)"
+
+while IFS= read -r password; do
+  mask_value "$password"
+done < <(
+  grep -E "^[[:space:]]*PASSWORD:" "$FILE" 2>/dev/null | sed -E "s/^[[:space:]]*PASSWORD:[[:space:]]*//; s/[[:space:]]+$//; s/^['\"]//; s/['\"]$//" || true
+)
+
+echo "✅ Registered GitHub Actions masks for test-variables credentials"

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -48,6 +48,9 @@ name: Cypress e2e Test
 #   PRIMARY:   OC_SERVER_PRIMARY, OCP_CONSOLE_URL_PRIMARY, ODH_DASHBOARD_URL_PRIMARY
 #   SECONDARY: OC_SERVER, OCP_CONSOLE_URL, ODH_DASHBOARD_URL
 #   AUTH:      GITLAB_TOKEN, GITLAB_TEST_VARS_URL, ODH_NAMESPACES
+#
+# After downloading test-variables.yml, e2e-tests registers GitHub Actions
+# masks for AWS keys and other credentials so Cypress [EXEC] logs cannot leak them.
 # =============================================================================
 
 on:
@@ -1074,6 +1077,8 @@ jobs:
                         "${{ secrets.GITLAB_TEST_VARS_URL }}" \
             -o ${{ github.workspace }}/packages/cypress/test-variables.yml
           echo "✅ Downloaded test configuration"
+          bash "${{ github.workspace }}/.github/scripts/mask-cypress-test-secrets.sh" \
+            "${{ github.workspace }}/packages/cypress/test-variables.yml"
 
       - name: Login to OpenShift cluster
         env:

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -1053,6 +1053,17 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
 
+      # The e2e job checks out the PR SHA, then downloads test-variables.yml.
+      # Run the mask script from the default branch, not from the PR workspace.
+      - name: Checkout trusted credential tools
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: ${{ runner.temp }}/trusted-credential-tools
+          persist-credentials: false
+          sparse-checkout: .github/scripts/mask-cypress-test-secrets.sh
+          sparse-checkout-cone-mode: false
+
       - name: Module caches
         uses: ./.github/actions/module-caches
         with:
@@ -1077,8 +1088,12 @@ jobs:
                         "${{ secrets.GITLAB_TEST_VARS_URL }}" \
             -o ${{ github.workspace }}/packages/cypress/test-variables.yml
           echo "✅ Downloaded test configuration"
-          bash "${{ github.workspace }}/.github/scripts/mask-cypress-test-secrets.sh" \
-            "${{ github.workspace }}/packages/cypress/test-variables.yml"
+          MASK_SCRIPT="${{ runner.temp }}/trusted-credential-tools/.github/scripts/mask-cypress-test-secrets.sh"
+          if [[ -f "$MASK_SCRIPT" ]]; then
+            bash "$MASK_SCRIPT" "${{ github.workspace }}/packages/cypress/test-variables.yml"
+          else
+            echo "⚠️ Trusted mask script not on default branch yet; skipping Actions masks"
+          fi
 
       - name: Login to OpenShift cluster
         env:

--- a/packages/cypress/cypress/support/e2e.ts
+++ b/packages/cypress/cypress/support/e2e.ts
@@ -284,18 +284,20 @@ Cypress.on('command:end', function handleCommandEnd() {
 });
 
 Cypress.on('command:enqueued', (command) => {
+  const arg = typeof command.args[0] === 'string' ? command.args[0] : '';
+  const maskedArg = maskSensitiveInfo(arg);
+
   if (command.name === 'step') {
     if (commandStack.length === 0) {
       stepCounter++;
-      cy.task('log', `[STEP ${stepCounter}] ${command.args[0]}`);
+      cy.task('log', `[STEP ${stepCounter}] ${maskedArg}`);
     } else {
-      cy.task('log', `${command.args[0]}`);
+      cy.task('log', maskedArg);
     }
   } else if (command.name === 'exec') {
-    const maskedCommand = maskSensitiveInfo(command.args[0]);
-    cy.task('log', `[EXEC] ${maskedCommand}`);
+    cy.task('log', `[EXEC] ${maskedArg}`);
   } else if (command.name === 'log') {
-    cy.task('log', `${command.args[0]}`);
+    cy.task('log', maskedArg);
   }
 });
 

--- a/packages/cypress/cypress/utils/maskSensitiveInfo.ts
+++ b/packages/cypress/cypress/utils/maskSensitiveInfo.ts
@@ -1,3 +1,83 @@
+const REDACTED = '***';
+
+const AWS_ENV_ASSIGNMENT =
+  /((?:--env=)?AWS_(?:ACCESS_KEY_ID|SECRET_ACCESS_KEY|SESSION_TOKEN))=('[^']*'|"[^"]*"|\S+)/gi;
+
+const FROM_LITERAL_SECRET =
+  /(--from-literal=[A-Za-z0-9_]*(?:KEY|SECRET|PASSWORD|TOKEN|PASSWD)[A-Za-z0-9_]*)=('[^']*'|"[^"]*"|\S+)/gi;
+
+const AWS_ACCESS_KEY_ID_PATTERN = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g;
+
+const CYPRESS_USER_ENV_KEYS = [
+  'HTPASSWD_CLUSTER_ADMIN_USER',
+  'LDAP_CLUSTER_ADMIN_USER',
+  'LDAP_CONTRIBUTOR_USER',
+  'LDAP_CONTRIBUTOR_GROUP',
+  'TEST_USER',
+] as const;
+
+const CYPRESS_STRING_SECRET_KEYS = [
+  'NGC_API_KEY',
+  'GEMINI_API_KEY',
+  'OGX_API_KEY',
+  'OCI_SECRET_VALUE',
+] as const;
+
+const toBase64 = (value: string): string => {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(value, 'utf8').toString('base64');
+  }
+  if (typeof btoa === 'function') {
+    return btoa(value);
+  }
+  return '';
+};
+
+const redactLiteral = (text: string, value: string | undefined): string => {
+  if (!value || value.length < 4) {
+    return text;
+  }
+  return text.split(value).join(REDACTED);
+};
+
+const collectKnownSecretValues = (): string[] => {
+  const values: string[] = [];
+
+  try {
+    if (typeof Cypress === 'undefined') {
+      return values;
+    }
+
+    const aws = Cypress.env('AWS_PIPELINES') as
+      | { AWS_ACCESS_KEY_ID?: string; AWS_SECRET_ACCESS_KEY?: string }
+      | undefined;
+    if (aws?.AWS_ACCESS_KEY_ID) {
+      values.push(aws.AWS_ACCESS_KEY_ID);
+    }
+    if (aws?.AWS_SECRET_ACCESS_KEY) {
+      values.push(aws.AWS_SECRET_ACCESS_KEY);
+    }
+
+    for (const key of CYPRESS_USER_ENV_KEYS) {
+      const user = Cypress.env(key) as { PASSWORD?: string } | undefined;
+      if (user?.PASSWORD) {
+        values.push(user.PASSWORD);
+      }
+    }
+
+    for (const key of CYPRESS_STRING_SECRET_KEYS) {
+      const secret = Cypress.env(key) as string | undefined;
+      if (secret) {
+        values.push(secret);
+      }
+    }
+  } catch {
+    // Cypress.env is unavailable outside the browser test runtime.
+  }
+
+  return values.filter((value) => value.length >= 4);
+};
+
 /**
  * Masks sensitive information in command strings and error messages.
  * This function provides consistent masking across all test logs, command outputs,
@@ -7,7 +87,15 @@
  * @returns The masked text string with sensitive information replaced by ***
  */
 export function maskSensitiveInfo(text: string): string {
+  if (!text) {
+    return text;
+  }
+
   let masked = text;
+
+  masked = masked.replace(AWS_ACCESS_KEY_ID_PATTERN, REDACTED);
+  masked = masked.replace(AWS_ENV_ASSIGNMENT, `$1=${REDACTED}`);
+  masked = masked.replace(FROM_LITERAL_SECRET, `$1=${REDACTED}`);
 
   // Mask usernames in oc login commands
   // Pattern: -u "username" or -u 'username' or -u username
@@ -32,6 +120,11 @@ export function maskSensitiveInfo(text: string): string {
   // Mask usernames in OpenShift server error messages
   // Pattern: User "username" or User 'username'
   masked = masked.replace(/User\s+(['"])([^'"]+)\1/g, 'User $1***$1');
+
+  for (const secret of collectKnownSecretValues()) {
+    masked = redactLiteral(masked, secret);
+    masked = redactLiteral(masked, toBase64(secret));
+  }
 
   return masked;
 }

--- a/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
+++ b/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
@@ -120,7 +120,8 @@ export const applyOpenShiftYaml = (
   // Write YAML to a temp file so `oc apply -f <path>` does not put secrets on argv.
   // log: false keeps Cypress from printing file contents (often Secret YAML) to CI logs.
   return cy.writeFile(tempFileName, yamlContent, { log: false }).then(() => {
-    const ocCommand = `oc apply ${ns} -f ${tempFileName} && rm -f ${tempFileName}`;
+    const ocCommand =
+      `oc apply ${ns} -f ${tempFileName}; status=$?; ` + `rm -f -- ${tempFileName}; exit $status`;
     return execWithOutput(ocCommand);
   });
 };

--- a/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
+++ b/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
@@ -117,8 +117,9 @@ export const applyOpenShiftYaml = (
     .toString(36)
     .substr(2, 9)}.yaml`;
 
-  // Write YAML content to temp file using Node.js fs to avoid logging
-  return cy.writeFile(tempFileName, yamlContent).then(() => {
+  // Write YAML to a temp file so `oc apply -f <path>` does not put secrets on argv.
+  // log: false keeps Cypress from printing file contents (often Secret YAML) to CI logs.
+  return cy.writeFile(tempFileName, yamlContent, { log: false }).then(() => {
     const ocCommand = `oc apply ${ns} -f ${tempFileName} && rm -f ${tempFileName}`;
     return execWithOutput(ocCommand);
   });

--- a/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
+++ b/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
@@ -1,7 +1,64 @@
+import { applyOpenShiftYaml } from './baseCommands';
 import { AWS_BUCKETS } from '../s3Buckets';
 
 /** Shell-escape a value by wrapping in single quotes (handles embedded quotes). */
 const shQuote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`;
+
+type AwsCliPodOptions = {
+  namespace: string;
+  podName: string;
+  region: string;
+  awsCliArgs: string;
+  failOnNonZeroExit?: boolean;
+  timeout?: number;
+};
+
+/**
+ * Run the AWS CLI in an ephemeral in-cluster pod.
+ *
+ * Credentials are mounted from a temporary Secret via `--env-from`, so the
+ * `oc run` argv (and therefore Cypress `[EXEC]` logs) never contain the keys.
+ * The Secret is deleted after the pod exits.
+ */
+export const runAwsCliInCluster = ({
+  namespace,
+  podName,
+  region,
+  awsCliArgs,
+  failOnNonZeroExit = false,
+  timeout = 120000,
+}: AwsCliPodOptions): void => {
+  const secretName = `${podName}-creds`;
+  const secretManifest = JSON.stringify({
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: {
+      name: secretName,
+      namespace,
+    },
+    stringData: {
+      AWS_ACCESS_KEY_ID: AWS_BUCKETS.AWS_ACCESS_KEY_ID,
+      AWS_SECRET_ACCESS_KEY: AWS_BUCKETS.AWS_SECRET_ACCESS_KEY,
+      AWS_DEFAULT_REGION: region,
+    },
+  });
+
+  applyOpenShiftYaml(secretManifest).then(() => {
+    cy.exec(
+      `oc run ${podName} -n ${namespace} ` +
+        `--image=amazon/aws-cli:latest ` +
+        `--restart=Never --rm --attach --tty=false ` +
+        `--env-from=secret/${secretName} ` +
+        `-- ${awsCliArgs}`,
+      { failOnNonZeroExit, log: false, timeout },
+    ).then(() => {
+      cy.exec(`oc delete secret ${secretName} -n ${namespace} --ignore-not-found`, {
+        failOnNonZeroExit: false,
+        log: false,
+      });
+    });
+  });
+};
 
 /**
  * Delete S3 objects whose keys match a given prefix pattern.
@@ -33,16 +90,13 @@ export const deleteS3TestFiles = (
   const bucketConfig = AWS_BUCKETS[bucketKey];
   const podName = `s3-cleanup-${Date.now()}`;
 
-  cy.exec(
-    `oc run ${podName} -n ${namespace} ` +
-      `--image=amazon/aws-cli:latest ` +
-      `--restart=Never --rm --attach ` +
-      `--env=AWS_ACCESS_KEY_ID=${shQuote(AWS_BUCKETS.AWS_ACCESS_KEY_ID)} ` +
-      `--env=AWS_SECRET_ACCESS_KEY=${shQuote(AWS_BUCKETS.AWS_SECRET_ACCESS_KEY)} ` +
-      `--env=AWS_DEFAULT_REGION=${shQuote(bucketConfig.REGION)} ` +
-      `-- s3 rm ${shQuote(`s3://${bucketConfig.NAME}/`)} --recursive ` +
+  runAwsCliInCluster({
+    namespace,
+    podName,
+    region: bucketConfig.REGION,
+    awsCliArgs:
+      `s3 rm ${shQuote(`s3://${bucketConfig.NAME}/`)} --recursive ` +
       `--endpoint-url ${shQuote(bucketConfig.ENDPOINT)} ` +
       `--exclude '*' --include '${prefix}'`,
-    { failOnNonZeroExit: false, log: false, timeout: 120000 },
-  );
+  });
 };

--- a/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
+++ b/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
@@ -4,11 +4,23 @@ import { AWS_BUCKETS } from '../s3Buckets';
 /** Shell-escape a value by wrapping in single quotes (handles embedded quotes). */
 const shQuote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`;
 
+/** Pinned AWS CLI image so the cleanup pod cannot drift to a mutated :latest tag. */
+const AWS_CLI_IMAGE =
+  'amazon/aws-cli:2.27.50@sha256:48c3d4212e2f5b0e24bdc6af7708f9412ce65425a79575e0f78b8f8c0dcd70ab';
+
+const K8S_DNS_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+const assertK8sDnsLabel = (kind: string, value: string): void => {
+  if (!K8S_DNS_LABEL.test(value) || value.length > 63) {
+    throw new Error(`Invalid ${kind} for oc command`);
+  }
+};
+
 type AwsCliPodOptions = {
   namespace: string;
   podName: string;
   region: string;
-  awsCliArgs: string;
+  awsCliArgs: string[];
   failOnNonZeroExit?: boolean;
   timeout?: number;
 };
@@ -18,7 +30,7 @@ type AwsCliPodOptions = {
  *
  * Credentials are mounted from a temporary Secret via `--env-from`, so the
  * `oc run` argv (and therefore Cypress `[EXEC]` logs) never contain the keys.
- * The Secret is deleted after the pod exits.
+ * The Secret is deleted after the pod exits, including when `oc run` fails.
  */
 export const runAwsCliInCluster = ({
   namespace,
@@ -28,7 +40,12 @@ export const runAwsCliInCluster = ({
   failOnNonZeroExit = false,
   timeout = 120000,
 }: AwsCliPodOptions): void => {
+  assertK8sDnsLabel('namespace', namespace);
+  assertK8sDnsLabel('pod name', podName);
+
   const secretName = `${podName}-creds`;
+  assertK8sDnsLabel('secret name', secretName);
+
   const secretManifest = JSON.stringify({
     apiVersion: 'v1',
     kind: 'Secret',
@@ -43,20 +60,33 @@ export const runAwsCliInCluster = ({
     },
   });
 
-  applyOpenShiftYaml(secretManifest).then(() => {
-    cy.exec(
-      `oc run ${podName} -n ${namespace} ` +
-        `--image=amazon/aws-cli:latest ` +
-        `--restart=Never --rm --attach --tty=false ` +
-        `--env-from=secret/${secretName} ` +
-        `-- ${awsCliArgs}`,
-      { failOnNonZeroExit, log: false, timeout },
-    ).then(() => {
-      cy.exec(`oc delete secret ${secretName} -n ${namespace} --ignore-not-found`, {
-        failOnNonZeroExit: false,
-        log: false,
-      });
+  const deleteCredentials = () =>
+    cy.exec(`oc delete secret ${shQuote(secretName)} -n ${shQuote(namespace)} --ignore-not-found`, {
+      failOnNonZeroExit: false,
+      log: false,
     });
+
+  const quotedArgs = awsCliArgs.map(shQuote).join(' ');
+
+  applyOpenShiftYaml(secretManifest).then(() => {
+    // failOnNonZeroExit must be false so Cypress still runs Secret cleanup after a
+    // non-zero oc run. Re-throw after deletion when the caller asked to fail.
+    return cy
+      .exec(
+        `oc run ${shQuote(podName)} -n ${shQuote(namespace)} ` +
+          `--image=${shQuote(AWS_CLI_IMAGE)} ` +
+          `--restart=Never --rm --attach --tty=false ` +
+          `--env-from=${shQuote(`secret/${secretName}`)} ` +
+          `-- ${quotedArgs}`,
+        { failOnNonZeroExit: false, log: false, timeout },
+      )
+      .then((result) =>
+        deleteCredentials().then(() => {
+          if (failOnNonZeroExit && result.exitCode !== 0) {
+            throw new Error(`AWS CLI pod ${podName} exited with code ${result.exitCode}`);
+          }
+        }),
+      );
   });
 };
 
@@ -94,9 +124,17 @@ export const deleteS3TestFiles = (
     namespace,
     podName,
     region: bucketConfig.REGION,
-    awsCliArgs:
-      `s3 rm ${shQuote(`s3://${bucketConfig.NAME}/`)} --recursive ` +
-      `--endpoint-url ${shQuote(bucketConfig.ENDPOINT)} ` +
-      `--exclude '*' --include '${prefix}'`,
+    awsCliArgs: [
+      's3',
+      'rm',
+      `s3://${bucketConfig.NAME}/`,
+      '--recursive',
+      '--endpoint-url',
+      bucketConfig.ENDPOINT,
+      '--exclude',
+      '*',
+      '--include',
+      prefix,
+    ],
   });
 };


### PR DESCRIPTION
## Description

Cypress e2e extra-tag jobs (`@AutoMLCI`, `@AutoRAGCI`, and Feature Store S3 helpers) were writing AWS access keys into GitHub Actions logs. The Cypress command logger records every `cy.exec` as `[EXEC] …`, and `deleteS3TestFiles` previously put `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` on the `oc run --env=…` argv. `log: false` does not stop that logger. Default `@ci-dashboard-regression-tags` jobs do not hit this path.

This PR:

- Passes S3 credentials into the AWS CLI pod via a temporary Secret and `--env-from`, so keys never appear on `oc run` argv. `runAwsCliInCluster` is exported so Feature Store PRs ([#9386](https://github.com/opendatahub-io/odh-dashboard/pull/9386), [#9302](https://github.com/opendatahub-io/odh-dashboard/pull/9302)) can reuse it instead of `oc run --env=AWS_*=…`.
- Redacts AWS env assignments, `AKIA`/`ASIA` key IDs, `--from-literal` secrets, and known `Cypress.env` values (including base64) in `maskSensitiveInfo`, and applies that mask to Cypress `exec` / `step` / `log` task output.
- Registers GitHub Actions `::add-mask::` values after `test-variables.yml` is downloaded.
- Suppresses Cypress `writeFile` logging when applying YAML (Secret manifests).

**If these keys are still active, rotate the IAM access key in GitLab `test-variables.yml`.** Deleting logs does not invalidate a leaked key.

## How Has This Been Tested?

- ESLint via lint-staged on the changed TypeScript files (pre-commit).
- Not run against a live cluster / Cypress e2e extra-tag job yet (this PR is for trying that path).

To verify the leak is gone, run (or wait for) a Cypress e2e extra-tag job that includes `@AutoMLCI` or `@AutoRAGCI` and confirm `[EXEC]` lines for S3 cleanup show `--env-from=secret/…` and **do not** contain `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` values. GitHub Actions should also mask those values if they still appear.

Add PR labels `test:AutoMLCI` and optionally `test:AutoRAGCI`. Cypress e2e uses the workflow YAML from `main`, but checks out this PR’s Cypress code, so the Secret/`--env-from` and `[EXEC]` redaction apply on the PR run. The `::add-mask::` workflow step does not run until this is merged.

Example leaked job (logs still contain the old command until deleted): https://github.com/opendatahub-io/odh-dashboard/actions/runs/32273387128/job/96135290400

## Test Impact

No new Cypress or Jest tests. `@odh-dashboard/cypress` has no unit-test target for this helper, and the leak is a CI logging issue: the important check is an extra-tag e2e job plus confirming Actions masks.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`