### PR TITLE
added genaici tag to test genai model deployement e2e test

### DIFF
--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiModelDeployment.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiModelDeployment.cy.ts
@@ -5,7 +5,12 @@ import {
   waitForUserProjectAccess,
 } from '../../../utils/oc_commands/project';
 import { waitForOGXServerReady } from '../../../utils/oc_commands/ogxServer';
-import { waitForResource } from '../../../utils/oc_commands/baseCommands';
+import {
+  startPortForward,
+  stopPortForward,
+  waitForResource,
+  type PortForwardHandle,
+} from '../../../utils/oc_commands/baseCommands';
 import { cleanupServingRuntimeTemplate, deployGenAiModel } from '../../../utils/oc_commands/genAi';
 import { retryableBefore } from '../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../utils/uuidGenerator';
@@ -20,6 +25,7 @@ describe('Verify vLLM model deployment - Playground Integration', { testIsolatio
   let projectName: string;
   let servingRuntimeName: string;
   let hardwareProfileName: string;
+  let portForwardHandle: PortForwardHandle | null = null;
 
   retryableBefore(() => {
     cy.fixture('e2e/genAi/testGenAiModelDeployment.yaml', 'utf8')
@@ -61,6 +67,8 @@ describe('Verify vLLM model deployment - Playground Integration', { testIsolatio
   });
 
   after(() => {
+    stopPortForward(portForwardHandle);
+
     if (projectName) {
       deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
@@ -117,9 +125,10 @@ describe('Verify vLLM model deployment - Playground Integration', { testIsolatio
       cy.step('Wait for playground service to be created');
       waitForResource('service', genAiTestData.playgroundServiceName, projectName);
 
-      // TODO: Remove port-forward once tests run in-cluster
-      // cy.step('Start port-forward for LSD service');
-      // startPortForward(projectName, genAiTestData.playgroundServiceName, 8321);
+      cy.step('Start port-forward for LSD service');
+      startPortForward(projectName, genAiTestData.playgroundServiceName, 8321).then((handle) => {
+        portForwardHandle = handle;
+      });
 
       cy.step('Navigate to playground');
       genAiPlayground.navigate(projectName);

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiModelDeployment.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiModelDeployment.cy.ts
@@ -5,7 +5,7 @@ import {
   waitForUserProjectAccess,
 } from '../../../utils/oc_commands/project';
 import { waitForOGXServerReady } from '../../../utils/oc_commands/ogxServer';
-import { waitForResource } from '../../../utils/oc_commands/baseCommands';
+import { startPortForward, waitForResource } from '../../../utils/oc_commands/baseCommands';
 import { cleanupServingRuntimeTemplate, deployGenAiModel } from '../../../utils/oc_commands/genAi';
 import { retryableBefore } from '../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../utils/uuidGenerator';
@@ -86,7 +86,6 @@ describe('Verify vLLM model deployment - Playground Integration', { testIsolatio
         '@Deployment',
         '@Playground',
         '@GenAICI',
-        '@NonConcurrent',
       ],
     },
     () => {
@@ -117,6 +116,10 @@ describe('Verify vLLM model deployment - Playground Integration', { testIsolatio
 
       cy.step('Wait for playground service to be created');
       waitForResource('service', genAiTestData.playgroundServiceName, projectName);
+
+      // TODO: Remove port-forward once tests run in-cluster
+      // cy.step('Start port-forward for LSD service');
+      // startPortForward(projectName, genAiTestData.playgroundServiceName, 8321);
 
       cy.step('Navigate to playground');
       genAiPlayground.navigate(projectName);

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiModelDeployment.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiModelDeployment.cy.ts
@@ -5,7 +5,7 @@ import {
   waitForUserProjectAccess,
 } from '../../../utils/oc_commands/project';
 import { waitForOGXServerReady } from '../../../utils/oc_commands/ogxServer';
-import { startPortForward, waitForResource } from '../../../utils/oc_commands/baseCommands';
+import { waitForResource } from '../../../utils/oc_commands/baseCommands';
 import { cleanupServingRuntimeTemplate, deployGenAiModel } from '../../../utils/oc_commands/genAi';
 import { retryableBefore } from '../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../utils/uuidGenerator';

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiModelDeployment.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiModelDeployment.cy.ts
@@ -85,6 +85,7 @@ describe('Verify vLLM model deployment - Playground Integration', { testIsolatio
         '@ModelServing',
         '@Deployment',
         '@Playground',
+        '@GenAICI',
         '@NonConcurrent',
       ],
     },

--- a/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
+++ b/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
@@ -338,6 +338,45 @@ export const deleteNotebook = (
   });
 };
 
+/**
+ * Starts a background `oc port-forward` for a service and briefly waits for the tunnel to establish.
+ * Only runs when the dashboard `baseUrl` is localhost (e.g. GitHub PR CI runs, where the test runner
+ * accesses cluster services via localhost rather than in-cluster networking). No-ops otherwise, since
+ * on a real cluster the service is already reachable directly.
+ *
+ * @param namespace The namespace containing the service.
+ * @param serviceName The name of the service to port-forward.
+ * @param port The port to forward (used as both the local and remote port).
+ * @param waitTimeMs Time to wait after starting the port-forward for the tunnel to establish (default 3000ms).
+ * @returns A Cypress chainable that resolves once the port-forward process has been started (or immediately if skipped).
+ */
+export const startPortForward = (
+  namespace: string,
+  serviceName: string,
+  port: number,
+  waitTimeMs = 3000,
+): Cypress.Chainable<CommandLineResult | null> => {
+  const baseUrl = Cypress.config('baseUrl') || '';
+  if (!baseUrl.includes('localhost')) {
+    cy.log(`Skipping port-forward for ${serviceName} - baseUrl is not localhost`);
+    return cy.wrap<CommandLineResult | null>(null);
+  }
+
+  const logFile = `/tmp/port-forward-${serviceName}-${port}.log`;
+
+  return cy
+    .exec(
+      `nohup oc port-forward -n ${namespace} svc/${serviceName} ${port}:${port} > ${logFile} 2>&1 & echo $!`,
+      { failOnNonZeroExit: false },
+    )
+    .then((result: CommandLineResult): Cypress.Chainable<CommandLineResult | null> => {
+      cy.log(`Port-forward PID: ${result.stdout.trim()}`);
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(waitTimeMs);
+      return cy.wrap<CommandLineResult | null>(result);
+    });
+};
+
 export type PollOptions = {
   maxAttempts?: number;
   pollIntervalMs?: number;

--- a/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
+++ b/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
@@ -339,40 +339,76 @@ export const deleteNotebook = (
 };
 
 /**
+ * Handle for a port-forward process started by `startPortForward`, used to stop it via `stopPortForward`.
+ */
+export type PortForwardHandle = {
+  pid: string;
+  logFile: string;
+};
+
+/**
  * Starts a background `oc port-forward` for a service and briefly waits for the tunnel to establish.
  * Only runs when the dashboard `baseUrl` is localhost (e.g. GitHub PR CI runs, where the test runner
  * accesses cluster services via localhost rather than in-cluster networking). No-ops otherwise, since
  * on a real cluster the service is already reachable directly.
  *
+ * Callers MUST pass the returned handle to `stopPortForward` (e.g. in an `after()` hook) to kill the
+ * detached process and remove its log file.
+ *
  * @param namespace The namespace containing the service.
  * @param serviceName The name of the service to port-forward.
  * @param port The port to forward (used as both the local and remote port).
  * @param waitTimeMs Time to wait after starting the port-forward for the tunnel to establish (default 3000ms).
- * @returns A Cypress chainable that resolves once the port-forward process has been started (or immediately if skipped).
+ * @returns A Cypress chainable resolving to a handle for cleanup, or `null` if the port-forward was skipped.
  */
 export const startPortForward = (
   namespace: string,
   serviceName: string,
   port: number,
   waitTimeMs = 3000,
-): Cypress.Chainable<CommandLineResult | null> => {
+): Cypress.Chainable<PortForwardHandle | null> => {
   const baseUrl = Cypress.config('baseUrl') || '';
   if (!baseUrl.includes('localhost')) {
     cy.log(`Skipping port-forward for ${serviceName} - baseUrl is not localhost`);
-    return cy.wrap<CommandLineResult | null>(null);
+    return cy.wrap<PortForwardHandle | null>(null);
   }
 
-  const logFile = `/tmp/port-forward-${serviceName}-${port}.log`;
+  const logFile = `/tmp/port-forward-${serviceName}-${port}-${Date.now()}.log`;
 
   return cy
     .exec(
       `nohup oc port-forward -n ${namespace} svc/${serviceName} ${port}:${port} > ${logFile} 2>&1 & echo $!`,
       { failOnNonZeroExit: false },
     )
-    .then((result: CommandLineResult): Cypress.Chainable<CommandLineResult | null> => {
-      cy.log(`Port-forward PID: ${result.stdout.trim()}`);
+    .then((result: CommandLineResult): Cypress.Chainable<PortForwardHandle | null> => {
+      const pid = result.stdout.trim();
+      cy.log(`Port-forward PID: ${pid}`);
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(waitTimeMs);
+      return cy.wrap<PortForwardHandle | null>({ pid, logFile });
+    });
+};
+
+/**
+ * Stops a port-forward process started by `startPortForward` and removes its log file.
+ * No-ops when `handle` is `null` (e.g. the port-forward was skipped because `baseUrl` was not localhost).
+ *
+ * @param handle The handle returned by `startPortForward`.
+ * @returns A Cypress chainable that resolves once cleanup has been attempted.
+ */
+export const stopPortForward = (
+  handle: PortForwardHandle | null,
+): Cypress.Chainable<CommandLineResult | null> => {
+  if (!handle) {
+    return cy.wrap<CommandLineResult | null>(null);
+  }
+
+  const { pid, logFile } = handle;
+
+  return cy
+    .exec(`kill ${pid} 2>/dev/null; rm -f ${logFile}`, { failOnNonZeroExit: false })
+    .then((result: CommandLineResult): Cypress.Chainable<CommandLineResult | null> => {
+      cy.log(`Stopped port-forward (PID ${pid}) and removed ${logFile}`);
       return cy.wrap<CommandLineResult | null>(result);
     });
 };

--- a/packages/gen-ai/package.json
+++ b/packages/gen-ai/package.json
@@ -36,7 +36,7 @@
     "cypress:server:wait": "wait-on -i 1000 http-get://localhost:9102/healthcheck",
     "cypress:server:e2e:wait": "npm run cypress:server:wait",
     "prepare:e2e": "cd bff && go mod download",
-    "cypress:server:e2e": "STATIC_ASSETS_DIR=../frontend/public-cypress make dev-bff-e2e-cluster E2E_BFF_PORT=9102",
+    "cypress:server:e2e": "LLAMA_STACK_URL=${LLAMA_STACK_URL:-http://localhost:8321} STATIC_ASSETS_DIR=../frontend/public-cypress make dev-bff-e2e-cluster E2E_BFF_PORT=9102",
     "lint": "cd frontend && npm run lint",
     "lint:fix": "cd frontend && npm run lint:fix"
   },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-56361

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
added genaici tag to test genai model deployement e2e test

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gen AI model deployment testing by managing service connectivity automatically during test setup and cleanup.
  * Added support for local Gen AI server configuration with a default local endpoint.
* **Tests**
  * Updated test categorization to use the Gen AI continuous-integration classification.
  * Added reliable startup and shutdown handling for service port forwarding during end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->