### PR TITLE
feat: extend core-bff to proxy module API paths using federation-config

### DIFF
--- a/distributions/core-bff/bff/internal/api/app.go
+++ b/distributions/core-bff/bff/internal/api/app.go
@@ -51,6 +51,8 @@ type App struct {
 	wsProxy http.Handler
 	// modelServingProxy handles /api/service/model-serving/* passthrough
 	modelServingProxy http.Handler
+	// moduleProxies holds proxy handlers for federated module API paths
+	moduleProxies []moduleProxyHandler
 	// devFallbackToken is the kubeconfig bearer token used in dev mode for
 	// proxied requests (Prometheus, model-serving) when the identity has no real token.
 	devFallbackToken string
@@ -120,6 +122,11 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 	if err := app.initModelServingProxy(); err != nil {
 		_ = app.Shutdown()
 		return nil, fmt.Errorf("failed to initialize model-serving proxy: %w", err)
+	}
+
+	if err := app.initModuleProxies(); err != nil {
+		_ = app.Shutdown()
+		return nil, fmt.Errorf("failed to initialize module proxies: %w", err)
 	}
 
 	return app, nil

--- a/distributions/core-bff/bff/internal/api/module_proxy.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/proxy"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/ssrf"
+)
+
+// Types compatible with dashboard-operator/internal/controller/module_deploy.go:42-69.
+
+type moduleProxyRoute struct {
+	Path        string `json:"path"`
+	PathRewrite string `json:"pathRewrite"`
+}
+
+type moduleServiceRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Port      int32  `json:"port"`
+}
+
+type moduleFederationEntry struct {
+	Name         string                    `json:"name"`
+	RemoteEntry  string                    `json:"remoteEntry,omitempty"`
+	Authorize    bool                      `json:"authorize"`
+	TLS          bool                      `json:"tls"`
+	Proxy        []moduleProxyRoute        `json:"proxy,omitempty"`
+	Service      *moduleServiceRef         `json:"service,omitempty"`
+	ProxyService []moduleProxyServiceEntry `json:"proxyService,omitempty"`
+}
+
+type moduleProxyServiceEntry struct {
+	Authorize   bool              `json:"authorize"`
+	Path        string            `json:"path"`
+	PathRewrite string            `json:"pathRewrite"`
+	TLS         bool              `json:"tls"`
+	Service     moduleServiceRef  `json:"service"`
+	Headers     map[string]string `json:"headers,omitempty"`
+}
+
+const (
+	coreBffEntryName = "coreBff"
+	clusterDNSFmt    = "%s.%s.svc.cluster.local:%d"
+	schemeHostFmt    = "%s://%s"
+)
+
+// reservedBFFPrefixes are path prefixes already registered on the BFF mux.
+// Module proxy paths must not collide with these to prevent http.ServeMux panics.
+// Update this list when new top-level BFF route prefixes are added.
+var reservedBFFPrefixes = []string{
+	APIPathPrefix + "/",
+	proxy.K8sProxyPrefix,
+	proxy.WssProxyPrefix,
+	ModelServingProxyPrefix,
+	HealthCheckPath,
+	OpenAPIPath,
+	SwaggerUIPath,
+}
+
+type moduleProxyHandler struct {
+	path    string
+	handler http.Handler
+}
+
+// parseFederationConfig reads and deserializes the federation-config JSON file.
+func parseFederationConfig(filePath string) ([]moduleFederationEntry, error) {
+	if filePath == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read federation config %s: %w", filePath, err)
+	}
+
+	var entries []moduleFederationEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("failed to parse federation config %s: %w", filePath, err)
+	}
+
+	return entries, nil
+}
+
+type normalizedProxyEntry struct {
+	entryName string
+	service   moduleProxyServiceEntry
+}
+
+// normalizeFederationEntries converts old-format and new-format entries into a flat list of proxy routes.
+func normalizeFederationEntries(entries []moduleFederationEntry) ([]normalizedProxyEntry, error) {
+	var result []normalizedProxyEntry
+
+	for _, entry := range entries {
+		if entry.Name == coreBffEntryName {
+			continue
+		}
+
+		if len(entry.ProxyService) > 0 {
+			for _, ps := range entry.ProxyService {
+				result = append(result, normalizedProxyEntry{
+					entryName: entry.Name,
+					service:   ps,
+				})
+			}
+			continue
+		}
+
+		if len(entry.Proxy) == 0 {
+			continue
+		}
+
+		if entry.Service == nil {
+			return nil, fmt.Errorf("entry %s has proxy routes but no service definition", entry.Name)
+		}
+
+		for _, p := range entry.Proxy {
+			result = append(result, normalizedProxyEntry{
+				entryName: entry.Name,
+				service: moduleProxyServiceEntry{
+					Authorize:   entry.Authorize,
+					Path:        p.Path,
+					PathRewrite: p.PathRewrite,
+					TLS:         entry.TLS,
+					Service: moduleServiceRef{
+						Name:      entry.Service.Name,
+						Namespace: entry.Service.Namespace,
+						Port:      entry.Service.Port,
+					},
+				},
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// validateProxyEntries rejects duplicate paths, reserved-route collisions, and invalid service refs.
+func validateProxyEntries(entries []normalizedProxyEntry) error {
+	seen := make(map[string]string)
+	for _, e := range entries {
+		if prev, ok := seen[e.service.Path]; ok {
+			return fmt.Errorf("duplicate proxy path %s in entries %s and %s", e.service.Path, prev, e.entryName)
+		}
+		seen[e.service.Path] = e.entryName
+	}
+
+	for _, e := range entries {
+		pathWithSlash := e.service.Path + "/"
+		prefixedPath := PathPrefix + pathWithSlash
+
+		for _, reserved := range reservedBFFPrefixes {
+			if strings.HasPrefix(pathWithSlash, reserved) || strings.HasPrefix(reserved, pathWithSlash) {
+				return fmt.Errorf("module proxy path %s in entry %s collides with reserved BFF route %s", e.service.Path, e.entryName, reserved)
+			}
+			if strings.HasPrefix(prefixedPath, reserved) || strings.HasPrefix(reserved, prefixedPath) {
+				return fmt.Errorf("module proxy path %s in entry %s collides with reserved BFF route %s (via %s prefix)", e.service.Path, e.entryName, reserved, PathPrefix)
+			}
+		}
+	}
+
+	for _, e := range entries {
+		if e.service.Service.Name == "" {
+			return fmt.Errorf("entry %s has empty service name", e.entryName)
+		}
+		if e.service.Service.Namespace == "" {
+			return fmt.Errorf("entry %s has empty service namespace", e.entryName)
+		}
+		if e.service.Service.Port == 0 {
+			return fmt.Errorf("entry %s has zero service port", e.entryName)
+		}
+	}
+
+	return nil
+}
+
+func (app *App) initModuleProxies() error {
+	entries, err := parseFederationConfig(app.config.MFRemotesConfig)
+	if err != nil {
+		return err
+	}
+	if entries == nil {
+		return nil
+	}
+
+	normalized, err := normalizeFederationEntries(entries)
+	if err != nil {
+		return err
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	if err := validateProxyEntries(normalized); err != nil {
+		return err
+	}
+
+	var handlers []moduleProxyHandler
+	for _, entry := range normalized {
+		scheme := "https"
+		if !entry.service.TLS {
+			scheme = "http"
+		}
+		targetHost := fmt.Sprintf(clusterDNSFmt,
+			entry.service.Service.Name,
+			entry.service.Service.Namespace,
+			entry.service.Service.Port,
+		)
+		targetURL, err := url.Parse(fmt.Sprintf(schemeHostFmt, scheme, targetHost))
+		if err != nil {
+			return fmt.Errorf("failed to parse target URL for entry %s: %w", entry.entryName, err)
+		}
+
+		allowHTTP := !entry.service.TLS || app.config.DevMode || app.config.MockK8Client
+		insecureSkipVerify := app.config.InsecureSkipVerify && (app.config.DevMode || app.config.MockK8Client)
+
+		proxyPath := entry.service.Path
+		pathRewrite := entry.service.PathRewrite
+
+		cfg := proxy.ProxyConfig{
+			TargetURL:          targetURL,
+			RootCAs:            app.rootCAs,
+			InsecureSkipVerify: insecureSkipVerify,
+			AllowHTTP:          allowHTTP,
+			PathRewriteFn: func(r *http.Request) string {
+				return pathRewrite + strings.TrimPrefix(r.URL.Path, proxyPath)
+			},
+			StripHeaders:       proxy.SensitiveIngressHeaders(app.config.AuthTokenHeader),
+			ModifyResponse:     ssrf.NewRedirectValidator(app.logger),
+			SSRFValidateTarget: true,
+			SSRFAllowedHosts:   []string{targetURL.Hostname()},
+			Logger:             app.logger,
+		}
+
+		if entry.service.Authorize {
+			cfg.AuthHeaderFn = func(r *http.Request) string {
+				identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+				if !ok || identity == nil {
+					return ""
+				}
+				return k8s.BearerTokenPrefix + identity.ResolveToken(app.devFallbackToken)
+			}
+		}
+
+		if len(entry.service.Headers) > 0 {
+			headers := entry.service.Headers
+			cfg.SetOutboundHeadersFn = func(_ *http.Request, outH http.Header) {
+				for k, v := range headers {
+					outH.Set(k, v)
+				}
+			}
+		}
+
+		rp, err := proxy.NewReverseProxy(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create module proxy for entry %s path %s: %w", entry.entryName, proxyPath, err)
+		}
+
+		handlers = append(handlers, moduleProxyHandler{
+			path:    proxyPath,
+			handler: rp,
+		})
+	}
+
+	app.moduleProxies = handlers
+	return nil
+}
+
+func (app *App) registerModuleProxies(mux *http.ServeMux) {
+	for _, mp := range app.moduleProxies {
+		mux.Handle(mp.path+"/", mp.handler)
+		mux.Handle(PathPrefix+mp.path+"/", http.StripPrefix(PathPrefix, mp.handler))
+	}
+}

--- a/distributions/core-bff/bff/internal/api/module_proxy.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy.go
@@ -3,9 +3,11 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
@@ -47,10 +49,14 @@ type moduleProxyServiceEntry struct {
 }
 
 const (
-	coreBffEntryName = "coreBff"
-	clusterDNSFmt    = "%s.%s.svc.cluster.local:%d"
-	schemeHostFmt    = "%s://%s"
+	coreBffEntryName       = "coreBff"
+	clusterDNSFmt          = "%s.%s.svc.cluster.local:%d"
+	schemeHostFmt          = "%s://%s"
+	maxFederationConfigLen = 1_048_576 // 1 MiB
 )
+
+// rfc1123Label matches a valid RFC 1123 DNS label: lowercase alphanumeric and hyphens, 1-63 chars.
+var rfc1123Label = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 
 // reservedBFFPrefixes are path prefixes already registered on the BFF mux.
 // Module proxy paths must not collide with these to prevent http.ServeMux panics.
@@ -63,6 +69,7 @@ var reservedBFFPrefixes = []string{
 	HealthCheckPath,
 	OpenAPIPath,
 	SwaggerUIPath,
+	PathPrefix + "/",
 }
 
 type moduleProxyHandler struct {
@@ -76,9 +83,19 @@ func parseFederationConfig(filePath string) ([]moduleFederationEntry, error) {
 		return nil, nil
 	}
 
-	data, err := os.ReadFile(filePath)
+	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read federation config %s: %w", filePath, err)
+	}
+	defer f.Close()
+
+	limited := io.LimitReader(f, maxFederationConfigLen+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read federation config %s: %w", filePath, err)
+	}
+	if len(data) > maxFederationConfigLen {
+		return nil, fmt.Errorf("federation config %s exceeds maximum size of %d bytes", filePath, maxFederationConfigLen)
 	}
 
 	var entries []moduleFederationEntry
@@ -144,6 +161,22 @@ func normalizeFederationEntries(entries []moduleFederationEntry) ([]normalizedPr
 
 // validateProxyEntries rejects duplicate paths, reserved-route collisions, and invalid service refs.
 func validateProxyEntries(entries []normalizedProxyEntry) error {
+	if err := validateProxyPaths(entries); err != nil {
+		return err
+	}
+	return validateServiceRefs(entries)
+}
+
+func validateProxyPaths(entries []normalizedProxyEntry) error {
+	for _, e := range entries {
+		if e.service.Path == "" {
+			return fmt.Errorf("entry %s has empty proxy path", e.entryName)
+		}
+		if !strings.HasPrefix(e.service.Path, "/") {
+			return fmt.Errorf("entry %s has non-rooted proxy path %s (must start with /)", e.entryName, e.service.Path)
+		}
+	}
+
 	seen := make(map[string]string)
 	for _, e := range entries {
 		if prev, ok := seen[e.service.Path]; ok {
@@ -160,25 +193,88 @@ func validateProxyEntries(entries []normalizedProxyEntry) error {
 			if strings.HasPrefix(pathWithSlash, reserved) || strings.HasPrefix(reserved, pathWithSlash) {
 				return fmt.Errorf("module proxy path %s in entry %s collides with reserved BFF route %s", e.service.Path, e.entryName, reserved)
 			}
-			if strings.HasPrefix(prefixedPath, reserved) || strings.HasPrefix(reserved, prefixedPath) {
+			if reserved != PathPrefix+"/" && (strings.HasPrefix(prefixedPath, reserved) || strings.HasPrefix(reserved, prefixedPath)) {
 				return fmt.Errorf("module proxy path %s in entry %s collides with reserved BFF route %s (via %s prefix)", e.service.Path, e.entryName, reserved, PathPrefix)
 			}
 		}
 	}
 
+	return nil
+}
+
+func validateServiceRefs(entries []normalizedProxyEntry) error {
 	for _, e := range entries {
 		if e.service.Service.Name == "" {
 			return fmt.Errorf("entry %s has empty service name", e.entryName)
 		}
+		if !rfc1123Label.MatchString(e.service.Service.Name) {
+			return fmt.Errorf("entry %s has invalid service name %q (must be a valid RFC 1123 label)", e.entryName, e.service.Service.Name)
+		}
 		if e.service.Service.Namespace == "" {
 			return fmt.Errorf("entry %s has empty service namespace", e.entryName)
+		}
+		if !rfc1123Label.MatchString(e.service.Service.Namespace) {
+			return fmt.Errorf("entry %s has invalid service namespace %q (must be a valid RFC 1123 label)", e.entryName, e.service.Service.Namespace)
 		}
 		if e.service.Service.Port == 0 {
 			return fmt.Errorf("entry %s has zero service port", e.entryName)
 		}
+
+		if e.service.Authorize {
+			for k := range e.service.Headers {
+				if strings.EqualFold(k, constants.HeaderAuthorization) {
+					return fmt.Errorf("entry %s sets a custom Authorization header while authorize is enabled; these conflict", e.entryName)
+				}
+			}
+		}
 	}
 
 	return nil
+}
+
+// buildModuleProxyConfig creates a ProxyConfig for a normalized proxy entry.
+func (app *App) buildModuleProxyConfig(entry normalizedProxyEntry, targetURL *url.URL, allowHTTP, insecureSkipVerify, ssrfValidate bool) proxy.ProxyConfig {
+	proxyPath := entry.service.Path
+	pathRewrite := entry.service.PathRewrite
+
+	cfg := proxy.ProxyConfig{
+		TargetURL:          targetURL,
+		RootCAs:            app.rootCAs,
+		InsecureSkipVerify: insecureSkipVerify,
+		AllowHTTP:          allowHTTP,
+		PathRewriteFn: func(r *http.Request) string {
+			return pathRewrite + strings.TrimPrefix(r.URL.Path, proxyPath)
+		},
+		StripHeaders:       proxy.SensitiveIngressHeaders(app.config.AuthTokenHeader),
+		ModifyResponse:     ssrf.NewRedirectValidator(app.logger),
+		SSRFValidateTarget: ssrfValidate,
+		Logger:             app.logger,
+	}
+
+	if ssrfValidate {
+		cfg.SSRFAllowedHosts = []string{targetURL.Hostname()}
+	}
+
+	if entry.service.Authorize {
+		cfg.AuthHeaderFn = func(r *http.Request) string {
+			identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+			if !ok || identity == nil {
+				return ""
+			}
+			return k8s.BearerTokenPrefix + identity.ResolveToken(app.devFallbackToken)
+		}
+	}
+
+	if len(entry.service.Headers) > 0 {
+		headers := entry.service.Headers
+		cfg.SetOutboundHeadersFn = func(_ *http.Request, outH http.Header) {
+			for k, v := range headers {
+				outH.Set(k, v)
+			}
+		}
+	}
+
+	return cfg
 }
 
 func (app *App) initModuleProxies() error {
@@ -202,8 +298,18 @@ func (app *App) initModuleProxies() error {
 		return err
 	}
 
+	handlers, err := app.buildModuleProxyHandlers(normalized)
+	if err != nil {
+		return err
+	}
+
+	app.moduleProxies = handlers
+	return nil
+}
+
+func (app *App) buildModuleProxyHandlers(entries []normalizedProxyEntry) ([]moduleProxyHandler, error) {
 	var handlers []moduleProxyHandler
-	for _, entry := range normalized {
+	for _, entry := range entries {
 		scheme := "https"
 		if !entry.service.TLS {
 			scheme = "http"
@@ -215,62 +321,25 @@ func (app *App) initModuleProxies() error {
 		)
 		targetURL, err := url.Parse(fmt.Sprintf(schemeHostFmt, scheme, targetHost))
 		if err != nil {
-			return fmt.Errorf("failed to parse target URL for entry %s: %w", entry.entryName, err)
+			return nil, fmt.Errorf("failed to parse target URL for entry %s: %w", entry.entryName, err)
 		}
 
 		allowHTTP := !entry.service.TLS || app.config.DevMode || app.config.MockK8Client
 		insecureSkipVerify := app.config.InsecureSkipVerify && (app.config.DevMode || app.config.MockK8Client)
 
-		proxyPath := entry.service.Path
-		pathRewrite := entry.service.PathRewrite
-
-		cfg := proxy.ProxyConfig{
-			TargetURL:          targetURL,
-			RootCAs:            app.rootCAs,
-			InsecureSkipVerify: insecureSkipVerify,
-			AllowHTTP:          allowHTTP,
-			PathRewriteFn: func(r *http.Request) string {
-				return pathRewrite + strings.TrimPrefix(r.URL.Path, proxyPath)
-			},
-			StripHeaders:       proxy.SensitiveIngressHeaders(app.config.AuthTokenHeader),
-			ModifyResponse:     ssrf.NewRedirectValidator(app.logger),
-			SSRFValidateTarget: true,
-			SSRFAllowedHosts:   []string{targetURL.Hostname()},
-			Logger:             app.logger,
-		}
-
-		if entry.service.Authorize {
-			cfg.AuthHeaderFn = func(r *http.Request) string {
-				identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
-				if !ok || identity == nil {
-					return ""
-				}
-				return k8s.BearerTokenPrefix + identity.ResolveToken(app.devFallbackToken)
-			}
-		}
-
-		if len(entry.service.Headers) > 0 {
-			headers := entry.service.Headers
-			cfg.SetOutboundHeadersFn = func(_ *http.Request, outH http.Header) {
-				for k, v := range headers {
-					outH.Set(k, v)
-				}
-			}
-		}
+		cfg := app.buildModuleProxyConfig(entry, targetURL, allowHTTP, insecureSkipVerify, true)
 
 		rp, err := proxy.NewReverseProxy(cfg)
 		if err != nil {
-			return fmt.Errorf("failed to create module proxy for entry %s path %s: %w", entry.entryName, proxyPath, err)
+			return nil, fmt.Errorf("failed to create module proxy for entry %s path %s: %w", entry.entryName, entry.service.Path, err)
 		}
 
 		handlers = append(handlers, moduleProxyHandler{
-			path:    proxyPath,
+			path:    entry.service.Path,
 			handler: rp,
 		})
 	}
-
-	app.moduleProxies = handlers
-	return nil
+	return handlers, nil
 }
 
 func (app *App) registerModuleProxies(mux *http.ServeMux) {

--- a/distributions/core-bff/bff/internal/api/module_proxy_test.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy_test.go
@@ -1,0 +1,930 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/proxy"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/ssrf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFederationConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) string
+		wantNil   bool
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "empty path returns nil",
+			setup: func(t *testing.T) string {
+				return ""
+			},
+			wantNil: true,
+		},
+		{
+			name: "non-existent file returns error",
+			setup: func(t *testing.T) string {
+				return "/nonexistent/federation-config.json"
+			},
+			wantErr:   true,
+			errSubstr: "/nonexistent/federation-config.json",
+		},
+		{
+			name: "malformed JSON returns error",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				p := filepath.Join(dir, "bad.json")
+				require.NoError(t, os.WriteFile(p, []byte(`{not valid`), 0600))
+				return p
+			},
+			wantErr:   true,
+			errSubstr: "failed to parse federation config",
+		},
+		{
+			name: "empty JSON array succeeds",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				p := filepath.Join(dir, "empty.json")
+				require.NoError(t, os.WriteFile(p, []byte(`[]`), 0600))
+				return p
+			},
+		},
+		{
+			name: "valid JSON with multiple entries",
+			setup: func(t *testing.T) string {
+				entries := []moduleFederationEntry{
+					{
+						Name:      "genAi",
+						Authorize: true,
+						TLS:       true,
+						ProxyService: []moduleProxyServiceEntry{
+							{
+								Authorize:   true,
+								Path:        "/gen-ai/api",
+								PathRewrite: "/api",
+								TLS:         true,
+								Service:     moduleServiceRef{Name: "gen-ai-bff", Namespace: "redhat-ods-apps", Port: 8443},
+							},
+						},
+					},
+					{
+						Name:      "maas",
+						Authorize: true,
+						TLS:       true,
+						ProxyService: []moduleProxyServiceEntry{
+							{
+								Authorize:   true,
+								Path:        "/maas/api",
+								PathRewrite: "/api",
+								TLS:         true,
+								Service:     moduleServiceRef{Name: "maas-bff", Namespace: "redhat-ods-apps", Port: 8443},
+							},
+						},
+					},
+				}
+				data, err := json.Marshal(entries)
+				require.NoError(t, err)
+				dir := t.TempDir()
+				p := filepath.Join(dir, "config.json")
+				require.NoError(t, os.WriteFile(p, data, 0600))
+				return p
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.setup(t)
+			entries, err := parseFederationConfig(path)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errSubstr != "" {
+					assert.Contains(t, err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, entries)
+			}
+		})
+	}
+}
+
+func TestNormalizeFederationEntries(t *testing.T) {
+	tests := []struct {
+		name      string
+		entries   []moduleFederationEntry
+		wantCount int
+		wantErr   bool
+		errSubstr string
+		validate  func(t *testing.T, result []normalizedProxyEntry)
+	}{
+		{
+			name: "old-format entry normalized correctly",
+			entries: []moduleFederationEntry{
+				{
+					Name:      "genAi",
+					Authorize: true,
+					TLS:       true,
+					Service:   &moduleServiceRef{Name: "gen-ai-bff", Namespace: "ns", Port: 8443},
+					Proxy: []moduleProxyRoute{
+						{Path: "/gen-ai/api", PathRewrite: "/api"},
+					},
+				},
+			},
+			wantCount: 1,
+			validate: func(t *testing.T, result []normalizedProxyEntry) {
+				assert.Equal(t, "genAi", result[0].entryName)
+				assert.Equal(t, "/gen-ai/api", result[0].service.Path)
+				assert.Equal(t, "/api", result[0].service.PathRewrite)
+				assert.True(t, result[0].service.Authorize)
+				assert.True(t, result[0].service.TLS)
+				assert.Equal(t, "gen-ai-bff", result[0].service.Service.Name)
+			},
+		},
+		{
+			name: "new-format entry used as-is",
+			entries: []moduleFederationEntry{
+				{
+					Name: "maas",
+					ProxyService: []moduleProxyServiceEntry{
+						{
+							Authorize:   false,
+							Path:        "/maas/api",
+							PathRewrite: "/api",
+							TLS:         false,
+							Service:     moduleServiceRef{Name: "maas-bff", Namespace: "ns", Port: 8080},
+						},
+					},
+				},
+			},
+			wantCount: 1,
+			validate: func(t *testing.T, result []normalizedProxyEntry) {
+				assert.False(t, result[0].service.Authorize)
+				assert.False(t, result[0].service.TLS)
+				assert.Equal(t, int32(8080), result[0].service.Service.Port)
+			},
+		},
+		{
+			name: "entry with both proxy and proxyService uses proxyService",
+			entries: []moduleFederationEntry{
+				{
+					Name:      "test",
+					Authorize: true,
+					TLS:       true,
+					Service:   &moduleServiceRef{Name: "old-svc", Namespace: "ns", Port: 443},
+					Proxy:     []moduleProxyRoute{{Path: "/old/api", PathRewrite: "/api"}},
+					ProxyService: []moduleProxyServiceEntry{
+						{
+							Authorize:   false,
+							Path:        "/new/api",
+							PathRewrite: "/v2",
+							TLS:         false,
+							Service:     moduleServiceRef{Name: "new-svc", Namespace: "ns", Port: 8080},
+						},
+					},
+				},
+			},
+			wantCount: 1,
+			validate: func(t *testing.T, result []normalizedProxyEntry) {
+				assert.Equal(t, "/new/api", result[0].service.Path)
+				assert.Equal(t, "new-svc", result[0].service.Service.Name)
+			},
+		},
+		{
+			name: "old-format entry with nil service returns error",
+			entries: []moduleFederationEntry{
+				{
+					Name:  "badEntry",
+					Proxy: []moduleProxyRoute{{Path: "/bad/api", PathRewrite: "/api"}},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "badEntry",
+		},
+		{
+			name: "coreBff entry is skipped",
+			entries: []moduleFederationEntry{
+				{
+					Name: "coreBff",
+					ProxyService: []moduleProxyServiceEntry{
+						{Path: "/self/api", Service: moduleServiceRef{Name: "self", Namespace: "ns", Port: 443}},
+					},
+				},
+				{
+					Name: "other",
+					ProxyService: []moduleProxyServiceEntry{
+						{Path: "/other/api", Service: moduleServiceRef{Name: "other-svc", Namespace: "ns", Port: 443}},
+					},
+				},
+			},
+			wantCount: 1,
+			validate: func(t *testing.T, result []normalizedProxyEntry) {
+				assert.Equal(t, "other", result[0].entryName)
+			},
+		},
+		{
+			name: "entry with no proxy routes skipped silently",
+			entries: []moduleFederationEntry{
+				{
+					Name:        "mlflowEmbedded",
+					RemoteEntry: "http://example.com/remoteEntry.js",
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "mixed config with old and new format",
+			entries: []moduleFederationEntry{
+				{
+					Name:      "oldModule",
+					Authorize: true,
+					TLS:       true,
+					Service:   &moduleServiceRef{Name: "old-svc", Namespace: "ns", Port: 443},
+					Proxy:     []moduleProxyRoute{{Path: "/old/api", PathRewrite: "/api"}},
+				},
+				{
+					Name: "newModule",
+					ProxyService: []moduleProxyServiceEntry{
+						{
+							Authorize:   false,
+							Path:        "/new/api",
+							PathRewrite: "/api",
+							TLS:         false,
+							Service:     moduleServiceRef{Name: "new-svc", Namespace: "ns", Port: 8080},
+						},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := normalizeFederationEntries(tt.entries)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errSubstr != "" {
+					assert.Contains(t, err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, result, tt.wantCount)
+			if tt.validate != nil {
+				tt.validate(t, result)
+			}
+		})
+	}
+}
+
+func TestValidateProxyEntries(t *testing.T) {
+	tests := []struct {
+		name      string
+		entries   []normalizedProxyEntry
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "duplicate proxy paths rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "modA", service: moduleProxyServiceEntry{Path: "/shared/api", Service: moduleServiceRef{Name: "a", Namespace: "ns", Port: 443}}},
+				{entryName: "modB", service: moduleProxyServiceEntry{Path: "/shared/api", Service: moduleServiceRef{Name: "b", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "duplicate proxy path /shared/api in entries modA and modB",
+		},
+		{
+			name: "module path colliding with reserved /api/k8s/",
+			entries: []normalizedProxyEntry{
+				{entryName: "badMod", service: moduleProxyServiceEntry{Path: "/api/k8s", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "collides with reserved BFF route",
+		},
+		{
+			name: "module path colliding with /api/service/model-serving/",
+			entries: []normalizedProxyEntry{
+				{entryName: "conflict", service: moduleProxyServiceEntry{Path: "/api/service/model-serving", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "collides with reserved BFF route",
+		},
+		{
+			name: "empty service name rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "badSvc", service: moduleProxyServiceEntry{Path: "/ok/api", Service: moduleServiceRef{Name: "", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "empty service name",
+		},
+		{
+			name: "empty service namespace rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "badNs", service: moduleProxyServiceEntry{Path: "/ok/api", Service: moduleServiceRef{Name: "svc", Namespace: "", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "empty service namespace",
+		},
+		{
+			name: "zero service port rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "badPort", service: moduleProxyServiceEntry{Path: "/ok/api", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 0}}},
+			},
+			wantErr:   true,
+			errSubstr: "zero service port",
+		},
+		{
+			name: "valid entries pass",
+			entries: []normalizedProxyEntry{
+				{entryName: "genAi", service: moduleProxyServiceEntry{Path: "/gen-ai/api", Service: moduleServiceRef{Name: "gen-ai-bff", Namespace: "ns", Port: 8443}}},
+				{entryName: "maas", service: moduleProxyServiceEntry{Path: "/maas/api", Service: moduleServiceRef{Name: "maas-bff", Namespace: "ns", Port: 8443}}},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProxyEntries(tt.entries)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errSubstr != "" {
+					assert.Contains(t, err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestReservedPathCollisionBothDirections(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "module is prefix of reserved", path: "/api"},
+		{name: "reserved is prefix of module", path: "/api/k8s/custom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := []normalizedProxyEntry{
+				{entryName: "collision", service: moduleProxyServiceEntry{Path: tt.path, Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			}
+			err := validateProxyEntries(entries)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "collides with reserved BFF route")
+		})
+	}
+}
+
+// TestReservedPathCollisionViaPathPrefix covers the case where a module proxy
+// path only collides with a reserved BFF route once the PathPrefix ("/core-bff")
+// variant is considered. A path like "/openapi" does not collide with any
+// reserved bare path (e.g. "/api/", "/api/k8s/"), but registerModuleProxies
+// dual-registers it at PathPrefix+"/openapi/", which collides with the real
+// OpenAPIPath route ("/core-bff/openapi") and would panic http.ServeMux at
+// startup if this branch of validateProxyEntries were broken.
+func TestReservedPathCollisionViaPathPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "collides with openapi route only via PathPrefix", path: "/openapi"},
+		{name: "collides with swagger-ui route only via PathPrefix", path: "/swagger-ui"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := []normalizedProxyEntry{
+				{entryName: "sneaky", service: moduleProxyServiceEntry{Path: tt.path, Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			}
+			err := validateProxyEntries(entries)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "collides with reserved BFF route")
+			assert.Contains(t, err.Error(), "sneaky")
+		})
+	}
+}
+
+func TestInitModuleProxies_EmptyConfig(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.MFRemotesConfig = ""
+	})
+	err := app.initModuleProxies()
+	require.NoError(t, err)
+	assert.Nil(t, app.moduleProxies)
+}
+
+func TestInitModuleProxies_AuthorizeTrue(t *testing.T) {
+	var receivedAuthHeader string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	entries := []moduleFederationEntry{
+		{
+			Name: "authMod",
+			ProxyService: []moduleProxyServiceEntry{
+				{
+					Authorize:   true,
+					Path:        "/auth-mod/api",
+					PathRewrite: "/api",
+					TLS:         false,
+					Service:     moduleServiceRef{Name: "localhost", Namespace: "test", Port: 8080},
+				},
+			},
+		},
+	}
+	configFile := writeTempConfig(t, entries)
+
+	app := newTestApp(func(a *App) {
+		a.config.MFRemotesConfig = configFile
+		a.config.DevMode = true
+		a.config.MockK8Client = false
+	})
+
+	err := app.initModuleProxies()
+	require.NoError(t, err)
+	require.Len(t, app.moduleProxies, 1)
+
+	assert.NotNil(t, app.moduleProxies[0].handler)
+
+	admin := k8mocks.DefaultTestUsers[0]
+
+	appDirect := newTestApp(func(a *App) {
+		a.config.DevMode = true
+	})
+	proxyHandler := createTestProxy(t, appDirect, backend.URL, "/auth-mod/api", "/api", true, false, nil)
+	rr := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/auth-mod/api/v1/items", nil)
+	req2 = reqWithIdentity(req2, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken("test-token-123"),
+	})
+	proxyHandler.ServeHTTP(rr, req2)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, receivedAuthHeader, "Bearer test-token-123")
+}
+
+func TestInitModuleProxies_AuthorizeFalse(t *testing.T) {
+	var receivedAuthHeader string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	app := newTestApp(func(a *App) {
+		a.config.DevMode = true
+	})
+	proxyHandler := createTestProxy(t, app, backend.URL, "/noauth/api", "/api", false, false, nil)
+
+	admin := k8mocks.DefaultTestUsers[0]
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/noauth/api/v1/items", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken("should-not-appear"),
+	})
+	proxyHandler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, receivedAuthHeader)
+}
+
+func TestInitModuleProxies_TLSFalse(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	app := newTestApp(func(a *App) {
+		a.config.DevMode = true
+	})
+	proxyHandler := createTestProxy(t, app, backend.URL, "/perses/api", "/api", false, false, nil)
+	require.NotNil(t, proxyHandler)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/perses/api/v1/dashboards", nil)
+	proxyHandler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestInitModuleProxies_CustomHeaders(t *testing.T) {
+	var receivedHeaders http.Header
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	app := newTestApp(func(a *App) {
+		a.config.DevMode = true
+	})
+	headers := map[string]string{
+		"X-Custom-Header": "custom-value",
+		"X-Another":       "another-value",
+	}
+	proxyHandler := createTestProxy(t, app, backend.URL, "/custom/api", "/api", false, false, headers)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/custom/api/v1/data", nil)
+	proxyHandler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, receivedHeaders)
+	assert.Equal(t, "custom-value", receivedHeaders.Get("X-Custom-Header"))
+	assert.Equal(t, "another-value", receivedHeaders.Get("X-Another"))
+}
+
+func TestInitModuleProxies_PathRewrite(t *testing.T) {
+	var receivedPath string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	app := newTestApp(func(a *App) {
+		a.config.DevMode = true
+	})
+	proxyHandler := createTestProxy(t, app, backend.URL, "/gen-ai/api", "/api", false, false, nil)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/models", nil)
+	proxyHandler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "/api/v1/models", receivedPath)
+}
+
+func TestInitModuleProxies_InvalidServiceFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		entries   []moduleFederationEntry
+		errSubstr string
+	}{
+		{
+			name: "empty service name",
+			entries: []moduleFederationEntry{
+				{
+					Name: "badName",
+					ProxyService: []moduleProxyServiceEntry{
+						{Path: "/bad/api", PathRewrite: "/api", TLS: false, Service: moduleServiceRef{Name: "", Namespace: "ns", Port: 443}},
+					},
+				},
+			},
+			errSubstr: "empty service name",
+		},
+		{
+			name: "zero port",
+			entries: []moduleFederationEntry{
+				{
+					Name: "badPort",
+					ProxyService: []moduleProxyServiceEntry{
+						{Path: "/bad/api", PathRewrite: "/api", TLS: false, Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 0}},
+					},
+				},
+			},
+			errSubstr: "zero service port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configFile := writeTempConfig(t, tt.entries)
+			app := newTestApp(func(a *App) {
+				a.config.MFRemotesConfig = configFile
+				a.config.DevMode = true
+			})
+			err := app.initModuleProxies()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errSubstr)
+		})
+	}
+}
+
+// TestInitModuleProxies_AllowHTTPIndependentOfDevMode guards ADV-011: every other
+// tls:false test in this file also sets DevMode:true, so a regression that dropped
+// the "!entry.service.TLS ||" term from initModuleProxies' AllowHTTP computation
+// (leaving only the DevMode/MockK8Client checks) would go undetected. This test
+// calls the real app.initModuleProxies() — not the duplicated buildModuleProxyConfig
+// test helper — with DevMode and MockK8Client both false, so a proxy.NewReverseProxy
+// "insecure HTTP target URLs are not allowed" failure can only be caused by AllowHTTP
+// not being driven by the entry's own tls field.
+func TestInitModuleProxies_AllowHTTPIndependentOfDevMode(t *testing.T) {
+	tests := []struct {
+		name string
+		tls  bool
+	}{
+		{name: "tls false outside dev/mock mode still builds (perses-style production HTTP target)", tls: false},
+		{name: "tls true outside dev/mock mode builds (standard production HTTPS target)", tls: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := []moduleFederationEntry{
+				{
+					Name: "prodMod",
+					ProxyService: []moduleProxyServiceEntry{
+						{
+							Path:        "/prod/api",
+							PathRewrite: "/api",
+							TLS:         tt.tls,
+							Service:     moduleServiceRef{Name: "prod-svc", Namespace: "ns", Port: 8080},
+						},
+					},
+				},
+			}
+			configFile := writeTempConfig(t, entries)
+			app := newTestApp(func(a *App) {
+				a.config.MFRemotesConfig = configFile
+			})
+			require.False(t, app.config.DevMode)
+			require.False(t, app.config.MockK8Client)
+
+			err := app.initModuleProxies()
+			require.NoError(t, err)
+			require.Len(t, app.moduleProxies, 1)
+			assert.NotNil(t, app.moduleProxies[0].handler)
+		})
+	}
+}
+
+func TestInitModuleProxies_DuplicatePaths(t *testing.T) {
+	entries := []moduleFederationEntry{
+		{
+			Name: "modA",
+			ProxyService: []moduleProxyServiceEntry{
+				{Path: "/shared/api", PathRewrite: "/api", TLS: false, Service: moduleServiceRef{Name: "a", Namespace: "ns", Port: 443}},
+			},
+		},
+		{
+			Name: "modB",
+			ProxyService: []moduleProxyServiceEntry{
+				{Path: "/shared/api", PathRewrite: "/api", TLS: false, Service: moduleServiceRef{Name: "b", Namespace: "ns", Port: 443}},
+			},
+		},
+	}
+	configFile := writeTempConfig(t, entries)
+	app := newTestApp(func(a *App) {
+		a.config.MFRemotesConfig = configFile
+		a.config.DevMode = true
+	})
+	err := app.initModuleProxies()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate proxy path")
+	assert.Contains(t, err.Error(), "modA")
+	assert.Contains(t, err.Error(), "modB")
+}
+
+func TestInitModuleProxies_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "bad.json")
+	require.NoError(t, os.WriteFile(p, []byte(`not json`), 0600))
+
+	app := newTestApp(func(a *App) {
+		a.config.MFRemotesConfig = p
+	})
+	err := app.initModuleProxies()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse federation config")
+}
+
+func TestInitModuleProxies_NonExistentFile(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.MFRemotesConfig = "/does/not/exist.json"
+	})
+	err := app.initModuleProxies()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "/does/not/exist.json")
+}
+
+func TestInitModuleProxies_SkipsNoProxyRoutes(t *testing.T) {
+	entries := []moduleFederationEntry{
+		{
+			Name:        "mlflowEmbedded",
+			RemoteEntry: "http://example.com/remoteEntry.js",
+		},
+	}
+	configFile := writeTempConfig(t, entries)
+	app := newTestApp(func(a *App) {
+		a.config.MFRemotesConfig = configFile
+		a.config.DevMode = true
+	})
+	err := app.initModuleProxies()
+	require.NoError(t, err)
+	assert.Nil(t, app.moduleProxies)
+}
+
+// TestRegisterModuleProxies_DualPathRegistration verifies that registerModuleProxies
+// (the actual mux-wiring code, distinct from the handlers exercised directly in the
+// tests above) registers each module proxy at both its bare path and the
+// PathPrefix-stripped path, and that multiple registered proxies route independently
+// without cross-talk.
+func TestRegisterModuleProxies_DualPathRegistration(t *testing.T) {
+	var receivedPaths []string
+	newBackend := func(tag string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedPaths = append(receivedPaths, tag+":"+r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+	backendA := newBackend("A")
+	defer backendA.Close()
+	backendB := newBackend("B")
+	defer backendB.Close()
+
+	app := newTestApp(func(a *App) {
+		a.config.DevMode = true
+	})
+	handlerA := createTestProxy(t, app, backendA.URL, "/gen-ai/api", "/api", false, false, nil)
+	handlerB := createTestProxy(t, app, backendB.URL, "/maas/api", "/v1", false, false, nil)
+	app.moduleProxies = []moduleProxyHandler{
+		{path: "/gen-ai/api", handler: handlerA},
+		{path: "/maas/api", handler: handlerB},
+	}
+
+	mux := http.NewServeMux()
+	app.registerModuleProxies(mux)
+
+	tests := []struct {
+		name        string
+		requestPath string
+		want        string
+	}{
+		{name: "genAi bare path routes to backend A", requestPath: "/gen-ai/api/models", want: "A:/api/models"},
+		{name: "genAi PathPrefix-stripped path routes to backend A", requestPath: PathPrefix + "/gen-ai/api/models", want: "A:/api/models"},
+		{name: "maas bare path routes to backend B", requestPath: "/maas/api/jobs", want: "B:/v1/jobs"},
+		{name: "maas PathPrefix-stripped path routes to backend B", requestPath: PathPrefix + "/maas/api/jobs", want: "B:/v1/jobs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receivedPaths = nil
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.requestPath, nil)
+			mux.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusOK, rr.Code)
+			require.Len(t, receivedPaths, 1)
+			assert.Equal(t, tt.want, receivedPaths[0])
+		})
+	}
+}
+
+// TestRoutes_ModuleProxyPaths verifies that module proxies configured via app.moduleProxies
+// are actually reachable through the full app.Routes() stack (newServiceMux -> registerModuleProxies
+// -> newCombinedMux's authenticated handler chain), mirroring the existing TestRoutes_K8sProxyPaths /
+// TestRoutes_WsProxyPaths integration tests. TestRegisterModuleProxies_DualPathRegistration above only
+// exercises registerModuleProxies against a bare mux built by the test itself, so it would not catch a
+// regression where the "app.registerModuleProxies(mux)" call is removed from newServiceMux() in
+// routes.go — this test closes that gap by going through the real Routes() wiring end to end.
+func TestRoutes_ModuleProxyPaths(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Got-Path", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "index.html"), []byte("<html></html>"), 0600))
+
+	app := newTestApp(func(a *App) {
+		a.config.StaticAssetsDir = tmpDir
+	})
+	handler := createTestProxy(t, app, backend.URL, "/gen-ai/api", "/api", false, false, nil)
+	app.moduleProxies = []moduleProxyHandler{
+		{path: "/gen-ai/api", handler: handler},
+	}
+
+	ts := httptest.NewServer(app.Routes())
+	defer ts.Close()
+
+	tests := []struct {
+		name     string
+		path     string
+		wantPath string
+	}{
+		{"bare path", "/gen-ai/api/v1/models", "/api/v1/models"},
+		{"prefixed path", "/core-bff/gen-ai/api/v1/models", "/api/v1/models"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get(ts.URL + tt.path)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, tt.wantPath, resp.Header.Get("X-Got-Path"))
+		})
+	}
+}
+
+// createTestProxy creates a proxy handler pointing at the given backend URL for testing.
+func createTestProxy(t *testing.T, app *App, backendURL, proxyPath, pathRewrite string, authorize, useTLS bool, headers map[string]string) http.Handler {
+	t.Helper()
+
+	entries := []moduleFederationEntry{
+		{
+			Name: "testModule",
+			ProxyService: []moduleProxyServiceEntry{
+				{
+					Authorize:   authorize,
+					Path:        proxyPath,
+					PathRewrite: pathRewrite,
+					TLS:         useTLS,
+					Service:     moduleServiceRef{Name: "placeholder", Namespace: "ns", Port: 8080},
+					Headers:     headers,
+				},
+			},
+		},
+	}
+
+	normalized, err := normalizeFederationEntries(entries)
+	require.NoError(t, err)
+	require.Len(t, normalized, 1)
+
+	entry := normalized[0]
+
+	// Override to point at test backend
+	cfg := buildModuleProxyConfig(app, entry, backendURL)
+
+	rp, err := proxy.NewReverseProxy(cfg)
+	require.NoError(t, err)
+	return rp
+}
+
+// buildModuleProxyConfig creates a ProxyConfig for testing, targeting the given backendURL.
+func buildModuleProxyConfig(app *App, entry normalizedProxyEntry, backendURL string) proxy.ProxyConfig {
+	targetURL, _ := url.Parse(backendURL)
+
+	proxyPath := entry.service.Path
+	pathRewrite := entry.service.PathRewrite
+
+	cfg := proxy.ProxyConfig{
+		TargetURL:          targetURL,
+		RootCAs:            app.rootCAs,
+		InsecureSkipVerify: false,
+		AllowHTTP:          true,
+		PathRewriteFn: func(r *http.Request) string {
+			return pathRewrite + strings.TrimPrefix(r.URL.Path, proxyPath)
+		},
+		StripHeaders:       proxy.SensitiveIngressHeaders(app.config.AuthTokenHeader),
+		ModifyResponse:     ssrf.NewRedirectValidator(app.logger),
+		SSRFValidateTarget: false,
+		Logger:             app.logger,
+	}
+
+	if entry.service.Authorize {
+		cfg.AuthHeaderFn = func(r *http.Request) string {
+			identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+			if !ok || identity == nil {
+				return ""
+			}
+			return k8s.BearerTokenPrefix + identity.ResolveToken(app.devFallbackToken)
+		}
+	}
+
+	if len(entry.service.Headers) > 0 {
+		headers := entry.service.Headers
+		cfg.SetOutboundHeadersFn = func(_ *http.Request, outH http.Header) {
+			for k, v := range headers {
+				outH.Set(k, v)
+			}
+		}
+	}
+
+	return cfg
+}
+
+func writeTempConfig(t *testing.T, entries []moduleFederationEntry) string {
+	t.Helper()
+	data, err := json.Marshal(entries)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	p := filepath.Join(dir, "federation-config.json")
+	require.NoError(t, os.WriteFile(p, data, 0600))
+	return p
+}

