### PR TITLE
fix(e2e): fetch Cypress mask script without checkout outside workspace

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -1053,16 +1053,29 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
 
-      # The e2e job checks out the PR SHA, then downloads test-variables.yml.
-      # Run the mask script from the default branch, not from the PR workspace.
-      - name: Checkout trusted credential tools
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          path: ${{ runner.temp }}/trusted-credential-tools
-          persist-credentials: false
-          sparse-checkout: .github/scripts/mask-cypress-test-secrets.sh
-          sparse-checkout-cone-mode: false
+      # Fetch the mask script from the default branch into RUNNER_TEMP so a
+      # malicious PR cannot replace it. Do not use actions/checkout with a
+      # path under RUNNER_TEMP — checkout requires the destination to be
+      # under GITHUB_WORKSPACE, which fails on these self-hosted runners.
+      - name: Fetch trusted credential mask script
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DEST_DIR="${{ runner.temp }}/trusted-credential-tools"
+          mkdir -p "$DEST_DIR"
+          DEST="$DEST_DIR/mask-cypress-test-secrets.sh"
+          API_URL="https://api.github.com/repos/${{ github.repository }}/contents/.github/scripts/mask-cypress-test-secrets.sh?ref=${{ github.event.repository.default_branch }}"
+          HTTP_CODE=$(curl -sS -L -o "$DEST" -w "%{http_code}" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$API_URL" || true)
+          if [[ "$HTTP_CODE" != "200" || ! -s "$DEST" ]]; then
+            echo "⚠️ Trusted mask script not available from default branch (HTTP ${HTTP_CODE:-failed}); skipping Actions masks"
+            rm -f "$DEST"
+          else
+            echo "✅ Fetched mask script from ${{ github.event.repository.default_branch }}"
+          fi
 
       - name: Module caches
         uses: ./.github/actions/module-caches
@@ -1088,11 +1101,11 @@ jobs:
                         "${{ secrets.GITLAB_TEST_VARS_URL }}" \
             -o ${{ github.workspace }}/packages/cypress/test-variables.yml
           echo "✅ Downloaded test configuration"
-          MASK_SCRIPT="${{ runner.temp }}/trusted-credential-tools/.github/scripts/mask-cypress-test-secrets.sh"
+          MASK_SCRIPT="${{ runner.temp }}/trusted-credential-tools/mask-cypress-test-secrets.sh"
           if [[ -f "$MASK_SCRIPT" ]]; then
             bash "$MASK_SCRIPT" "${{ github.workspace }}/packages/cypress/test-variables.yml"
           else
-            echo "⚠️ Trusted mask script not on default branch yet; skipping Actions masks"
+            echo "⚠️ Trusted mask script not available; skipping Actions masks"
           fi
 
       - name: Login to OpenShift cluster


### PR DESCRIPTION
## Description

Hotfix for Cypress e2e after #9414. Every e2e job on the self-hosted runners is failing at **Checkout trusted credential tools**:

```text
Error: Repository path '.../_work/_temp/trusted-credential-tools' is not under
'.../_work/odh-dashboard/odh-dashboard'
```

`actions/checkout` only allows `path` under `GITHUB_WORKSPACE`. `#9414` cloned the mask script into `RUNNER_TEMP` so a PR could not replace it; that path is rejected on these runners (example: https://github.com/opendatahub-io/odh-dashboard/actions/runs/32374754869/job/96443623954).

This PR keeps the script on the default branch and outside the PR tree, but fetches it with `curl` + the GitHub Contents API into `RUNNER_TEMP` instead of a nested checkout.

## How Has This Been Tested?

Not yet — this is the unblocker. **Cypress e2e Test is `workflow_run` and uses the workflow YAML from `main`**, so this PR’s own e2e jobs will still hit the broken checkout until this merges.

To prove the fetch step before merge:

1. On this PR, run **Actions → Cypress e2e Test → Run workflow** (`workflow_dispatch`) and select branch `fix/cypress-e2e-mask-script-checkout`.
2. Confirm **Fetch trusted credential mask script** succeeds (HTTP 200) and **Download test configuration** logs that masks were registered.
3. Confirm e2e gets past that step (no `Repository path ... is not under ...` error).

After merge, Cypress e2e on other PRs should start again without that checkout failure.

## Test Impact

No unit or Cypress tests — this is GitHub Actions workflow YAML only. The regression is a runner path check inside `actions/checkout`, which those tests cannot exercise.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)