### PR TITLE
RHAI-419: Implement BFF contract tests for data-registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35105,6 +35105,7 @@
       },
       "devDependencies": {
         "@odh-dashboard/app-config": "*",
+        "@odh-dashboard/contract-tests": "*",
         "@odh-dashboard/eslint-config": "*",
         "@odh-dashboard/tsconfig": "*"
       }

--- a/packages/data-registry/bff/Makefile
+++ b/packages/data-registry/bff/Makefile
@@ -13,7 +13,7 @@ INSECURE_SKIP_VERIFY ?= false
 #frontend static assets root directory
 STATIC_ASSETS_DIR ?= ./static
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.29.0
+ENVTEST_K8S_VERSION = 1.29.3
 LOG_LEVEL ?= info
 ALLOWED_ORIGINS ?= ""
 DEBUG ?= false
@@ -78,7 +78,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 
 ## Tool Versions
 GOLANGCI_LINT_VERSION ?= v2.0.2
-ENVTEST_VERSION ?= release-0.17
+ENVTEST_VERSION ?= release-0.19
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.

--- a/packages/data-registry/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -48,15 +48,25 @@ type TestEnvInput struct {
 }
 
 func SetupEnvTest(input TestEnvInput) (*envtest.Environment, kubernetes.Interface, error) {
-	projectRoot, err := getProjectRoot()
-	if err != nil {
-		input.Logger.Error("failed to find project root", slog.String("error", err.Error()))
-		input.Cancel()
-		os.Exit(1)
+	// ENVTEST_ASSETS is set by "make test"; fallback only applies when running tests without make (e.g. IDE, ad-hoc go test).
+	var binaryAssetsDir string
+	if envtestAssets := os.Getenv("ENVTEST_ASSETS"); envtestAssets != "" {
+		binaryAssetsDir = envtestAssets
+		input.Logger.Info("Using ENVTEST_ASSETS environment variable", slog.String("path", binaryAssetsDir))
+	} else {
+		projectRoot, err := getProjectRoot()
+		if err != nil {
+			input.Logger.Error("failed to find project root", slog.String("error", err.Error()))
+			input.Cancel()
+			os.Exit(1)
+		}
+		platformDir := fmt.Sprintf("1.29.3-%s-%s", runtime.GOOS, runtime.GOARCH)
+		binaryAssetsDir = filepath.Join(projectRoot, "bin", "k8s", platformDir)
+		input.Logger.Info("Using fallback binary assets directory", slog.String("path", binaryAssetsDir))
 	}
 
 	testEnv := &envtest.Environment{
-		BinaryAssetsDirectory: filepath.Join(projectRoot, "bin", "k8s", fmt.Sprintf("1.29.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		BinaryAssetsDirectory: binaryAssetsDir,
 	}
 
 	cfg, err := testEnv.Start()

--- a/packages/data-registry/contract-tests/__tests__/testDataRegistryContract.test.ts
+++ b/packages/data-registry/contract-tests/__tests__/testDataRegistryContract.test.ts
@@ -1,0 +1,247 @@
+/**
+ * @jest-environment node
+ */
+import { ContractApiClient, loadOpenAPISchema } from '@odh-dashboard/contract-tests';
+
+describe('Data Registry BFF Contract Tests', () => {
+  const baseUrl = process.env.CONTRACT_MOCK_BFF_URL || 'http://localhost:8080';
+  const apiClient = new ContractApiClient({
+    baseUrl,
+    defaultHeaders: {
+      Authorization: 'Bearer FAKE_CLUSTER_ADMIN_TOKEN',
+    },
+  });
+
+  const bffSchema = loadOpenAPISchema('bff/openapi/src/data-registry.yaml');
+
+  describe('Health Check Endpoint', () => {
+    it('should return health status', async () => {
+      const result = await apiClient.get('/healthcheck');
+      expect(result).toMatchContract(bffSchema, {
+        ref: '#/components/responses/HealthCheckResponse/content/application~1json/schema',
+        status: 200,
+      });
+    });
+  });
+
+  describe('User Endpoint', () => {
+    it('should retrieve current user information', async () => {
+      const result = await apiClient.get('/api/v1/user');
+      expect(result).toMatchContract(bffSchema, {
+        ref: '#/components/responses/ConfigResponse/content/application~1json/schema',
+        status: 200,
+      });
+    });
+  });
+
+  describe('Namespaces Endpoint', () => {
+    it('should successfully retrieve namespaces list', async () => {
+      const result = await apiClient.get('/api/v1/namespaces');
+      expect(result).toMatchContract(bffSchema, {
+        ref: '#/components/responses/NamespacesResponse/content/application~1json/schema',
+        status: 200,
+      });
+    });
+  });
+
+  describe('Data Registry Proxy Routes - Upstream Unavailable', () => {
+    it('should return 503 for list projects when upstream is unavailable', async () => {
+      const result = await apiClient.get('/api/v1/projects');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(503);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/ServiceUnavailable/content/application~1json/schema',
+          status: 503,
+        });
+      }
+    });
+
+    it('should return 503 for get config when upstream is unavailable', async () => {
+      const result = await apiClient.get('/api/v1/config');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(503);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/ServiceUnavailable/content/application~1json/schema',
+          status: 503,
+        });
+      }
+    });
+
+    it('should return 503 for list collections when upstream is unavailable', async () => {
+      const result = await apiClient.get('/api/v1/test-project/namespaces');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(503);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/ServiceUnavailable/content/application~1json/schema',
+          status: 503,
+        });
+      }
+    });
+
+    it('should return 503 for list tables when upstream is unavailable', async () => {
+      const result = await apiClient.get('/api/v1/test-project/namespaces/test-collection/tables');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(503);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/ServiceUnavailable/content/application~1json/schema',
+          status: 503,
+        });
+      }
+    });
+
+    it('should return 503 for get table when upstream is unavailable', async () => {
+      const result = await apiClient.get(
+        '/api/v1/test-project/namespaces/test-collection/tables/test-table',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(503);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/ServiceUnavailable/content/application~1json/schema',
+          status: 503,
+        });
+      }
+    });
+
+    it('should return 503 for create table when upstream is unavailable', async () => {
+      const result = await apiClient.post(
+        '/api/v1/test-project/namespaces/test-collection/tables',
+        {
+          name: 'new-table',
+          schema: {
+            type: 'struct',
+            fields: [{ id: 1, name: 'col1', type: 'string', required: true }],
+          },
+        },
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(503);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/ServiceUnavailable/content/application~1json/schema',
+          status: 503,
+        });
+      }
+    });
+
+    it('should return 503 for delete table when upstream is unavailable', async () => {
+      const result = await apiClient.delete(
+        '/api/v1/test-project/namespaces/test-collection/tables/test-table',
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(503);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/ServiceUnavailable/content/application~1json/schema',
+          status: 503,
+        });
+      }
+    });
+
+    it('should return 503 for list volumes when upstream is unavailable', async () => {
+      const result = await apiClient.get('/api/v1/test-project/namespaces/test-collection/volumes');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(503);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/ServiceUnavailable/content/application~1json/schema',
+          status: 503,
+        });
+      }
+    });
+
+    it('should return 503 for search when upstream is unavailable', async () => {
+      const result = await apiClient.get('/api/v1/test-project/search?query=sales');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(503);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/ServiceUnavailable/content/application~1json/schema',
+          status: 503,
+        });
+      }
+    });
+  });
+
+  describe('Authentication Error Handling', () => {
+    const unauthenticatedClient = new ContractApiClient({
+      baseUrl,
+    });
+
+    it('should return 400 for user endpoint without auth headers', async () => {
+      const result = await unauthenticatedClient.get('/api/v1/user');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(400);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/BadRequest/content/application~1json/schema',
+          status: 400,
+        });
+      }
+    });
+
+    it('should return 400 for namespaces endpoint without auth headers', async () => {
+      const result = await unauthenticatedClient.get('/api/v1/namespaces');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(400);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/BadRequest/content/application~1json/schema',
+          status: 400,
+        });
+      }
+    });
+
+    it('should return 400 for proxy routes without auth headers', async () => {
+      const result = await unauthenticatedClient.get('/api/v1/projects');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(400);
+        expect({
+          status: result.error.status,
+          data: result.error.data,
+        }).toMatchContract(bffSchema, {
+          ref: '#/components/responses/BadRequest/content/application~1json/schema',
+          status: 400,
+        });
+      }
+    });
+  });
+});

