### PR TITLE
feat(data-registry): implement asset detail views for tables and volumes

### DIFF
--- a/packages/data-registry/frontend/package-lock.json
+++ b/packages/data-registry/frontend/package-lock.json
@@ -97,6 +97,7 @@
         "eslint-plugin-prettier": "^5.4.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "mocha-junit-reporter": "^2.2.1",
         "npm-run-all": "^4.1.5",
         "serve": "^14.2.6",
         "ts-jest": "^29.4.5"
@@ -3368,283 +3369,6 @@
         "tslib": "2"
       }
     },
-    "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
-      "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
-      "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.68.1",
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
-      "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.68.1",
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "@jsonjoy.com/fs-print": "4.68.1",
-        "@jsonjoy.com/fs-snapshot": "4.68.1",
-        "glob-to-regex.js": "^1.0.0",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
-      "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
-      "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.68.1",
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
-      "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "glob-to-regex.js": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
-      "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
-      "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "@jsonjoy.com/json-pack": "^17.65.0",
-        "@jsonjoy.com/util": "^17.65.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
-      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
-      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
-      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/base64": "17.67.0",
-        "@jsonjoy.com/buffers": "17.67.0",
-        "@jsonjoy.com/codegen": "17.67.0",
-        "@jsonjoy.com/json-pointer": "17.67.0",
-        "@jsonjoy.com/util": "17.67.0",
-        "hyperdyperid": "^1.2.0",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
-      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/util": "17.67.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
-      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "17.67.0",
-        "@jsonjoy.com/codegen": "17.67.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
     "node_modules/@jsonjoy.com/json-pack": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
@@ -4684,24 +4408,24 @@
       }
     },
     "node_modules/@rsdoctor/client": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@rsdoctor/client/-/client-1.6.2.tgz",
-      "integrity": "sha512-6HngWsWIUcMoHD2ruCZLVbjeqA6Vh41xD3MQhTb/LQ1CWSpU7KVkvge0iV5JqLEv9EemSojIz5RhMRdg3AsCSA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/client/-/client-1.6.3.tgz",
+      "integrity": "sha512-Vj1YCR8/amxlgjXn1rHOG56c6BBjEwiVM+qiQDRUBmn26oDxBsPwE0iCdn05ROyspepUXhuyE/4wBdYY7UtbUA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rsdoctor/core": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@rsdoctor/core/-/core-1.6.2.tgz",
-      "integrity": "sha512-YPf71epg7RDU3nT6Q3sI53y7xdksen6B/DTVCQl6mbMnG096r8Ilx0ggV9nXaa4vDOXZpiZZ+vGOhb5VeWFMMA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/core/-/core-1.6.3.tgz",
+      "integrity": "sha512-P96dNevDmlMbHBZ+G9c3G3D2kC/Bx6bHgkTz0DIJcsA/6QKQCwHO5bGlBqVndOlIzNV2b8nONQdaMLUujq5iaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rsbuild/plugin-check-syntax": "^1.6.1",
-        "@rsdoctor/graph": "1.6.2",
-        "@rsdoctor/sdk": "1.6.2",
-        "@rsdoctor/types": "1.6.2",
-        "@rsdoctor/utils": "1.6.2",
+        "@rsdoctor/graph": "1.6.3",
+        "@rsdoctor/sdk": "1.6.3",
+        "@rsdoctor/types": "1.6.3",
+        "@rsdoctor/utils": "1.6.3",
         "@rspack/resolver": "^0.2.8",
         "browserslist-load-config": "^1.0.2",
         "es-toolkit": "^1.49.0",
@@ -4740,31 +4464,31 @@
       }
     },
     "node_modules/@rsdoctor/graph": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@rsdoctor/graph/-/graph-1.6.2.tgz",
-      "integrity": "sha512-EzwDKYs43UyZW/FmhQAZUqw3Z0lFA/b6XVq4OQRMUcMpNBmn/hxCDWUYUubRQEiCaqJthgl1Puu4anTJhof61g==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/graph/-/graph-1.6.3.tgz",
+      "integrity": "sha512-lsW+DGiwSjeBt3sQh9eU9/kd1LjizjE+esrW7nud0cmRTzneHZ9TYM+v/WAaWlk2o7kvS7NEN7NLC/qqwKDZEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rsdoctor/types": "1.6.2",
-        "@rsdoctor/utils": "1.6.2",
+        "@rsdoctor/types": "1.6.3",
+        "@rsdoctor/utils": "1.6.3",
         "es-toolkit": "^1.49.0",
         "path-browserify": "1.0.1",
         "source-map": "^0.7.6"
       }
     },
     "node_modules/@rsdoctor/rspack-plugin": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@rsdoctor/rspack-plugin/-/rspack-plugin-1.6.2.tgz",
-      "integrity": "sha512-vDRf/n6Uj6JkmolLFAG4rC115NMQ2W2T6OVjSiMU7oAds8yn1dtKzt8slL/OErCBl2p2sFcGZ1pGkdleZpFD/w==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/rspack-plugin/-/rspack-plugin-1.6.3.tgz",
+      "integrity": "sha512-pM80ts4BRN+iXSXA0YNXK5G6PvkiH0hytC91Ww8bcoDrdl3gIrx1inhFNmbwArDVNaRRFDFJDr/zyfatTMDr4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rsdoctor/core": "1.6.2",
-        "@rsdoctor/graph": "1.6.2",
-        "@rsdoctor/sdk": "1.6.2",
-        "@rsdoctor/types": "1.6.2",
-        "@rsdoctor/utils": "1.6.2"
+        "@rsdoctor/core": "1.6.3",
+        "@rsdoctor/graph": "1.6.3",
+        "@rsdoctor/sdk": "1.6.3",
+        "@rsdoctor/types": "1.6.3",
+        "@rsdoctor/utils": "1.6.3"
       },
       "peerDependencies": {
         "@rspack/core": "*"
@@ -4776,16 +4500,16 @@
       }
     },
     "node_modules/@rsdoctor/sdk": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@rsdoctor/sdk/-/sdk-1.6.2.tgz",
-      "integrity": "sha512-wP26caE6hnYRQuDF5uyBXSKiBlwcOSEXtYoJRdG9ZMyf2rz0/8KWgKlp3V5Mtobf0zYlFnpi5H+8/JHfczdHVQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/sdk/-/sdk-1.6.3.tgz",
+      "integrity": "sha512-UX+j+Tapz4VxT7DV2YLKP8eFXjmxHDxBSMH+WJLu0GaZv/ljHTjk+h/aJF1kOlA3gdXmbvas2vBQzTuEI9rKww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rsdoctor/client": "1.6.2",
-        "@rsdoctor/graph": "1.6.2",
-        "@rsdoctor/types": "1.6.2",
-        "@rsdoctor/utils": "1.6.2",
+        "@rsdoctor/client": "1.6.3",
+        "@rsdoctor/graph": "1.6.3",
+        "@rsdoctor/types": "1.6.3",
+        "@rsdoctor/utils": "1.6.3",
         "launch-editor": "^2.13.2",
         "safer-buffer": "2.1.2",
         "socket.io": "4.8.1",
@@ -4793,9 +4517,9 @@
       }
     },
     "node_modules/@rsdoctor/types": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@rsdoctor/types/-/types-1.6.2.tgz",
-      "integrity": "sha512-+giYQPsgpPyo8OCGM9qNrdZKc2oaU+gUsZ5cnpHgbD3zwgUDj39PGgnnRj3kc9BP4PFrhVrBIJUnVVG/v60Jxw==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/types/-/types-1.6.3.tgz",
+      "integrity": "sha512-iCivPceJuCkUtxMswrUsIbKdARGyCnw3e1QEf8nTNWygWmud1nM8kr1Y8ZaqJGbe/g7c1KZebWpN5/hzUbBHPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4825,14 +4549,14 @@
       "license": "MIT"
     },
     "node_modules/@rsdoctor/utils": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@rsdoctor/utils/-/utils-1.6.2.tgz",
-      "integrity": "sha512-e6veT/5SdXxmTKV6K6Ay0S2LyvDMtedwaHIeRJNgT0a2T0esdAuL+O5q/jWqa33k9+Df+o+E/i2boX9CP3rYLA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/utils/-/utils-1.6.3.tgz",
+      "integrity": "sha512-xuZalAwSE8r/8Ro+N9RxyA+0OXvaSGXOaggmbmF89YGrYhQ4R3h05XvgZKQLtd//w8DxR6znUqb1xKp8a4NYDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.26.2",
-        "@rsdoctor/types": "1.6.2",
+        "@rsdoctor/types": "1.6.3",
         "@types/estree": "1.0.5",
         "acorn": "^8.10.0",
         "acorn-import-attributes": "^1.9.5",
@@ -5194,9 +4918,9 @@
       }
     },
     "node_modules/@rspack/dev-server": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-2.2.0.tgz",
-      "integrity": "sha512-Bd0DNphOJ5/KAm3bFpUUZeP7O6jvVDNdXJEmlpsVZLfdSgjmrd6Ut/EHCBv95tmiwOQN0M41SdvlUU4f855HFA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-2.2.1.tgz",
+      "integrity": "sha512-Il8HbYGK3rH5rM0XmUOsOGZVw69BKRpBZ61P28Fy8ry35CtfniDBWtbo/rvJtIT/sK0qwijmNrhF498ltsV+uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7706,6 +7430,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/browserslist": {
       "version": "4.28.8",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
@@ -8078,6 +7810,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -8691,6 +8450,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/css-loader": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
@@ -9221,6 +8990,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -9772,15 +9552,16 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
         "benchmarks",
-        "tests/types"
+        "tests/types",
+        "tests/browser-compat"
       ]
     },
     "node_modules/es6-error": {
@@ -10999,6 +10780,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -11106,40 +10898,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "extraneous": true,
-      "license": "MIT"
     },
     "node_modules/form-data": {
       "version": "4.0.6",
@@ -11852,6 +11610,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -12362,6 +12131,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
@@ -15049,6 +14825,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
@@ -15256,6 +15044,141 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha-junit-reporter": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.2.1.tgz",
+      "integrity": "sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "md5": "^2.3.0",
+        "mkdirp": "^3.0.0",
+        "strip-ansi": "^6.0.1",
+        "xml": "^1.0.1"
+      },
+      "peerDependencies": {
+        "mocha": ">=2.2.5"
+      }
+    },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/mod-arch-core": {
@@ -17035,6 +16958,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17310,6 +17244,21 @@
       "optional": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/redent": {
@@ -19636,6 +19585,304 @@
         }
       }
     },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/base64": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/codegen": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-core": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.2.tgz",
