### PR TITLE
Fix 2.25 CI failures on the breadcrumbs

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureDataSet.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureDataSet.cy.ts
@@ -511,7 +511,7 @@ describe('DataSet Details', () => {
     cy.wait('@getDataSetDetails');
 
     featureDataSetDetails.findSourceFeatureService().within(() => {
-      cy.findByText('test-feature-service').click();
+      cy.findByText('test-feature-service').click({ force: true });
     });
 
     cy.url().should(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
@@ -311,14 +311,16 @@ describe('Experiments', () => {
       pipelineRunsGlobal.findCreateRunButton().click();
       cy.findByLabelText('Breadcrumb')
         .findByRole('link', { name: `Experiments in ${projectName}` })
-        .click();
+        .click({ force: true });
       verifyRelativeURL(`/experiments/${projectName}`);
       pipelineRunsGlobal.findProjectNavigatorLink().should('exist');
     });
 
     it('navigates back to experiment runs page from "Create run" page breadcrumb', () => {
       pipelineRunsGlobal.findCreateRunButton().click();
-      cy.findByLabelText('Breadcrumb').findByText(mockExperiment.display_name).click();
+      cy.findByLabelText('Breadcrumb')
+        .findByText(mockExperiment.display_name)
+        .click({ force: true });
       verifyRelativeURL(`/experiments/${projectName}/${mockExperiment.experiment_id}/runs`);
     });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/runs/manageRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/runs/manageRuns.cy.ts
@@ -68,7 +68,10 @@ describe('Manage runs', () => {
   });
 
   it('navigates to "Compare runs" page when "Compare runs" breadcrumb is clicked', () => {
-    manageRunsPage.findBreadcrumb().findByRole('link', { name: 'Compare runs' }).click();
+    manageRunsPage
+      .findBreadcrumb()
+      .findByRole('link', { name: 'Compare runs' })
+      .click({ force: true });
     cy.location('pathname').should(
       'equal',
       `/experiments/${projectName}/${experimentId}/compareRuns`,
@@ -77,7 +80,7 @@ describe('Manage runs', () => {
   });
 
   it('navigates to experiment runs page when the experiment name breadcrumb is clicked', () => {
-    manageRunsPage.findBreadcrumb().findByRole('link', { name: 'Default' }).click();
+    manageRunsPage.findBreadcrumb().findByRole('link', { name: 'Default' }).click({ force: true });
     cy.location('pathname').should('equal', `/experiments/${projectName}/${experimentId}/runs`);
   });
 
@@ -85,7 +88,7 @@ describe('Manage runs', () => {
     manageRunsPage
       .findBreadcrumb()
       .findByRole('link', { name: 'Experiments in Test project' })
-      .click();
+      .click({ force: true });
     cy.location('pathname').should('equal', `/experiments/${projectName}`);
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
@@ -383,7 +383,11 @@ describe('Pipeline topology', () => {
         pipelineRecurringRunDetails.visit(projectId, mockRecurringRun.recurring_run_id);
 
         pipelineRecurringRunDetails.findDetailsTab().click();
-        pipelineRecurringRunDetails.findDetailItem('Project').findValue().find('a').click();
+        pipelineRecurringRunDetails
+          .findDetailItem('Project')
+          .findValue()
+          .find('a')
+          .click({ force: true });
         verifyRelativeURL(`/projects/${projectId}`);
       });
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Context: https://redhat-internal.slack.com/archives/C07BFD5J4CB/p1787241477720319

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Make sure all the CI passes

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Changed the test files only

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
