### PR TITLE
fix(RHOAIENG-79968): restore "up to 2 minutes" microcopy on model deployment settings save

### DIFF
--- a/packages/model-serving/src/components/settings/GeneralSettingsTab.tsx
+++ b/packages/model-serving/src/components/settings/GeneralSettingsTab.tsx
@@ -163,7 +163,10 @@ const GeneralSettingsTab: React.FC = () => {
       }
 
       setBaselineSettings(payload);
-      notification.success('Model deployment settings saved successfully.');
+      notification.success(
+        'Model deployment settings saved successfully.',
+        'It can take up to 2 minutes for configuration changes to be applied.',
+      );
     } catch (error) {
       notification.error(
         'Error saving settings',

--- a/packages/model-serving/src/components/settings/__tests__/GeneralSettingsTab.spec.tsx
+++ b/packages/model-serving/src/components/settings/__tests__/GeneralSettingsTab.spec.tsx
@@ -156,7 +156,10 @@ describe('GeneralSettingsTab', () => {
       );
     });
 
-    expect(mockNotification.success).toHaveBeenCalled();
+    expect(mockNotification.success).toHaveBeenCalledWith(
+      'Model deployment settings saved successfully.',
+      'It can take up to 2 minutes for configuration changes to be applied.',
+    );
   });
 
   it('should show error notification when save fails', async () => {


### PR DESCRIPTION
For microcopy review https://issues.redhat.com/browse/RHOAIENG-79968

<img width="650" height="128" alt="image" src="https://github.com/user-attachments/assets/a5836fba-f144-47c8-944a-b35d99fc3c36" />

## Description

When the "Model deployments" settings section was extracted from `ClusterSettings.tsx` into the model-serving **General Settings** tab in #9286, the save success toast dropped the follow-up message that the original notification showed:

> It can take up to 2 minutes for configuration changes to be applied.

The original `ClusterSettings` toast still shows this message for the rest of the cluster settings form we extracted this section from, so this was an oversight during the extraction rather than an intentional change. This restores the message so users are still told that the model deployment configuration changes may take a couple of minutes to propagate.

**Before:**
> Model deployment settings saved successfully.

**After (title + body, matching the original):**
> **Model deployment settings saved successfully.**
> It can take up to 2 minutes for configuration changes to be applied.

## How Has This Been Tested?

- Ran the model-serving settings unit tests — all 11 `GeneralSettingsTab` tests pass, including the updated assertion that verifies the exact success-toast title and body.
- Linted the two changed files (0 errors/warnings).

## Test Impact

**Updated:**
- `packages/model-serving/src/components/settings/__tests__/GeneralSettingsTab.spec.tsx` — tightened the existing success-notification test from `toHaveBeenCalled()` to `toHaveBeenCalledWith(...)`, asserting both the title and the restored "up to 2 minutes" body message.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Save-success notifications now clarify that configuration changes may take up to two minutes to apply.

* **Tests**
  * Improved coverage to verify the notification title and message shown after a successful save.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->