### PR TITLE
Make pipeline e2e tests handle the MLflow integration section

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/pipelines/testPipelineMLflowIntegration.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/pipelines/testPipelineMLflowIntegration.yaml
@@ -1,0 +1,17 @@
+# testPipelineMLflowIntegration.cy.ts Test Data #
+projectNamePrefix: "test-pipelines-mlflow-integration"
+dspaSecretName: dashboard-mlflow-dspa-secret
+pipelineName: test-mlflow-base-pipeline
+pipelineDescription: "Iris pipeline without any MLflow calls in its code"
+experimentName: "Default"
+mlflowExperimentName: test-mlflow-pipeline-integration-experiment
+run1:
+  name: test-mlflow-base-run-1
+  description: "Iris pipeline run 1 - creates a new MLflow experiment"
+  neighbors: "1"
+  standardScaler: "true"
+run2:
+  name: test-mlflow-base-run-2
+  description: "Iris pipeline run 2 - reuses the MLflow experiment from run 1"
+  neighbors: "2"
+  standardScaler: "false"

--- a/packages/cypress/cypress/fixtures/resources/yaml/dspa.yaml
+++ b/packages/cypress/cypress/fixtures/resources/yaml/dspa.yaml
@@ -19,6 +19,7 @@ spec:
     trackArtifacts: true
     collectMetrics: true
     injectDefaultScript: true
+    pipelineStore: {{PIPELINE_STORE}}
   database:
     disableHealthCheck: false
     mariaDB:
@@ -27,20 +28,23 @@ spec:
       pvcSize: 10Gi
       username: mlpipeline
   dspVersion: v2
+  mlflow:
+    integrationMode: {{MLFLOW_INTEGRATION_MODE}}
+    injectUserEnvVars: {{MLFLOW_INJECT_USER_ENV_VARS}}
   objectStorage:
     disableHealthCheck: false
     enableExternalRoute: false
     externalStorage:
       basePath: ''
       bucket: {{AWS_S3_BUCKET}}
-      host: s3.amazonaws.com
+      host: {{AWS_S3_HOST}}
       port: ''
       region: {{AWS_REGION}}
       s3CredentialsSecret:
         accessKey: AWS_ACCESS_KEY_ID
         secretKey: AWS_SECRET_ACCESS_KEY
         secretName: {{DSPA_SECRET_NAME}}
-      scheme: https
+      scheme: {{AWS_S3_SCHEME}}
   persistenceAgent:
     deploy: true
     numWorkers: 2

--- a/packages/cypress/cypress/pages/appChrome.ts
+++ b/packages/cypress/cypress/pages/appChrome.ts
@@ -20,8 +20,8 @@ class AppChrome {
     return cy.get('#page-nav-toggle');
   }
 
