### PR TITLE
fix(RHOAIENG-85369): drop "Best for custom runtimes" from Inference service description

### DIFF
--- a/packages/kserve/src/wizardFields/deploymentMethodField.ts
+++ b/packages/kserve/src/wizardFields/deploymentMethodField.ts
@@ -6,7 +6,7 @@ const LEGACY_OPTION = {
   key: LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY,
   label: 'Inference service',
   description:
-    'Deploy a model using a serving runtime template. Best for custom runtimes. Not compatible with Models as a Service.',
+    'Deploy a model using a serving runtime template. Not compatible with Models as a Service.',
   order: 3,
 };
 


### PR DESCRIPTION
Part 2 of https://issues.redhat.com/browse/RHOAIENG-85369 after https://github.com/opendatahub-io/odh-dashboard/pull/9381.

**Both will need cherrypicks to 3.5.1**

## Description

Follow-up microcopy tweak to [#9381](https://github.com/opendatahub-io/odh-dashboard/pull/9381). Removes the "Best for custom runtimes." sentence from the **Inference service** deployment-method description, leaving the functional distinction intact:

> **Inference service** — Deploy a model using a serving runtime template. Not compatible with Models as a Service.

The three deployment-method options as they render in the wizard (step 2, Generative model type):

<img width="921" height="251" alt="image" src="https://github.com/user-attachments/assets/6d2b5048-8bd7-4774-aca9-4d0457d45de3" />

## How Has This Been Tested?

Verified in the running dashboard (deploy-model wizard → step 2 with `vLLMDeploymentOnMaaS` and `llmdTemplates` flags and a Generative model), confirming the "Inference service" option now reads "Deploy a model using a serving runtime template. Not compatible with Models as a Service." with no "Best for custom runtimes." sentence. Lint passes (pre-commit lint-staged).

## Test Impact

No new or changed tests — this is a description-only microcopy change. The deployment-method description text is not asserted by any unit or Cypress test (tests target the stable `legacy` key/testid, and the display-label test constant is unchanged), so no test updates are required.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
