### PR TITLE
test(RHOAIENG-85770): wait for Active project before opening from the list

### DIFF
--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -125,8 +125,11 @@ class ProjectListPage {
     return new ProjectRow(() => this.findProjectLink(projectName).parents('tr'));
   }
 
-  findProjectLink(projectName: string) {
-    return this.findProjectsTable().findByRole('link', { name: projectName });
+  findProjectLink(projectName: string, timeout?: number) {
+    return this.findProjectsTable().findByRole('link', {
+      name: projectName,
+      ...(timeout !== undefined ? { timeout } : {}),
+    });
   }
 
   findEmptyResults() {
@@ -158,6 +161,17 @@ class ProjectListPage {
     const projectListToolbar = projectListPage.getTableToolbar();
     projectListToolbar.findNameFilter().type(projectName);
   };
+
+  /**
+   * Filter the Projects table by name and open the matching project.
+   * Waits up to 30s for the row: the dashboard list can lag behind oc
+   * (Active phase / watch lag). Filter typing matches filterProjectByName.
+   */
+  openFilteredProject(projectName: string) {
+    cy.findByTestId('projects-table-toolbar', { timeout: 30000 }).should('be.visible');
+    this.getTableToolbar().findNameFilter().type(projectName);
+    this.findProjectLink(projectName, 30000).should('be.visible').click();
+  }
 }
 
 class CreateEditProjectModal extends Modal {

--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -125,8 +125,11 @@ class ProjectListPage {
     return new ProjectRow(() => this.findProjectLink(projectName).parents('tr'));
   }
 
-  findProjectLink(projectName: string) {
-    return this.findProjectsTable().findByRole('link', { name: projectName });
+  findProjectLink(projectName: string, timeout?: number) {
+    return this.findProjectsTable().findByRole('link', {
+      name: projectName,
+      ...(timeout !== undefined ? { timeout } : {}),
+    });
   }
 
   findEmptyResults() {
@@ -158,6 +161,17 @@ class ProjectListPage {
     const projectListToolbar = projectListPage.getTableToolbar();
     projectListToolbar.findNameFilter().type(projectName);
   };
+
+  /**
+   * Filter the Projects table by name and open the matching project.
+   * Waits up to 30s for the row: oc can report the project exists before the
+   * dashboard list includes it (Active phase / watch lag).
+   */
+  openFilteredProject(projectName: string) {
+    cy.findByTestId('projects-table-toolbar', { timeout: 30000 }).should('be.visible');
+    this.getTableToolbar().findNameFilter().clear().type(projectName);
+    this.findProjectLink(projectName, 30000).should('be.visible').click();
+  }
 }
 
 class CreateEditProjectModal extends Modal {

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
@@ -114,8 +114,7 @@ describe('Workbench Storage Classes Tests', () => {
 
     cy.step(`Navigate to the Project list tab and search for ${projectName}`);
     projectListPage.navigate();
-    projectListPage.filterProjectByName(projectName);
-    projectListPage.findProjectLink(projectName).click();
+    projectListPage.openFilteredProject(projectName);
   });
 
   it(

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
@@ -19,6 +19,7 @@ import { retryableBefore } from '../../../../utils/retryableHooks';
 import type { WBStorageClassesTestData } from '../../../../types';
 import { AccessMode } from '../../../../types';
 import { selectNotebookImageWithBackendFallback } from '../../../../utils/oc_commands/imageStreams';
+import { waitForProjectActive } from '../../../../utils/oc_commands/project';
 import { loadWBStorageClassesFixture } from '../../../../utils/dataLoader';
 import { generateTestUUID } from '../../../../utils/uuidGenerator';
 
@@ -96,6 +97,7 @@ describe('Workbench Storage Classes Tests', () => {
 
         cy.step('Provisioning project');
         provisionClusterStorageSCFeature(projectName, HTPASSWD_CLUSTER_ADMIN_USER.USERNAME);
+        waitForProjectActive(projectName);
       });
   });
 
@@ -114,8 +116,7 @@ describe('Workbench Storage Classes Tests', () => {
 
     cy.step(`Navigate to the Project list tab and search for ${projectName}`);
     projectListPage.navigate();
-    projectListPage.filterProjectByName(projectName);
-    projectListPage.findProjectLink(projectName).click();
+    projectListPage.openFilteredProject(projectName);
   });
 
   it(

--- a/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts
@@ -169,8 +169,7 @@ describe('Verify Connection Type Creation', () => {
       // Project navigation
       cy.step(`Navigate to the Connections tab and validate the connection type is available`);
       projectListPage.navigate();
-      projectListPage.filterProjectByName(projectName);
-      projectListPage.findProjectLink(projectName).click();
+      projectListPage.openFilteredProject(projectName);
       projectDetails.findSectionTab('connections').click();
       connectionsPage.findCreateConnectionButton().click();
       addConnectionModal.findConnectionTypeDropdown().click();
@@ -192,8 +191,7 @@ describe('Verify Connection Type Creation', () => {
 
       cy.step(`Navigate to the Connections tab and validate the connection type is not available`);
       projectListPage.navigate();
-      projectListPage.filterProjectByName(projectName);
-      projectListPage.findProjectLink(projectName).click();
+      projectListPage.openFilteredProject(projectName);
       projectDetails.findSectionTab('connections').click();
       connectionsPage.findCreateConnectionButton().click();
       addConnectionModal.findConnectionTypeDropdown().click();
@@ -236,8 +234,7 @@ describe('Verify Connection Type Creation', () => {
       // Project navigation
       cy.step(`Navigate to the Deployments tab and validate the connection type is available`);
       projectListPage.visit();
-      projectListPage.filterProjectByName(projectName);
-      projectListPage.findProjectLink(projectName).click();
+      projectListPage.openFilteredProject(projectName);
       projectDetails.findSectionTab('model-server').click();
       modelServingGlobal.selectSingleServingModelButtonIfExists();
       modelServingGlobal.findDeployModelButton().click();
@@ -263,8 +260,7 @@ describe('Verify Connection Type Creation', () => {
 
       cy.step(`Navigate to the Deployments tab and validate the connection type is not available`);
       projectListPage.navigate();
-      projectListPage.filterProjectByName(projectName);
-      projectListPage.findProjectLink(projectName).click();
+      projectListPage.openFilteredProject(projectName);
       projectDetails.findSectionTab('model-server').click();
       modelServingGlobal.selectSingleServingModelButtonIfExists();
       modelServingGlobal.findDeployModelButton().click();

--- a/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts
@@ -13,7 +13,10 @@ import { loadOOTBConnectionTypesFixture } from '../../../../utils/dataLoader';
 import type { OOTBConnectionTypesData } from '../../../../types';
 import { createCleanProject } from '../../../../utils/projectChecker';
 import { projectDetails, projectListPage } from '../../../../pages/projects';
-import { deleteOpenShiftProject } from '../../../../utils/oc_commands/project';
+import {
+  deleteOpenShiftProject,
+  waitForProjectActive,
+} from '../../../../utils/oc_commands/project';
 import { deleteConnectionTypeByName } from '../../../../utils/oc_commands/connectionTypes';
 import { modelServingWizard, modelServingGlobal } from '../../../../pages/modelServing';
 
@@ -59,6 +62,7 @@ describe('Verify Connection Type Creation', () => {
       }
       cy.log(`Loaded project name: ${projectName}`);
       createCleanProject(projectName);
+      waitForProjectActive(projectName);
     }),
   );
 
@@ -169,8 +173,7 @@ describe('Verify Connection Type Creation', () => {
       // Project navigation
       cy.step(`Navigate to the Connections tab and validate the connection type is available`);
       projectListPage.navigate();
-      projectListPage.filterProjectByName(projectName);
-      projectListPage.findProjectLink(projectName).click();
+      projectListPage.openFilteredProject(projectName);
       projectDetails.findSectionTab('connections').click();
       connectionsPage.findCreateConnectionButton().click();
       addConnectionModal.findConnectionTypeDropdown().click();
@@ -192,8 +195,7 @@ describe('Verify Connection Type Creation', () => {
 
       cy.step(`Navigate to the Connections tab and validate the connection type is not available`);
       projectListPage.navigate();
-      projectListPage.filterProjectByName(projectName);
-      projectListPage.findProjectLink(projectName).click();
+      projectListPage.openFilteredProject(projectName);
       projectDetails.findSectionTab('connections').click();
       connectionsPage.findCreateConnectionButton().click();
       addConnectionModal.findConnectionTypeDropdown().click();
@@ -236,8 +238,7 @@ describe('Verify Connection Type Creation', () => {
       // Project navigation
       cy.step(`Navigate to the Deployments tab and validate the connection type is available`);
       projectListPage.visit();
-      projectListPage.filterProjectByName(projectName);
-      projectListPage.findProjectLink(projectName).click();
+      projectListPage.openFilteredProject(projectName);
       projectDetails.findSectionTab('model-server').click();
       modelServingGlobal.selectSingleServingModelButtonIfExists();
       modelServingGlobal.findDeployModelButton().click();
@@ -263,8 +264,7 @@ describe('Verify Connection Type Creation', () => {
 
       cy.step(`Navigate to the Deployments tab and validate the connection type is not available`);
       projectListPage.navigate();
-      projectListPage.filterProjectByName(projectName);
-      projectListPage.findProjectLink(projectName).click();
+      projectListPage.openFilteredProject(projectName);
       projectDetails.findSectionTab('model-server').click();
       modelServingGlobal.selectSingleServingModelButtonIfExists();
       modelServingGlobal.findDeployModelButton().click();

--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -179,7 +179,7 @@ export const waitForProjectActive = (
   projectName: string,
   timeout = 60000,
 ): Cypress.Chainable<CommandLineResult> => {
-  const timeoutSeconds = Math.floor(timeout / 1000);
+  const timeoutSeconds = Math.max(1, Math.ceil(timeout / 1000));
   const waitCmd = `oc wait --for=jsonpath='{.status.phase}'=Active project/${projectName} --timeout=${timeoutSeconds}s`;
 
   cy.log(`Waiting for project ${projectName} to become Active`);

--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -167,6 +167,31 @@ export const waitForUserProjectAccess = (
     },
   );
 
+/**
+ * Wait until a project's status.phase is Active.
+ * The dashboard project list only includes Active projects; oc get can succeed
+ * before that. This is not the same as waitForUserProjectAccess (RBAC via --as).
+ *
+ * @param projectName OpenShift Project name
+ * @param timeout Timeout in milliseconds (default: 60000)
+ */
+export const waitForProjectActive = (
+  projectName: string,
+  timeout = 60000,
+): Cypress.Chainable<CommandLineResult> => {
+  const timeoutSeconds = Math.floor(timeout / 1000);
+  const waitCmd = `oc wait --for=jsonpath='{.status.phase}'=Active project/${projectName} --timeout=${timeoutSeconds}s`;
+
+  cy.log(`Waiting for project ${projectName} to become Active`);
+  return cy.exec(waitCmd, { failOnNonZeroExit: false, timeout: timeout + 10000 }).then((result) => {
+    if (result.exitCode !== 0) {
+      const maskedStderr = maskSensitiveInfo(result.stderr || '');
+      throw new Error(`Project ${projectName} did not become Active: ${maskedStderr}`);
+    }
+    return result;
+  });
+};
+
 export const patchInferenceServiceFinalizers = (
   projectName: string,
 ): Cypress.Chainable<CommandLineResult> => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-85770

## Description

CI Cypress E2E can click a project name before that name is in the dashboard Projects table. `oc get project` (and `createCleanProject`) can succeed while the dashboard list still omits the project: `ProjectsContext` only includes projects with `status.phase === 'Active'`, and the watch can lag.

This change:

- Adds `waitForProjectActive` (`oc wait` on `status.phase=Active`) and calls it after project provisioning in the two flaky specs only. It is **not** wired into `createCleanProject` (avoids suite-wide blast radius). It is distinct from `waitForUserProjectAccess` (RBAC via `--as=`).
- Adds `projectListPage.openFilteredProject(name)`: wait for the toolbar (30s), filter by name, then wait up to 30s for the project link before clicking. Callers keep their own `navigate()` / `visit()`.
- Leaves `filterProjectByName` unchanged (deletion tests filter then expect empty results).
- Does **not** default `findProjectLink` to 30s. Optional timeout only; mocked tests still use the 10s default for `should('not.exist')`.

Scoped to `testWorkbenchStorageClasses.cy.ts` and `testCreateConnectionTypes.cy.ts`. Other specs still use filter + click.

## How Has This Been Tested?

- Pre-commit eslint on the four staged files passed.
- Local analogue of GitHub `Test` workflow: lint, type-check, unit, contract tests passed after `npm install` / `install:modules`.
- Mocked Cypress (`frontend` `npm run test:cypress-ci`): `projectList.cy.ts` (uses `findProjectLink`) 13/13 pass. Failures in observability/model-serving Cypress compile (`TS6059` rootDir) are outside this change.
- **Not** run against a live cluster. These two specs need `test-variables.yml` and `oc`. To verify on a cluster:

```bash
# from packages/cypress, with CY_TEST_CONFIG / test-variables.yml set
npm run test:cypress -- --spec 'cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts'
npm run test:cypress -- --spec 'cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts'
```

## Test Impact

Existing E2E specs were updated; no new unit tests. `findProjectLink` remains optional-timeout so mocked `not.exist` assertions keep the 10s default.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved project navigation in end-to-end test flows.
  * Added reliable filtering and opening of projects, including extended wait handling for matching results.
  * Simplified project selection across workbench storage and connection type validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->