+      "integrity": "sha512-PoBeUNEbjyLKKwCap2z8LkkqdhdfttS4rTHCALVuP65BdF+sAoyBqHo1m+uGTRBiQWv3H7MGfr8f7lY4pDwanw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.68.2",
+        "@jsonjoy.com/fs-node-utils": "4.68.2",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-fsa": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.2.tgz",
+      "integrity": "sha512-h6eGXlLGGMyPfNliDQrbuHKTB9Z29ksCLjreAmdBqrDOBdfrTrHssi+b9WLfrF+J2KzAbIt9OMjJu6AEpTnYkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.68.2",
+        "@jsonjoy.com/fs-node-builtins": "4.68.2",
+        "@jsonjoy.com/fs-node-utils": "4.68.2",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-node": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.2.tgz",
+      "integrity": "sha512-Kpj519Qk4OXG4+mZ8vTf9BEflliJrPueIDEVcbx8tAOufMJJ8IxR0WwdbcEvJol2KQog3PJjtALXVclorE+xbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.68.2",
+        "@jsonjoy.com/fs-node-builtins": "4.68.2",
+        "@jsonjoy.com/fs-node-utils": "4.68.2",
+        "@jsonjoy.com/fs-print": "4.68.2",
+        "@jsonjoy.com/fs-snapshot": "4.68.2",
+        "glob-to-regex.js": "^1.0.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-node-builtins": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.2.tgz",
+      "integrity": "sha512-V8WzQsW2YIrH3RxBGY6HZisxn+dDUltHgksVRuCdPEOXEkAfXuhL/01eHFrabNu84Dn13XuLqvcQUKOYVKAUOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-node-to-fsa": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.2.tgz",
+      "integrity": "sha512-4O1K4w5G4oJIpKpoa3WSLG83AsQYVnGv+aUSBGOvIUph9Axm6bB1mPlvldkNg2tBx/4dkiTlZnqNrK5SQ21Wtg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-fsa": "4.68.2",
+        "@jsonjoy.com/fs-node-builtins": "4.68.2",
+        "@jsonjoy.com/fs-node-utils": "4.68.2"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-node-utils": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.2.tgz",
+      "integrity": "sha512-CxFwyG9fJr7dAKAd1uanNRNrRMtDDqbYJA8do53+M4LY7SxcBEEmMjC1zi9MOsBlVLHTXvA7OP9+n639UqtIcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.68.2",
+        "glob-to-regex.js": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-print": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.2.tgz",
+      "integrity": "sha512-cBABQmZJXig6bahwNka3+yPNGUF1GeMWbR76ZM1N2ajgCd+S+twZigCoe9+0ueZmkhM9xd2a7688Gy/ch7T+2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.68.2",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-snapshot": {
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.2.tgz",
+      "integrity": "sha512-Aix7+NM38LzvewM0T3PICSgFdF5BVCtVgsjNsrlDPGc9hiMgJzReTDDl2/elgl0A9USMl3QP27x5WwxZSOtrfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^17.65.0",
+        "@jsonjoy.com/fs-node-utils": "4.68.2",
+        "@jsonjoy.com/json-pack": "^17.65.0",
+        "@jsonjoy.com/util": "^17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "17.67.0",
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0",
+        "@jsonjoy.com/json-pointer": "17.67.0",
+        "@jsonjoy.com/util": "17.67.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/json-pointer": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/ts-checker-rspack-plugin/node_modules/@jsonjoy.com/json-pointer/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/ts-checker-rspack-plugin/node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -19675,20 +19922,20 @@
       }
     },
     "node_modules/ts-checker-rspack-plugin/node_modules/memfs": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.1.tgz",
-      "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
+      "version": "4.68.2",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.2.tgz",
+      "integrity": "sha512-Un1ElEBoIdPI9kg0sm3LebVEuEViodfIvlaG8Z1MFXa7ZnR9vWuPKUo3dt/vuWY2ivc05l76B5QOjdgCzAzmGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.68.1",
-        "@jsonjoy.com/fs-fsa": "4.68.1",
-        "@jsonjoy.com/fs-node": "4.68.1",
-        "@jsonjoy.com/fs-node-builtins": "4.68.1",
-        "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
-        "@jsonjoy.com/fs-node-utils": "4.68.1",
-        "@jsonjoy.com/fs-print": "4.68.1",
-        "@jsonjoy.com/fs-snapshot": "4.68.1",
+        "@jsonjoy.com/fs-core": "4.68.2",
+        "@jsonjoy.com/fs-fsa": "4.68.2",
+        "@jsonjoy.com/fs-node": "4.68.2",
+        "@jsonjoy.com/fs-node-builtins": "4.68.2",
+        "@jsonjoy.com/fs-node-to-fsa": "4.68.2",
+        "@jsonjoy.com/fs-node-utils": "4.68.2",
+        "@jsonjoy.com/fs-print": "4.68.2",
+        "@jsonjoy.com/fs-snapshot": "4.68.2",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -20915,6 +21162,14 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/workerpool": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -21068,6 +21323,13 @@
         }
       }
     },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -21145,6 +21407,62 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yauzl": {

--- a/packages/data-registry/frontend/package.json
+++ b/packages/data-registry/frontend/package.json
@@ -109,6 +109,7 @@
     "cypress": "^15.16.0",
     "cypress-axe": "^1.5.0",
     "cypress-high-resolution": "^1.0.0",
+    "mocha-junit-reporter": "^2.2.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-node": "^0.3.7",

--- a/packages/data-registry/frontend/src/__mocks__/mockAssetResponse.ts
+++ b/packages/data-registry/frontend/src/__mocks__/mockAssetResponse.ts
@@ -1,0 +1,27 @@
+import { AssetResponse } from '~/app/types';
+
+/* eslint-disable camelcase */
+export const mockAssetResponse = (overrides?: Partial<AssetResponse>): AssetResponse => ({
+  name: 'test-table',
+  asset_type: 'table',
+  uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  format: 'parquet',
+  location: 's3://my-bucket/data/test-table/',
+  content_type: undefined,
+  columns: [
+    { name: 'id', type: 'integer', nullable: false, description: 'Primary key' },
+    { name: 'name', type: 'string', nullable: true, description: 'Display name' },
+    { name: 'created_at', type: 'timestamp', nullable: false },
+  ],
+  collection: 'default',
+  connection_ref: { type: 'rhai', secret_name: 'my-s3-connection' },
+  owner: 'data-team',
+  description: 'A test table for unit testing',
+  labels: ['production', 'analytics'],
+  properties: { 'data.quality': 'verified', source: 'etl-pipeline' },
+  registered_by: 'user@example.com',
+  updated_by: 'admin@example.com',
+  created_at: '2026-07-15T10:30:00Z',
+  updated_at: '2026-08-20T14:45:00Z',
+  ...overrides,
+});

