### PR TITLE
Hide resource tab for non-admin users without ClusterQueue view access

### DIFF
--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -50,6 +50,8 @@ import {
 } from '@patternfly/react-icons';
 import type { PodContainerStatus } from '@odh-dashboard/k8s-core';
 import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { useAccessReview } from '@odh-dashboard/plugin-core/host-api';
+import { ClusterQueueModel } from '#~/api/models/kueue';
 import { EventStatus, NotebookStatus } from '#~/types';
 import { EventKind, NotebookKind } from '#~/k8sTypes';
 import { useNotebookProgress, getNotebookDisplayName } from '#~/utilities/notebookControllerUtils';
@@ -193,7 +195,13 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
   const inProgress = isStarting || isStopping;
   const { currentProject: project, localQueues } = React.useContext(ProjectDetailsContext);
   const { isProjectKueueEnabled, isKueueFeatureEnabled } = useKueueConfiguration(project);
-  const showResourcesTab = Boolean(isKueueFeatureEnabled && isProjectKueueEnabled);
+  const [canViewClusterQueue] = useAccessReview(
+    { group: ClusterQueueModel.apiGroup, resource: ClusterQueueModel.plural, verb: 'get' },
+    Boolean(isKueueFeatureEnabled && isProjectKueueEnabled),
+  );
+  const showResourcesTab = Boolean(
+    isKueueFeatureEnabled && isProjectKueueEnabled && canViewClusterQueue,
+  );
   const [activeTab, setActiveTab] = React.useState<string>(PROGRESS_TAB);
 
   const kueueTrackingInput = React.useMemo(
@@ -225,7 +233,9 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
   }, [showResourcesTab, activeTab]);
   const localQueueName = notebook?.metadata.labels?.[KUEUE_QUEUE_LABEL];
   const clusterQueueName = getClusterQueueNameFromLocalQueues(localQueueName, localQueues);
-  const shouldShowResources = Boolean(isProjectKueueEnabled && localQueueName && clusterQueueName);
+  const shouldShowResources = Boolean(
+    showResourcesTab && isProjectKueueEnabled && localQueueName && clusterQueueName,
+  );
   const {
     clusterQueue,
     loaded: clusterQueueLoaded,

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchKueueStatus.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchKueueStatus.cy.ts
@@ -1,5 +1,6 @@
 import { mockClusterQueueK8sResource } from '@odh-dashboard/internal/__mocks__/mockClusterQueueK8sResource';
 import { mockLocalQueueK8sResource } from '@odh-dashboard/internal/__mocks__/mockLocalQueueK8sResource';
+import { mockSelfSubjectAccessReview } from '@odh-dashboard/internal/__mocks__/mockSelfSubjectAccessReview';
 import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
@@ -16,9 +17,22 @@ import {
   LocalQueueModel,
   PodModel,
   ProjectModel,
+  SelfSubjectAccessReviewModel,
   WorkloadModel,
 } from '../../../../utils/models';
 import { workbenchPage, workbenchStatusModal } from '../../../../pages/workbench';
+
+const mockCanViewClusterQueue = (allowed = true) =>
+  cy.interceptK8s(
+    'POST',
+    SelfSubjectAccessReviewModel,
+    mockSelfSubjectAccessReview({
+      group: ClusterQueueModel.apiGroup,
+      resource: ClusterQueueModel.plural,
+      verb: 'get',
+      allowed,
+    }),
+  );
 
 const notebookWithKueueQueue = mockNotebookK8sResource({
   lastImageSelection: 'test-imagestream:1.2',
@@ -61,6 +75,7 @@ const mockNotebookEvents = [
 
 const initKueueEnabledForStatusModal = () => {
   initIntercepts({ notebooks: [notebookWithKueueQueue] });
+  mockCanViewClusterQueue();
   cy.interceptOdh(
     'GET /api/config',
     mockDashboardConfig({ disableKueue: false, disableProjectScoped: true }),
@@ -96,6 +111,7 @@ const initKueueWorkloadStatus = (
   opts?: { evictionReason?: string },
 ) => {
   initIntercepts({ notebooks: [notebookWithKueueQueue] });
+  mockCanViewClusterQueue();
   cy.interceptOdh(
     'GET /api/config',
     mockDashboardConfig({ disableKueue: false, disableProjectScoped: true }),

--- a/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
@@ -39,6 +39,8 @@ import {
 } from '@patternfly/react-tokens';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { useKueueConfiguration } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
+import { useAccessReview } from '@odh-dashboard/plugin-core/host-api';
+import { ClusterQueueModel } from '@odh-dashboard/internal/api/models/kueue';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { KUEUE_QUEUE_LABEL } from '@odh-dashboard/internal/concepts/kueue/index';
 import { KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT } from '@odh-dashboard/internal/concepts/kueue/types';
@@ -248,10 +250,16 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
   const project = projects.find((p) => p.metadata.name === namespace);
   const { isKueueFeatureEnabled, isProjectKueueEnabled } = useKueueConfiguration(project);
   const localQueueName = deployment.model.metadata.labels?.[KUEUE_QUEUE_LABEL];
+  const [canViewClusterQueue] = useAccessReview(
+    { group: ClusterQueueModel.apiGroup, resource: ClusterQueueModel.plural, verb: 'get' },
+    Boolean(isKueueFeatureEnabled && isProjectKueueEnabled),
+  );
   // Tab visibility depends only on Kueue being enabled for this project — not on whether this
   // particular deployment has a queue label. A missing label is handled as an empty state inside
   // DeploymentResourcesTab, so the tab strip stays consistent across all deployment states.
-  const showResourcesTab = Boolean(isKueueFeatureEnabled && isProjectKueueEnabled);
+  const showResourcesTab = Boolean(
+    isKueueFeatureEnabled && isProjectKueueEnabled && canViewClusterQueue,
+  );
 
   const [activeTab, setActiveTab] = React.useState<string>(PROGRESS_TAB);
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-87412

## Description
The "Resources" tab in the notebook start modal (`StartNotebookModal`) and the model deployment status modal (`DeploymentStatusModal`) shows Kueue `ClusterQueue` usage information. Previously this tab was shown any time Kueue was enabled for the project, regardless of whether the current user actually had permission to view `ClusterQueue` resources.

This meant non-admin users without `ClusterQueue` view RBAC would see the tab but it would fail to load meaningful data.

This PR adds a `useAccessReview` check (`get` on `ClusterQueue`) and only shows the Resources tab when the user has that permission, in addition to the existing Kueue-enabled checks.
Admin user
<img width="1482" height="873" alt="admin-user" src="https://github.com/user-attachments/assets/1cb4f334-c43a-48ac-a3b8-4a6d4f71c4c9" />
non admin user
<img width="1482" height="873" alt="non-admin-user" src="https://github.com/user-attachments/assets/d1af700c-e701-4565-92b3-e7a1a8f77b7d" />

## How Has This Been Tested?
Manually verified locally that the Resources tab visibility now depends on the `ClusterQueue` access review result in both `StartNotebookModal` and `DeploymentStatusModal`.

## Test Impact
No new automated tests added for this change.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource controls are now shown only when Kueue is enabled and you have permission to view cluster queue information.
  * Improved access handling in notebook startup and deployment status views.

* **Tests**
  * Added coverage for cluster queue permission checks in Kueue status workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->