### PR TITLE
fix(RHOAIENG-85200): correct gateway URL extraction for LLMInferenceService in GenAI Playground (#9387)

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1140,9 +1140,11 @@ func ExtractStatusFromInferenceService(isvc *kservev1beta1.InferenceService) str
 	return "Stop"
 }
 
-// EnsureV1Suffix ensures that the URL ends with /v1 suffix
-// This function is exported for testing purposes
+// EnsureV1Suffix ensures that the URL ends with /v1 suffix.
+// Trailing slashes are stripped before checking/appending to avoid double-slash URLs.
+// This function is exported for testing purposes.
 func EnsureV1Suffix(url string) string {
+	url = strings.TrimRight(url, "/")
 	if !strings.HasSuffix(url, "/v1") {
 		return url + "/v1"
 	}
@@ -2705,18 +2707,59 @@ func (kc *TokenKubernetesClient) findLLMInferenceServiceByModelName(ctx context.
 	return nil, fmt.Errorf("LLMInferenceService with model name '%s' not found in namespace %s", modelName, namespace)
 }
 
+// Address name types from the KServe LLMInferenceService status contract.
+// See: https://kserve.github.io/website/docs/next/model-serving/generative-inference/llmisvc/llmisvc-status#statusaddresses
+const (
+	addressNameGatewayInternal = "gateway-internal"
+	addressNameInternal        = "internal"
+)
+
 // extractEndpointFromLLMInferenceService extracts the internal endpoint URL from LLMInferenceService
-// using the standard KServe status.addresses field. This replaces the previous workaround that
-// manually discovered K8s services and constructed URLs, which bypassed llm-d gateway routing.
+// using the standard KServe status.addresses field.
+//
+// Selection priority (per KServe status contract):
+//  1. First "gateway-internal" address (path-based routing, cluster-local gateway URL)
+//  2. First "internal" address (private IP / internal hostname, no gateway)
+//  3. First address with an internal cluster host (unnamed fallback)
+//  4. Singular status.address as last resort
 func (kc *TokenKubernetesClient) extractEndpointFromLLMInferenceService(_ context.Context, llmSvc *kservev1alpha1.LLMInferenceService) (string, error) {
+	var internalCandidate, anyInternalCandidate string
+
 	for _, addr := range llmSvc.Status.Addresses {
-		if addr.URL != nil && isInternalClusterHost(addr.URL.Host) {
-			u := addr.URL.String()
-			kc.Logger.Debug("extracted internal URL from LLMInferenceService status.addresses",
+		if addr.URL == nil || !isInternalClusterHost(addr.URL.Host) {
+			continue
+		}
+
+		u := addr.URL.String()
+
+		if addr.Name != nil && *addr.Name == addressNameGatewayInternal {
+			kc.Logger.Debug("extracted gateway-internal URL from LLMInferenceService status.addresses",
 				"llmServiceName", llmSvc.Name,
 				"endpoint", EnsureV1Suffix(u))
 			return EnsureV1Suffix(u), nil
 		}
+
+		if addr.Name != nil && *addr.Name == addressNameInternal && internalCandidate == "" {
+			internalCandidate = u
+		}
+
+		if anyInternalCandidate == "" {
+			anyInternalCandidate = u
+		}
+	}
+
+	if internalCandidate != "" {
+		kc.Logger.Debug("extracted internal URL from LLMInferenceService status.addresses",
+			"llmServiceName", llmSvc.Name,
+			"endpoint", EnsureV1Suffix(internalCandidate))
+		return EnsureV1Suffix(internalCandidate), nil
+	}
+
+	if anyInternalCandidate != "" {
+		kc.Logger.Debug("extracted internal URL from LLMInferenceService status.addresses (fallback)",
+			"llmServiceName", llmSvc.Name,
+			"endpoint", EnsureV1Suffix(anyInternalCandidate))
+		return EnsureV1Suffix(anyInternalCandidate), nil
 	}
 
 	if llmSvc.Status.Address != nil && llmSvc.Status.Address.URL != nil && isInternalClusterHost(llmSvc.Status.Address.URL.Host) {

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -490,6 +490,155 @@ func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "has no internal URL")
 	})
+
+	t.Run("prefers gateway-internal over gateway-internal-model-routing", func(t *testing.T) {
+		modelRoutingName := "gateway-internal-model-routing"
+		gatewayInternalName := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &modelRoutingName, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/")},
+						{Name: &gatewayInternalName, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/myns/mymodel")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/myns/mymodel/v1", endpoint,
+			"should pick gateway-internal with path, not gateway-internal-model-routing root URL")
+	})
+
+	t.Run("picks first gateway-internal address", func(t *testing.T) {
+		gatewayInternalName := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &gatewayInternalName, URL: mustParseURL("https://gw.openshift-ingress.svc.cluster.local/publishers/myns/models/mymodel")},
+						{Name: &gatewayInternalName, URL: mustParseURL("https://gw.openshift-ingress.svc.cluster.local/myns/mymodel")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://gw.openshift-ingress.svc.cluster.local/publishers/myns/models/mymodel/v1", endpoint,
+			"should pick the first gateway-internal address")
+	})
+
+	t.Run("realistic openshift-ai-inference gateway addresses", func(t *testing.T) {
+		externalModelRouting := "gateway-external-model-routing"
+		externalName := "gateway-external"
+		internalModelRouting := "gateway-internal-model-routing"
+		internalName := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &externalModelRouting, URL: mustParseURL("http://a7aba.elb.amazonaws.com/")},
+						{Name: &externalName, URL: mustParseURL("http://a7aba.elb.amazonaws.com/publishers/repro-85200/models/llama-32-1b-instruct")},
+						{Name: &externalName, URL: mustParseURL("http://a7aba.elb.amazonaws.com/repro-85200/llama-32-1b-instruct")},
+						{Name: &internalModelRouting, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/")},
+						{Name: &internalName, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/publishers/repro-85200/models/llama-32-1b-instruct")},
+						{Name: &internalName, URL: mustParseURL("http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/repro-85200/llama-32-1b-instruct")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local/publishers/repro-85200/models/llama-32-1b-instruct/v1", endpoint,
+			"should select the first gateway-internal address, not model-routing or external")
+	})
+
+	t.Run("trailing slash on gateway root URL does not produce double-slash", func(t *testing.T) {
+		modelRoutingName := "gateway-internal-model-routing"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &modelRoutingName, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://gw.openshift-ingress.svc.cluster.local/v1", endpoint,
+			"should not produce //v1 from trailing slash")
+	})
+
+	t.Run("gateway-internal with publishers path works", func(t *testing.T) {
+		gatewayInternalName := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &gatewayInternalName, URL: mustParseURL("https://gw.openshift-ingress.svc.cluster.local/publishers/ns/models/model")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://gw.openshift-ingress.svc.cluster.local/publishers/ns/models/model/v1", endpoint)
+	})
+
+	t.Run("prefers gateway-internal over internal name type", func(t *testing.T) {
+		internalName := "internal"
+		gwInternalName := "gateway-internal"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &internalName, URL: mustParseURL("http://my-model-svc.myns.svc.cluster.local:8080")},
+						{Name: &gwInternalName, URL: mustParseURL("http://gw.openshift-ingress.svc.cluster.local/myns/mymodel")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://gw.openshift-ingress.svc.cluster.local/myns/mymodel/v1", endpoint,
+			"gateway-internal should be preferred over internal")
+	})
+
+	t.Run("falls back to internal name type when no gateway-internal", func(t *testing.T) {
+		internalName := "internal"
+		modelRoutingName := "internal-model-routing"
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{Name: &modelRoutingName, URL: mustParseURL("http://my-model-svc.myns.svc.cluster.local/")},
+						{Name: &internalName, URL: mustParseURL("http://my-model-svc.myns.svc.cluster.local/myns/mymodel")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://my-model-svc.myns.svc.cluster.local/myns/mymodel/v1", endpoint,
+			"should pick internal address, not internal-model-routing")
+	})
+
+	t.Run("falls back to any internal address when no gateway-internal name match", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: mustParseURL("https://tinyllama-kserve-workload-svc.kserve-test.svc.cluster.local")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://tinyllama-kserve-workload-svc.kserve-test.svc.cluster.local/v1", endpoint,
+			"backward-compatible: addresses without Name field still work")
+	})
 }
 
 // TestInferenceServiceURLSuffixConstruction tests that InferenceService URLs
