### PR TITLE
fix(RHOAIENG-87447): Support Markdown rendering and improve HTML visualization in artifact drawer

### DIFF
--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/MarkdownCompare.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/MarkdownCompare.tsx
@@ -12,6 +12,8 @@ import { CompareRunsEmptyState } from '#~/concepts/pipelines/content/compareRuns
 import { PipelineRunArtifactSelect } from '#~/concepts/pipelines/content/compareRuns/metricsSection/PipelineRunArtifactSelect';
 import { PipelineRunKF } from '#~/concepts/pipelines/kfTypes';
 import { CompareRunsNoMetrics } from '#~/concepts/pipelines/content/compareRuns/CompareRunsNoMetrics';
+import MarkdownComponent from '#~/components/markdown/MarkdownComponent';
+import '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.scss';
 
 type MarkdownCompareProps = {
   configMap: Record<string, MarkdownAndTitle[]>;
@@ -24,6 +26,7 @@ export type MarkdownAndTitle = {
   title: string;
   config: string;
   fileSize?: number;
+  markdownContent?: string;
 };
 
 const MarkdownCompare: React.FC<MarkdownCompareProps> = ({
@@ -33,6 +36,7 @@ const MarkdownCompare: React.FC<MarkdownCompareProps> = ({
   isEmpty,
 }) => {
   const [expandedGraph, setExpandedGraph] = React.useState<MarkdownAndTitle | undefined>(undefined);
+
   if (!isLoaded) {
     return (
       <Bullseye>
@@ -52,12 +56,17 @@ const MarkdownCompare: React.FC<MarkdownCompareProps> = ({
   const renderMarkdownWithSize = (config: MarkdownAndTitle) => (
     <Stack hasGutter>
       <StackItem>
-        <iframe
-          sandbox="allow-scripts"
-          data-testid="markdown-compare"
-          src={config.config}
-          title="markdown view"
-        />
+        {config.markdownContent ? (
+          <MarkdownComponent data={config.markdownContent} dataTestId="markdown-compare" />
+        ) : (
+          <iframe
+            className="odh-artifact-visualization__iframe pf-v6-u-w-100"
+            sandbox="allow-scripts"
+            data-testid="markdown-compare"
+            src={config.config}
+            title="markdown view"
+          />
+        )}
       </StackItem>
     </Stack>
   );

--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/useFetchMarkdownMaps.ts
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/useFetchMarkdownMaps.ts
@@ -7,6 +7,7 @@ import {
   getFullArtifactPaths,
 } from '#~/concepts/pipelines/content/compareRuns/metricsSection/utils';
 import { ArtifactType, PipelineRunKF } from '#~/concepts/pipelines/kfTypes';
+import { readBoundedText } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils';
 import { allSettledPromises } from '#~/utilities/allSettledPromises';
 
 const useFetchMarkdownMaps = (
@@ -17,7 +18,7 @@ const useFetchMarkdownMaps = (
   configsLoaded: boolean;
 } => {
   const [configsLoaded, setConfigsLoaded] = React.useState(false);
-  const { getStorageObjectRenderUrl } = useArtifactStorage();
+  const { getStorageObjectRenderUrl, getStorageObjectDownloadUrl } = useArtifactStorage();
 
   const [configMapBuilder, setConfigMapBuilder] = React.useState<
     Record<string, MarkdownAndTitle[]>
@@ -40,22 +41,39 @@ const useFetchMarkdownMaps = (
           const { run } = path;
           let sizeBytes: number | undefined;
           let url: string | undefined;
-          if (
-            path.linkedArtifact.artifact.getType() === ArtifactType.MARKDOWN ||
-            path.linkedArtifact.artifact.getType() === ArtifactType.HTML
-          ) {
+          let markdownContent: string | undefined;
+          const artifactType = path.linkedArtifact.artifact.getType();
+
+          if (artifactType === ArtifactType.MARKDOWN) {
+            try {
+              const downloadUrl = await getStorageObjectDownloadUrl(path.linkedArtifact.artifact);
+              if (downloadUrl) {
+                const response = await fetch(downloadUrl);
+                if (response.ok) {
+                  markdownContent = await readBoundedText(response);
+                }
+              }
+            } catch {
+              // Fall back to render URL for iframe display
+            }
+            if (!markdownContent) {
+              url = await getStorageObjectRenderUrl(path.linkedArtifact.artifact).catch(
+                () => undefined,
+              );
+            }
+          } else if (artifactType === ArtifactType.HTML) {
             url = await getStorageObjectRenderUrl(path.linkedArtifact.artifact).catch(
               () => undefined,
             );
           }
 
-          if (url === undefined) {
+          if (url === undefined && markdownContent === undefined) {
             return null;
           }
-          return { run, sizeBytes, url, path };
+          return { run, sizeBytes, url, markdownContent, path };
         }),
 
-    [fullArtifactPaths, getStorageObjectRenderUrl],
+    [fullArtifactPaths, getStorageObjectRenderUrl, getStorageObjectDownloadUrl],
   );
 
   React.useEffect(() => {
@@ -66,13 +84,14 @@ const useFetchMarkdownMaps = (
     allSettledPromises(fetchStorageObjectPromises).then(([successes]) => {
       successes.forEach((result) => {
         if (result.value) {
-          const { url, sizeBytes, run, path } = result.value;
+          const { url, markdownContent: mdContent, sizeBytes, run, path } = result.value;
           setRunMapBuilder((runMap) => ({ ...runMap, [run.run_id]: run }));
 
-          const config = {
+          const config: MarkdownAndTitle = {
             title: getFullArtifactPathLabel(path),
-            config: url,
+            config: url ?? '',
             fileSize: sizeBytes,
+            markdownContent: mdContent,
           };
 
           setConfigMapBuilder((configMap) => ({

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
@@ -8,6 +8,11 @@ import PipelineRunDrawerRightContent from '#~/concepts/pipelines/content/pipelin
 import { PipelineTask } from '#~/concepts/pipelines/topology';
 import { Artifact } from '#~/third_party/mlmd';
 
+jest.mock('#~/components/markdown/MarkdownComponent', () => ({
+  __esModule: true,
+  default: ({ data }: { data: string }) => <div data-testid="mock-markdown">{data}</div>,
+}));
+
 const artifactTask: PipelineTask = {
   type: 'artifact',
   name: 'metrics',

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.scss
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.scss
@@ -1,0 +1,16 @@
+.odh-artifact-visualization {
+  &__iframe {
+    min-height: 300px;
+    border: none;
+  }
+
+  &__iframe--fullscreen {
+    height: 75vh;
+    border: none;
+  }
+
+  &__markdown--fullscreen {
+    max-height: 75vh;
+    overflow: auto;
+  }
+}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
 
 import {
+  Button,
   Bullseye,
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
   Flex,
+  FlexItem,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- ContentModal adds a constrained body height that causes double scrollbars with the iframe/markdown scroll containers
+  Modal,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
+  ModalBody,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
+  ModalHeader,
   Spinner,
   Stack,
   StackItem,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
+import { ExpandIcon } from '@patternfly/react-icons';
 import { TableVariant, Td, Tr } from '@patternfly/react-table';
 
 import { Table } from '@odh-dashboard/ui-core';
@@ -27,7 +37,9 @@ import { buildConfusionMatrixConfig } from '#~/concepts/pipelines/content/artifa
 import { isConfusionMatrix } from '#~/concepts/pipelines/content/compareRuns/metricsSection/confusionMatrix/utils';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import { useArtifactStorage } from '#~/concepts/pipelines/apiHooks/useArtifactStorage';
-import { getArtifactProperties } from './utils';
+import MarkdownComponent from '#~/components/markdown/MarkdownComponent';
+import { getArtifactProperties, readBoundedText } from './utils';
+import './ArtifactVisualization.scss';
 
 interface ArtifactVisualizationProps {
   artifact: Artifact;
@@ -35,29 +47,79 @@ interface ArtifactVisualizationProps {
 
 export const ArtifactVisualization: React.FC<ArtifactVisualizationProps> = ({ artifact }) => {
   const [renderUrl, setRenderUrl] = React.useState<string>();
+  const [markdownContent, setMarkdownContent] = React.useState<string>();
   const [loading, setLoading] = React.useState<boolean>(false);
+  const [isFullscreen, setIsFullscreen] = React.useState(false);
   const { namespace } = usePipelinesAPI();
-  const { getStorageObjectRenderUrl } = useArtifactStorage();
+  const { getStorageObjectRenderUrl, getStorageObjectDownloadUrl } = useArtifactStorage();
   const artifactType = artifact.getType();
 
   const memoizedArtifact = useDeepCompareMemoize(artifact);
 
   React.useEffect(() => {
-    if (artifactType === ArtifactType.MARKDOWN || artifactType === ArtifactType.HTML) {
-      const uri = memoizedArtifact.getUri();
-      if (uri) {
-        const renderArtifact = async () => {
-          await getStorageObjectRenderUrl(memoizedArtifact)
-            .then((url) => setRenderUrl(url))
-            .catch(() => null);
-          setLoading(false);
-        };
-        setLoading(true);
-        setRenderUrl(undefined);
-        renderArtifact();
-      }
+    if (artifactType !== ArtifactType.MARKDOWN && artifactType !== ArtifactType.HTML) {
+      return undefined;
     }
-  }, [memoizedArtifact, getStorageObjectRenderUrl, artifactType, namespace]);
+    const uri = memoizedArtifact.getUri();
+    if (!uri) {
+      return undefined;
+    }
+
+    const abortController = new AbortController();
+    const { signal } = abortController;
+
+    setLoading(true);
+    setRenderUrl(undefined);
+    setMarkdownContent(undefined);
+
+    const renderArtifact = async () => {
+      if (artifactType === ArtifactType.MARKDOWN) {
+        let content: string | undefined;
+        try {
+          const url = await getStorageObjectDownloadUrl(memoizedArtifact);
+          if (url && !signal.aborted) {
+            const response = await fetch(url, { signal });
+            if (response.ok) {
+              content = await readBoundedText(response);
+            }
+          }
+        } catch {
+          // Fall through to render URL fallback
+        }
+        if (!signal.aborted) {
+          if (content) {
+            setMarkdownContent(content);
+          } else {
+            const url = await getStorageObjectRenderUrl(memoizedArtifact).catch(() => undefined);
+            setRenderUrl(url);
+          }
+        }
+      } else if (!signal.aborted) {
+        await getStorageObjectRenderUrl(memoizedArtifact)
+          .then((url) => {
+            if (!signal.aborted) {
+              setRenderUrl(url);
+            }
+          })
+          .catch(() => null);
+      }
+      if (!signal.aborted) {
+        setLoading(false);
+      }
+    };
+
+    renderArtifact();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [
+    memoizedArtifact,
+    getStorageObjectRenderUrl,
+    getStorageObjectDownloadUrl,
+    artifactType,
+    namespace,
+  ]);
 
   if (artifactType === ArtifactType.CLASSIFICATION_METRICS) {
     const confusionMatrix = artifact.getCustomPropertiesMap().get('confusionMatrix');
@@ -154,20 +216,73 @@ export const ArtifactVisualization: React.FC<ArtifactVisualizationProps> = ({ ar
         </Bullseye>
       );
     }
-    if (renderUrl) {
+
+    const hasContent = markdownContent || renderUrl;
+    if (hasContent) {
+      const visualizationContent = markdownContent ? (
+        <MarkdownComponent data={markdownContent} dataTestId="artifact-visualization" />
+      ) : (
+        <iframe
+          className="odh-artifact-visualization__iframe pf-v6-u-w-100"
+          sandbox="allow-scripts"
+          src={renderUrl}
+          data-testid="artifact-visualization"
+          title="Artifact details"
+        />
+      );
+
+      const fullscreenContent = markdownContent ? (
+        <div className="odh-artifact-visualization__markdown--fullscreen">
+          <MarkdownComponent
+            data={markdownContent}
+            dataTestId="artifact-visualization-fullscreen"
+          />
+        </div>
+      ) : (
+        <iframe
+          className="odh-artifact-visualization__iframe--fullscreen pf-v6-u-w-100"
+          sandbox="allow-scripts"
+          src={renderUrl}
+          data-testid="artifact-visualization-fullscreen"
+          title="Artifact details"
+        />
+      );
+
       return (
         <Stack className="pf-v6-u-pt-lg pf-v6-u-pb-lg" hasGutter>
           <StackItem>
-            <Title headingLevel="h3">Artifact details</Title>
+            <Flex
+              justifyContent={{ default: 'justifyContentSpaceBetween' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+            >
+              <FlexItem>
+                <Title headingLevel="h3">Artifact details</Title>
+              </FlexItem>
+              <FlexItem>
+                <Tooltip content="Expand">
+                  <Button
+                    variant="plain"
+                    aria-label="Expand visualization"
+                    onClick={() => setIsFullscreen(true)}
+                    data-testid="artifact-visualization-expand"
+                    icon={<ExpandIcon />}
+                  />
+                </Tooltip>
+              </FlexItem>
+            </Flex>
           </StackItem>
-          <StackItem>
-            <iframe
-              sandbox="allow-scripts"
-              src={renderUrl}
-              data-testid="artifact-visualization"
-              title="Artifact details"
-            />
-          </StackItem>
+          <StackItem>{visualizationContent}</StackItem>
+          {isFullscreen && (
+            <Modal
+              isOpen
+              onClose={() => setIsFullscreen(false)}
+              variant="large"
+              aria-label="Artifact visualization expanded"
+            >
+              <ModalHeader title="Artifact visualization" />
+              <ModalBody>{fullscreenContent}</ModalBody>
+            </Modal>
+          )}
         </Stack>
       );
     }

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
@@ -2,13 +2,26 @@ import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import { Drawer } from '@patternfly/react-core';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { act } from 'react';
 import { PipelineTask } from '#~/concepts/pipelines/topology';
 import { Artifact, Value } from '#~/third_party/mlmd';
 import { ArtifactNodeDrawerContent } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent';
+
+jest.mock('#~/components/markdown/MarkdownComponent', () => ({
+  __esModule: true,
+  default: ({ data }: { data: string }) => <div data-testid="mock-markdown">{data}</div>,
+}));
+
+const mockReadBoundedText = jest.fn();
+jest.mock('#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils', () => ({
+  ...jest.requireActual(
+    '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils',
+  ),
+  readBoundedText: (...args: unknown[]) => mockReadBoundedText(...args),
+}));
 
 const task: PipelineTask = {
   type: 'artifact',
@@ -26,7 +39,6 @@ jest.mock('#~/concepts/pipelines/content/compareRuns/metricsSection/roc/utils', 
   isConfidenceMetric: jest.fn(() => true),
 }));
 
-// Mock the useDispatch hook
 jest.mock('#~/redux/hooks', () => ({
   useAppDispatch: jest.fn(),
 }));
@@ -76,7 +88,24 @@ jest.mock('#~/concepts/pipelines/context/PipelinesContext', () => ({
   })),
 }));
 
+const mockGetStorageObjectDownloadUrl = jest.fn();
+const mockGetStorageObjectRenderUrl = jest.fn();
+
+jest.mock('#~/concepts/pipelines/apiHooks/useArtifactStorage', () => ({
+  useArtifactStorage: () => ({
+    getStorageObjectSize: jest.fn(),
+    getStorageObjectDownloadUrl: mockGetStorageObjectDownloadUrl,
+    getStorageObjectRenderUrl: mockGetStorageObjectRenderUrl,
+  }),
+}));
+
 describe('ArtifactNodeDrawerContent', () => {
+  beforeEach(() => {
+    mockGetStorageObjectDownloadUrl.mockReset();
+    mockGetStorageObjectRenderUrl.mockReset();
+    mockReadBoundedText.mockReset();
+  });
+
   it('renders artifact drawer content', async () => {
     await act(async () =>
       render(
@@ -233,6 +262,62 @@ describe('ArtifactNodeDrawerContent', () => {
     );
 
     expect(screen.queryByRole('tab', { name: 'Visualization' })).toBeNull();
+  });
+
+  it('renders markdown visualization natively when fetch succeeds', async () => {
+    mockGetStorageObjectDownloadUrl.mockResolvedValue('https://example.com/md');
+    mockReadBoundedText.mockResolvedValue('# Hello Markdown');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+
+    const user = userEvent.setup();
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={{
+              ...task,
+              metadata: createArtifact('system.Markdown'),
+            }}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Visualization' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-markdown')).toHaveTextContent('# Hello Markdown');
+    });
+    expect(screen.queryByTestId('artifact-visualization')).toBeNull();
+    expect(screen.getByTestId('artifact-visualization-expand')).toBeInTheDocument();
+  });
+
+  it('falls back to iframe when markdown fetch fails', async () => {
+    mockGetStorageObjectDownloadUrl.mockRejectedValue(new Error('CORS'));
+    mockGetStorageObjectRenderUrl.mockResolvedValue('https://example.com/render');
+
+    const user = userEvent.setup();
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={{
+              ...task,
+              metadata: createArtifact('system.Markdown'),
+            }}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Visualization' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('artifact-visualization')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('mock-markdown')).toBeNull();
   });
 });
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
@@ -36,6 +36,47 @@ export const getArtifactProperties = (artifact: Artifact): ArtifactProperty[] =>
   return result;
 };
 
+const MAX_MARKDOWN_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Read a Response body as text with a byte-size cap (5 MB).
+ * Returns undefined when the artifact exceeds the limit, letting
+ * callers fall back to an iframe.
+ *
+ * When Content-Length is available and within limits, uses response.text().
+ * When Content-Length is missing, streams the body and aborts if the
+ * limit is exceeded — prevents unbounded memory consumption (CWE-400).
+ */
+export const readBoundedText = async (response: Response): Promise<string | undefined> => {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return undefined;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_MARKDOWN_BYTES) {
+      await reader.cancel();
+      return undefined;
+    }
+    chunks.push(value);
+  }
+
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+};
+
 export const isMetricsArtifactType = (artifactType?: string): boolean =>
   artifactType === ArtifactType.METRICS ||
   artifactType === ArtifactType.CLASSIFICATION_METRICS ||


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-87447
https://redhat.atlassian.net/browse/RHOAIENG-56884

## Description

https://github.com/user-attachments/assets/c37e2324-d62e-4db4-9963-44c2b1ad9aeb


Fixes two related issues with the artifact Visualization tab in pipeline run details:

1. **Markdown rendered as plain text** ([RHOAIENG-87447](https://redhat.atlassian.net/browse/RHOAIENG-87447)): `Output[Markdown]` artifacts were loaded in an iframe that displayed raw markdown text without formatting. Now, markdown artifacts are fetched as raw text and rendered natively using the project's `MarkdownComponent` (react-markdown + remark-gfm + rehype-sanitize). Falls back to iframe if the fetch fails.

2. **HTML visualization unreadable** ([RHOAIENG-56884](https://redhat.atlassian.net/browse/RHOAIENG-56884)): HTML artifacts (e.g. AutoML leaderboard tables) were rendered in an iframe with no width/height styling, making them nearly invisible. The iframe now has proper sizing (`width: 100%` via PF utility class, `min-height: 300px`).

3. **Expand to fullscreen**: Both HTML and Markdown artifacts now have an expand button that opens a Modal at `variant="large"`, allowing users to view the full content outside the narrow drawer panel.

All changes are also applied to the compare-runs markdown view (`MarkdownCompare` + `useFetchMarkdownMaps`).

### Files changed

| File | Change |
|------|--------|
| `ArtifactVisualization.tsx` | Split MARKDOWN vs HTML rendering paths; markdown uses `MarkdownComponent`, HTML keeps iframe; both get expand button + fullscreen modal |
| `ArtifactVisualization.scss` | New — iframe sizing and markdown scroll containers (only styles PF can't handle) |
| `MarkdownCompare.tsx` | Extended `MarkdownAndTitle` type with `markdownContent?`; renders `MarkdownComponent` when available; fullscreen modal |
| `useFetchMarkdownMaps.ts` | For MARKDOWN artifacts, fetches raw text via download URL; passes `markdownContent` through to config |

## How Has This Been Tested?

- Manually tested with a KFP pipeline that produces both `system.Markdown` and `system.HTML` artifacts
- Verified markdown renders with proper formatting (headings, tables, code blocks, lists)
- Verified HTML iframe renders with correct sizing
- Verified expand button opens fullscreen modal for both types
- Verified fallback to iframe when markdown content fetch fails
- Verified existing Cypress tests are unaffected (fallback chain preserves iframe behavior)

## Test Impact

Existing Cypress tests (`artifacts.cy.ts`, `compareRuns.cy.ts`) continue to pass — the download URL fallback ensures the iframe path is still exercised when the download URL is not mocked.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-87447]: https://redhat.atlassian.net/browse/RHOAIENG-87447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-56884]: https://redhat.atlassian.net/browse/RHOAIENG-56884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown artifacts and comparisons now render directly in the interface when available.
  * Added expand controls and fullscreen modal views for artifact visualizations.
  * Large or unavailable Markdown content automatically falls back to the existing viewer.

* **Style**
  * Improved sizing, scrolling, borders, and fullscreen layouts for clearer visualization.

* **Tests**
  * Added coverage for inline Markdown rendering and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->