### PR TITLE
fix: odh subtree sync

### DIFF
--- a/packages/app-config/scripts/package-subtree.sh
+++ b/packages/app-config/scripts/package-subtree.sh
@@ -268,7 +268,7 @@ if [ "$CONTINUE_MODE" = true ]; then
     clean_exit 1 "" true
   fi
 
-  commits=$(git rev-list --reverse "$CURRENT_COMMIT..$TARGET_COMMIT")
+  commits=$(git rev-list --ancestry-path --no-merges --reverse "$CURRENT_COMMIT..$TARGET_COMMIT")
   if [ -n "$commits" ]; then
     continue_commit=$(echo "$commits" | head -n 1)
     continue_commit_msg=$(git log -1 --format="%s" "$continue_commit")
@@ -375,7 +375,11 @@ _git_upstream_cmd() {
 _filter_rev_list() {
   local from_commit="$1"
   local to_commit="$2"
-  git rev-list --no-merges --reverse "$from_commit..$to_commit"
+  # --ancestry-path excludes commits reachable from $from_commit via other
+  # merge paths, preventing re-application of commits already in the subtree
+  # when upstream merges a branch whose commits are ancestors of the tracking
+  # pointer through a different path.
+  git rev-list --ancestry-path --no-merges --reverse "$from_commit..$to_commit"
 }
 
 _get_commit_url() {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->


  Description

  The package-subtree.sh sync script can re-apply commits that are already present in the subtree when upstream merges a branch whose commits are ancestors of the tracking pointer through a different merge path. This happens because git rev-list walks all paths between the tracking pointer and the target, including side-merge paths that contain already-applied commits.

This PR adds --ancestry-path to both the main _filter_rev_list function and the --continue mode's rev-list call, restricting the commit walk to the direct ancestry path between the two refs. This prevents merge cycles from producing duplicate cherry-pick attempts during sync.

Changes:
  - _filter_rev_list(): Added --ancestry-path to exclude commits reachable via side merges
  - --continue mode: Added --ancestry-path and --no-merges to match the filtering behavior of the main sync loop

## How Has This Been Tested?

Verified by running a subtree sync (npm run upstream:sync -- notebooks) against an upstream history that includes merge commits with ancestors reachable through multiple paths. Before the fix, the sync attempted to re-apply already-present commits and failed with cherry-pick conflicts. After the fix, only new commits on the direct ancestry path are applied.

##  Test Impact

 No automated tests — package-subtree.sh is a developer-facing shell script with no existing test harness. The change is a two-line addition of a well-documented git flag (--ancestry-path) to existing rev-list calls.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subtree update handling by limiting commit processing to the relevant ancestry path.
  * Reduced the risk of unrelated changes being included during regular updates and conflict resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->