@@ -520,11 +669,25 @@ func TestInferenceServiceURLSuffixConstruction(t *testing.T) {
 			inputURL: "https://my-service.namespace.svc.cluster.local:8443/v1",
 			expected: "https://my-service.namespace.svc.cluster.local:8443/v1",
 		},
+		{
+			name:     "URL with trailing slash gets slash trimmed then /v1 added",
+			inputURL: "http://gateway.openshift-ingress.svc.cluster.local/",
+			expected: "http://gateway.openshift-ingress.svc.cluster.local/v1",
+		},
+		{
+			name:     "URL with path and trailing slash gets slash trimmed then /v1 added",
+			inputURL: "http://gateway.openshift-ingress.svc.cluster.local/ns/model/",
+			expected: "http://gateway.openshift-ingress.svc.cluster.local/ns/model/v1",
+		},
+		{
+			name:     "URL with multiple trailing slashes gets all trimmed",
+			inputURL: "http://gateway.openshift-ingress.svc.cluster.local///",
+			expected: "http://gateway.openshift-ingress.svc.cluster.local/v1",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Call the actual function used for InferenceService URLs
 			actual := EnsureV1Suffix(tt.inputURL)
 
 			assert.Equal(t, tt.expected, actual,


### PR DESCRIPTION
Cherry-pick for 3.5 blocker, tested in the original PR: See original PR: https://github.com/opendatahub-io/odh-dashboard/pull/9387

Issue: https://redhat.atlassian.net/browse/RHOAIENG-85200

## Description
See original PR: https://github.com/opendatahub-io/odh-dashboard/pull/9387

## How Has This Been Tested?
See original PR: https://github.com/opendatahub-io/odh-dashboard/pull/9387

## Test Impact
See original PR: https://github.com/opendatahub-io/odh-dashboard/pull/9387

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)