--- a/packages/data-registry/frontend/src/__mocks__/mockVolumeInfo.ts
+++ b/packages/data-registry/frontend/src/__mocks__/mockVolumeInfo.ts
@@ -1,0 +1,16 @@
+import { VolumeInfo } from '~/app/types';
+
+export const mockVolumeInfo = (overrides?: Partial<VolumeInfo>): VolumeInfo => ({
+  name: 'test-volume',
+  'catalog-name': 'my-project',
+  'schema-name': 'default',
+  'volume-type': 'EXTERNAL',
+  'storage-location': 's3://my-bucket/volumes/test-volume/',
+  comment: 'A test volume for unit testing',
+  owner: 'data-team',
+  'created-at': '2026-07-15T10:30:00Z',
+  'updated-at': '2026-08-20T14:45:00Z',
+  labels: ['source-docs', 'unstructured'],
+  properties: { purpose: 'testing' },
+  ...overrides,
+});

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress.config.ts
@@ -16,7 +16,7 @@ const resultsDir = `${env.CY_RESULTS_DIR || 'results'}/${env.CY_MOCK ? 'mocked' 
 
 export default defineConfig({
   experimentalMemoryManagement: true,
-  reporter: 'mocha-junit-reporter',
+  reporter: '../../../node_modules/mocha-junit-reporter',
   reporterOptions: {
     mochaFile: `${resultsDir}/junit/junit-[hash].xml`,
   },

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/assetDetailView.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/assetDetailView.cy.ts
@@ -1,0 +1,191 @@
+/* eslint-disable camelcase */
+import { mockNamespace } from '~/__mocks__/mockNamespace';
+import { mockUserSettings } from '~/__mocks__/mockUserSettings';
+import { CLIENT_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+
+const REGISTRY_API = '/data-registry/api/v1';
+
+const mockTableResponse = {
+  name: 'claims-data',
+  asset_type: 'table',
+  uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  format: 'parquet',
+  location: 's3://bucket/claims',
+  content_type: undefined,
+  columns: [
+    { name: 'id', type: 'integer', nullable: false, description: 'Primary key' },
+    { name: 'claim_amount', type: 'decimal', nullable: true, description: 'Amount' },
+    { name: 'status', type: 'string', nullable: false },
+  ],
+  collection: 'analytics',
+  connection_ref: { type: 'rhai', secret_name: 'my-s3-connection' },
+  owner: 'data-team',
+  description: 'Claims processing data',
+  labels: ['production', 'claims', 'analytics'],
+  properties: { 'data.quality': 'verified', source: 'etl-pipeline' },
+  registered_by: 'user@example.com',
+  updated_by: 'admin@example.com',
+  created_at: '2026-07-15T10:30:00Z',
+  updated_at: '2026-08-20T14:45:00Z',
+};
+
+const mockVolumeResponse = {
+  name: 'training-documents',
+  'catalog-name': 'test-project',
+  'schema-name': 'default',
+  'volume-type': 'EXTERNAL',
+  'storage-location': 's3://bucket/docs/training',
+  comment: 'Training document storage',
+  owner: 'ml-team',
+  'created-at': '2026-06-01T08:00:00Z',
+  'updated-at': '2026-08-10T12:00:00Z',
+  labels: ['source-docs', 'unstructured'],
+  properties: { purpose: 'training', environment: 'production' },
+  config: {},
+};
+
+const initIntercepts = () => {
+  cy.interceptApi(
+    'GET /api/:apiVersion/user',
+    { path: { apiVersion: CLIENT_API_VERSION } },
+    mockUserSettings({ userId: 'test-user' }),
+  );
+  cy.interceptApi('GET /api/:apiVersion/namespaces', { path: { apiVersion: CLIENT_API_VERSION } }, [
+    mockNamespace({ name: 'test-project' }),
+  ]);
+};
+
+describe('Table Detail View', () => {
+  beforeEach(() => {
+    initIntercepts();
+    cy.intercept(
+      'GET',
+      `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables/claims-data`,
+      { body: mockTableResponse },
+    ).as('getTable');
+  });
+
+  it('should display table metadata in two-column layout', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.findByTestId('data-details-card').should('exist');
+    cy.findByTestId('asset-description').should('contain.text', 'Claims processing data');
+    cy.findByTestId('asset-format').should('contain.text', 'parquet');
+    cy.findByTestId('asset-collection').should('contain.text', 'analytics');
+    cy.findByTestId('asset-type').should('contain.text', 'Structured');
+    cy.findByTestId('asset-location').should('contain.text', 's3://bucket/claims');
+    cy.findByTestId('asset-owner').should('contain.text', 'data-team');
+    cy.findByTestId('connection-ref-rhai').should('contain.text', 'my-s3-connection');
+  });
+
+  it('should display asset type badge and Overview tab', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.findByTestId('asset-type-badge').should('contain.text', 'Data asset');
+    cy.findByTestId('detail-tabs').should('exist');
+    cy.contains('Overview').should('exist');
+  });
+
+  it('should display labels, properties, and schema cards', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.findByTestId('labels-card').should('exist');
+    cy.contains('production').should('exist');
+    cy.contains('claims').should('exist');
+
+    cy.findByTestId('properties-card').should('exist');
+    cy.contains('data.quality: verified').should('exist');
+    cy.contains('source: etl-pipeline').should('exist');
+
+    cy.findByTestId('schema-card').should('exist');
+    cy.findByTestId('schema-column-count').should('contain.text', '3 columns');
+    cy.findByTestId('schema-columns-table').should('exist');
+    cy.findByTestId('schema-column-name-id').should('contain.text', 'id');
+  });
+
+  it('should display created and modified with user attribution', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.findByTestId('asset-created-at').should('contain.text', 'by user@example.com');
+    cy.findByTestId('asset-updated-at').should('contain.text', 'by admin@example.com');
+  });
+
+  it('should show breadcrumb navigation', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.get('.pf-v6-c-breadcrumb').should('exist');
+    cy.contains('Data').should('exist');
+    cy.contains('analytics').should('exist');
+    cy.contains('claims-data').should('exist');
+  });
+
+  it('should open delete modal from kebab menu', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-delete').click();
+    cy.findByTestId('delete-asset-modal').should('exist');
+    cy.contains('Delete table').should('exist');
+  });
+});
+
+describe('Volume Detail View', () => {
+  beforeEach(() => {
+    initIntercepts();
+    cy.intercept(
+      'GET',
+      `${REGISTRY_API}/test-project/namespaces/default/volumes/training-documents`,
+      { body: mockVolumeResponse },
+    ).as('getVolume');
+  });
+
+  it('should display volume metadata', () => {
+    cy.visit('/main-view/volumes/test-project/default/training-documents');
+    cy.wait('@getVolume');
+
+    cy.findByTestId('data-details-card').should('exist');
+    cy.findByTestId('volume-comment').should('contain.text', 'Training document storage');
+    cy.findByTestId('volume-type').should('contain.text', 'EXTERNAL');
+    cy.findByTestId('volume-project').should('contain.text', 'test-project');
+    cy.findByTestId('volume-storage-location').should('contain.text', 's3://bucket/docs/training');
+    cy.findByTestId('volume-owner').should('contain.text', 'ml-team');
+  });
+
+  it('should display volume type badge and Overview tab', () => {
+    cy.visit('/main-view/volumes/test-project/default/training-documents');
+    cy.wait('@getVolume');
+
+    cy.findByTestId('asset-type-badge').should('contain.text', 'Volume');
+    cy.findByTestId('detail-tabs').should('exist');
+    cy.contains('Overview').should('exist');
+  });
+
+  it('should display labels and properties cards', () => {
+    cy.visit('/main-view/volumes/test-project/default/training-documents');
+    cy.wait('@getVolume');
+
+    cy.findByTestId('labels-card').should('exist');
+    cy.contains('source-docs').should('exist');
+    cy.contains('unstructured').should('exist');
+
+    cy.findByTestId('properties-card').should('exist');
+    cy.contains('purpose: training').should('exist');
+    cy.contains('environment: production').should('exist');
+  });
+
+  it('should handle delete action', () => {
+    cy.visit('/main-view/volumes/test-project/default/training-documents');
+    cy.wait('@getVolume');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-delete').click();
+    cy.findByTestId('delete-asset-modal').should('exist');
+    cy.contains('Delete volume').should('exist');
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/components/ConnectionRefLink.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/ConnectionRefLink.spec.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ConnectionRefLink from '~/app/components/ConnectionRefLink';
+
+describe('ConnectionRefLink', () => {
+  it('should render rhai connection reference as text', () => {
+    render(<ConnectionRefLink connectionRef={{ type: 'rhai', secret_name: 'my-secret' }} />);
+    const el = screen.getByTestId('connection-ref-rhai');
+    expect(el).toHaveTextContent('Connection: my-secret');
+    expect(el.tagName).toBe('SPAN');
+  });
+
+  it('should render rhai connection reference as link when linkTo is provided', () => {
+    render(
+      <MemoryRouter>
+        <ConnectionRefLink
+          connectionRef={{ type: 'rhai', secret_name: 'my-secret' }}
+          linkTo="/connections/my-secret"
+        />
+      </MemoryRouter>,
+    );
+    const el = screen.getByTestId('connection-ref-rhai');
+    expect(el).toHaveTextContent('Connection: my-secret');
+    expect(el.tagName).toBe('A');
+    expect(el).toHaveAttribute('href', '/connections/my-secret');
+  });
+
+  it('should render dch connection reference', () => {
+    render(<ConnectionRefLink connectionRef={{ type: 'dch', id: 'conn-123' }} />);
+    expect(screen.getByTestId('connection-ref-dch')).toHaveTextContent('DCH Connection: conn-123');
+  });
+
+  it('should render dash when connectionRef is null', () => {
+    const { container } = render(<ConnectionRefLink connectionRef={null} />);
+    expect(container).toHaveTextContent('-');
+  });
+
+  it('should render dash when connectionRef is undefined', () => {
+    const { container } = render(<ConnectionRefLink />);
+    expect(container).toHaveTextContent('-');
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/components/DeleteAssetModal.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/DeleteAssetModal.spec.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DeleteAssetModal from '~/app/components/DeleteAssetModal';
+
+describe('DeleteAssetModal', () => {
+  const defaultProps = {
+    assetName: 'my-table',
+    assetType: 'table' as const,
+    onDelete: jest.fn().mockResolvedValue(undefined),
+    onClose: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render asset name and type', () => {
+    render(<DeleteAssetModal {...defaultProps} />);
+    expect(screen.getByText('Delete table?')).toBeTruthy();
+    expect(screen.getByText('my-table')).toBeTruthy();
+  });
+
+  it('should render volume type', () => {
+    render(<DeleteAssetModal {...defaultProps} assetType="volume" />);
+    expect(screen.getByText('Delete volume?')).toBeTruthy();
+  });
+
+  it('should call onDelete when confirm is clicked', async () => {
+    render(<DeleteAssetModal {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('delete-asset-confirm'));
+    await waitFor(() => {
+      expect(defaultProps.onDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should call onClose when cancel is clicked', () => {
+    render(<DeleteAssetModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show error when delete fails', async () => {
+    const onDelete = jest.fn().mockRejectedValue(new Error('Delete failed'));
+    render(<DeleteAssetModal {...defaultProps} onDelete={onDelete} />);
+    fireEvent.click(screen.getByTestId('delete-asset-confirm'));
+    await waitFor(() => {
+      expect(screen.getByText('Delete failed')).toBeTruthy();
+    });
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
@@ -37,6 +37,7 @@ const renderTable = (props?: Partial<React.ComponentProps<typeof RegistryTable>>
         loaded
         error={undefined}
         labels={mockLabels}
+        project="test-project"
         onManageCollections={jest.fn()}
         onManageLabels={jest.fn()}
         onRegisterData={jest.fn()}

--- a/packages/data-registry/frontend/src/__tests__/unit/components/SchemaColumnsTable.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/SchemaColumnsTable.spec.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SchemaColumnsTable from '~/app/components/SchemaColumnsTable';
+import { SchemaField } from '~/app/types';
+
+const mockColumns: SchemaField[] = [
+  { name: 'id', type: 'integer', nullable: false, description: 'Primary key' },
+  { name: 'name', type: 'string', nullable: true, description: 'Display name' },
+  { name: 'status', type: 'string', nullable: false },
+];
+
+describe('SchemaColumnsTable', () => {
+  it('should render column names', () => {
+    render(<SchemaColumnsTable columns={mockColumns} />);
+    expect(screen.getByTestId('schema-column-name-id')).toHaveTextContent('id');
+    expect(screen.getByTestId('schema-column-name-name')).toHaveTextContent('name');
+    expect(screen.getByTestId('schema-column-name-status')).toHaveTextContent('status');
+  });
+
+  it('should render column types', () => {
+    render(<SchemaColumnsTable columns={mockColumns} />);
+    expect(screen.getByText('integer')).toBeTruthy();
+    expect(screen.getAllByText('string')).toHaveLength(2);
+  });
+
+  it('should only show Name and Type columns', () => {
+    render(<SchemaColumnsTable columns={mockColumns} />);
+    const headers = screen.getByTestId('schema-columns-table').querySelectorAll('thead th');
+    expect(headers).toHaveLength(2);
+    expect(headers[0]).toHaveTextContent('Name');
+    expect(headers[1]).toHaveTextContent('Type');
+  });
+
+  it('should render empty state when no columns', () => {
+    render(<SchemaColumnsTable columns={[]} />);
+    expect(screen.getByText('No schema columns')).toBeTruthy();
+    expect(screen.queryByTestId('schema-columns-table')).not.toBeInTheDocument();
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/components/TableDetailView.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/TableDetailView.spec.tsx
@@ -1,0 +1,131 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TableDetailView from '~/app/pages/TableDetailView';
+import { mockAssetResponse } from '~/__mocks__/mockAssetResponse';
+
+const renderView = (asset: ReturnType<typeof mockAssetResponse>, project = 'test-project') =>
+  render(
+    <MemoryRouter>
+      <TableDetailView asset={asset} project={project} />
+    </MemoryRouter>,
+  );
+
+describe('TableDetailView', () => {
+  it('should render data details card with metadata fields', () => {
+    const asset = mockAssetResponse();
+    renderView(asset);
+
+    expect(screen.getByTestId('data-details-card')).toBeTruthy();
+    expect(screen.getByTestId('asset-description')).toHaveTextContent(
+      'A test table for unit testing',
+    );
+    expect(screen.getByTestId('asset-format')).toHaveTextContent('parquet');
+    expect(screen.getByTestId('asset-collection')).toHaveTextContent('default');
+    expect(screen.getByTestId('asset-location')).toHaveTextContent(
+      's3://my-bucket/data/test-table/',
+    );
+    expect(screen.getByTestId('asset-owner')).toHaveTextContent('data-team');
+    expect(screen.getByTestId('asset-type')).toHaveTextContent('Structured');
+  });
+
+  it('should render collection as a link when project is provided', () => {
+    const asset = mockAssetResponse();
+    renderView(asset);
+
+    const collectionElement = screen.getByTestId('asset-collection');
+    const link = collectionElement.querySelector('a');
+    expect(link).toBeTruthy();
+    expect(link).toHaveTextContent('default');
+  });
+
+  it('should render connection name without prefix', () => {
+    const asset = mockAssetResponse();
+    renderView(asset);
+    expect(screen.getByTestId('connection-ref-rhai')).toHaveTextContent('my-s3-connection');
+    expect(screen.getByTestId('connection-ref-rhai').textContent).not.toContain('Connection:');
+  });
+
+  it('should render created and last modified with user attribution', () => {
+    const asset = mockAssetResponse();
+    renderView(asset);
+
+    expect(screen.getByTestId('asset-created-at')).toHaveTextContent('by user@example.com');
+    expect(screen.getByTestId('asset-updated-at')).toHaveTextContent('by admin@example.com');
+  });
+
+  it('should render labels card with expandable label group', () => {
+    const asset = mockAssetResponse();
+    renderView(asset);
+    expect(screen.getByTestId('labels-card')).toBeTruthy();
+    expect(screen.getByText('production')).toBeTruthy();
+    expect(screen.getByText('analytics')).toBeTruthy();
+  });
+
+  it('should render "No labels" when labels are empty', () => {
+    const asset = mockAssetResponse({ labels: [] });
+    renderView(asset);
+    expect(screen.getByTestId('asset-labels')).toHaveTextContent('No labels');
+  });
+
+  it('should render properties card with key:value labels', () => {
+    const asset = mockAssetResponse();
+    renderView(asset);
+    expect(screen.getByTestId('properties-card')).toBeTruthy();
+    expect(screen.getByText('data.quality: verified')).toBeTruthy();
+    expect(screen.getByText('source: etl-pipeline')).toBeTruthy();
+  });
+
+  it('should render schema card with column count and columns table', () => {
+    const asset = mockAssetResponse();
+    renderView(asset);
+    expect(screen.getByTestId('schema-card')).toBeTruthy();
+    expect(screen.getByTestId('schema-column-count')).toHaveTextContent('3 columns');
+    expect(screen.getByTestId('schema-columns-table')).toBeTruthy();
+    expect(screen.getByTestId('schema-column-name-id')).toHaveTextContent('id');
+  });
+
+  it('should render schema column types as labels', () => {
+    const asset = mockAssetResponse();
+    renderView(asset);
+    expect(screen.getByTestId('schema-column-type-id')).toHaveTextContent('integer');
+    expect(screen.getByTestId('schema-column-type-name')).toHaveTextContent('string');
+  });
+
+  it('should hide format field when format is not set', () => {
+    const asset = mockAssetResponse({ format: undefined });
+    renderView(asset);
+    expect(screen.queryByTestId('asset-format')).not.toBeInTheDocument();
+    expect(screen.getByTestId('asset-type')).toHaveTextContent('table');
+  });
+
+  it('should render dash for missing optional fields', () => {
+    const asset = mockAssetResponse({
+      format: undefined,
+      description: undefined,
+      location: undefined,
+      owner: undefined,
+      labels: [],
+      properties: undefined,
+      created_at: undefined,
+      updated_at: undefined,
+    });
+    renderView(asset);
+
+    expect(screen.queryByTestId('asset-format')).not.toBeInTheDocument();
+    expect(screen.getByTestId('asset-description')).toHaveTextContent('-');
+    expect(screen.getByTestId('asset-location')).toHaveTextContent('-');
+    expect(screen.getByTestId('asset-owner')).toHaveTextContent('-');
+    expect(screen.getByTestId('asset-labels')).toHaveTextContent('No labels');
+    expect(screen.getByTestId('asset-created-at')).toHaveTextContent('-');
+    expect(screen.getByTestId('asset-updated-at')).toHaveTextContent('-');
+    expect(screen.queryByTestId('properties-card')).not.toBeInTheDocument();
+  });
+
+  it('should render empty schema columns state when no columns', () => {
+    const asset = mockAssetResponse({ columns: [] });
+    renderView(asset);
+    expect(screen.getByText('No schema columns')).toBeTruthy();
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/components/VolumeDetailView.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/VolumeDetailView.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import VolumeDetailView from '~/app/pages/VolumeDetailView';
+import { mockVolumeInfo } from '~/__mocks__/mockVolumeInfo';
+
+describe('VolumeDetailView', () => {
+  it('should render data details card with metadata fields', () => {
+    const volume = mockVolumeInfo();
+    render(<VolumeDetailView volume={volume} />);
+
+    expect(screen.getByTestId('data-details-card')).toBeTruthy();
+    expect(screen.getByTestId('volume-comment')).toHaveTextContent(
+      'A test volume for unit testing',
+    );
+    expect(screen.getByTestId('volume-type')).toHaveTextContent('EXTERNAL');
+    expect(screen.getByTestId('volume-project')).toHaveTextContent('my-project');
+    expect(screen.getByTestId('volume-storage-location')).toHaveTextContent(
+      's3://my-bucket/volumes/test-volume/',
+    );
+    expect(screen.getByTestId('volume-owner')).toHaveTextContent('data-team');
+  });
+
+  it('should not render schema-name field', () => {
+    const volume = mockVolumeInfo();
+    render(<VolumeDetailView volume={volume} />);
+    expect(screen.queryByTestId('volume-collection')).not.toBeInTheDocument();
+  });
+
+  it('should render labels card', () => {
+    const volume = mockVolumeInfo();
+    render(<VolumeDetailView volume={volume} />);
+    expect(screen.getByTestId('labels-card')).toBeTruthy();
+    expect(screen.getByText('source-docs')).toBeTruthy();
+    expect(screen.getByText('unstructured')).toBeTruthy();
+  });
+
+  it('should render properties card with key:value labels', () => {
+    const volume = mockVolumeInfo();
+    render(<VolumeDetailView volume={volume} />);
+    expect(screen.getByTestId('properties-card')).toBeTruthy();
+    expect(screen.getByText('purpose: testing')).toBeTruthy();
+  });
+
+  it('should render dash for missing optional fields', () => {
+    const volume = mockVolumeInfo({
+      comment: undefined,
+      owner: undefined,
+      'created-at': undefined,
+      'updated-at': undefined,
+      labels: [],
+      properties: {},
+    });
+    render(<VolumeDetailView volume={volume} />);
+
+    expect(screen.getByTestId('volume-comment')).toHaveTextContent('-');
+    expect(screen.getByTestId('volume-owner')).toHaveTextContent('-');
+    expect(screen.getByTestId('volume-created-at')).toHaveTextContent('-');
+    expect(screen.getByTestId('volume-updated-at')).toHaveTextContent('-');
+    expect(screen.getByTestId('volume-labels')).toHaveTextContent('No labels');
+    expect(screen.queryByTestId('properties-card')).not.toBeInTheDocument();
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/hooks/useGenericTable.spec.ts
+++ b/packages/data-registry/frontend/src/__tests__/unit/hooks/useGenericTable.spec.ts
@@ -1,0 +1,72 @@
+/* eslint-disable camelcase */
+import { renderHook, waitFor } from '@testing-library/react';
+import * as api from '~/app/api/dataRegistry';
+import { useGenericTable } from '~/app/hooks/useGenericTable';
+
+jest.mock('~/app/api/dataRegistry');
+
+const mockFetchGenericTable = jest.mocked(api.fetchGenericTable);
+
+describe('useGenericTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return null when project is missing', () => {
+    const { result } = renderHook(() => useGenericTable(undefined, 'default', 'my-table'));
+    expect(result.current[0]).toBeNull();
+    expect(mockFetchGenericTable).not.toHaveBeenCalled();
+  });
+
+  it('should return null when collection is missing', () => {
+    const { result } = renderHook(() => useGenericTable('my-project', undefined, 'my-table'));
+    expect(result.current[0]).toBeNull();
+    expect(mockFetchGenericTable).not.toHaveBeenCalled();
+  });
+
+  it('should return null when name is missing', () => {
+    const { result } = renderHook(() => useGenericTable('my-project', 'default', undefined));
+    expect(result.current[0]).toBeNull();
+    expect(mockFetchGenericTable).not.toHaveBeenCalled();
+  });
+
+  it('should fetch table data when all params are provided', async () => {
+    const mockTable = {
+      name: 'my-table',
+      asset_type: 'table',
+      format: 'parquet',
+      location: 's3://bucket/path',
+      collection: 'default',
+      connection_ref: null,
+      owner: 'user1',
+      description: 'A table',
+      labels: [],
+      properties: {},
+      registered_by: 'user1',
+      created_at: '2026-01-01',
+    };
+    mockFetchGenericTable.mockResolvedValue(mockTable);
+
+    const { result } = renderHook(() => useGenericTable('my-project', 'default', 'my-table'));
+
+    await waitFor(() => {
+      expect(result.current[1]).toBe(true);
+    });
+
+    expect(result.current[0]).toEqual(mockTable);
+    expect(mockFetchGenericTable).toHaveBeenCalledWith('my-project', 'default', 'my-table');
+  });
+
+  it('should handle fetch errors', async () => {
+    mockFetchGenericTable.mockRejectedValue(new Error('Not found'));
+
+    const { result } = renderHook(() => useGenericTable('my-project', 'default', 'missing-table'));
+
+    await waitFor(() => {
+      expect(result.current[2]).toBeDefined();
+    });
+
+    expect(result.current[2]?.message).toBe('Not found');
+    expect(result.current[0]).toBeNull();
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/hooks/useVolume.spec.ts
+++ b/packages/data-registry/frontend/src/__tests__/unit/hooks/useVolume.spec.ts
@@ -1,0 +1,70 @@
+/* eslint-disable camelcase */
+import { renderHook, waitFor } from '@testing-library/react';
+import * as api from '~/app/api/dataRegistry';
+import { useVolume } from '~/app/hooks/useVolume';
+
+jest.mock('~/app/api/dataRegistry');
+
+const mockFetchVolume = jest.mocked(api.fetchVolume);
+
+describe('useVolume', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return null when project is missing', () => {
+    const { result } = renderHook(() => useVolume(undefined, 'default', 'my-volume'));
+    expect(result.current[0]).toBeNull();
+    expect(mockFetchVolume).not.toHaveBeenCalled();
+  });
+
+  it('should return null when collection is missing', () => {
+    const { result } = renderHook(() => useVolume('my-project', undefined, 'my-volume'));
+    expect(result.current[0]).toBeNull();
+    expect(mockFetchVolume).not.toHaveBeenCalled();
+  });
+
+  it('should return null when name is missing', () => {
+    const { result } = renderHook(() => useVolume('my-project', 'default', undefined));
+    expect(result.current[0]).toBeNull();
+    expect(mockFetchVolume).not.toHaveBeenCalled();
+  });
+
+  it('should fetch volume data when all params are provided', async () => {
+    const mockVolume = {
+      name: 'my-volume',
+      'catalog-name': 'my-project',
+      'schema-name': 'default',
+      'volume-type': 'EXTERNAL',
+      'storage-location': 's3://bucket/volumes/my-volume/',
+      comment: 'A volume',
+      owner: 'user1',
+      'created-at': '2026-01-01',
+      'updated-at': '2026-01-02',
+      properties: {},
+    };
+    mockFetchVolume.mockResolvedValue(mockVolume);
+
+    const { result } = renderHook(() => useVolume('my-project', 'default', 'my-volume'));
+
+    await waitFor(() => {
+      expect(result.current[1]).toBe(true);
+    });
+
+    expect(result.current[0]).toEqual(mockVolume);
+    expect(mockFetchVolume).toHaveBeenCalledWith('my-project', 'default', 'my-volume');
+  });
+
+  it('should handle fetch errors', async () => {
+    mockFetchVolume.mockRejectedValue(new Error('Not found'));
+
+    const { result } = renderHook(() => useVolume('my-project', 'default', 'missing-volume'));
+
+    await waitFor(() => {
+      expect(result.current[2]).toBeDefined();
+    });
+
+    expect(result.current[2]?.message).toBe('Not found');
+    expect(result.current[0]).toBeNull();
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/jest.d.ts
+++ b/packages/data-registry/frontend/src/__tests__/unit/jest.d.ts
@@ -8,7 +8,7 @@ declare namespace jest {
     hookToStrictEqual: (expected: unknown) => R;
     hookToHaveUpdateCount: (expected: number) => R;
     hookToBeStable: <
-      V extends T extends Pick<
+      V extends (T extends Pick<
         import('~/__tests__/unit/testUtils/hooks').RenderHookResultExt<
           infer Result,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -17,7 +17,7 @@ declare namespace jest {
         'result'
       >
         ? import('~/__tests__/unit/testUtils/hooks').BooleanValues<Result>
-        : never,
+        : never),
     >(
       expected?: V,
     ) => R;

--- a/packages/data-registry/frontend/src/__tests__/unit/jest.setup.ts
+++ b/packages/data-registry/frontend/src/__tests__/unit/jest.setup.ts
@@ -1,5 +1,6 @@
 import { TextEncoder } from 'util';
 import { JestAssertionError } from 'expect';
+import '@testing-library/jest-dom';
 import 'core-js/actual/array/to-sorted';
 import {
   BooleanValues,

--- a/packages/data-registry/frontend/src/app/api/dataRegistry.ts
+++ b/packages/data-registry/frontend/src/app/api/dataRegistry.ts
@@ -1,11 +1,12 @@
 import {
+  AssetResponse,
   AssetListResponse,
+  VolumeInfo,
   ListVolumesResponse,
   ListNamespacesResponse,
   NamespaceResponse,
   CreateNamespaceRequest,
   CreateVolumeRequest,
-  VolumeInfo,
   LabelListResponse,
   CreateLabelRequest,
   LabelResponse,
@@ -74,6 +75,29 @@ export { ApiError };
 export const fetchAssets = (project: string, collection: string): Promise<AssetListResponse> =>
   fetchJSON(registryUrl(`/${project}/namespaces/${collection}/generic-tables`));
 
+export const fetchGenericTable = (
+  project: string,
+  collection: string,
+  name: string,
+): Promise<AssetResponse> =>
+  fetchJSON(
+    registryUrl(
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(collection)}/generic-tables/${encodeURIComponent(name)}`,
+    ),
+  );
+
+export const deleteGenericTable = (
+  project: string,
+  collection: string,
+  name: string,
+): Promise<void> =>
+  fetchRequest(
+    registryUrl(
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(collection)}/generic-tables/${encodeURIComponent(name)}`,
+    ),
+    'DELETE',
+  ).then(() => undefined);
+
 // Volumes
 
 export const fetchVolumes = (project: string, collection: string): Promise<ListVolumesResponse> =>
@@ -91,6 +115,25 @@ export const createVolume = async (
   );
   return response.json();
 };
+
+export const fetchVolume = (
+  project: string,
+  collection: string,
+  name: string,
+): Promise<VolumeInfo> =>
+  fetchJSON(
+    registryUrl(
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(collection)}/volumes/${encodeURIComponent(name)}`,
+    ),
+  );
+
+export const deleteVolume = (project: string, collection: string, name: string): Promise<void> =>
+  fetchRequest(
+    registryUrl(
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(collection)}/volumes/${encodeURIComponent(name)}`,
+    ),
+    'DELETE',
+  ).then(() => undefined);
 
 // Labels
 

--- a/packages/data-registry/frontend/src/app/components/ConnectionRefLink.tsx
+++ b/packages/data-registry/frontend/src/app/components/ConnectionRefLink.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ConnectionRef } from '~/app/types';
+
+type ConnectionRefLinkProps = {
+  connectionRef?: ConnectionRef | null;
+  linkTo?: string;
+};
+
+const ConnectionRefLink: React.FC<ConnectionRefLinkProps> = ({ connectionRef, linkTo }) => {
+  if (!connectionRef) {
+    return <>-</>;
+  }
+
+  const label = connectionRef.type === 'rhai' ? connectionRef.secret_name : connectionRef.id;
+
+  const testId = connectionRef.type === 'rhai' ? 'connection-ref-rhai' : 'connection-ref-dch';
+
+  if (linkTo) {
+    return (
+      <Link to={linkTo} data-testid={testId}>
+        {label}
+      </Link>
+    );
+  }
+
+  return <span data-testid={testId}>{label}</span>;
+};
+
+export default ConnectionRefLink;

--- a/packages/data-registry/frontend/src/app/components/DeleteAssetModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/DeleteAssetModal.tsx
@@ -29,7 +29,12 @@ const DeleteAssetModal: React.FC<DeleteAssetModalProps> = ({
   }, [onDelete]);
 
   return (
-    <Modal isOpen onClose={onClose} variant="small" data-testid="delete-asset-modal">
+    <Modal
+      isOpen
+      onClose={isDeleting ? undefined : onClose}
+      variant="small"
+      data-testid="delete-asset-modal"
+    >
       <ModalHeader title={`Delete ${assetType}?`} />
       <ModalBody>
         {error ? <Alert variant="danger" isInline title={error} /> : null}

--- a/packages/data-registry/frontend/src/app/components/DeleteAssetModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/DeleteAssetModal.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Modal, ModalBody, ModalFooter, ModalHeader, Button, Alert } from '@patternfly/react-core';
+
+type DeleteAssetModalProps = {
+  assetName: string;
+  assetType: 'table' | 'volume';
+  onDelete: () => Promise<void>;
+  onClose: () => void;
+};
+
+const DeleteAssetModal: React.FC<DeleteAssetModalProps> = ({
+  assetName,
+  assetType,
+  onDelete,
+  onClose,
+}) => {
+  const [isDeleting, setIsDeleting] = React.useState(false);
+  const [error, setError] = React.useState<string>();
+
+  const handleDelete = React.useCallback(async () => {
+    setIsDeleting(true);
+    setError(undefined);
+    try {
+      await onDelete();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete asset');
+      setIsDeleting(false);
+    }
+  }, [onDelete]);
+
+  return (
+    <Modal isOpen onClose={onClose} variant="small" data-testid="delete-asset-modal">
+      <ModalHeader title={`Delete ${assetType}?`} />
+      <ModalBody>
+        {error ? <Alert variant="danger" isInline title={error} /> : null}
+        <p>
+          Are you sure you want to delete the {assetType} <strong>{assetName}</strong>? This action
+          cannot be undone.
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="danger"
+          onClick={handleDelete}
+          isLoading={isDeleting}
+          isDisabled={isDeleting}
+          data-testid="delete-asset-confirm"
+        >
+          Delete
+        </Button>
+        <Button variant="link" onClick={onClose} isDisabled={isDeleting}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default DeleteAssetModal;

--- a/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
@@ -27,13 +27,17 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, Tbody, Td, ThProps } from '@patternfly/react-table';
+import { Link } from 'react-router-dom';
 import { RegistryAsset } from '~/app/hooks/useAssets';
+import { tableDetailUrl, volumeDetailUrl } from '~/app/utilities/routes';
+import { getFormatBadge, isStructured, FORMAT_OPTIONS } from '~/app/utilities/formatUtils';
 
 type RegistryTableProps = {
   assets: RegistryAsset[];
   loaded: boolean;
   error: Error | undefined;
   labels: string[];
+  project: string;
   onManageCollections: () => void;
   onManageLabels: () => void;
   onRegisterData: () => void;
@@ -41,72 +45,18 @@ type RegistryTableProps = {
 
 type FilterCategory = 'labels' | 'assetType' | 'format';
 
-const FORMAT_LABELS: Record<
-  string,
-  { text: string; color: 'blue' | 'green' | 'orange' | 'purple' | 'grey' }
-> = {
-  iceberg: { text: 'Structured', color: 'blue' },
-  parquet: { text: 'Structured', color: 'blue' },
-  csv: { text: 'Structured', color: 'blue' },
-  postgresql: { text: 'Structured', color: 'blue' },
-  mysql: { text: 'Structured', color: 'blue' },
-  milvus: { text: 'Structured', color: 'blue' },
-  delta: { text: 'Structured', color: 'blue' },
-  'application/pdf': { text: 'Unstructured', color: 'orange' },
-  pdf: { text: 'Unstructured', color: 'orange' },
-  documents: { text: 'Unstructured', color: 'orange' },
-  images: { text: 'Unstructured', color: 'orange' },
-  audio: { text: 'Unstructured', color: 'orange' },
-  video: { text: 'Unstructured', color: 'orange' },
-  binary: { text: 'Unstructured', color: 'orange' },
-  other: { text: 'Unstructured', color: 'orange' },
-};
-
-const UNSTRUCTURED_FORMATS = [
-  'documents',
-  'images',
-  'audio',
-  'video',
-  'binary',
-  'other',
-  'application/pdf',
-  'pdf',
-];
-
-const FORMAT_OPTIONS: { key: string; label: string }[] = [
-  { key: 'iceberg', label: 'Apache Iceberg' },
-  { key: 'parquet', label: 'Apache Parquet' },
-  { key: 'csv', label: 'CSV' },
-  { key: 'delta', label: 'Delta Lake' },
-  { key: 'postgresql', label: 'PostgreSQL' },
-  { key: 'milvus', label: 'Milvus' },
-  { key: 'documents', label: 'Documents' },
-  { key: 'images', label: 'Images' },
-  { key: 'audio', label: 'Audio' },
-  { key: 'video', label: 'Video' },
-  { key: 'binary', label: 'Binary' },
-  { key: 'other', label: 'Other' },
-];
-
 const CATEGORY_LABELS: Record<FilterCategory, string> = {
   labels: 'Labels',
   assetType: 'Asset type',
   format: 'Format',
 };
 
-const getFormatBadge = (
-  format: string,
-): { text: string; color: 'blue' | 'green' | 'orange' | 'purple' | 'grey' } =>
-  FORMAT_LABELS[format.toLowerCase()] ?? { text: 'Unknown', color: 'grey' };
-
-const isStructured = (format: string): boolean =>
-  !UNSTRUCTURED_FORMATS.includes(format.toLowerCase());
-
 const RegistryTable: React.FC<RegistryTableProps> = ({
   assets,
   loaded,
   error,
   labels,
+  project,
   onManageCollections,
   onManageLabels,
   onRegisterData,
@@ -540,7 +490,20 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
                 return (
                   <Tr key={`${asset.collection}-${asset.name}`}>
                     <Td dataLabel="Name">
-                      <Button variant="link" isInline>
+                      <Button
+                        variant="link"
+                        isInline
+                        component={(props) => (
+                          <Link
+                            {...props}
+                            to={
+                              asset.assetType === 'volume'
+                                ? volumeDetailUrl(project, asset.collection, asset.name)
+                                : tableDetailUrl(project, asset.collection, asset.name)
+                            }
+                          />
+                        )}
+                      >
                         {asset.name}
                       </Button>
                       {asset.description ? (

--- a/packages/data-registry/frontend/src/app/components/SchemaColumnsTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/SchemaColumnsTable.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { EmptyState, EmptyStateBody, EmptyStateVariant, Label } from '@patternfly/react-core';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { SchemaField } from '~/app/types';
+
+type SchemaColumnsTableProps = {
+  columns: SchemaField[];
+};
+
+const SchemaColumnsTable: React.FC<SchemaColumnsTableProps> = ({ columns }) => {
+  if (columns.length === 0) {
+    return (
+      <EmptyState headingLevel="h3" titleText="No schema columns" variant={EmptyStateVariant.xs}>
+        <EmptyStateBody>This table has no schema columns defined.</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <Table aria-label="Schema columns" variant="compact" data-testid="schema-columns-table">
+      <Thead>
+        <Tr>
+          <Th>Name</Th>
+          <Th>Type</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {columns.map((col) => (
+          <Tr key={col.name}>
+            <Td dataLabel="Name" data-testid={`schema-column-name-${col.name}`}>
+              {col.name}
+            </Td>
+            <Td dataLabel="Type">
+              <Label isCompact data-testid={`schema-column-type-${col.name}`}>
+                {col.type}
+              </Label>
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+};
+
+export default SchemaColumnsTable;

--- a/packages/data-registry/frontend/src/app/components/SchemaColumnsTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/SchemaColumnsTable.tsx
@@ -22,6 +22,8 @@ const SchemaColumnsTable: React.FC<SchemaColumnsTableProps> = ({ columns }) => {
         <Tr>
           <Th>Name</Th>
           <Th>Type</Th>
+          <Th>Description</Th>
+          <Th>Nullable</Th>
         </Tr>
       </Thead>
       <Tbody>
@@ -35,6 +37,8 @@ const SchemaColumnsTable: React.FC<SchemaColumnsTableProps> = ({ columns }) => {
                 {col.type}
               </Label>
             </Td>
+            <Td dataLabel="Description">{col.description || '-'}</Td>
+            <Td dataLabel="Nullable">{col.nullable ? 'Yes' : 'No'}</Td>
           </Tr>
         ))}
       </Tbody>

--- a/packages/data-registry/frontend/src/app/hooks/useGenericTable.ts
+++ b/packages/data-registry/frontend/src/app/hooks/useGenericTable.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useFetchState, NotReadyError, type FetchState } from 'mod-arch-core';
+import { fetchGenericTable } from '~/app/api/dataRegistry';
+import { AssetResponse } from '~/app/types';
+
+export const useGenericTable = (
+  project?: string,
+  collection?: string,
+  name?: string,
+): FetchState<AssetResponse | null> => {
+  const callback = React.useCallback(() => {
+    if (!project || !collection || !name) {
+      return Promise.reject(new NotReadyError('Missing project, collection, or asset name'));
+    }
+    return fetchGenericTable(project, collection, name);
+  }, [project, collection, name]);
+
+  return useFetchState<AssetResponse | null>(callback, null);
+};

--- a/packages/data-registry/frontend/src/app/hooks/useVolume.ts
+++ b/packages/data-registry/frontend/src/app/hooks/useVolume.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useFetchState, NotReadyError, type FetchState } from 'mod-arch-core';
+import { fetchVolume } from '~/app/api/dataRegistry';
+import { VolumeInfo } from '~/app/types';
+
+export const useVolume = (
+  project?: string,
+  collection?: string,
+  name?: string,
+): FetchState<VolumeInfo | null> => {
+  const callback = React.useCallback(() => {
+    if (!project || !collection || !name) {
+      return Promise.reject(new NotReadyError('Missing project, collection, or volume name'));
+    }
+    return fetchVolume(project, collection, name);
+  }, [project, collection, name]);
+
+  return useFetchState<VolumeInfo | null>(callback, null);
+};

--- a/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
@@ -166,6 +166,7 @@ const DataRegistryPage: React.FC = () => {
             loaded={assetsLoaded && collectionsLoaded}
             error={assetsError}
             labels={labels}
+            project={selectedProject}
             onManageCollections={() => {
               if (!collectionsError) {
                 setIsCollectionsModalOpen(true);

--- a/packages/data-registry/frontend/src/app/pages/MainPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/MainPage.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
+import { Route, Routes } from 'react-router-dom';
 import DataRegistryPage from './DataRegistryPage';
+import TableDetailPage from './TableDetailPage';
+import VolumeDetailPage from './VolumeDetailPage';
 
-const MainPage: React.FC = () => <DataRegistryPage />;
+const MainPage: React.FC = () => (
+  <Routes>
+    <Route path="tables/:project/:collection/:name" element={<TableDetailPage />} />
+    <Route path="volumes/:project/:collection/:name" element={<VolumeDetailPage />} />
+    <Route path="*" element={<DataRegistryPage />} />
+  </Routes>
+);
 
 export default MainPage;

--- a/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
@@ -3,9 +3,14 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbItem,
+  Button,
   Dropdown,
   DropdownList,
   DropdownItem,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateVariant,
   Flex,
   FlexItem,
   Label,
@@ -16,7 +21,7 @@ import {
   TabTitleText,
   Tooltip,
 } from '@patternfly/react-core';
-import { EllipsisVIcon } from '@patternfly/react-icons';
+import { EllipsisVIcon, SearchIcon } from '@patternfly/react-icons';
 import ApplicationsPage from '~/app/components/ApplicationsPage';
 import { useGenericTable } from '~/app/hooks/useGenericTable';
 import { deleteGenericTable } from '~/app/api/dataRegistry';
@@ -44,7 +49,7 @@ const TableDetailPage: React.FC = () => {
     navigate(browseUrl(project));
   }, [project, collection, name, navigate]);
 
-  const decodedName = name ? decodeURIComponent(name) : 'Loading...';
+  const displayName = name || 'Loading...';
 
   const breadcrumb = (
     <Breadcrumb>
@@ -59,12 +64,12 @@ const TableDetailPage: React.FC = () => {
         <BreadcrumbItem
           render={({ className }) => (
             <Link className={className} to={browseUrl(project)}>
-              {decodeURIComponent(collection)}
+              {collection}
             </Link>
           )}
         />
       ) : null}
-      <BreadcrumbItem isActive>{decodedName}</BreadcrumbItem>
+      <BreadcrumbItem isActive>{displayName}</BreadcrumbItem>
     </Breadcrumb>
   );
 
@@ -105,7 +110,7 @@ const TableDetailPage: React.FC = () => {
       </Dropdown>
       {isDeleteModalOpen && name ? (
         <DeleteAssetModal
-          assetName={decodedName}
+          assetName={displayName}
           assetType="table"
           onDelete={handleDelete}
           onClose={() => setIsDeleteModalOpen(false)}
@@ -116,7 +121,7 @@ const TableDetailPage: React.FC = () => {
 
   const title = (
     <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-      <FlexItem>{decodedName}</FlexItem>
+      <FlexItem>{displayName}</FlexItem>
       <FlexItem>
         <Label isCompact data-testid="asset-type-badge">
           Data asset
@@ -133,7 +138,27 @@ const TableDetailPage: React.FC = () => {
       loaded={loaded}
       loadError={loadError}
       empty={loaded && !asset}
-      emptyMessage="Table not found"
+      emptyStatePage={
+        <EmptyState
+          headingLevel="h2"
+          icon={SearchIcon}
+          titleText="Table not found"
+          variant={EmptyStateVariant.full}
+          data-testid="table-not-found-empty-state"
+        >
+          <EmptyStateBody>
+            The table you are looking for does not exist or you do not have permission to view it.
+          </EmptyStateBody>
+          <EmptyStateFooter>
+            <Button
+              variant="primary"
+              component={(props) => <Link {...props} to={browseUrl(project)} />}
+            >
+              Return to data browse
+            </Button>
+          </EmptyStateFooter>
+        </EmptyState>
+      }
       provideChildrenPadding
     >
       <Tabs defaultActiveKey={0} data-testid="detail-tabs">

--- a/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Dropdown,
+  DropdownList,
+  DropdownItem,
+  Flex,
+  FlexItem,
+  Label,
+  MenuToggle,
+  Tab,
+  Tabs,
+  TabContent,
+  TabTitleText,
+  Tooltip,
+} from '@patternfly/react-core';
+import { EllipsisVIcon } from '@patternfly/react-icons';
+import ApplicationsPage from '~/app/components/ApplicationsPage';
+import { useGenericTable } from '~/app/hooks/useGenericTable';
+import { deleteGenericTable } from '~/app/api/dataRegistry';
+import { browseUrl } from '~/app/utilities/routes';
+import DeleteAssetModal from '~/app/components/DeleteAssetModal';
+import TableDetailView from './TableDetailView';
+
+const TableDetailPage: React.FC = () => {
+  const { project, collection, name } = useParams<{
+    project: string;
+    collection: string;
+    name: string;
+  }>();
+  const navigate = useNavigate();
+
+  const [asset, loaded, loadError] = useGenericTable(project, collection, name);
+  const [isActionsOpen, setIsActionsOpen] = React.useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
+
+  const handleDelete = React.useCallback(async () => {
+    if (!project || !collection || !name) {
+      return;
+    }
+    await deleteGenericTable(project, collection, name);
+    navigate(browseUrl(project));
+  }, [project, collection, name, navigate]);
+
+  const decodedName = name ? decodeURIComponent(name) : 'Loading...';
+
+  const breadcrumb = (
+    <Breadcrumb>
+      <BreadcrumbItem
+        render={({ className }) => (
+          <Link className={className} to={browseUrl(project)}>
+            Data
+          </Link>
+        )}
+      />
+      {collection ? (
+        <BreadcrumbItem
+          render={({ className }) => (
+            <Link className={className} to={browseUrl(project)}>
+              {decodeURIComponent(collection)}
+            </Link>
+          )}
+        />
+      ) : null}
+      <BreadcrumbItem isActive>{decodedName}</BreadcrumbItem>
+    </Breadcrumb>
+  );
+
+  const headerAction = (
+    <>
+      <Dropdown
+        isOpen={isActionsOpen}
+        onSelect={() => setIsActionsOpen(false)}
+        onOpenChange={setIsActionsOpen}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="plain"
+            onClick={() => setIsActionsOpen((prev) => !prev)}
+            isExpanded={isActionsOpen}
+            aria-label="Actions"
+            data-testid="asset-actions-toggle"
+          >
+            <EllipsisVIcon />
+          </MenuToggle>
+        )}
+        popperProps={{ position: 'right' }}
+      >
+        <DropdownList>
+          <Tooltip content="Edit functionality coming soon">
+            <DropdownItem key="edit" isDisabled data-testid="asset-action-edit">
+              Edit
+            </DropdownItem>
+          </Tooltip>
+          <DropdownItem
+            key="delete"
+            onClick={() => setIsDeleteModalOpen(true)}
+            data-testid="asset-action-delete"
+          >
+            Delete
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
+      {isDeleteModalOpen && name ? (
+        <DeleteAssetModal
+          assetName={decodedName}
+          assetType="table"
+          onDelete={handleDelete}
+          onClose={() => setIsDeleteModalOpen(false)}
+        />
+      ) : null}
+    </>
+  );
+
+  const title = (
+    <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+      <FlexItem>{decodedName}</FlexItem>
+      <FlexItem>
+        <Label isCompact data-testid="asset-type-badge">
+          Data asset
+        </Label>
+      </FlexItem>
+    </Flex>
+  );
+
+  return (
+    <ApplicationsPage
+      title={title}
+      breadcrumb={breadcrumb}
+      headerAction={headerAction}
+      loaded={loaded}
+      loadError={loadError}
+      empty={loaded && !asset}
+      emptyMessage="Table not found"
+      provideChildrenPadding
+    >
+      <Tabs defaultActiveKey={0} data-testid="detail-tabs">
+        <Tab eventKey={0} title={<TabTitleText>Overview</TabTitleText>}>
+          <TabContent id="overview-tab">
+            {asset ? <TableDetailView asset={asset} project={project} /> : null}
+          </TabContent>
+        </Tab>
+      </Tabs>
+    </ApplicationsPage>
+  );
+};
+
+export default TableDetailPage;

--- a/packages/data-registry/frontend/src/app/pages/TableDetailView.tsx
+++ b/packages/data-registry/frontend/src/app/pages/TableDetailView.tsx
@@ -1,0 +1,199 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Grid,
+  GridItem,
+  Label,
+  LabelGroup,
+  Stack,
+  StackItem,
+  Timestamp,
+  TimestampFormat,
+} from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { AssetResponse } from '~/app/types';
+import SchemaColumnsTable from '~/app/components/SchemaColumnsTable';
+import ConnectionRefLink from '~/app/components/ConnectionRefLink';
+import { browseUrl } from '~/app/utilities/routes';
+import { getFormatBadge } from '~/app/utilities/formatUtils';
+
+type TableDetailViewProps = {
+  asset: AssetResponse;
+  project?: string;
+};
+
+const TableDetailView: React.FC<TableDetailViewProps> = ({ asset, project }) => {
+  const formatBadge = asset.format ? getFormatBadge(asset.format) : undefined;
+
+  return (
+    <Grid hasGutter>
+      <GridItem md={7}>
+        <Card data-testid="data-details-card">
+          <CardTitle>Data details</CardTitle>
+          <CardBody>
+            <DescriptionList
+              data-testid="table-detail-description-list"
+              columnModifier={{ default: '2Col' }}
+            >
+              <DescriptionListGroup>
+                <DescriptionListTerm>Description</DescriptionListTerm>
+                <DescriptionListDescription data-testid="asset-description">
+                  {asset.description || '-'}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              {asset.format ? (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Format</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="asset-format">
+                    <Label isCompact variant="outline" color={formatBadge?.color}>
+                      {asset.format}
+                    </Label>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              ) : null}
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>Collection</DescriptionListTerm>
+                <DescriptionListDescription data-testid="asset-collection">
+                  {asset.collection ? (
+                    project ? (
+                      <Link to={browseUrl(project)}>{asset.collection}</Link>
+                    ) : (
+                      asset.collection
+                    )
+                  ) : (
+                    '-'
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>Asset type</DescriptionListTerm>
+                <DescriptionListDescription data-testid="asset-type">
+                  {formatBadge ? formatBadge.text : asset.asset_type || '-'}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>Connection</DescriptionListTerm>
+                <DescriptionListDescription data-testid="asset-connection">
+                  <ConnectionRefLink connectionRef={asset.connection_ref} />
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>Owner</DescriptionListTerm>
+                <DescriptionListDescription data-testid="asset-owner">
+                  {asset.owner || '-'}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>Path</DescriptionListTerm>
+                <DescriptionListDescription data-testid="asset-location">
+                  {asset.location || '-'}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>Created</DescriptionListTerm>
+                <DescriptionListDescription data-testid="asset-created-at">
+                  {asset.created_at ? (
+                    <>
+                      <Timestamp
+                        date={new Date(asset.created_at)}
+                        dateFormat={TimestampFormat.long}
+                      />
+                      {asset.registered_by ? ` by ${asset.registered_by}` : null}
+                    </>
+                  ) : (
+                    '-'
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>Last modified</DescriptionListTerm>
+                <DescriptionListDescription data-testid="asset-updated-at">
+                  {asset.updated_at ? (
+                    <>
+                      <Timestamp
+                        date={new Date(asset.updated_at)}
+                        dateFormat={TimestampFormat.long}
+                      />
+                      {asset.updated_by ? ` by ${asset.updated_by}` : null}
+                    </>
+                  ) : (
+                    '-'
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </CardBody>
+        </Card>
+      </GridItem>
+
+      <GridItem md={5}>
+        <Stack hasGutter>
+          <StackItem>
+            <Card data-testid="labels-card">
+              <CardTitle>Labels</CardTitle>
+              <CardBody>
+                {asset.labels && asset.labels.length > 0 ? (
+                  <LabelGroup data-testid="asset-labels" numLabels={5}>
+                    {asset.labels.map((label) => (
+                      <Label key={label} isCompact>
+                        {label}
+                      </Label>
+                    ))}
+                  </LabelGroup>
+                ) : (
+                  <span data-testid="asset-labels">No labels</span>
+                )}
+              </CardBody>
+            </Card>
+          </StackItem>
+
+          {asset.properties && Object.keys(asset.properties).length > 0 ? (
+            <StackItem>
+              <Card data-testid="properties-card">
+                <CardTitle>Properties</CardTitle>
+                <CardBody>
+                  <LabelGroup data-testid="asset-properties" numLabels={5}>
+                    {Object.entries(asset.properties).map(([key, value]) => (
+                      <Label key={key} isCompact>
+                        {key}: {value}
+                      </Label>
+                    ))}
+                  </LabelGroup>
+                </CardBody>
+              </Card>
+            </StackItem>
+          ) : null}
+
+          <StackItem>
+            <Card data-testid="schema-card">
+              <CardTitle>Schema</CardTitle>
+              <CardBody>
+                {(asset.columns?.length ?? 0) > 0 ? (
+                  <span data-testid="schema-column-count">{asset.columns?.length} columns</span>
+                ) : null}
+                <SchemaColumnsTable columns={asset.columns ?? []} />
+              </CardBody>
+            </Card>
+          </StackItem>
+        </Stack>
+      </GridItem>
+    </Grid>
+  );
+};
+
+export default TableDetailView;

--- a/packages/data-registry/frontend/src/app/pages/VolumeDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/VolumeDetailPage.tsx
@@ -3,9 +3,14 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbItem,
+  Button,
   Dropdown,
   DropdownList,
   DropdownItem,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateVariant,
   Flex,
   FlexItem,
   Label,
@@ -16,7 +21,7 @@ import {
   TabTitleText,
   Tooltip,
 } from '@patternfly/react-core';
-import { EllipsisVIcon } from '@patternfly/react-icons';
+import { EllipsisVIcon, SearchIcon } from '@patternfly/react-icons';
 import ApplicationsPage from '~/app/components/ApplicationsPage';
 import { useVolume } from '~/app/hooks/useVolume';
 import { deleteVolume } from '~/app/api/dataRegistry';
@@ -44,7 +49,7 @@ const VolumeDetailPage: React.FC = () => {
     navigate(browseUrl(project));
   }, [project, collection, name, navigate]);
 
-  const decodedName = name ? decodeURIComponent(name) : 'Loading...';
+  const displayName = name || 'Loading...';
 
   const breadcrumb = (
     <Breadcrumb>
@@ -59,12 +64,12 @@ const VolumeDetailPage: React.FC = () => {
         <BreadcrumbItem
           render={({ className }) => (
             <Link className={className} to={browseUrl(project)}>
-              {decodeURIComponent(collection)}
+              {collection}
             </Link>
           )}
         />
       ) : null}
-      <BreadcrumbItem isActive>{decodedName}</BreadcrumbItem>
+      <BreadcrumbItem isActive>{displayName}</BreadcrumbItem>
     </Breadcrumb>
   );
 
@@ -105,7 +110,7 @@ const VolumeDetailPage: React.FC = () => {
       </Dropdown>
       {isDeleteModalOpen && name ? (
         <DeleteAssetModal
-          assetName={decodedName}
+          assetName={displayName}
           assetType="volume"
           onDelete={handleDelete}
           onClose={() => setIsDeleteModalOpen(false)}
@@ -116,7 +121,7 @@ const VolumeDetailPage: React.FC = () => {
 
   const title = (
     <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-      <FlexItem>{decodedName}</FlexItem>
+      <FlexItem>{displayName}</FlexItem>
       <FlexItem>
         <Label isCompact data-testid="asset-type-badge">
           Volume
@@ -133,7 +138,27 @@ const VolumeDetailPage: React.FC = () => {
       loaded={loaded}
       loadError={loadError}
       empty={loaded && !volume}
-      emptyMessage="Volume not found"
+      emptyStatePage={
+        <EmptyState
+          headingLevel="h2"
+          icon={SearchIcon}
+          titleText="Volume not found"
+          variant={EmptyStateVariant.full}
+          data-testid="volume-not-found-empty-state"
+        >
+          <EmptyStateBody>
+            The volume you are looking for does not exist or you do not have permission to view it.
+          </EmptyStateBody>
+          <EmptyStateFooter>
+            <Button
+              variant="primary"
+              component={(props) => <Link {...props} to={browseUrl(project)} />}
+            >
+              Return to data browse
+            </Button>
+          </EmptyStateFooter>
+        </EmptyState>
+      }
       provideChildrenPadding
     >
       <Tabs defaultActiveKey={0} data-testid="detail-tabs">

--- a/packages/data-registry/frontend/src/app/pages/VolumeDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/VolumeDetailPage.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Dropdown,
+  DropdownList,
+  DropdownItem,
+  Flex,
+  FlexItem,
+  Label,
+  MenuToggle,
+  Tab,
+  Tabs,
+  TabContent,
+  TabTitleText,
+  Tooltip,
+} from '@patternfly/react-core';
+import { EllipsisVIcon } from '@patternfly/react-icons';
+import ApplicationsPage from '~/app/components/ApplicationsPage';
+import { useVolume } from '~/app/hooks/useVolume';
+import { deleteVolume } from '~/app/api/dataRegistry';
+import { browseUrl } from '~/app/utilities/routes';
+import DeleteAssetModal from '~/app/components/DeleteAssetModal';
+import VolumeDetailView from './VolumeDetailView';
+
+const VolumeDetailPage: React.FC = () => {
+  const { project, collection, name } = useParams<{
+    project: string;
+    collection: string;
+    name: string;
+  }>();
+  const navigate = useNavigate();
+
+  const [volume, loaded, loadError] = useVolume(project, collection, name);
+  const [isActionsOpen, setIsActionsOpen] = React.useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
+
+  const handleDelete = React.useCallback(async () => {
+    if (!project || !collection || !name) {
+      return;
+    }
+    await deleteVolume(project, collection, name);
+    navigate(browseUrl(project));
+  }, [project, collection, name, navigate]);
+
+  const decodedName = name ? decodeURIComponent(name) : 'Loading...';
+
+  const breadcrumb = (
+    <Breadcrumb>
+      <BreadcrumbItem
+        render={({ className }) => (
+          <Link className={className} to={browseUrl(project)}>
+            Data
+          </Link>
+        )}
+      />
+      {collection ? (
+        <BreadcrumbItem
+          render={({ className }) => (
+            <Link className={className} to={browseUrl(project)}>
+              {decodeURIComponent(collection)}
+            </Link>
+          )}
+        />
+      ) : null}
+      <BreadcrumbItem isActive>{decodedName}</BreadcrumbItem>
+    </Breadcrumb>
+  );
+
+  const headerAction = (
+    <>
+      <Dropdown
+        isOpen={isActionsOpen}
+        onSelect={() => setIsActionsOpen(false)}
+        onOpenChange={setIsActionsOpen}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="plain"
+            onClick={() => setIsActionsOpen((prev) => !prev)}
+            isExpanded={isActionsOpen}
+            aria-label="Actions"
+            data-testid="asset-actions-toggle"
+          >
+            <EllipsisVIcon />
+          </MenuToggle>
+        )}
+        popperProps={{ position: 'right' }}
+      >
+        <DropdownList>
+          <Tooltip content="Edit functionality coming soon">
+            <DropdownItem key="edit" isDisabled data-testid="asset-action-edit">
+              Edit
+            </DropdownItem>
+          </Tooltip>
+          <DropdownItem
+            key="delete"
+            onClick={() => setIsDeleteModalOpen(true)}
+            data-testid="asset-action-delete"
+          >
+            Delete
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
+      {isDeleteModalOpen && name ? (
+        <DeleteAssetModal
+          assetName={decodedName}
+          assetType="volume"
+          onDelete={handleDelete}
+          onClose={() => setIsDeleteModalOpen(false)}
+        />
+      ) : null}
+    </>
+  );
+
+  const title = (
+    <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+      <FlexItem>{decodedName}</FlexItem>
+      <FlexItem>
+        <Label isCompact data-testid="asset-type-badge">
+          Volume
+        </Label>
+      </FlexItem>
+    </Flex>
+  );
+
+  return (
+    <ApplicationsPage
+      title={title}
+      breadcrumb={breadcrumb}
+      headerAction={headerAction}
+      loaded={loaded}
+      loadError={loadError}
+      empty={loaded && !volume}
+      emptyMessage="Volume not found"
+      provideChildrenPadding
+    >
+      <Tabs defaultActiveKey={0} data-testid="detail-tabs">
+        <Tab eventKey={0} title={<TabTitleText>Overview</TabTitleText>}>
+          <TabContent id="overview-tab">
+            {volume ? <VolumeDetailView volume={volume} /> : null}
+          </TabContent>
+        </Tab>
+      </Tabs>
+    </ApplicationsPage>
+  );
+};
+
+export default VolumeDetailPage;

--- a/packages/data-registry/frontend/src/app/pages/VolumeDetailView.tsx
+++ b/packages/data-registry/frontend/src/app/pages/VolumeDetailView.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Grid,
+  GridItem,
+  Label,
+  LabelGroup,
+  Stack,
+  StackItem,
+  Timestamp,
+  TimestampFormat,
+} from '@patternfly/react-core';
+import { VolumeInfo } from '~/app/types';
+
+type VolumeDetailViewProps = {
+  volume: VolumeInfo;
+};
+
+const VolumeDetailView: React.FC<VolumeDetailViewProps> = ({ volume }) => (
+  <Grid hasGutter>
+    <GridItem md={7}>
+      <Card data-testid="data-details-card">
+        <CardTitle>Data details</CardTitle>
+        <CardBody>
+          <DescriptionList
+            data-testid="volume-detail-description-list"
+            columnModifier={{ default: '2Col' }}
+          >
+            <DescriptionListGroup>
+              <DescriptionListTerm>Description</DescriptionListTerm>
+              <DescriptionListDescription data-testid="volume-comment">
+                {volume.comment || '-'}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>Volume type</DescriptionListTerm>
+              <DescriptionListDescription data-testid="volume-type">
+                {volume['volume-type'] ? (
+                  <Label isCompact variant="outline" color="orange">
+                    {volume['volume-type']}
+                  </Label>
+                ) : (
+                  '-'
+                )}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>Project</DescriptionListTerm>
+              <DescriptionListDescription data-testid="volume-project">
+                {volume['catalog-name']}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>Storage location</DescriptionListTerm>
+              <DescriptionListDescription data-testid="volume-storage-location">
+                {volume['storage-location']}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>Owner</DescriptionListTerm>
+              <DescriptionListDescription data-testid="volume-owner">
+                {volume.owner || '-'}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>Created</DescriptionListTerm>
+              <DescriptionListDescription data-testid="volume-created-at">
+                {volume['created-at'] ? (
+                  <Timestamp
+                    date={new Date(volume['created-at'])}
+                    dateFormat={TimestampFormat.long}
+                  />
+                ) : (
+                  '-'
+                )}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>Last modified</DescriptionListTerm>
+              <DescriptionListDescription data-testid="volume-updated-at">
+                {volume['updated-at'] ? (
+                  <Timestamp
+                    date={new Date(volume['updated-at'])}
+                    dateFormat={TimestampFormat.long}
+                  />
+                ) : (
+                  '-'
+                )}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </CardBody>
+      </Card>
+    </GridItem>
+
+    <GridItem md={5}>
+      <Stack hasGutter>
+        <StackItem>
+          <Card data-testid="labels-card">
+            <CardTitle>Labels</CardTitle>
+            <CardBody>
+              {volume.labels && volume.labels.length > 0 ? (
+                <LabelGroup data-testid="volume-labels" numLabels={5}>
+                  {volume.labels.map((label) => (
+                    <Label key={label} isCompact>
+                      {label}
+                    </Label>
+                  ))}
+                </LabelGroup>
+              ) : (
+                <span data-testid="volume-labels">No labels</span>
+              )}
+            </CardBody>
+          </Card>
+        </StackItem>
+
+        {volume.properties && Object.keys(volume.properties).length > 0 ? (
+          <StackItem>
+            <Card data-testid="properties-card">
+              <CardTitle>Properties</CardTitle>
+              <CardBody>
+                <LabelGroup data-testid="volume-properties" numLabels={5}>
+                  {Object.entries(volume.properties).map(([key, value]) => (
+                    <Label key={key} isCompact>
+                      {key}: {value}
+                    </Label>
+                  ))}
+                </LabelGroup>
+              </CardBody>
+            </Card>
+          </StackItem>
+        ) : null}
+      </Stack>
+    </GridItem>
+  </Grid>
+);
+
+export default VolumeDetailView;

--- a/packages/data-registry/frontend/src/app/types.ts
+++ b/packages/data-registry/frontend/src/app/types.ts
@@ -39,7 +39,17 @@ export type SchemaField = {
   nullable?: boolean;
 };
 
-export type ConnectionRef = { type: 'dch'; id: string } | { type: 'rhai'; secret_name: string };
+export type DchConnectionRef = {
+  type: 'dch';
+  id: string;
+};
+
+export type RhaiConnectionRef = {
+  type: 'rhai';
+  secret_name: string;
+};
+
+export type ConnectionRef = DchConnectionRef | RhaiConnectionRef;
 
 export type AssetResponse = {
   name: string;

--- a/packages/data-registry/frontend/src/app/utilities/formatUtils.ts
+++ b/packages/data-registry/frontend/src/app/utilities/formatUtils.ts
@@ -1,0 +1,52 @@
+type FormatBadge = {
+  text: string;
+  color: 'blue' | 'green' | 'orange' | 'purple' | 'grey';
+};
+
+const FORMAT_LABELS: Record<string, FormatBadge> = {
+  iceberg: { text: 'Structured', color: 'blue' },
+  parquet: { text: 'Structured', color: 'blue' },
+  csv: { text: 'Structured', color: 'blue' },
+  postgresql: { text: 'Structured', color: 'blue' },
+  mysql: { text: 'Structured', color: 'blue' },
+  milvus: { text: 'Structured', color: 'blue' },
+  delta: { text: 'Structured', color: 'blue' },
+  'application/pdf': { text: 'Unstructured', color: 'orange' },
+  pdf: { text: 'Unstructured', color: 'orange' },
+  documents: { text: 'Unstructured', color: 'orange' },
+  images: { text: 'Unstructured', color: 'orange' },
+  audio: { text: 'Unstructured', color: 'orange' },
+  video: { text: 'Unstructured', color: 'orange' },
+  binary: { text: 'Unstructured', color: 'orange' },
+};
+
+const UNSTRUCTURED_FORMATS = [
+  'documents',
+  'images',
+  'audio',
+  'video',
+  'binary',
+  'application/pdf',
+  'pdf',
+];
+
+export const FORMAT_OPTIONS: { key: string; label: string }[] = [
+  { key: 'iceberg', label: 'Apache Iceberg' },
+  { key: 'parquet', label: 'Apache Parquet' },
+  { key: 'csv', label: 'CSV' },
+  { key: 'delta', label: 'Delta Lake' },
+  { key: 'postgresql', label: 'PostgreSQL' },
+  { key: 'milvus', label: 'Milvus' },
+  { key: 'documents', label: 'Documents' },
+  { key: 'images', label: 'Images' },
+  { key: 'audio', label: 'Audio' },
+  { key: 'video', label: 'Video' },
+  { key: 'binary', label: 'Binary' },
+  { key: 'other', label: 'Other' },
+];
+
+export const getFormatBadge = (format: string): FormatBadge =>
+  FORMAT_LABELS[format.toLowerCase()] ?? { text: 'Unknown', color: 'grey' };
+
+export const isStructured = (format: string): boolean =>
+  !UNSTRUCTURED_FORMATS.includes(format.toLowerCase());

--- a/packages/data-registry/frontend/src/app/utilities/routes.ts
+++ b/packages/data-registry/frontend/src/app/utilities/routes.ts
@@ -1,5 +1,5 @@
 export const browseUrl = (project?: string): string => {
-  const base = '.';
+  const base = '..';
   if (!project) {
     return base;
   }

--- a/packages/data-registry/frontend/src/app/utilities/routes.ts
+++ b/packages/data-registry/frontend/src/app/utilities/routes.ts
@@ -1,0 +1,13 @@
+export const browseUrl = (project?: string): string => {
+  const base = '.';
+  if (!project) {
+    return base;
+  }
+  return `${base}?project=${encodeURIComponent(project)}`;
+};
+
+export const tableDetailUrl = (project: string, collection: string, name: string): string =>
+  `tables/${encodeURIComponent(project)}/${encodeURIComponent(collection)}/${encodeURIComponent(name)}`;
+
+export const volumeDetailUrl = (project: string, collection: string, name: string): string =>
+  `volumes/${encodeURIComponent(project)}/${encodeURIComponent(collection)}/${encodeURIComponent(name)}`;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAI-428

## Description

Implements detail views for tables and volumes in the data-registry package, matching the UX mockup from Miro.

**Changes:**
- **TableDetailPage / VolumeDetailPage** — Asset detail pages with breadcrumb navigation, kebab actions (edit disabled, delete), asset type badge, and Overview tab
- **TableDetailView / VolumeDetailView** — Two-column card layout: left side has "Data details" card with 2-column DescriptionList (description, format/volume-type, collection/project, asset type, connection, owner, path/storage-location, created/modified with user attribution); right side has stacked Labels, Properties, and Schema cards
- **SchemaColumnsTable** — Composable PF table with Name and Type columns, empty state when no schema
- **ConnectionRefLink** — Renders connection reference as text or link (with `linkTo` prop for future connection detail page)
- **DeleteAssetModal** — Confirmation modal for asset deletion with loading/error states
- **Routing** — Added sub-routes for `tables/:project/:collection/:name` and `volumes/:project/:collection/:name`
- **API functions** — `fetchGenericTable`, `deleteGenericTable`, `fetchVolume`, `deleteVolume`
- **Hooks** — `useGenericTable`, `useVolume` using `useFetchState` from mod-arch-core

**Connection ref link:** The `ConnectionRefLink` component supports a `linkTo` prop that renders the connection as a clickable link when provided. Currently displayed as plain text because no connection detail page exists yet — once [RHAI-430](https://redhat.atlassian.net/browse/RHAI-430) (connection picker) lands and a detail page is available, passing the URL via `linkTo` will activate the link with no component changes needed.

**Note:** This PR is based on top of #9412 ([RHAI-423](https://redhat.atlassian.net/browse/RHAI-423)).

**Screenshots:** from mstoklus2 cluster

<img width="2224" height="752" alt="Screenshot 2026-08-25 at 12 41 24" src="https://github.com/user-attachments/assets/6562b317-caf2-4b7d-bc08-4aa2862bf3ef" />
<img width="2235" height="587" alt="Screenshot 2026-08-25 at 12 41 37" src="https://github.com/user-attachments/assets/9a6777e2-23be-4f46-bc05-b0d30a5b7262" />


## How Has This Been Tested?

- Unit tests covering all new components and hooks (62 tests, 11 suites)
- Cypress mock tests covering detail view flows (10 tests)
- Type-check and ESLint pass with zero warnings

## Test Impact

**Unit tests** for:
- `ConnectionRefLink` — rhai/dch rendering, null/undefined, linkTo prop
- `DeleteAssetModal` — render, confirm, cancel, loading, error states
- `SchemaColumnsTable` — columns rendering, empty state
- `TableDetailView` — all metadata fields, labels, properties, schema, missing optional fields
- `VolumeDetailView` — all metadata fields, properties, missing optional fields
- `useGenericTable` / `useVolume` hooks — loading, success, error, missing params

**Cypress mock tests** for:
- Table detail view — metadata display, two-column layout, labels, properties, schema with column count
- Volume detail view — metadata display, properties card
- Asset type badge and Overview tab on both views
- Breadcrumb navigation
- Delete modal via kebab menu
- Created/modified user attribution

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work (see screenshots above)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHAI-430]: https://redhat.atlassian.net/browse/RHAI-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated detail pages for table and volume assets.
  * Added metadata, labels, properties, connection details, timestamps, and schema displays.
  * Added navigation from registry listings to asset details.
  * Added delete actions with confirmation dialogs and error handling.
  * Added clear placeholders and empty states for unavailable details.
  * Added format badges and improved presentation of structured and unstructured assets.

* **Bug Fixes**
  * Improved handling of asset routes and encoded resource names.
  * Added loading and error states when retrieving asset details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->