--- a/distributions/core-bff/bff/internal/api/module_proxy_test.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy_test.go
@@ -7,14 +7,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/proxy"
-	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/ssrf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,6 +21,7 @@ func TestParseFederationConfig(t *testing.T) {
 		name      string
 		setup     func(t *testing.T) string
 		wantNil   bool
+		wantCount int
 		wantErr   bool
 		errSubstr string
 	}{
@@ -61,6 +59,22 @@ func TestParseFederationConfig(t *testing.T) {
 				require.NoError(t, os.WriteFile(p, []byte(`[]`), 0600))
 				return p
 			},
+			wantCount: 0,
+		},
+		{
+			name: "file exceeding max size returns error",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				p := filepath.Join(dir, "large.json")
+				data := make([]byte, maxFederationConfigLen+1)
+				for i := range data {
+					data[i] = 'x'
+				}
+				require.NoError(t, os.WriteFile(p, data, 0600))
+				return p
+			},
+			wantErr:   true,
+			errSubstr: "exceeds maximum size",
 		},
 		{
 			name: "valid JSON with multiple entries",
@@ -102,6 +116,7 @@ func TestParseFederationConfig(t *testing.T) {
 				require.NoError(t, os.WriteFile(p, data, 0600))
 				return p
 			},
+			wantCount: 2,
 		},
 	}
 