--- a/packages/data-registry/package.json
+++ b/packages/data-registry/package.json
@@ -33,6 +33,7 @@
     "startCommand": "make dev-bff-e2e-mock"
   },
   "scripts": {
+    "test:contract": "BFF_MOCK_FLAGS='--mock-k8s-client --auth-method=user_token' odh-ct-bff-consumer --bff-dir bff",
     "install:module": "npm install --prefix frontend",
     "cypress:server:build": "cd frontend && DIST_DIR=./public-cypress DEPLOYMENT_MODE=federated npm run build",
     "cypress:server:build:coverage": "COVERAGE=true npm run cypress:server:build",
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@odh-dashboard/app-config": "*",
+    "@odh-dashboard/contract-tests": "*",
     "@odh-dashboard/eslint-config": "*",
     "@odh-dashboard/tsconfig": "*"
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAI-419

## Description

Adds contract tests for the data-registry BFF, validating API responses against the OpenAPI spec (`bff/openapi/src/data-registry.yaml`).

**Tests added (15 total):**
- **BFF-native endpoints (3):** healthcheck, user, namespaces — validated with `toMatchContract` against schema
- **Proxy route error handling (9):** all proxy routes return 503 `ServiceUnavailable` when the upstream Data Registry API is not configured (list projects, get config, list collections, list/get/create/delete tables, list volumes, search)
- **Authentication error handling (3):** BFF-native and proxy endpoints return 400 `BadRequest` when no auth headers are provided

**Implementation notes:**
- Uses `--auth-method=user_token` with `FAKE_CLUSTER_ADMIN_TOKEN` (differs from other packages that use `kubeflow-userid`/`kubeflow-groups`) because the data-registry proxy handler requires a bearer token — `internal` auth mode produces an empty token, which hits 401 before reaching the 503 path
- Error response tests follow the mlflow pattern: reconstruct `{ status, data }` and pass to `toMatchContract` for schema validation
- Success response tests use standard `toMatchContract` directly

## How Has This Been Tested?

All 15 contract tests pass locally:
```
npm run test:contract
# Test Suites: 1 passed, 1 total
# Tests:       15 passed, 15 total
```

Also runnable via Turbo:
```
npx turbo run test:contract --filter=@odh-dashboard/data-registry
```

## Test Impact

This PR is entirely test code — adds contract tests for the data-registry BFF. No production code changes.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded contract coverage for Data Registry health, user, namespace, and proxy endpoints.
  * Added validation for authenticated requests and expected error responses when authentication is missing or upstream services are unavailable.
  * Added a dedicated command for running Data Registry contract tests with mock services.
  * Updated test environment tooling and Kubernetes assets to support more consistent validation across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->