-  findSideBar() {
-    return cy.get('#page-sidebar');
+  findSideBar(options?: { timeout?: number }) {
+    return cy.get('#page-sidebar', options);
   }
 
   findMainContent() {

--- a/packages/cypress/cypress/pages/pipelines/createRunPage.ts
+++ b/packages/cypress/cypress/pages/pipelines/createRunPage.ts
@@ -214,8 +214,10 @@ export class CreateRunPage {
     return this.find().findByTestId('no-pipeline-versions-available-alert');
   }
 
-  findMlflowIntegrationSection(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('run-section-mlflow-integration');
+  findMlflowIntegrationSection(options?: {
+    timeout?: number;
+  }): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('run-section-mlflow-integration', options);
   }
 
   findMlflowIntegrationJumpLink(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/pages/pipelines/pipelineImportModal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelineImportModal.ts
@@ -10,8 +10,8 @@ class PipelineImportModal extends Modal {
     super('Import pipeline');
   }
 
-  find() {
-    return cy.findByTestId('import-pipeline-modal');
+  find(options?: { timeout?: number }) {
+    return cy.findByTestId('import-pipeline-modal', options);
   }
 
   findPipelineNameInput() {
@@ -72,6 +72,15 @@ class PipelineImportModal extends Modal {
 
   findImportModalError() {
     return this.find().findByTestId('error-message-alert');
+  }
+
+  /**
+   * After submit the dialog is still open. Fail immediately if an import error
+   * is shown, then wait for the dialog to close.
+   */
+  shouldCloseWithoutError(timeout = 60000): void {
+    this.findImportModalError().should('not.exist');
+    this.find({ timeout }).should('not.exist');
   }
 
   mockCreatePipelineAndVersion(params: CreatePipelineAndVersionKFData, namespace: string) {

--- a/packages/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
@@ -63,8 +63,8 @@ class PipelineRunsGlobal {
     return cy.findByTestId('restore-button');
   }
 
-  findCompareRunsButton() {
-    return cy.findByTestId('compare-runs-button');
+  findCompareRunsButton(timeout?: number) {
+    return cy.findByTestId('compare-runs-button', { timeout });
   }
 
   findActiveRunsToolbar() {

--- a/packages/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
@@ -6,12 +6,12 @@ import { SearchSelector } from '../components/subComponents/SearchSelector';
 class PipelinesGlobal {
   projectDropdown = new SearchSelector('project-selector');
 
-  visit(projectName: string) {
+  visit(projectName: string, timeout?: number) {
     cy.visitWithLogin(`/develop-train/pipelines/definitions/${projectName}`);
-    this.wait();
+    this.wait(timeout);
   }
 
-  navigate() {
+  navigate(timeout?: number) {
     appChrome
       .findNavItem({
         name: 'Pipeline definitions',
@@ -19,11 +19,11 @@ class PipelinesGlobal {
         subSection: 'Pipelines',
       })
       .click();
-    this.wait();
+    this.wait(timeout);
   }
 
-  private wait() {
-    cy.findByTestId('app-page-title').contains('Pipeline definitions');
+  private wait(timeout?: number) {
+    cy.findByTestId('app-page-title', { timeout }).contains('Pipeline definitions');
     cy.testA11y();
   }
 
@@ -48,8 +48,8 @@ class PipelinesGlobal {
     cy.findByRole('menuitem', { name }).click();
   }
 
-  findImportPipelineButton() {
-    return cy.findByTestId('import-pipeline-button');
+  findImportPipelineButton(timeout = 60000) {
+    return cy.findByTestId('import-pipeline-button', { timeout });
   }
 
   findUploadVersionButton() {

--- a/packages/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
@@ -48,7 +48,7 @@ class PipelinesGlobal {
     cy.findByRole('menuitem', { name }).click();
   }
 
-  findImportPipelineButton(timeout = 60000) {
+  findImportPipelineButton(timeout?: number) {
     return cy.findByTestId('import-pipeline-button', { timeout });
   }
 

--- a/packages/cypress/cypress/pages/pipelines/pipelinesTable.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelinesTable.ts
@@ -168,6 +168,10 @@ class PipelinesTable {
     return cy.findByTestId(this.testId);
   }
 
+  findPipelineLinkByName(name: string, timeout = 60000) {
+    return this.find().contains('a', name, { timeout });
+  }
+
   findRows() {
     return this.find().find('tbody tr');
   }

--- a/packages/cypress/cypress/pages/pipelines/pipelinesTable.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelinesTable.ts
@@ -168,7 +168,7 @@ class PipelinesTable {
     return cy.findByTestId(this.testId);
   }
 
-  findPipelineLinkByName(name: string, timeout = 60000) {
+  findPipelineLinkByName(name: string, timeout?: number) {
     return this.find().contains('a', name, { timeout });
   }
 

--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -244,7 +244,7 @@ class ProjectDetails {
     return cy.findByTestId('delete-project-action');
   }
 
-  findImportPipelineButton(timeout = 60000) {
+  findImportPipelineButton(timeout?: number) {
     return cy.findByTestId('import-pipeline-button', { timeout });
   }
 

--- a/packages/cypress/cypress/tests/e2e/pipelines/testPipelineMLflowIntegration.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/pipelines/testPipelineMLflowIntegration.cy.ts
@@ -10,7 +10,7 @@ import {
 import { provisionProjectForPipelines } from '../../../utils/pipelines';
 import { waitForDspaReady } from '../../../utils/oc_commands/dspa';
 import { getIrisPipelinePath } from '../../../utils/fileImportUtils';
-import { createOpenShiftConfigMap } from '../../../utils/oc_commands/configmap';
+import { createDsPipelineCustomEnvVarsConfigMap } from '../../../utils/oc_commands/configmap';
 import {
   disableMlflowFeatures,
   enableMlflowFeatures,
@@ -35,9 +35,19 @@ import type { MlflowPipelineIntegrationTestData } from '../../../types';
 
 const uuid = generateTestUUID();
 const awsBucket = 'BUCKET_2' as const;
-const tags = ['@Pipelines', '@MLflow', '@Dashboard', '@NonConcurrent'] as const;
+const tags = [
+  '@Smoke',
+  '@SmokeSet4',
+  '@Pipelines',
+  '@MLflow',
+  '@MLflowIntegration',
+  '@Dashboard',
+  '@NonConcurrent',
+] as const;
 
 const BASE_RUN_TIMEOUT_MS = 240000;
+const DSPA_READY_TIMEOUT_MS = 600000;
+const DSPA_POD_TIMEOUT_MS = 310000;
 
 describe(
   'An admin user can configure MLflow experiment tracking for a pipeline server',
@@ -59,17 +69,10 @@ describe(
             integrationMode: 'AUTODETECT',
             pipelineStore: 'kubernetes',
           });
-          createOpenShiftConfigMap(
-            'ds-pipeline-custom-env-vars',
-            projectName,
-            Object.fromEntries([
-              ['pip_index_url', Cypress.env('PIP_INDEX_URL')],
-              ['pip_trusted_host', Cypress.env('PIP_TRUSTED_HOST')],
-            ]),
-          );
-          waitForDspaReady(projectName);
-          waitForDspaWebhookReady(projectName);
-          waitForDspaApiServerPodReady(projectName);
+          createDsPipelineCustomEnvVarsConfigMap(projectName);
+          waitForDspaReady(projectName, DSPA_READY_TIMEOUT_MS);
+          waitForDspaWebhookReady(projectName, DSPA_READY_TIMEOUT_MS);
+          waitForDspaApiServerPodReady(projectName, DSPA_POD_TIMEOUT_MS);
         },
       );
     });
@@ -90,9 +93,9 @@ describe(
       projectListPage.findProjectLink(projectName).click();
 
       cy.step('Wait for the pipeline server (DSPA) and MLflow webhook to be ready');
-      waitForDspaReady(projectName);
-      waitForDspaWebhookReady(projectName);
-      waitForDspaApiServerPodReady(projectName);
+      waitForDspaReady(projectName, DSPA_READY_TIMEOUT_MS);
+      waitForDspaWebhookReady(projectName, DSPA_READY_TIMEOUT_MS);
+      waitForDspaApiServerPodReady(projectName, DSPA_POD_TIMEOUT_MS);
 
       cy.step('Ensure Import Pipeline button is loaded');
       projectDetails.ensureImportPipelineButtonLoaded();

--- a/packages/cypress/cypress/tests/e2e/pipelines/testPipelineMLflowIntegration.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/pipelines/testPipelineMLflowIntegration.cy.ts
@@ -1,0 +1,140 @@
+import { cleanupTestProject } from '../../../utils/projectChecker';
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
+import { projectListPage, projectDetails } from '../../../pages/projects';
+import {
+  pipelineRunsGlobal,
+  activeRunsTable,
+  pipelinesGlobal,
+  pipelineDetails,
+} from '../../../pages/pipelines';
+import { provisionProjectForPipelines } from '../../../utils/pipelines';
+import { waitForDspaReady } from '../../../utils/oc_commands/dspa';
+import { getIrisPipelinePath } from '../../../utils/fileImportUtils';
+import { createOpenShiftConfigMap } from '../../../utils/oc_commands/configmap';
+import {
+  disableMlflowFeatures,
+  enableMlflowFeatures,
+  waitForDashboardSession,
+  waitForDspaApiServerPodReady,
+  waitForDspaWebhookReady,
+  waitForMlflowBffConfigured,
+} from '../../../utils/oc_commands/mlflow';
+import { retryableBefore } from '../../../utils/retryableHooks';
+import { generateTestUUID } from '../../../utils/uuidGenerator';
+import { loadMlflowPipelineIntegrationFixture } from '../../../utils/dataLoader';
+import {
+  MLFLOW_UI_TIMEOUT_MS,
+  fillAndSubmitMlflowIrisRun,
+  importMlflowPipelineFromFile,
+  createMlflowRunFromPipelineDetails,
+  expectMlflowCompareRunsRedirect,
+  waitForMlflowCompareRunsButton,
+  waitForMlflowExperimentLink,
+} from '../../../utils/mlflowPipelineTestFlows';
+import type { MlflowPipelineIntegrationTestData } from '../../../types';
+
+const uuid = generateTestUUID();
+const awsBucket = 'BUCKET_2' as const;
+const tags = ['@Pipelines', '@MLflow', '@Dashboard', '@NonConcurrent'] as const;
+
+const BASE_RUN_TIMEOUT_MS = 240000;
+
+describe(
+  'An admin user can configure MLflow experiment tracking for a pipeline server',
+  { testIsolation: false },
+  () => {
+    let testData: MlflowPipelineIntegrationTestData;
+    let projectName = '';
+
+    retryableBefore(() => {
+      loadMlflowPipelineIntegrationFixture('e2e/pipelines/testPipelineMLflowIntegration.yaml').then(
+        (fixtureData: MlflowPipelineIntegrationTestData) => {
+          testData = fixtureData;
+          projectName = `${testData.projectNamePrefix}-${uuid}`;
+
+          cy.step('Enable the shared MLflow backend required for pipeline integration');
+          enableMlflowFeatures();
+          cy.step('Provision a project with a pipeline server (DSPA)');
+          provisionProjectForPipelines(projectName, testData.dspaSecretName, awsBucket, undefined, {
+            integrationMode: 'AUTODETECT',
+            pipelineStore: 'kubernetes',
+          });
+          createOpenShiftConfigMap(
+            'ds-pipeline-custom-env-vars',
+            projectName,
+            Object.fromEntries([
+              ['pip_index_url', Cypress.env('PIP_INDEX_URL')],
+              ['pip_trusted_host', Cypress.env('PIP_TRUSTED_HOST')],
+            ]),
+          );
+          waitForDspaReady(projectName);
+          waitForDspaWebhookReady(projectName);
+          waitForDspaApiServerPodReady(projectName);
+        },
+      );
+    });
+
+    after(() => {
+      if (projectName) {
+        cleanupTestProject(projectName);
+      }
+      disableMlflowFeatures();
+    });
+
+    it('MLflow autodetect: create and compare iris pipeline runs', { tags: [...tags] }, () => {
+      cy.step(`Navigate to project ${projectName}`);
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+      waitForDashboardSession();
+      projectListPage.navigate();
+      projectListPage.filterProjectByName(projectName);
+      projectListPage.findProjectLink(projectName).click();
+
+      cy.step('Wait for the pipeline server (DSPA) and MLflow webhook to be ready');
+      waitForDspaReady(projectName);
+      waitForDspaWebhookReady(projectName);
+      waitForDspaApiServerPodReady(projectName);
+
+      cy.step('Ensure Import Pipeline button is loaded');
+      projectDetails.ensureImportPipelineButtonLoaded();
+
+      cy.step('Import the iris pipeline');
+      pipelinesGlobal.visit(projectName, MLFLOW_UI_TIMEOUT_MS);
+      waitForMlflowBffConfigured(MLFLOW_UI_TIMEOUT_MS);
+      importMlflowPipelineFromFile(
+        testData.pipelineName,
+        testData.pipelineDescription,
+        getIrisPipelinePath(),
+      );
+
+      cy.step('Create iris run 1 with a new MLflow experiment');
+      pipelineDetails.selectActionDropdownItem('Create run');
+      fillAndSubmitMlflowIrisRun(
+        testData.run1,
+        testData.experimentName,
+        { newExperimentName: testData.mlflowExperimentName },
+        projectName,
+        BASE_RUN_TIMEOUT_MS,
+      );
+
+      cy.step('Create iris run 2 reusing the MLflow experiment');
+      createMlflowRunFromPipelineDetails(testData.pipelineName, projectName);
+      fillAndSubmitMlflowIrisRun(
+        testData.run2,
+        testData.experimentName,
+        { existingExperimentName: testData.mlflowExperimentName },
+        projectName,
+        BASE_RUN_TIMEOUT_MS,
+      );
+
+      cy.step('Compare both iris runs via MLflow');
+      pipelineRunsGlobal.visit(projectName, 'active');
+      waitForMlflowExperimentLink(testData.run1.name);
+      waitForMlflowExperimentLink(testData.run2.name);
+      activeRunsTable.getRowByName(testData.run1.name).findCheckbox().click();
+      activeRunsTable.getRowByName(testData.run2.name).findCheckbox().click();
+      waitForMlflowCompareRunsButton();
+      pipelineRunsGlobal.findCompareRunsButton().click();
+      expectMlflowCompareRunsRedirect(projectName, { exactRunCount: 2 });
+    });
+  },
+);

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -68,9 +68,9 @@ export type DspaReplacements = {
   AWS_REGION: string;
   AWS_S3_HOST: string;
   AWS_S3_SCHEME: string;
-  MLFLOW_INTEGRATION_MODE?: string;
-  MLFLOW_INJECT_USER_ENV_VARS?: string;
-  PIPELINE_STORE?: string;
+  MLFLOW_INTEGRATION_MODE: string;
+  MLFLOW_INJECT_USER_ENV_VARS: string;
+  PIPELINE_STORE: string;
 };
 
 export type StorageClassConfig = {

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -66,6 +66,11 @@ export type DspaReplacements = {
   NAMESPACE: string;
   AWS_S3_BUCKET: string;
   AWS_REGION: string;
+  AWS_S3_HOST: string;
+  AWS_S3_SCHEME: string;
+  MLFLOW_INTEGRATION_MODE?: string;
+  MLFLOW_INJECT_USER_ENV_VARS?: string;
+  PIPELINE_STORE?: string;
 };
 
 export type StorageClassConfig = {
@@ -969,4 +974,22 @@ export type AgentRuntimesTestData = {
   filterOptionStatus: string;
   statusPending: string;
   statusReady: string;
+};
+
+export type MlflowIrisRunData = {
+  name: string;
+  description: string;
+  neighbors: string;
+  standardScaler: 'true' | 'false';
+};
+
+export type MlflowPipelineIntegrationTestData = {
+  projectNamePrefix: string;
+  dspaSecretName: string;
+  pipelineName: string;
+  pipelineDescription: string;
+  experimentName: string;
+  mlflowExperimentName: string;
+  run1: MlflowIrisRunData;
+  run2: MlflowIrisRunData;
 };

--- a/packages/cypress/cypress/utils/autoXPipelines.ts
+++ b/packages/cypress/cypress/utils/autoXPipelines.ts
@@ -76,6 +76,9 @@ export const provisionProjectForAutoX = (
     AWS_REGION: bucketConfig.REGION,
     AWS_S3_HOST: host,
     AWS_S3_SCHEME: scheme,
+    MLFLOW_INTEGRATION_MODE: 'DISABLED',
+    MLFLOW_INJECT_USER_ENV_VARS: 'false',
+    PIPELINE_STORE: 'database',
   };
   createDSPA(dspaReplacements, 'resources/yaml/autox_dspa.yaml');
 };

--- a/packages/cypress/cypress/utils/dataLoader.ts
+++ b/packages/cypress/cypress/utils/dataLoader.ts
@@ -25,6 +25,7 @@ import type {
   PromptManagementTestData,
   MlflowExperimentsTestData,
   ModelAsAServiceTestData,
+  MlflowPipelineIntegrationTestData,
 } from '../types';
 
 // Load fixture function that returns DataScienceProjectData
@@ -229,6 +230,15 @@ export const loadMlflowExperimentsFixture = (
 export const loadMaaSFixture = (fixturePath: string): Cypress.Chainable<ModelAsAServiceTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ModelAsAServiceTestData;
+
+    return data;
+  });
+
+export const loadMlflowPipelineIntegrationFixture = (
+  fixturePath: string,
+): Cypress.Chainable<MlflowPipelineIntegrationTestData> =>
+  cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
+    const data = yaml.load(yamlContent) as MlflowPipelineIntegrationTestData;
 
     return data;
   });

--- a/packages/cypress/cypress/utils/mlflowPipelineTestFlows.ts
+++ b/packages/cypress/cypress/utils/mlflowPipelineTestFlows.ts
@@ -5,6 +5,7 @@ import {
   pipelineDetails,
   pipelineImportModal,
   pipelinesGlobal,
+  pipelineRunsGlobal,
   createRunPage,
   activeRunsTable,
 } from '../pages/pipelines';
@@ -100,7 +101,7 @@ export const importMlflowPipelineFromFile = (
   description: string,
   yamlPath: string,
 ): void => {
-  pipelinesGlobal.findImportPipelineButton().click();
+  pipelinesGlobal.findImportPipelineButton(MLFLOW_UI_TIMEOUT_MS).click();
   pipelineImportModal.findPipelineNameInput().type(name);
   pipelineImportModal.findPipelineDescriptionInput().type(description);
   pipelineImportModal.findUploadPipelineRadio().click();
@@ -131,15 +132,16 @@ export const createMlflowRunFromPipelineDetails = (
  * run's Argo workflow via oc until Succeeded.
  */
 export const waitForMlflowRunSucceeded = (projectName: string, timeout: number): void => {
-  cy.location('pathname', { timeout: MLFLOW_UI_TIMEOUT_MS }).should((pathname) => {
-    const runId = pathname.split('/').filter(Boolean).pop() ?? '';
-    expect(runId, `run details URL, got ${pathname}`).to.not.eq('create');
-    expect(runId.length, `run details URL, got ${pathname}`).to.be.greaterThan(0);
-  });
-  cy.location('pathname').then((pathname) => {
-    const runId = pathname.split('/').filter(Boolean).pop() ?? '';
-    waitForKfpRunSucceeded(projectName, runId, timeout);
-  });
+  cy.location('pathname', { timeout: MLFLOW_UI_TIMEOUT_MS })
+    .should((pathname) => {
+      const runId = pathname.split('/').filter(Boolean).pop() ?? '';
+      expect(runId, `run details URL, got ${pathname}`).to.not.eq('create');
+      expect(runId.length, `run details URL, got ${pathname}`).to.be.greaterThan(0);
+    })
+    .then((pathname) => {
+      const runId = pathname.split('/').filter(Boolean).pop() ?? '';
+      waitForKfpRunSucceeded(projectName, runId, timeout);
+    });
 };
 
 /** Assert that submitting the compare-runs action redirected to the MLflow compare-runs page. */
@@ -177,7 +179,7 @@ export const waitForMlflowExperimentLink = (runName: string, timeout = 60000): v
  * Wait for the compare-runs button to link to MLflow.
  */
 export const waitForMlflowCompareRunsButton = (timeout = 180000): void => {
-  cy.findByTestId('compare-runs-button', { timeout }).should(($btn) => {
+  pipelineRunsGlobal.findCompareRunsButton(timeout).should(($btn) => {
     const href = $btn.closest('a').attr('href') ?? $btn.attr('href') ?? '';
     expect(href, 'compare-runs-button href').to.include('/mlflow/');
   });

--- a/packages/cypress/cypress/utils/mlflowPipelineTestFlows.ts
+++ b/packages/cypress/cypress/utils/mlflowPipelineTestFlows.ts
@@ -1,0 +1,184 @@
+import { waitForMlflowBffConfigured } from './oc_commands/mlflow';
+import { waitForKfpRunSucceeded } from './oc_commands/pipelineRuns';
+import {
+  pipelinesTable,
+  pipelineDetails,
+  pipelineImportModal,
+  pipelinesGlobal,
+  createRunPage,
+  activeRunsTable,
+} from '../pages/pipelines';
+import type { MlflowIrisRunData } from '../types';
+
+export const MLFLOW_UI_TIMEOUT_MS = 60000;
+export const MLFLOW_COMPARE_RUNS_PATH = '/develop-train/mlflow/experiments/compare-runs';
+
+/**
+ * INTEGER params render PatternFly NumberInput: data-testid is on the wrapper,
+ * and clear() normalizes empty to 0 so a later type() can become "30" instead of "3".
+ */
+const fillIntegerRunParam = (id: string, value: string): void => {
+  createRunPage
+    .getParamsSection()
+    .findParamById(id)
+    .find('input')
+    .type('{selectall}', { parseSpecialCharSequences: true })
+    .type(value, { parseSpecialCharSequences: false })
+    .should('have.value', value);
+};
+
+/** Fill the iris pipeline's run parameters. */
+export const fillMlflowIrisRunParams = (run: MlflowIrisRunData): void => {
+  fillIntegerRunParam('neighbors', run.neighbors);
+  createRunPage
+    .getParamsSection()
+    .findParamById(`radio-standard_scaler-${run.standardScaler}`)
+    .click();
+};
+
+/** Select an existing MLflow experiment by name in the create-run MLflow section. */
+export const selectExistingMlflowExperiment = (name: string): void => {
+  createRunPage.findMlflowExistingRadio().click();
+  createRunPage.mlflowExperimentSelect.findToggleButton().click();
+  createRunPage.selectMlflowExperimentByName(name);
+};
+
+/** Fill the create-run form for an iris run, submit, and wait until the KFP run succeeds. */
+export const fillAndSubmitMlflowIrisRun = (
+  run: MlflowIrisRunData,
+  experimentName: string,
+  mlflow:
+    | { newExperimentName: string; existingExperimentName?: never }
+    | { existingExperimentName: string; newExperimentName?: never },
+  projectName: string,
+  timeout: number,
+): void => {
+  createRunPage.find().should('exist');
+  createRunPage.fillRunGroup(experimentName);
+  createRunPage.fillName(run.name);
+  createRunPage.fillDescription(run.description);
+  createRunPage
+    .findMlflowIntegrationSection({ timeout: MLFLOW_UI_TIMEOUT_MS })
+    .scrollIntoView()
+    .should('be.visible');
+  if (mlflow.newExperimentName != null) {
+    createRunPage.findMlflowNewRadio().click();
+    createRunPage.findMlflowNewExperimentNameInput().clear().type(mlflow.newExperimentName);
+  } else {
+    selectExistingMlflowExperiment(mlflow.existingExperimentName);
+  }
+  fillMlflowIrisRunParams(run);
+  createRunPage.findSubmitButton().click();
+  waitForMlflowRunSucceeded(projectName, timeout);
+};
+
+const openPipelineDetails = (pipelineName: string): void => {
+  pipelineDetails.findPageTitle(MLFLOW_UI_TIMEOUT_MS).should(($title) => {
+    if ($title.text().trim() === pipelineName) {
+      return;
+    }
+    expect(
+      $title
+        .closest('body')
+        .find('[data-testid="pipelines-table"] a')
+        .filter((_, el) => (el.textContent || '').trim() === pipelineName).length,
+      `pipelines-table link for ${pipelineName}`,
+    ).to.be.greaterThan(0);
+  });
+  pipelineDetails.findPageTitle().then(($title) => {
+    if ($title.text().trim() === pipelineName) {
+      return;
+    }
+    pipelinesTable.findPipelineLinkByName(pipelineName, MLFLOW_UI_TIMEOUT_MS).click();
+  });
+  pipelineDetails.findPageTitle(MLFLOW_UI_TIMEOUT_MS).should('have.text', pipelineName);
+};
+
+/** Import a pipeline from a local YAML file and wait for its details page. */
+export const importMlflowPipelineFromFile = (
+  name: string,
+  description: string,
+  yamlPath: string,
+): void => {
+  pipelinesGlobal.findImportPipelineButton().click();
+  pipelineImportModal.findPipelineNameInput().type(name);
+  pipelineImportModal.findPipelineDescriptionInput().type(description);
+  pipelineImportModal.findUploadPipelineRadio().click();
+  pipelineImportModal.uploadPipelineYaml(yamlPath);
+  pipelineImportModal.submit();
+  pipelineImportModal.shouldCloseWithoutError(MLFLOW_UI_TIMEOUT_MS);
+  openPipelineDetails(name);
+};
+
+/**
+ * Create-run from pipeline details (client-side) is the path that actually
+ * renders the MLflow section on this cluster. A full visit of the runs page
+ * resets useMLflowStatus; even a 60s wait never saw the section afterwards.
+ */
+export const createMlflowRunFromPipelineDetails = (
+  pipelineName: string,
+  projectName: string,
+): void => {
+  pipelinesGlobal.visit(projectName, MLFLOW_UI_TIMEOUT_MS);
+  waitForMlflowBffConfigured(MLFLOW_UI_TIMEOUT_MS);
+  openPipelineDetails(pipelineName);
+  pipelineDetails.selectActionDropdownItem('Create run');
+  createRunPage.find().should('exist');
+};
+
+/**
+ * After submit, wait for the run-details URL (not /create), then poll that
+ * run's Argo workflow via oc until Succeeded.
+ */
+export const waitForMlflowRunSucceeded = (projectName: string, timeout: number): void => {
+  cy.location('pathname', { timeout: MLFLOW_UI_TIMEOUT_MS }).should((pathname) => {
+    const runId = pathname.split('/').filter(Boolean).pop() ?? '';
+    expect(runId, `run details URL, got ${pathname}`).to.not.eq('create');
+    expect(runId.length, `run details URL, got ${pathname}`).to.be.greaterThan(0);
+  });
+  cy.location('pathname').then((pathname) => {
+    const runId = pathname.split('/').filter(Boolean).pop() ?? '';
+    waitForKfpRunSucceeded(projectName, runId, timeout);
+  });
+};
+
+/** Assert that submitting the compare-runs action redirected to the MLflow compare-runs page. */
+export const expectMlflowCompareRunsRedirect = (
+  projectName: string,
+  options: { exactRunCount?: number; minRunCount?: number },
+): void => {
+  cy.location('pathname').should('eq', MLFLOW_COMPARE_RUNS_PATH);
+  cy.location('search').should((search) => {
+    const params = new URLSearchParams(search);
+    expect(params.get('workspace')).to.eq(projectName);
+
+    const runs = JSON.parse(params.get('runs') ?? '[]') as string[];
+    const experiments = JSON.parse(params.get('experiments') ?? '[]') as string[];
+    expect(experiments.length).to.be.greaterThan(0);
+
+    if (options.exactRunCount != null) {
+      expect(runs).to.have.length(options.exactRunCount);
+    }
+    if (options.minRunCount != null) {
+      expect(runs.length).to.be.at.least(options.minRunCount);
+    }
+  });
+};
+
+export const waitForMlflowExperimentLink = (runName: string, timeout = 60000): void => {
+  activeRunsTable
+    .getRowByName(runName)
+    .find()
+    .findByTestId('mlflow-experiment-link', { timeout })
+    .should('exist');
+};
+
+/**
+ * Wait for the compare-runs button to link to MLflow.
+ */
+export const waitForMlflowCompareRunsButton = (timeout = 180000): void => {
+  cy.findByTestId('compare-runs-button', { timeout }).should(($btn) => {
+    const href = $btn.closest('a').attr('href') ?? $btn.attr('href') ?? '';
+    expect(href, 'compare-runs-button href').to.include('/mlflow/');
+  });
+};

--- a/packages/cypress/cypress/utils/oc_commands/configmap.ts
+++ b/packages/cypress/cypress/utils/oc_commands/configmap.ts
@@ -33,3 +33,29 @@ export const createOpenShiftConfigMap = (
     return result;
   });
 };
+
+/**
+ * ConfigMap the iris pip-index pipeline mounts as PIP_INDEX_URL / PIP_TRUSTED_HOST.
+ * No-op when those Cypress env vars are unset.
+ */
+export const createDsPipelineCustomEnvVarsConfigMap = (
+  namespace: string,
+): Cypress.Chainable<CommandLineResult> | undefined => {
+  const entries: [string, string][] = [];
+  const pipIndexUrl = Cypress.env('PIP_INDEX_URL') as string | undefined;
+  const pipTrustedHost = Cypress.env('PIP_TRUSTED_HOST') as string | undefined;
+  if (pipIndexUrl) {
+    entries.push(['pip_index_url', pipIndexUrl]);
+  }
+  if (pipTrustedHost) {
+    entries.push(['pip_trusted_host', pipTrustedHost]);
+  }
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return createOpenShiftConfigMap(
+    'ds-pipeline-custom-env-vars',
+    namespace,
+    Object.fromEntries(entries),
+  );
+};

--- a/packages/cypress/cypress/utils/oc_commands/dspa.ts
+++ b/packages/cypress/cypress/utils/oc_commands/dspa.ts
@@ -53,17 +53,17 @@ type DspaCondition = { type?: string; status?: string; reason?: string; message?
  * Uses oc wait --for=condition=Ready similar to other resource waits in the codebase.
  *
  * @param projectName - The namespace/project containing the DSPA
- * @param timeout - Timeout in seconds (default 600s = 10 minutes)
+ * @param timeout - Cypress/oc wait timeout in milliseconds (default 600s)
  */
 export const waitForDspaReady = (
   projectName: string,
-  timeout = '600s',
+  timeout = 600000,
 ): Cypress.Chainable<CommandLineResult> => {
-  const command = `oc wait --for=condition=Ready dspa/${DSPA_RESOURCE_NAME} -n ${projectName} --timeout=${timeout}`;
+  const command = `oc wait --for=condition=Ready dspa/${DSPA_RESOURCE_NAME} -n ${projectName} --timeout=${timeout}ms`;
   cy.log(`Waiting for DSPA to be ready: ${command}`);
 
   return cy
-    .exec(command, { failOnNonZeroExit: false, timeout: 610000 })
+    .exec(command, { failOnNonZeroExit: false, timeout })
     .then((result: CommandLineResult) => {
       if (result.exitCode !== 0) {
         cy.log(`DSPA wait failed (exit ${result.exitCode}): ${maskSensitiveInfo(result.stderr)}`);

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -136,6 +136,12 @@ const waitForMlflowCRAvailable = (namespace: string): Cypress.Chainable<Cypress.
  * then cy.reload() for subsequent attempts to avoid repeated OAuth overhead.
  */
 const SIDEBAR_SETTLE_TIMEOUT = 30000;
+const DASHBOARD_SESSION_TIMEOUT = 60000;
+
+export const waitForDashboardSession = (): Cypress.Chainable<JQuery<HTMLElement>> =>
+  cy.get('#page-sidebar', {
+    timeout: DASHBOARD_SESSION_TIMEOUT,
+  });
 
 const logSidebarDiagnostics = (): void => {
   cy.window({ log: false }).then((win) => {
@@ -233,7 +239,7 @@ const waitForNavItemInSidebar = (navLabel: string, url = '/'): Cypress.Chainable
     cy.get('[data-testid="dashboard-page-main"]', { timeout: SIDEBAR_SETTLE_TIMEOUT });
 
     return appChrome
-      .findSideBar()
+      .findSideBar({ timeout: SIDEBAR_SETTLE_TIMEOUT })
       .then(() => findNavItemInSidebar(navLabel))
       .then((found) => {
         const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
@@ -421,6 +427,97 @@ export const enableMlflowBackend = (): Cypress.Chainable<Cypress.Exec> => {
 };
 
 /**
+ * Poll the dashboard MLflow BFF until it reports configured=true.
+ *
+ * After a full cy.visit the shared useMLflowStatus store resets; create-run
+ * hides the MLflow section until this endpoint succeeds. Requires an active
+ * browser session (call after cy.visitWithLogin).
+ */
+export const waitForMlflowBffConfigured = (timeoutMs = 60000): Cypress.Chainable<boolean> => {
+  const pollIntervalMs = 2000;
+  const maxAttempts = Math.ceil(timeoutMs / pollIntervalMs);
+  const startTime = Date.now();
+
+  const check = (attempt = 1): Cypress.Chainable<boolean> => {
+    return cy
+      .request({
+        url: '/_bff/mlflow/api/v1/status',
+        failOnStatusCode: false,
+        timeout: 10000,
+        log: false,
+      })
+      .then((resp: Cypress.Response<{ configured?: boolean }>) => {
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        if (resp.status === 200 && resp.body.configured === true) {
+          cy.log(`MLflow BFF configured=true (after ${elapsed}s)`);
+          return cy.wrap(true);
+        }
+        if (attempt >= maxAttempts) {
+          throw new Error(
+            `MLflow BFF not configured after ${elapsed}s (HTTP ${
+              resp.status
+            }, body=${JSON.stringify(resp.body)})`,
+          );
+        }
+        cy.log(
+          `MLflow BFF not configured yet (attempt ${attempt}/${maxAttempts}, HTTP ${resp.status})`,
+        );
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        return cy.wait(pollIntervalMs).then(() => check(attempt + 1));
+      });
+  };
+
+  cy.log(`Polling MLflow BFF /status for configured=true (max ${timeoutMs / 1000}s)`);
+  return check();
+};
+
+export const waitForDspaWebhookReady = (
+  projectName: string,
+  timeout = '600s',
+): Cypress.Chainable<CommandLineResult> =>
+  cy
+    .exec(`oc wait --for=condition=WebhookReady dspa/dspa -n ${projectName} --timeout=${timeout}`, {
+      failOnNonZeroExit: false,
+      timeout: 610000,
+    })
+    .then((result) => {
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `DSPA WebhookReady wait failed: ${maskSensitiveInfo(result.stderr || result.stdout)}`,
+        );
+      }
+      return result;
+    });
+
+/**
+ * DSPA condition Ready can flip True before the API server pod is Ready.
+ * CreateRun in that window stores plugins_input (experiment column works) but
+ * skips the MLflow plugin, so plugins_output / root_run_id never appear and
+ * Compare stays on the KFP URL.
+ */
+export const waitForDspaApiServerPodReady = (
+  projectName: string,
+  timeout = '300s',
+): Cypress.Chainable<CommandLineResult> => {
+  const timeoutMs = (Number.parseInt(timeout, 10) || 300) * 1000 + 10000;
+  return cy
+    .exec(
+      `oc wait --for=condition=Ready pod -l app=ds-pipeline-dspa -n ${projectName} --timeout=${timeout}`,
+      { failOnNonZeroExit: false, timeout: timeoutMs },
+    )
+    .then((result) => {
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `DSPA API server pod Ready wait failed: ${maskSensitiveInfo(
+            result.stderr || result.stdout,
+          )}`,
+        );
+      }
+      return result;
+    });
+};
+
+/**
  * Enable MLflow tracking server (no Gen AI):
  * 1. Wait for MLflow operator pod to be running
  * 2. Create an MLflow CR and wait for it to be ready
@@ -435,7 +532,7 @@ export const enableMlflowFeatures = (): Cypress.Chainable<boolean> => {
     .then(() => {
       cy.step('Establish browser session for remote entry check');
       cy.visitWithLogin('/');
-      return cy.get('#page-sidebar', { timeout: 15000 });
+      return waitForDashboardSession();
     })
     .then(() => {
       cy.step('Wait for mlflowEmbedded module federation remote to be loadable');
@@ -480,7 +577,7 @@ export const enablePromptManagementFeatures = (): Cypress.Chainable<boolean> => 
     .then(() => {
       cy.step('Establish browser session for remote entry check');
       cy.visitWithLogin(devFlagsUrl);
-      return cy.get('#page-sidebar', { timeout: 15000 });
+      return waitForDashboardSession();
     })
     .then(() => {
       cy.step('Wait for mlflowEmbedded module federation remote to be loadable');

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -10,7 +10,7 @@ const UI_POLL_CONFIG = {
   pollIntervalMs: 5000,
 } as const;
 
-const assertNamespace = (namespace: string): string => {
+export const assertNamespace = (namespace: string): string => {
   if (!K8S_NAMESPACE_RE.test(namespace)) {
     throw new Error(`Invalid namespace: ${namespace}`);
   }
@@ -473,12 +473,13 @@ export const waitForMlflowBffConfigured = (timeoutMs = 60000): Cypress.Chainable
 
 export const waitForDspaWebhookReady = (
   projectName: string,
-  timeout = '600s',
-): Cypress.Chainable<CommandLineResult> =>
-  cy
-    .exec(`oc wait --for=condition=WebhookReady dspa/dspa -n ${projectName} --timeout=${timeout}`, {
+  timeout: number,
+): Cypress.Chainable<CommandLineResult> => {
+  const ns = assertNamespace(projectName);
+  return cy
+    .exec(`oc wait --for=condition=WebhookReady dspa/dspa -n ${ns} --timeout=${timeout}ms`, {
       failOnNonZeroExit: false,
-      timeout: 610000,
+      timeout,
     })
     .then((result) => {
       if (result.exitCode !== 0) {
@@ -488,6 +489,7 @@ export const waitForDspaWebhookReady = (
       }
       return result;
     });
+};
 
 /**
  * DSPA condition Ready can flip True before the API server pod is Ready.
@@ -497,13 +499,13 @@ export const waitForDspaWebhookReady = (
  */
 export const waitForDspaApiServerPodReady = (
   projectName: string,
-  timeout = '300s',
+  timeout: number,
 ): Cypress.Chainable<CommandLineResult> => {
-  const timeoutMs = (Number.parseInt(timeout, 10) || 300) * 1000 + 10000;
+  const ns = assertNamespace(projectName);
   return cy
     .exec(
-      `oc wait --for=condition=Ready pod -l app=ds-pipeline-dspa -n ${projectName} --timeout=${timeout}`,
-      { failOnNonZeroExit: false, timeout: timeoutMs },
+      `oc wait --for=condition=Ready pod -l app=ds-pipeline-dspa -n ${ns} --timeout=${timeout}ms`,
+      { failOnNonZeroExit: false, timeout },
     )
     .then((result) => {
       if (result.exitCode !== 0) {

--- a/packages/cypress/cypress/utils/oc_commands/pipelineRuns.ts
+++ b/packages/cypress/cypress/utils/oc_commands/pipelineRuns.ts
@@ -1,3 +1,4 @@
+import { assertNamespace } from './mlflow';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
 
 const FAILED_PHASES = new Set(['Failed', 'Error']);
@@ -45,7 +46,7 @@ export const waitForKfpRunSucceeded = (
 ): void => {
   const pollIntervalMs = 5000;
   const maxAttempts = Math.max(1, Math.ceil(timeoutMs / pollIntervalMs));
-  const ns = JSON.stringify(namespace);
+  const ns = assertNamespace(namespace);
   const listCommand = `oc get workflow.argoproj.io -n ${ns} -o json`;
   const startTime = Date.now();
 
@@ -70,6 +71,13 @@ export const waitForKfpRunSucceeded = (
           const phase = phaseResult.stdout.trim();
           if (FAILED_PHASES.has(phase)) {
             throw new Error(`Workflow ${workflowName} for run ${runId} ended with phase ${phase}`);
+          }
+          const lookupOutput = `${phaseResult.stderr} ${phaseResult.stdout}`;
+          if (phaseResult.exitCode !== 0 && /not found/i.test(lookupOutput)) {
+            cy.log(
+              `Workflow ${workflowName} was deleted while waiting; treating as completed by DSPA cleanup`,
+            );
+            return;
           }
           throw new Error(
             `Workflow ${workflowName} for run ${runId} did not succeed (phase=${

--- a/packages/cypress/cypress/utils/oc_commands/pipelineRuns.ts
+++ b/packages/cypress/cypress/utils/oc_commands/pipelineRuns.ts
@@ -1,0 +1,116 @@
+import { maskSensitiveInfo } from '../maskSensitiveInfo';
+
+const FAILED_PHASES = new Set(['Failed', 'Error']);
+
+type ArgoWorkflow = {
+  metadata?: {
+    name?: string;
+    creationTimestamp?: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  status?: { phase?: string };
+};
+
+const workflowHasRunId = (workflow: ArgoWorkflow, runId: string): boolean => {
+  const { name = '', labels = {}, annotations = {} } = workflow.metadata ?? {};
+  return (
+    Object.values(labels).includes(runId) ||
+    Object.values(annotations).includes(runId) ||
+    name.includes(runId)
+  );
+};
+
+const findWorkflowForRun = (stdout: string, runId: string): ArgoWorkflow | undefined => {
+  try {
+    const items = (JSON.parse(stdout) as { items?: ArgoWorkflow[] }).items ?? [];
+    return items
+      .filter((workflow) => workflowHasRunId(workflow, runId))
+      .toSorted((a, b) =>
+        (b.metadata?.creationTimestamp ?? '').localeCompare(a.metadata?.creationTimestamp ?? ''),
+      )[0];
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Find the Argo workflow for a KFP run, then `oc wait` that object until Succeeded.
+ * DSPA may delete completed workflows quickly, so a 5s list poll can miss Succeeded.
+ */
+export const waitForKfpRunSucceeded = (
+  namespace: string,
+  runId: string,
+  timeoutMs: number,
+): void => {
+  const pollIntervalMs = 5000;
+  const maxAttempts = Math.max(1, Math.ceil(timeoutMs / pollIntervalMs));
+  const ns = JSON.stringify(namespace);
+  const listCommand = `oc get workflow.argoproj.io -n ${ns} -o json`;
+  const startTime = Date.now();
+
+  const waitOnWorkflow = (workflowName: string): void => {
+    const remainingMs = Math.max(30000, timeoutMs - (Date.now() - startTime));
+    const timeoutSec = Math.ceil(remainingMs / 1000);
+    const waitCommand = `oc wait workflow.argoproj.io/${workflowName} -n ${ns} --for=jsonpath='{.status.phase}'=Succeeded --timeout=${timeoutSec}s`;
+
+    cy.exec(waitCommand, { failOnNonZeroExit: false, timeout: remainingMs + 15000 }).then(
+      (result) => {
+        if (result.exitCode === 0) {
+          cy.log(`Workflow ${workflowName} Succeeded`);
+          return;
+        }
+        cy.exec(
+          `oc get workflow.argoproj.io/${workflowName} -n ${ns} -o jsonpath='{.status.phase}'`,
+          {
+            failOnNonZeroExit: false,
+            timeout: 30000,
+          },
+        ).then((phaseResult) => {
+          const phase = phaseResult.stdout.trim();
+          if (FAILED_PHASES.has(phase)) {
+            throw new Error(`Workflow ${workflowName} for run ${runId} ended with phase ${phase}`);
+          }
+          throw new Error(
+            `Workflow ${workflowName} for run ${runId} did not succeed (phase=${
+              phase || 'not found'
+            }): ${maskSensitiveInfo(result.stderr || result.stdout)}`,
+          );
+        });
+      },
+    );
+  };
+
+  const find = (attempt = 1): void => {
+    cy.exec(listCommand, { failOnNonZeroExit: false, timeout: 30000 }).then((result) => {
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      const matched = findWorkflowForRun(result.stdout, runId);
+      const phase = matched?.status?.phase ?? '';
+      const workflowName = matched?.metadata?.name;
+
+      if (phase === 'Succeeded' && workflowName) {
+        cy.log(`Workflow ${workflowName} Succeeded after ${elapsed}s`);
+        return;
+      }
+      if (workflowName && FAILED_PHASES.has(phase)) {
+        throw new Error(`Workflow ${workflowName} for run ${runId} ended with phase ${phase}`);
+      }
+      if (workflowName) {
+        cy.log(
+          `Found workflow ${workflowName} (phase=${phase || 'unknown'}); waiting for Succeeded`,
+        );
+        waitOnWorkflow(workflowName);
+        return;
+      }
+      if (attempt >= maxAttempts) {
+        throw new Error(`Run ${runId} did not create an Argo workflow after ${elapsed}s`);
+      }
+      cy.log(`Waiting for Argo workflow for run ${runId} (${elapsed}s)`);
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(pollIntervalMs).then(() => find(attempt + 1));
+    });
+  };
+
+  cy.log(`Waiting for Argo workflow ${runId} to succeed (max ${timeoutMs / 1000}s)`);
+  find();
+};

--- a/packages/cypress/cypress/utils/pipelines.ts
+++ b/packages/cypress/cypress/utils/pipelines.ts
@@ -1,12 +1,18 @@
 import { createDataConnection } from './oc_commands/dataConnection';
 import { createDSPASecret, createDSPA } from './oc_commands/dspa';
-import { AWS_BUCKETS } from './s3Buckets';
+import { AWS_BUCKETS, parseS3Endpoint } from './s3Buckets';
 import { createCleanProject } from './projectChecker';
 import type {
   DataConnectionReplacements,
   DspaSecretReplacements,
   DspaReplacements,
 } from '../types';
+
+export type PipelineDspaMlflowOptions = {
+  integrationMode?: 'AUTODETECT' | 'DISABLED';
+  injectUserEnvVars?: boolean;
+  pipelineStore?: 'kubernetes' | 'database';
+};
 
 /**
  * Provision (using oc) a Project in order to make it usable with pipelines
@@ -20,8 +26,11 @@ export const provisionProjectForPipelines = (
   dspaSecretName: string,
   bucketKey: 'BUCKET_2' | 'BUCKET_3',
   customDataConnectionYamlPath?: string,
+  mlflow?: PipelineDspaMlflowOptions,
 ): void => {
   const bucketConfig = AWS_BUCKETS[bucketKey];
+  const dspaEndpoint = Cypress.env('DSPA_S3_ENDPOINT') as string | undefined;
+  const { host, scheme } = parseS3Endpoint(dspaEndpoint ?? bucketConfig.ENDPOINT);
 
   // Provision a Project
   createCleanProject(projectName);
@@ -52,6 +61,11 @@ export const provisionProjectForPipelines = (
     NAMESPACE: projectName,
     AWS_S3_BUCKET: bucketConfig.NAME,
     AWS_REGION: bucketConfig.REGION,
+    AWS_S3_HOST: host,
+    AWS_S3_SCHEME: scheme,
+    MLFLOW_INTEGRATION_MODE: mlflow?.integrationMode || 'DISABLED',
+    MLFLOW_INJECT_USER_ENV_VARS: String(mlflow?.injectUserEnvVars || false),
+    PIPELINE_STORE: mlflow?.pipelineStore || 'database',
   };
   createDSPA(dspaReplacements);
 };

--- a/packages/cypress/cypress/utils/s3Buckets.ts
+++ b/packages/cypress/cypress/utils/s3Buckets.ts
@@ -3,10 +3,14 @@ import type { AWSS3Buckets } from '../types';
 export const AWS_BUCKETS: AWSS3Buckets = Cypress.env('AWS_PIPELINES');
 
 export const parseS3Endpoint = (endpoint: string): { host: string; scheme: string } => {
+  const normalized = /^https?:\/\//.test(endpoint) ? endpoint : `https://${endpoint}`;
   try {
-    const url = new URL(endpoint);
-    return { host: url.host, scheme: url.protocol.replace(':', '') };
+    const url = new URL(normalized);
+    if (url.host && (url.protocol === 'http:' || url.protocol === 'https:')) {
+      return { host: url.host, scheme: url.protocol.replace(':', '') };
+    }
   } catch {
-    return { host: endpoint.replace(/\/+$/, ''), scheme: 'https' };
+    // Fall through to the host/https fallback.
   }
+  return { host: endpoint.replace(/\/+$/, ''), scheme: 'https' };
 };

--- a/packages/cypress/cypress/utils/s3Buckets.ts
+++ b/packages/cypress/cypress/utils/s3Buckets.ts
@@ -1,3 +1,12 @@
 import type { AWSS3Buckets } from '../types';
 
 export const AWS_BUCKETS: AWSS3Buckets = Cypress.env('AWS_PIPELINES');
+
+export const parseS3Endpoint = (endpoint: string): { host: string; scheme: string } => {
+  try {
+    const url = new URL(endpoint);
+    return { host: url.host, scheme: url.protocol.replace(':', '') };
+  } catch {
+    return { host: endpoint.replace(/\/+$/, ''), scheme: 'https' };
+  }
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-85214

## Description

Pipeline smoke specs (`pipelines.cy.ts`, `createRunDeletePipelineCustomPipMirror.cy.ts`, `testSchedulePipeline.cy.ts`) fill create-run / schedule and click Submit with no MLflow step. When MLflow is configured on the cluster, DSPA treats a missing `spec.mlflow` as **AUTODETECT**, so the MLflow integration section appears, tracking defaults on, and Submit stays disabled on a new project with an empty experiment dropdown. That can also happen when another suite leaves MLflow enabled (including parallel CI).

This PR isolates the smokes and covers the MLflow pipelines path in a dedicated spec:

- Shared `dspa.yaml` is parameterized. `provisionProjectForPipelines()` defaults to `spec.mlflow.integrationMode: DISABLED` (and `injectUserEnvVars: false`, `pipelineStore: database`), so existing pipeline smokes never render the MLflow section and keep their current Submit flow whether cluster MLflow is configured or not.
- New e2e spec `testPipelineMLflowIntegration.cy.ts` (not `@Smoke`) provisions DSPA with `AUTODETECT` and kubernetes pipeline store, then:
  1. Imports the iris pipeline
  2. Creates run 1 with a **new** MLflow experiment
  3. Creates run 2 **reusing** that experiment
  4. Compares both runs and asserts redirect to the MLflow compare-runs URL (`exactRunCount: 2`)
- Create-run is opened from pipeline details. A full visit of the runs page was resetting `useMLflowStatus` so the MLflow section never appeared.
- After Submit, the spec waits on the Argo workflow via `oc` (`waitForKfpRunSucceeded`) instead of the UI status icon, which was flaky (detached table, ChunkLoadError after long `cy.exec`).
- DSPA S3 `host`/`scheme` are parsed from the endpoint so the fixture matches cluster MinIO (wrong `minio123` credentials left DSPA never Ready).

Out of scope vs the Jira AC (intentionally deferred): autolog inject-off / inject-on, and disabling DSPA MLflow to assert the section hides and compare stays on KFP. No separate `dspa_mlflow.yaml`; AUTODETECT is passed as options into the shared fixture.

## How Has This Been Tested?

```bash
cd packages/cypress
export CY_TEST_CONFIG="/path/to/packages/cypress/test-variables.yml"
export CY_RETRY=0
unset CY_MOCK CYPRESS_E2E_PROXY CY_TEST_TAGS CYPRESS_BASE_URL
npx cypress run --browser chrome --spec "cypress/tests/e2e/pipelines/testPipelineMLflowIntegration.cy.ts"
```

`test-variables.yml` must point at the same cluster as `oc`, and MinIO credentials must match the cluster `minio-secret`.

The spec passed in ~5–6 minutes (iris workflows succeeded, compare-runs redirected to MLflow).

Smoke specs were not re-run in this pass; they are isolated by the `DISABLED` DSPA default.

## Test Impact

This PR is Cypress e2e coverage:

- New: `testPipelineMLflowIntegration.cy.ts` (`@Pipelines`, `@MLflow`, `@Dashboard`, `@NonConcurrent`)
- Helpers: `mlflowPipelineTestFlows.ts`, `oc_commands/pipelineRuns.ts`, DSPA MLflow options on `provisionProjectForPipelines`
- Page-object timeouts for import / create-run / MLflow section (needed for kubernetes-store import and BFF readiness)

No product UI code changes, so no unit tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end coverage for MLflow pipeline integration.
  - Added support for creating and comparing pipeline runs using new or existing MLflow experiments.
  - Added configurable MLflow, pipeline storage, and object-storage settings.
  - Added validation for successful pipeline execution and MLflow navigation.

- **Bug Fixes**
  - Improved reliability by waiting for dashboard sessions, services, and pipeline completion.
  - Added configurable timeouts for pipeline navigation, imports, and MLflow controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->