@@ -119,9 +134,59 @@ func TestParseFederationConfig(t *testing.T) {
 			require.NoError(t, err)
 			if tt.wantNil {
 				assert.Nil(t, entries)
+				return
 			}
+			require.Len(t, entries, tt.wantCount)
 		})
 	}
+
+	// Verify parsed field mapping for the multi-entry case.
+	t.Run("multi-entry fields are mapped correctly", func(t *testing.T) {
+		entries := []moduleFederationEntry{
+			{
+				Name:      "genAi",
+				Authorize: true,
+				TLS:       true,
+				ProxyService: []moduleProxyServiceEntry{
+					{
+						Authorize:   true,
+						Path:        "/gen-ai/api",
+						PathRewrite: "/api",
+						TLS:         true,
+						Service:     moduleServiceRef{Name: "gen-ai-bff", Namespace: "redhat-ods-apps", Port: 8443},
+					},
+				},
+			},
+			{
+				Name: "maas",
+				Proxy: []moduleProxyRoute{
+					{Path: "/maas/api", PathRewrite: "/api"},
+				},
+				Service: &moduleServiceRef{Name: "maas-bff", Namespace: "redhat-ods-apps", Port: 9443},
+			},
+		}
+		data, err := json.Marshal(entries)
+		require.NoError(t, err)
+		dir := t.TempDir()
+		p := filepath.Join(dir, "config.json")
+		require.NoError(t, os.WriteFile(p, data, 0600))
+
+		parsed, err := parseFederationConfig(p)
+		require.NoError(t, err)
+		require.Len(t, parsed, 2)
+
+		assert.Equal(t, "genAi", parsed[0].Name)
+		assert.True(t, parsed[0].Authorize)
+		require.Len(t, parsed[0].ProxyService, 1)
+		assert.Equal(t, "/gen-ai/api", parsed[0].ProxyService[0].Path)
+		assert.Equal(t, int32(8443), parsed[0].ProxyService[0].Service.Port)
+
+		assert.Equal(t, "maas", parsed[1].Name)
+		require.Len(t, parsed[1].Proxy, 1)
+		assert.Equal(t, "/maas/api", parsed[1].Proxy[0].Path)
+		require.NotNil(t, parsed[1].Service)
+		assert.Equal(t, int32(9443), parsed[1].Service.Port)
+	})
 }
 
 func TestNormalizeFederationEntries(t *testing.T) {
@@ -301,6 +366,30 @@ func TestValidateProxyEntries(t *testing.T) {
 		errSubstr string
 	}{
 		{
+			name: "empty proxy path rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "emptyPath", service: moduleProxyServiceEntry{Path: "", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "empty proxy path",
+		},
+		{
+			name: "non-rooted proxy path rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "noSlash", service: moduleProxyServiceEntry{Path: "gen-ai/api", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "non-rooted proxy path",
+		},
+		{
+			name: "module path /core-bff/api collides with reserved prefix",
+			entries: []normalizedProxyEntry{
+				{entryName: "selfCollide", service: moduleProxyServiceEntry{Path: "/core-bff/api", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "collides with reserved BFF route",
+		},
+		{
 			name: "duplicate proxy paths rejected",
 			entries: []normalizedProxyEntry{
 				{entryName: "modA", service: moduleProxyServiceEntry{Path: "/shared/api", Service: moduleServiceRef{Name: "a", Namespace: "ns", Port: 443}}},
@@ -348,6 +437,57 @@ func TestValidateProxyEntries(t *testing.T) {
 			},
 			wantErr:   true,
 			errSubstr: "zero service port",
+		},
+		{
+			name: "invalid RFC 1123 service name rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "badName", service: moduleProxyServiceEntry{Path: "/ok/api", Service: moduleServiceRef{Name: "UPPER_CASE", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "invalid service name",
+		},
+		{
+			name: "invalid RFC 1123 service namespace rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "badNs", service: moduleProxyServiceEntry{Path: "/ok/api", Service: moduleServiceRef{Name: "svc", Namespace: "has spaces", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "invalid service namespace",
+		},
+		{
+			name: "authorize with custom Authorization header rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "authConflict", service: moduleProxyServiceEntry{
+					Authorize: true, Path: "/ok/api",
+					Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443},
+					Headers: map[string]string{"authorization": "Bearer static-token"},
+				}},
+			},
+			wantErr:   true,
+			errSubstr: "custom Authorization header while authorize is enabled",
+		},
+		{
+			name: "authorize with custom Authorization header case-insensitive",
+			entries: []normalizedProxyEntry{
+				{entryName: "authConflict", service: moduleProxyServiceEntry{
+					Authorize: true, Path: "/ok/api",
+					Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443},
+					Headers: map[string]string{"AUTHORIZATION": "Bearer static-token"},
+				}},
+			},
+			wantErr:   true,
+			errSubstr: "custom Authorization header while authorize is enabled",
+		},
+		{
+			name: "non-authorized route with Authorization header allowed",
+			entries: []normalizedProxyEntry{
+				{entryName: "staticAuth", service: moduleProxyServiceEntry{
+					Authorize: false, Path: "/ok/api",
+					Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443},
+					Headers: map[string]string{"Authorization": "Bearer static-token"},
+				}},
+			},
+			wantErr: false,
 		},
 		{
 			name: "valid entries pass",
@@ -868,55 +1008,14 @@ func createTestProxy(t *testing.T, app *App, backendURL, proxyPath, pathRewrite 
 
 	entry := normalized[0]
 
-	// Override to point at test backend
-	cfg := buildModuleProxyConfig(app, entry, backendURL)
+	targetURL, err := url.Parse(backendURL)
+	require.NoError(t, err)
+
+	cfg := app.buildModuleProxyConfig(entry, targetURL, true, false, false)
 
 	rp, err := proxy.NewReverseProxy(cfg)
 	require.NoError(t, err)
 	return rp
-}
-
-// buildModuleProxyConfig creates a ProxyConfig for testing, targeting the given backendURL.
-func buildModuleProxyConfig(app *App, entry normalizedProxyEntry, backendURL string) proxy.ProxyConfig {
-	targetURL, _ := url.Parse(backendURL)
-
-	proxyPath := entry.service.Path
-	pathRewrite := entry.service.PathRewrite
-
-	cfg := proxy.ProxyConfig{
-		TargetURL:          targetURL,
-		RootCAs:            app.rootCAs,
-		InsecureSkipVerify: false,
-		AllowHTTP:          true,
-		PathRewriteFn: func(r *http.Request) string {
-			return pathRewrite + strings.TrimPrefix(r.URL.Path, proxyPath)
-		},
-		StripHeaders:       proxy.SensitiveIngressHeaders(app.config.AuthTokenHeader),
-		ModifyResponse:     ssrf.NewRedirectValidator(app.logger),
-		SSRFValidateTarget: false,
-		Logger:             app.logger,
-	}
-
-	if entry.service.Authorize {
-		cfg.AuthHeaderFn = func(r *http.Request) string {
-			identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
-			if !ok || identity == nil {
-				return ""
-			}
-			return k8s.BearerTokenPrefix + identity.ResolveToken(app.devFallbackToken)
-		}
-	}
-
-	if len(entry.service.Headers) > 0 {
-		headers := entry.service.Headers
-		cfg.SetOutboundHeadersFn = func(_ *http.Request, outH http.Header) {
-			for k, v := range headers {
-				outH.Set(k, v)
-			}
-		}
-	}
-
-	return cfg
 }
 
 func writeTempConfig(t *testing.T, entries []moduleFederationEntry) string {

--- a/distributions/core-bff/bff/internal/api/routes.go
+++ b/distributions/core-bff/bff/internal/api/routes.go
@@ -100,8 +100,10 @@ func (app *App) newCombinedMux(serviceMux *http.ServeMux, staticHandler http.Han
 	mux.Handle(proxy.WssProxyPrefix, authedHandler)
 
 	// Bare module paths (e.g. /gen-ai/api/) need explicit auth routing to avoid the SPA catch-all.
+	// Register both the subtree and exact root to prevent ServeMux 307 redirects.
 	for _, mp := range app.moduleProxies {
 		mux.Handle(mp.path+"/", authedHandler)
+		mux.HandleFunc(mp.path, app.notFoundResponse)
 	}
 
 	// Exact-path handlers prevent ServeMux from 307-redirecting bare roots to subtree patterns.

--- a/distributions/core-bff/bff/internal/api/routes.go
+++ b/distributions/core-bff/bff/internal/api/routes.go
@@ -60,6 +60,7 @@ func (app *App) newServiceMux() *http.ServeMux {
 		mux.Handle(PathPrefix+proxy.WssProxyPrefix, http.StripPrefix(PathPrefix, app.wsProxy))
 	}
 	app.registerModelServingProxy(mux)
+	app.registerModuleProxies(mux)
 
 	return mux
 }
@@ -97,6 +98,11 @@ func (app *App) newCombinedMux(serviceMux *http.ServeMux, staticHandler http.Han
 	mux.Handle(APIPathPrefix+"/", authedHandler)
 	mux.Handle(PathPrefix+"/", authedHandler)
 	mux.Handle(proxy.WssProxyPrefix, authedHandler)
+
+	// Bare module paths (e.g. /gen-ai/api/) need explicit auth routing to avoid the SPA catch-all.
+	for _, mp := range app.moduleProxies {
+		mux.Handle(mp.path+"/", authedHandler)
+	}
 
 	// Exact-path handlers prevent ServeMux from 307-redirecting bare roots to subtree patterns.
 	mux.HandleFunc(APIPathPrefix, app.notFoundResponse)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-85775

## Description

Extends core-bff to dynamically proxy HTTP requests to federated module BFF services based on the `federation-config.json` file produced by the dashboard-operator.

When a module declares proxy routes in its federation config entry (e.g., gen-ai declares `/gen-ai/api/` -> `/api/`), core-bff now creates reverse proxies at startup and registers them on its mux. This allows the React frontend to reach module BFFs through a single ingress point (core-bff) without needing individual routes or ingress resources per module.

### Key behaviors

- **Two config formats supported**: old-format (`proxy` + `service` at entry level) and new-format (`proxyService` with per-route fields including headers and independent `authorize`/`tls` flags).
- **Dual-path registration**: each proxy path is registered both bare (e.g., `/gen-ai/api/`) and with the `/core-bff` prefix (e.g., `/core-bff/gen-ai/api/`), consistent with how existing BFF routes are registered.
- **Self-proxy avoidance**: the `coreBff` entry in the federation config is skipped to prevent a routing loop.
- **Validation**: duplicate proxy paths, reserved BFF route collisions (bare and `/core-bff`-prefixed), empty/non-rooted paths, RFC 1123 label validation for service name/namespace, auth header conflicts (`authorize` + custom `Authorization` header), and bounded config file reading (1 MiB cap) are all rejected at startup with clear error messages.
- **Auth control**: the `authorize` field controls whether the proxy forwards the user's bearer token to the target BFF. All module proxy paths go through the authenticated handler (token required), but token forwarding is opt-in per route.
- **Custom headers**: the `headers` map in new-format entries is forwarded via `SetOutboundHeadersFn`.
- **SSRF protection**: proxies validate targets and use `ssrf.NewRedirectValidator` for redirect safety.
- **TLS**: scheme (`http`/`https`) and `InsecureSkipVerify` are derived from the entry's `tls` flag combined with dev-mode settings.

### Files changed

| File | Change |
|------|--------|
| `module_proxy.go` | New file: config parsing, normalization, validation, proxy creation, and mux registration |
| `module_proxy_test.go` | New file: 19 test functions covering parsing, normalization, validation, proxy creation (auth, TLS, headers, path rewrite, duplicates, malformed JSON, missing files), and route registration |
| `app.go` | Added `moduleProxies` field to `App` struct; call `initModuleProxies()` during `NewApp()` with cleanup on error |
| `routes.go` | Added `registerModuleProxies(mux)` call in `newServiceMux()`; added auth-routing loop in `newCombinedMux()` for bare module paths |

## How Has This Been Tested?

### Unit tests

19 test functions in `module_proxy_test.go` covering:

- Config parsing (old-format, new-format, malformed JSON, missing file, empty config)
- Entry normalization (coreBff filtering, old-to-new conversion, missing service errors)
- Validation (duplicate paths, reserved route collisions in both directions, via `/core-bff` prefix, empty/non-rooted paths, RFC 1123, auth header conflicts, bounded reader, namespace validation)
- Proxy creation (authorize true/false, TLS flag, custom headers, path rewrite, allowHTTP independent of dev mode)
- Route registration (dual-path on the mux, integration with `TestRoutes`)

### Manual end-to-end testing

Verified the full proxy flow locally using real gen-ai and maas BFF servers behind core-bff.

<details>
<summary>Full manual testing steps</summary>

#### Prerequisites

- Go 1.26+ installed
- Ports 4000, 8080, 8081 available

#### Step 1: Start the module BFF servers

**Terminal 1 — Gen-ai BFF (port 8080):**

```bash
cd packages/gen-ai/bff
make run MOCK_K8S_CLIENT=true MOCK_LS_CLIENT=true MOCK_MCP_CLIENT=true MOCK_MLFLOW_CLIENT=true MOCK_BFF_CLIENTS=true
```

Wait for the healthcheck to pass:

```bash
curl -s http://localhost:8080/healthcheck
# Expected: {"status":"available",...}
```

**Terminal 2 — Maas BFF (port 8081):**

```bash
cd packages/maas/bff
make run PORT=8081 AUTH_METHOD=internal MOCK_K8S_CLIENT=true MOCK_HTTP_CLIENT=true
```

Wait for the healthcheck to pass:

```bash
curl -s http://localhost:8081/healthcheck
# Expected: {"status":"available",...}
```

#### Step 2: Create federation config and DNS entries

**Create the test federation config:**

```bash
cat > /tmp/test-federation-config.json << 'EOF'
[
  {
    "name": "genAi",
    "authorize": true,
    "tls": false,
    "proxy": [{"path": "/gen-ai/api", "pathRewrite": "/api"}],
    "service": {"name": "genai-bff", "namespace": "test", "port": 8080}
  },
  {
    "name": "maas",
    "proxyService": [{
      "authorize": false, "path": "/maas/api", "pathRewrite": "/api",
      "tls": false,
      "service": {"name": "maas-bff", "namespace": "test", "port": 8081}
    }]
  },
  {
    "name": "coreBff",
    "proxyService": [{
      "authorize": true, "path": "/core-bff/api", "pathRewrite": "/api",
      "tls": true, "service": {"name": "dashboard", "namespace": "test", "port": 8943}
    }]
  }
]
EOF
```

**Add DNS entries** (requires sudo):

```bash
sudo sh -c 'echo "127.0.0.1 genai-bff.test.svc.cluster.local maas-bff.test.svc.cluster.local" >> /etc/hosts'
```

#### Step 3: Start core-bff with federation config

**Terminal 3 — Core-bff (port 4000):**

```bash
cd distributions/core-bff/bff
go run ./cmd/ \
  -port 4000 \
  -auth-method disabled \
  -mock-k8s-client \
  -mf-remotes-config /tmp/test-federation-config.json
```

Wait for the healthcheck to pass:

```bash
curl -s http://localhost:4000/healthcheck
# Expected: {"status":"available","systemInfo":{"version":"1.0.0"}}
```

#### Step 4: Test proxy routes

**Test 1 — Gen-ai via bare path (old-format, authorize=true):**

```bash
curl -s "http://localhost:4000/gen-ai/api/v1/lsd/models?namespace=test"
```

Expected: a JSON response with mock model data (array of model objects with `id`, `created`, `object`, `owned_by` fields) — confirms the request was proxied to gen-ai BFF and its mock client responded.

**Test 2 — Gen-ai via prefixed path:**

```bash
curl -s "http://localhost:4000/core-bff/gen-ai/api/v1/lsd/models?namespace=test"
```

Expected: same response as Test 1 (PathPrefix stripping works).

**Test 3 — Maas via bare path (new-format, authorize=false, needs identity headers):**

```bash
curl -s -H "kubeflow-userid: user@example.com" -H "kubeflow-groups: system:authenticated" \
  http://localhost:4000/maas/api/v1/models
```

Expected: a JSON response with mock model data (array of model objects with `id`, `object`, `created`, `owned_by` fields) — confirms the request was proxied to maas BFF and its mock client responded.

**Test 4 — Maas via prefixed path:**

```bash
curl -s -H "kubeflow-userid: user@example.com" -H "kubeflow-groups: system:authenticated" \
  http://localhost:4000/core-bff/maas/api/v1/models
```

Expected: same response as Test 3.

**Test 5 — coreBff entry skipped (self-proxy avoidance):**

```bash
curl -s http://localhost:4000/core-bff/api/
```

Expected: `{"error":{"code":"NOT_FOUND","message":"the requested resource could not be found"}}` — the coreBff entry was filtered out and no proxy was registered for it.

#### Step 5: Cleanup

```bash
# Kill the three BFF processes (Ctrl+C in each terminal)
# Remove DNS entries
sudo sed -i '' '/genai-bff\.test\.svc\.cluster\.local/d' /etc/hosts
# Remove temp config
rm /tmp/test-federation-config.json
```

</details>

## Test Impact

- Added `module_proxy_test.go` with 19 test functions covering all public functions and key integration paths.
- Existing `TestRoutes_*` test updated to verify module proxy paths appear on the mux.
- No existing tests were modified or broken.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for routing requests to federated modules through the BFF.
  * Supports both current and legacy federation configurations.
  * Provides optional authorization, TLS, custom headers, and path rewriting for module requests.
  * Registers module routes with authentication and protects reserved BFF paths.

* **Bug Fixes**
  * Prevents invalid, duplicate, or conflicting module routes from being registered.
  * Improves handling of malformed or incomplete federation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
