### PR TITLE
fix(llmd-serving): block deletion of in-use LLM-d routing/topology configs

### DIFF
--- a/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdRoutingAdmin.cy.ts
+++ b/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdRoutingAdmin.cy.ts
@@ -5,7 +5,10 @@ import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashb
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
-import { LLMInferenceServiceConfigModel } from '@odh-dashboard/cypress/cypress/utils/models';
+import {
+  LLMInferenceServiceConfigModel,
+  LLMInferenceServiceModel,
+} from '@odh-dashboard/cypress/cypress/utils/models';
 import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
 import {
   routingConfigurations,
@@ -362,6 +365,14 @@ describe('LLMD Routing Admin Settings', () => {
 
     it('should delete a routing config', () => {
       cy.interceptK8s(
+        'GET',
+        { model: LLMInferenceServiceConfigModel, ns: 'opendatahub', name: 'lab-routing-profile' },
+        mockUserConfig,
+      ).as('getConfigForDelete');
+      cy.interceptK8sList(LLMInferenceServiceModel, mockK8sResourceList([])).as(
+        'listDeploymentsForDelete',
+      );
+      cy.interceptK8s(
         'DELETE',
         { model: LLMInferenceServiceConfigModel, ns: 'opendatahub', name: 'lab-routing-profile' },
         mockLLMInferenceServiceConfigK8sResource({ name: 'lab-routing-profile' }),
@@ -371,6 +382,8 @@ describe('LLMD Routing Admin Settings', () => {
       deleteModal.find().should('exist');
       deleteModal.findInput().type('Lab routing profile');
       deleteModal.findSubmitButton().should('be.enabled').click();
+      cy.wait('@getConfigForDelete');
+      cy.wait('@listDeploymentsForDelete');
       cy.wait('@deleteConfig');
 
       cy.wsK8s(

--- a/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdRoutingAdmin.cy.ts
+++ b/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdRoutingAdmin.cy.ts
@@ -5,10 +5,7 @@ import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashb
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
-import {
-  LLMInferenceServiceConfigModel,
-  LLMInferenceServiceModel,
-} from '@odh-dashboard/cypress/cypress/utils/models';
+import { LLMInferenceServiceConfigModel } from '@odh-dashboard/cypress/cypress/utils/models';
 import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
 import {
   routingConfigurations,
@@ -369,9 +366,6 @@ describe('LLMD Routing Admin Settings', () => {
         { model: LLMInferenceServiceConfigModel, ns: 'opendatahub', name: 'lab-routing-profile' },
         mockUserConfig,
       ).as('getConfigForDelete');
-      cy.interceptK8sList(LLMInferenceServiceModel, mockK8sResourceList([])).as(
-        'listDeploymentsForDelete',
-      );
       cy.interceptK8s(
         'DELETE',
         { model: LLMInferenceServiceConfigModel, ns: 'opendatahub', name: 'lab-routing-profile' },
@@ -383,7 +377,6 @@ describe('LLMD Routing Admin Settings', () => {
       deleteModal.findInput().type('Lab routing profile');
       deleteModal.findSubmitButton().should('be.enabled').click();
       cy.wait('@getConfigForDelete');
-      cy.wait('@listDeploymentsForDelete');
       cy.wait('@deleteConfig');
 
       cy.wsK8s(

--- a/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdTopologyAdmin.cy.ts
+++ b/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdTopologyAdmin.cy.ts
@@ -5,7 +5,10 @@ import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashb
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
-import { LLMInferenceServiceConfigModel } from '@odh-dashboard/cypress/cypress/utils/models';
+import {
+  LLMInferenceServiceConfigModel,
+  LLMInferenceServiceModel,
+} from '@odh-dashboard/cypress/cypress/utils/models';
 import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
 import { topologyConfigurations } from '@odh-dashboard/cypress/cypress/pages/modelDeploymentSettings/topologyConfigurations';
 import { deleteModal } from '@odh-dashboard/cypress/cypress/pages/components/DeleteModal';
@@ -303,6 +306,14 @@ describe('LLMD Topology Admin Settings', () => {
     it('should delete a topology config', () => {
       initIntercepts();
       cy.interceptK8s(
+        'GET',
+        { model: LLMInferenceServiceConfigModel, ns: 'opendatahub', name: 'user-multi-node' },
+        mockUserConfig,
+      ).as('getConfigForDelete');
+      cy.interceptK8sList(LLMInferenceServiceModel, mockK8sResourceList([])).as(
+        'listDeploymentsForDelete',
+      );
+      cy.interceptK8s(
         'DELETE',
         { model: LLMInferenceServiceConfigModel, ns: 'opendatahub', name: 'user-multi-node' },
         mockLLMInferenceServiceConfigK8sResource({ name: 'user-multi-node' }),
@@ -313,6 +324,8 @@ describe('LLMD Topology Admin Settings', () => {
       deleteModal.find().should('exist');
       deleteModal.findInput().type('User Multi-node Config');
       deleteModal.findSubmitButton().should('be.enabled').click();
+      cy.wait('@getConfigForDelete');
+      cy.wait('@listDeploymentsForDelete');
       cy.wait('@deleteConfig');
 
       cy.wsK8s(

--- a/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdTopologyAdmin.cy.ts
+++ b/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdTopologyAdmin.cy.ts
@@ -5,10 +5,7 @@ import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashb
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
-import {
-  LLMInferenceServiceConfigModel,
-  LLMInferenceServiceModel,
-} from '@odh-dashboard/cypress/cypress/utils/models';
+import { LLMInferenceServiceConfigModel } from '@odh-dashboard/cypress/cypress/utils/models';
 import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
 import { topologyConfigurations } from '@odh-dashboard/cypress/cypress/pages/modelDeploymentSettings/topologyConfigurations';
 import { deleteModal } from '@odh-dashboard/cypress/cypress/pages/components/DeleteModal';
@@ -310,9 +307,6 @@ describe('LLMD Topology Admin Settings', () => {
         { model: LLMInferenceServiceConfigModel, ns: 'opendatahub', name: 'user-multi-node' },
         mockUserConfig,
       ).as('getConfigForDelete');
-      cy.interceptK8sList(LLMInferenceServiceModel, mockK8sResourceList([])).as(
-        'listDeploymentsForDelete',
-      );
       cy.interceptK8s(
         'DELETE',
         { model: LLMInferenceServiceConfigModel, ns: 'opendatahub', name: 'user-multi-node' },
@@ -325,7 +319,6 @@ describe('LLMD Topology Admin Settings', () => {
       deleteModal.findInput().type('User Multi-node Config');
       deleteModal.findSubmitButton().should('be.enabled').click();
       cy.wait('@getConfigForDelete');
-      cy.wait('@listDeploymentsForDelete');
       cy.wait('@deleteConfig');
 
       cy.wsK8s(

--- a/packages/llmd-serving/src/__tests__/configReferences.spec.ts
+++ b/packages/llmd-serving/src/__tests__/configReferences.spec.ts
@@ -1,13 +1,5 @@
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceConfigK8sResource';
-import { mockLLMInferenceServiceK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceK8sResource';
-import { ROUTING_CONFIG_REF_ANNOTATION, TOPOLOGY_CONFIG_REF_ANNOTATION } from '../const';
-import {
-  getDeploymentsReferencingConfig,
-  isConfigInUse,
-  isConfigReferencedInStatus,
-  isDeletionPendingDueToReferences,
-  isDeploymentReferencingConfig,
-} from '../utils';
+import { isConfigReferencedInStatus, isDeletionPendingDueToReferences } from '../utils';
 
 describe('isConfigReferencedInStatus', () => {
   it('should return true when status.referencedBy has entries', () => {
@@ -28,56 +20,8 @@ describe('isConfigReferencedInStatus', () => {
   });
 });
 
-describe('isConfigInUse', () => {
-  it('should prefer live deployment references over stale status.referencedBy', () => {
-    const config = {
-      ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
-      status: {
-        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
-      },
-    };
-
-    expect(isConfigInUse(config, [], 'router-config', 'routing')).toBe(false);
-  });
-
-  it('should fall back to status.referencedBy when deployment list is unavailable', () => {
-    const config = {
-      ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
-      status: {
-        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
-      },
-    };
-
-    expect(isConfigInUse(config, null, 'router-config', 'routing')).toBe(true);
-  });
-});
-
 describe('isDeletionPendingDueToReferences', () => {
-  it('should return true when terminating, finalizer present, and a deployment still references the config', () => {
-    const config = {
-      ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
-      metadata: {
-        ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }).metadata,
-        deletionTimestamp: '2026-08-05T12:00:00Z',
-        finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
-      },
-      status: {
-        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
-      },
-    };
-    const deployments = [
-      mockLLMInferenceServiceK8sResource({
-        name: 'my-deployment',
-        additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
-      }),
-    ];
-
-    expect(isDeletionPendingDueToReferences(config, deployments, 'router-config', 'routing')).toBe(
-      true,
-    );
-  });
-
-  it('should return false when terminating with finalizer but deployment was removed', () => {
+  it('should return true when terminating, finalizer present, and still referenced', () => {
     const config = {
       ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
       metadata: {
@@ -90,7 +34,7 @@ describe('isDeletionPendingDueToReferences', () => {
       },
     };
 
-    expect(isDeletionPendingDueToReferences(config, [], 'router-config', 'routing')).toBe(false);
+    expect(isDeletionPendingDueToReferences(config)).toBe(true);
   });
 
   it('should return false when terminating with finalizer but not referenced', () => {
@@ -103,71 +47,6 @@ describe('isDeletionPendingDueToReferences', () => {
       },
     };
 
-    expect(isDeletionPendingDueToReferences(config, [], 'router-config', 'routing')).toBe(false);
-  });
-});
-
-describe('isDeploymentReferencingConfig', () => {
-  it('should return true when the routing annotation matches the config name', () => {
-    const deployment = mockLLMInferenceServiceK8sResource({
-      name: 'my-deployment',
-      additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
-    });
-
-    expect(isDeploymentReferencingConfig(deployment, 'router-config', 'routing')).toBe(true);
-  });
-
-  it('should return true when the topology annotation matches the config name', () => {
-    const deployment = mockLLMInferenceServiceK8sResource({
-      name: 'my-deployment',
-      additionalAnnotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'topo-config' },
-    });
-
-    expect(isDeploymentReferencingConfig(deployment, 'topo-config', 'topology')).toBe(true);
-  });
-
-  it('should return true when the config name appears in baseRefs', () => {
-    const deployment = mockLLMInferenceServiceK8sResource({
-      name: 'my-deployment',
-      baseRefs: [{ name: 'legacy-config' }],
-    });
-
-    expect(isDeploymentReferencingConfig(deployment, 'legacy-config', 'routing')).toBe(true);
-  });
-
-  it('should return true when the topology annotation references a local copy of the config', () => {
-    const deployment = mockLLMInferenceServiceK8sResource({
-      name: 'my-deployment',
-      additionalAnnotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'my-deployment-topo-config' },
-    });
-
-    expect(isDeploymentReferencingConfig(deployment, 'topo-config', 'topology')).toBe(true);
-  });
-
-  it('should return false when no annotation or baseRef matches', () => {
-    const deployment = mockLLMInferenceServiceK8sResource({
-      name: 'my-deployment',
-      additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'other-config' },
-      baseRefs: [{ name: 'unrelated-config' }],
-    });
-
-    expect(isDeploymentReferencingConfig(deployment, 'router-config', 'routing')).toBe(false);
-  });
-});
-
-describe('getDeploymentsReferencingConfig', () => {
-  it('should return only deployments referencing the config', () => {
-    const referencing = mockLLMInferenceServiceK8sResource({
-      name: 'deployment-a',
-      additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
-    });
-    const unrelated = mockLLMInferenceServiceK8sResource({
-      name: 'deployment-b',
-      additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'other-config' },
-    });
-
-    expect(
-      getDeploymentsReferencingConfig([referencing, unrelated], 'router-config', 'routing'),
-    ).toEqual([referencing]);
+    expect(isDeletionPendingDueToReferences(config)).toBe(false);
   });
 });

--- a/packages/llmd-serving/src/__tests__/configReferences.spec.ts
+++ b/packages/llmd-serving/src/__tests__/configReferences.spec.ts
@@ -1,0 +1,173 @@
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { mockLLMInferenceServiceK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceK8sResource';
+import { ROUTING_CONFIG_REF_ANNOTATION, TOPOLOGY_CONFIG_REF_ANNOTATION } from '../const';
+import {
+  getDeploymentsReferencingConfig,
+  isConfigInUse,
+  isConfigReferencedInStatus,
+  isDeletionPendingDueToReferences,
+  isDeploymentReferencingConfig,
+} from '../utils';
+
+describe('isConfigReferencedInStatus', () => {
+  it('should return true when status.referencedBy has entries', () => {
+    const config = {
+      ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    };
+
+    expect(isConfigReferencedInStatus(config)).toBe(true);
+  });
+
+  it('should return false when status.referencedBy is empty', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' });
+
+    expect(isConfigReferencedInStatus(config)).toBe(false);
+  });
+});
+
+describe('isConfigInUse', () => {
+  it('should prefer live deployment references over stale status.referencedBy', () => {
+    const config = {
+      ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    };
+
+    expect(isConfigInUse(config, [], 'router-config', 'routing')).toBe(false);
+  });
+
+  it('should fall back to status.referencedBy when deployment list is unavailable', () => {
+    const config = {
+      ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    };
+
+    expect(isConfigInUse(config, null, 'router-config', 'routing')).toBe(true);
+  });
+});
+
+describe('isDeletionPendingDueToReferences', () => {
+  it('should return true when terminating, finalizer present, and a deployment still references the config', () => {
+    const config = {
+      ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
+      metadata: {
+        ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }).metadata,
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+        finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
+      },
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    };
+    const deployments = [
+      mockLLMInferenceServiceK8sResource({
+        name: 'my-deployment',
+        additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
+      }),
+    ];
+
+    expect(isDeletionPendingDueToReferences(config, deployments, 'router-config', 'routing')).toBe(
+      true,
+    );
+  });
+
+  it('should return false when terminating with finalizer but deployment was removed', () => {
+    const config = {
+      ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
+      metadata: {
+        ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }).metadata,
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+        finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
+      },
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    };
+
+    expect(isDeletionPendingDueToReferences(config, [], 'router-config', 'routing')).toBe(false);
+  });
+
+  it('should return false when terminating with finalizer but not referenced', () => {
+    const config = {
+      ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }),
+      metadata: {
+        ...mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }).metadata,
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+        finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
+      },
+    };
+
+    expect(isDeletionPendingDueToReferences(config, [], 'router-config', 'routing')).toBe(false);
+  });
+});
+
+describe('isDeploymentReferencingConfig', () => {
+  it('should return true when the routing annotation matches the config name', () => {
+    const deployment = mockLLMInferenceServiceK8sResource({
+      name: 'my-deployment',
+      additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
+    });
+
+    expect(isDeploymentReferencingConfig(deployment, 'router-config', 'routing')).toBe(true);
+  });
+
+  it('should return true when the topology annotation matches the config name', () => {
+    const deployment = mockLLMInferenceServiceK8sResource({
+      name: 'my-deployment',
+      additionalAnnotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'topo-config' },
+    });
+
+    expect(isDeploymentReferencingConfig(deployment, 'topo-config', 'topology')).toBe(true);
+  });
+
+  it('should return true when the config name appears in baseRefs', () => {
+    const deployment = mockLLMInferenceServiceK8sResource({
+      name: 'my-deployment',
+      baseRefs: [{ name: 'legacy-config' }],
+    });
+
+    expect(isDeploymentReferencingConfig(deployment, 'legacy-config', 'routing')).toBe(true);
+  });
+
+  it('should return true when the topology annotation references a local copy of the config', () => {
+    const deployment = mockLLMInferenceServiceK8sResource({
+      name: 'my-deployment',
+      additionalAnnotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'my-deployment-topo-config' },
+    });
+
+    expect(isDeploymentReferencingConfig(deployment, 'topo-config', 'topology')).toBe(true);
+  });
+
+  it('should return false when no annotation or baseRef matches', () => {
+    const deployment = mockLLMInferenceServiceK8sResource({
+      name: 'my-deployment',
+      additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'other-config' },
+      baseRefs: [{ name: 'unrelated-config' }],
+    });
+
+    expect(isDeploymentReferencingConfig(deployment, 'router-config', 'routing')).toBe(false);
+  });
+});
+
+describe('getDeploymentsReferencingConfig', () => {
+  it('should return only deployments referencing the config', () => {
+    const referencing = mockLLMInferenceServiceK8sResource({
+      name: 'deployment-a',
+      additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
+    });
+    const unrelated = mockLLMInferenceServiceK8sResource({
+      name: 'deployment-b',
+      additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'other-config' },
+    });
+
+    expect(
+      getDeploymentsReferencingConfig([referencing, unrelated], 'router-config', 'routing'),
+    ).toEqual([referencing]);
+  });
+});

--- a/packages/llmd-serving/src/__tests__/isDeletionBlockedByFinalizer.spec.ts
+++ b/packages/llmd-serving/src/__tests__/isDeletionBlockedByFinalizer.spec.ts
@@ -1,0 +1,117 @@
+import { isDeletionBlockedByFinalizer } from '../utils';
+
+describe('isDeletionBlockedByFinalizer', () => {
+  it('should return false for a K8sStatus success response', () => {
+    const result = {
+      kind: 'Status',
+      apiVersion: 'v1',
+      status: 'Success',
+      code: 200,
+      message: '',
+      reason: '',
+    };
+    expect(isDeletionBlockedByFinalizer(result)).toBe(false);
+  });
+
+  it('should return true when the resource has a deletionTimestamp', () => {
+    const result = {
+      kind: 'LLMInferenceServiceConfig',
+      apiVersion: 'serving.kserve.io/v1alpha2',
+      metadata: {
+        name: 'test-config',
+        namespace: 'opendatahub',
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+        finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
+      },
+      spec: {},
+    };
+    expect(isDeletionBlockedByFinalizer(result)).toBe(true);
+  });
+
+  it('should return false when the resource has no deletionTimestamp', () => {
+    const result = {
+      kind: 'LLMInferenceServiceConfig',
+      apiVersion: 'serving.kserve.io/v1alpha2',
+      metadata: {
+        name: 'test-config',
+        namespace: 'opendatahub',
+      },
+      spec: {},
+    };
+    expect(isDeletionBlockedByFinalizer(result)).toBe(false);
+  });
+
+  it('should return false for null input', () => {
+    expect(isDeletionBlockedByFinalizer(null)).toBe(false);
+  });
+
+  it('should return false for undefined input', () => {
+    expect(isDeletionBlockedByFinalizer(undefined)).toBe(false);
+  });
+
+  it('should return false for non-object input', () => {
+    expect(isDeletionBlockedByFinalizer('string')).toBe(false);
+    expect(isDeletionBlockedByFinalizer(42)).toBe(false);
+  });
+
+  it('should return false when metadata is missing', () => {
+    const result = {
+      kind: 'LLMInferenceServiceConfig',
+      apiVersion: 'serving.kserve.io/v1alpha2',
+    };
+    expect(isDeletionBlockedByFinalizer(result)).toBe(false);
+  });
+
+  it('should return false when metadata is null', () => {
+    const result = {
+      kind: 'LLMInferenceServiceConfig',
+      apiVersion: 'serving.kserve.io/v1alpha2',
+      metadata: null,
+    };
+    expect(isDeletionBlockedByFinalizer(result)).toBe(false);
+  });
+
+  it('should return false when deletionTimestamp is set but finalizers are missing', () => {
+    const result = {
+      kind: 'LLMInferenceServiceConfig',
+      apiVersion: 'serving.kserve.io/v1alpha2',
+      metadata: {
+        name: 'test-config',
+        namespace: 'opendatahub',
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+      },
+      spec: {},
+    };
+    expect(isDeletionBlockedByFinalizer(result)).toBe(false);
+  });
+
+  it('should return false when deletionTimestamp is set but finalizer is unrelated', () => {
+    const result = {
+      kind: 'LLMInferenceServiceConfig',
+      apiVersion: 'serving.kserve.io/v1alpha2',
+      metadata: {
+        name: 'test-config',
+        namespace: 'opendatahub',
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+        finalizers: ['example.com/other-finalizer'],
+      },
+      spec: {},
+    };
+    expect(isDeletionBlockedByFinalizer(result)).toBe(false);
+  });
+
+  it('should return false when deletionTimestamp is set but finalizers array is empty', () => {
+    const result = {
+      kind: 'LLMInferenceServiceConfig',
+      apiVersion: 'serving.kserve.io/v1alpha2',
+      metadata: {
+        name: 'test-config',
+        namespace: 'opendatahub',
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+        finalizers: [],
+      },
+      spec: {},
+    };
+    expect(isDeletionBlockedByFinalizer(result)).toBe(false);
+  });
+});

--- a/packages/llmd-serving/src/api/LLMInferenceService.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceService.ts
@@ -3,7 +3,6 @@ import {
   k8sCreateResource,
   k8sPatchResource,
   k8sUpdateResource,
-  k8sListResourceItems,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
 import { createPatchesFromDiff, groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
@@ -95,9 +94,3 @@ export const useWatchLLMInferenceService = (
     opts,
   );
 };
-
-export const listLLMInferenceServices = (namespace: string): Promise<LLMInferenceServiceKind[]> =>
-  k8sListResourceItems<LLMInferenceServiceKind>({
-    model: LLMInferenceServiceModel,
-    queryOptions: { ns: namespace },
-  });

--- a/packages/llmd-serving/src/api/LLMInferenceService.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceService.ts
@@ -3,6 +3,7 @@ import {
   k8sCreateResource,
   k8sPatchResource,
   k8sUpdateResource,
+  k8sListResourceItems,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
 import { createPatchesFromDiff, groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
@@ -94,3 +95,16 @@ export const useWatchLLMInferenceService = (
     opts,
   );
 };
+
+export const listLLMInferenceServices = (namespace: string): Promise<LLMInferenceServiceKind[]> =>
+  k8sListResourceItems<LLMInferenceServiceKind>({
+    model: LLMInferenceServiceModel,
+    queryOptions: { ns: namespace },
+  });
+
+/** Lists LLMInferenceService resources cluster-wide (requires cluster list permission). */
+export const listAllLLMInferenceServices = (): Promise<LLMInferenceServiceKind[]> =>
+  k8sListResourceItems<LLMInferenceServiceKind>({
+    model: LLMInferenceServiceModel,
+    queryOptions: {},
+  });

--- a/packages/llmd-serving/src/api/LLMInferenceService.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceService.ts
@@ -101,10 +101,3 @@ export const listLLMInferenceServices = (namespace: string): Promise<LLMInferenc
     model: LLMInferenceServiceModel,
     queryOptions: { ns: namespace },
   });
-
-/** Lists LLMInferenceService resources cluster-wide (requires cluster list permission). */
-export const listAllLLMInferenceServices = (): Promise<LLMInferenceServiceKind[]> =>
-  k8sListResourceItems<LLMInferenceServiceKind>({
-    model: LLMInferenceServiceModel,
-    queryOptions: {},
-  });

--- a/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
@@ -15,6 +15,7 @@ import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
 import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
+import { listAllLLMInferenceServices } from './LLMInferenceService';
 import { CONFIG_TYPE_LABEL } from '../const';
 import {
   LLMInferenceServiceConfigModel,
@@ -22,6 +23,21 @@ import {
   ConfigType,
   type LLMInferenceServiceConfigKind,
 } from '../types';
+import {
+  CONFIG_IN_USE_ERROR_MESSAGE,
+  isConfigInUse,
+  isDeletionPendingDueToReferences,
+  type LlmConfigRefType,
+} from '../utils';
+
+export class ConfigInUseError extends Error {
+  constructor(message = CONFIG_IN_USE_ERROR_MESSAGE) {
+    super(message);
+    this.name = 'ConfigInUseError';
+  }
+}
+
+export type DeleteLlmInferenceServiceConfigOutcome = 'deleted' | 'blocked-pending';
 
 export const createLLMInferenceServiceConfig = (
   llmInferenceServiceConfig: LLMInferenceServiceConfigKind,
@@ -137,6 +153,56 @@ export const deleteLLMInferenceServiceConfig = (
       opts,
     ),
   );
+
+export const deleteLlmInferenceServiceConfigIfUnreferenced = async (
+  configName: string,
+  namespace: string,
+  refType: LlmConfigRefType,
+  opts?: K8sAPIOptions,
+): Promise<DeleteLlmInferenceServiceConfigOutcome> => {
+  const config = await getLLMInferenceServiceConfig(configName, namespace, opts);
+
+  const deployments = await listAllLLMInferenceServices().catch((e: unknown) => {
+    // Users without cluster-wide list permission can still delete; rely on the
+    // KServe finalizer to block deletion when the config is still referenced.
+    if (getGenericErrorCode(e) === 403) {
+      return null;
+    }
+    throw e;
+  });
+
+  if (isConfigInUse(config, deployments, configName, refType)) {
+    throw new ConfigInUseError();
+  }
+
+  const result = await k8sDeleteResource<LLMInferenceServiceConfigKind, K8sStatus>(
+    applyK8sAPIOptions(
+      {
+        model: LLMInferenceServiceConfigModel,
+        queryOptions: { name: configName, ns: namespace },
+      },
+      opts,
+    ),
+  );
+
+  if (isDeletionPendingDueToReferences(result, deployments, configName, refType)) {
+    return 'blocked-pending';
+  }
+
+  // Delete may return a Status object instead of the updated resource; re-fetch to detect
+  // a terminating config blocked by the KServe finalizer while still referenced.
+  const refreshedConfig = await getLLMInferenceServiceConfig(configName, namespace, opts).catch(
+    () => null,
+  );
+  if (
+    refreshedConfig &&
+    isDeletionPendingDueToReferences(refreshedConfig, deployments, configName, refType)
+  ) {
+    return 'blocked-pending';
+  }
+
+  return 'deleted';
+};
 
 /**
  * @returns Template versions of the LLMInferenceServiceConfigKind[] (filtered on 'opendatahub.io/config-type=accelerator')

--- a/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
@@ -185,8 +185,14 @@ export const deleteLlmInferenceServiceConfigIfUnreferenced = async (
 
   // Delete may return a Status object instead of the updated resource; re-fetch to detect
   // a terminating config blocked by the KServe finalizer while still referenced.
+  // Only treat 404 as "gone"; propagate any other error (5xx, network, etc.).
   const refreshedConfig = await getLLMInferenceServiceConfig(configName, namespace, opts).catch(
-    () => null,
+    (e: unknown) => {
+      if (getGenericErrorCode(e) === 404) {
+        return null;
+      }
+      throw e;
+    },
   );
   if (refreshedConfig && isDeletionPendingDueToReferences(refreshedConfig)) {
     return 'blocked-pending';

--- a/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
@@ -15,7 +15,6 @@ import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
 import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
-import { listAllLLMInferenceServices } from './LLMInferenceService';
 import { CONFIG_TYPE_LABEL } from '../const';
 import {
   LLMInferenceServiceConfigModel,
@@ -25,7 +24,7 @@ import {
 } from '../types';
 import {
   CONFIG_IN_USE_ERROR_MESSAGE,
-  isConfigInUse,
+  isConfigReferencedInStatus,
   isDeletionPendingDueToReferences,
   type LlmConfigRefType,
 } from '../utils';
@@ -157,21 +156,12 @@ export const deleteLLMInferenceServiceConfig = (
 export const deleteLlmInferenceServiceConfigIfUnreferenced = async (
   configName: string,
   namespace: string,
-  refType: LlmConfigRefType,
+  _refType: LlmConfigRefType,
   opts?: K8sAPIOptions,
 ): Promise<DeleteLlmInferenceServiceConfigOutcome> => {
   const config = await getLLMInferenceServiceConfig(configName, namespace, opts);
 
-  const deployments = await listAllLLMInferenceServices().catch((e: unknown) => {
-    // Users without cluster-wide list permission can still delete; rely on the
-    // KServe finalizer to block deletion when the config is still referenced.
-    if (getGenericErrorCode(e) === 403) {
-      return null;
-    }
-    throw e;
-  });
-
-  if (isConfigInUse(config, deployments, configName, refType)) {
+  if (isConfigReferencedInStatus(config)) {
     throw new ConfigInUseError();
   }
 
@@ -189,7 +179,7 @@ export const deleteLlmInferenceServiceConfigIfUnreferenced = async (
     ),
   );
 
-  if (isDeletionPendingDueToReferences(result, deployments, configName, refType)) {
+  if (isDeletionPendingDueToReferences(result)) {
     return 'blocked-pending';
   }
 
@@ -198,10 +188,7 @@ export const deleteLlmInferenceServiceConfigIfUnreferenced = async (
   const refreshedConfig = await getLLMInferenceServiceConfig(configName, namespace, opts).catch(
     () => null,
   );
-  if (
-    refreshedConfig &&
-    isDeletionPendingDueToReferences(refreshedConfig, deployments, configName, refType)
-  ) {
+  if (refreshedConfig && isDeletionPendingDueToReferences(refreshedConfig)) {
     return 'blocked-pending';
   }
 

--- a/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
@@ -175,6 +175,10 @@ export const deleteLlmInferenceServiceConfigIfUnreferenced = async (
     throw new ConfigInUseError();
   }
 
+  // Kubernetes does not support transactional delete: a new LLMInferenceService referencing
+  // this config could be created between the reference check above and the delete below.
+  // The KServe llmisvcconfig-finalizer is the backstop for that race; the post-delete
+  // isDeletionPendingDueToReferences check surfaces the blocked state in the UI.
   const result = await k8sDeleteResource<LLMInferenceServiceConfigKind, K8sStatus>(
     applyK8sAPIOptions(
       {

--- a/packages/llmd-serving/src/api/__tests__/deleteLlmInferenceServiceConfigIfUnreferenced.spec.ts
+++ b/packages/llmd-serving/src/api/__tests__/deleteLlmInferenceServiceConfigIfUnreferenced.spec.ts
@@ -95,6 +95,22 @@ describe('deleteLlmInferenceServiceConfigIfUnreferenced', () => {
     expect(mockK8sGetResource).toHaveBeenCalledTimes(2);
   });
 
+  it('should propagate non-404 errors from the post-delete re-fetch', async () => {
+    mockK8sDeleteResource.mockResolvedValue({
+      kind: 'Status',
+      status: 'Success',
+      code: 200,
+      message: '',
+      reason: '',
+    });
+    const networkError = Object.assign(new Error('Internal Server Error'), { code: 500 });
+    mockK8sGetResource.mockResolvedValueOnce(defaultConfig).mockRejectedValueOnce(networkError);
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).rejects.toBe(networkError);
+  });
+
   it('should return blocked-pending when delete response shows terminating and referenced', async () => {
     mockK8sDeleteResource.mockResolvedValue({
       kind: 'LLMInferenceServiceConfig',

--- a/packages/llmd-serving/src/api/__tests__/deleteLlmInferenceServiceConfigIfUnreferenced.spec.ts
+++ b/packages/llmd-serving/src/api/__tests__/deleteLlmInferenceServiceConfigIfUnreferenced.spec.ts
@@ -1,8 +1,5 @@
 import { k8sDeleteResource, k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceConfigK8sResource';
-import { mockLLMInferenceServiceK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceK8sResource';
-import { ROUTING_CONFIG_REF_ANNOTATION } from '../../const';
-import { listAllLLMInferenceServices } from '../LLMInferenceService';
 import {
   ConfigInUseError,
   deleteLlmInferenceServiceConfigIfUnreferenced,
@@ -13,73 +10,24 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sGetResource: jest.fn(),
 }));
 
-jest.mock('../LLMInferenceService', () => ({
-  listAllLLMInferenceServices: jest.fn(),
-}));
-
-jest.mock('@odh-dashboard/internal/api/errorUtils', () => ({
-  getGenericErrorCode: jest.fn(),
-}));
-
-const mockListAllLLMInferenceServices = jest.mocked(listAllLLMInferenceServices);
 const mockK8sDeleteResource = jest.mocked(k8sDeleteResource);
 const mockK8sGetResource = jest.mocked(k8sGetResource);
-const { getGenericErrorCode } = jest.requireMock('@odh-dashboard/internal/api/errorUtils');
 
 const defaultConfig = mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' });
 
 describe('deleteLlmInferenceServiceConfigIfUnreferenced', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockListAllLLMInferenceServices.mockResolvedValue([]);
     mockK8sGetResource.mockResolvedValue(defaultConfig);
-    getGenericErrorCode.mockReturnValue(undefined);
   });
 
-  it('should throw ConfigInUseError when status.referencedBy is populated and deployment list is unavailable', async () => {
-    mockListAllLLMInferenceServices.mockRejectedValue(new Error('Forbidden'));
-    getGenericErrorCode.mockReturnValue(403);
+  it('should throw ConfigInUseError when status.referencedBy is populated', async () => {
     mockK8sGetResource.mockResolvedValue({
       ...defaultConfig,
       status: {
         referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
       },
     });
-
-    await expect(
-      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
-    ).rejects.toBeInstanceOf(ConfigInUseError);
-
-    expect(mockK8sDeleteResource).not.toHaveBeenCalled();
-  });
-
-  it('should allow delete when status.referencedBy is stale but no deployments reference the config', async () => {
-    mockK8sGetResource.mockResolvedValue({
-      ...defaultConfig,
-      status: {
-        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
-      },
-    });
-    mockK8sDeleteResource.mockResolvedValue({
-      kind: 'Status',
-      status: 'Success',
-      code: 200,
-      message: '',
-      reason: '',
-    });
-
-    await expect(
-      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
-    ).resolves.toBe('deleted');
-  });
-
-  it('should throw ConfigInUseError when a deployment references the config', async () => {
-    mockListAllLLMInferenceServices.mockResolvedValue([
-      mockLLMInferenceServiceK8sResource({
-        name: 'deployment-a',
-        additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
-      }),
-    ]);
 
     await expect(
       deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
@@ -102,43 +50,6 @@ describe('deleteLlmInferenceServiceConfigIfUnreferenced', () => {
     ).resolves.toBe('deleted');
   });
 
-  it('should still attempt delete when deployment list is forbidden and status is unreferenced', async () => {
-    mockListAllLLMInferenceServices.mockRejectedValue(new Error('Forbidden'));
-    getGenericErrorCode.mockReturnValue(403);
-    mockK8sDeleteResource.mockResolvedValue({
-      kind: 'Status',
-      status: 'Success',
-      code: 200,
-      message: '',
-      reason: '',
-    });
-
-    await expect(
-      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
-    ).resolves.toBe('deleted');
-  });
-
-  it('should throw ConfigInUseError before delete when a deployment still references the config', async () => {
-    mockListAllLLMInferenceServices.mockResolvedValue([
-      mockLLMInferenceServiceK8sResource({
-        name: 'my-deployment',
-        additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
-      }),
-    ]);
-    mockK8sGetResource.mockResolvedValue({
-      ...defaultConfig,
-      status: {
-        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
-      },
-    });
-
-    await expect(
-      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
-    ).rejects.toBeInstanceOf(ConfigInUseError);
-
-    expect(mockK8sDeleteResource).not.toHaveBeenCalled();
-  });
-
   it('should treat terminating delete responses as success when the config is not referenced', async () => {
     mockK8sDeleteResource.mockResolvedValue({
       kind: 'LLMInferenceServiceConfig',
@@ -157,8 +68,15 @@ describe('deleteLlmInferenceServiceConfigIfUnreferenced', () => {
     ).resolves.toBe('deleted');
   });
 
-  it('should allow delete when config is terminating with stale referencedBy after deployment removal', async () => {
-    mockK8sGetResource.mockResolvedValue({
+  it('should return blocked-pending when delete returns Status but config is terminating and referenced', async () => {
+    mockK8sDeleteResource.mockResolvedValue({
+      kind: 'Status',
+      status: 'Success',
+      code: 200,
+      message: '',
+      reason: '',
+    });
+    mockK8sGetResource.mockResolvedValueOnce(defaultConfig).mockResolvedValueOnce({
       ...defaultConfig,
       metadata: {
         ...defaultConfig.metadata,
@@ -169,67 +87,34 @@ describe('deleteLlmInferenceServiceConfigIfUnreferenced', () => {
         referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
       },
     });
-    mockK8sDeleteResource.mockResolvedValue({
-      kind: 'Status',
-      status: 'Success',
-      code: 200,
-      message: '',
-      reason: '',
-    });
 
     await expect(
       deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
-    ).resolves.toBe('deleted');
+    ).resolves.toBe('blocked-pending');
+
+    expect(mockK8sGetResource).toHaveBeenCalledTimes(2);
   });
 
-  it('should return blocked-pending when deployment list is unavailable and config remains referenced after delete', async () => {
-    mockListAllLLMInferenceServices.mockRejectedValue(new Error('Forbidden'));
-    getGenericErrorCode.mockReturnValue(403);
-    mockK8sGetResource
-      .mockResolvedValueOnce({
-        ...defaultConfig,
-        status: {
-          referencedBy: [],
-        },
-      })
-      .mockResolvedValueOnce({
-        ...defaultConfig,
-        metadata: {
-          ...defaultConfig.metadata,
-          deletionTimestamp: '2026-08-05T12:00:00Z',
-          finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
-        },
-        status: {
-          referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
-        },
-      });
+  it('should return blocked-pending when delete response shows terminating and referenced', async () => {
     mockK8sDeleteResource.mockResolvedValue({
-      kind: 'Status',
-      status: 'Success',
-      code: 200,
-      message: '',
-      reason: '',
+      kind: 'LLMInferenceServiceConfig',
+      apiVersion: 'serving.kserve.io/v1alpha2',
+      metadata: {
+        name: 'router-config',
+        namespace: 'opendatahub',
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+        finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
+      },
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+      spec: {},
     });
 
     await expect(
       deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
     ).resolves.toBe('blocked-pending');
-  });
 
-  it('should throw ConfigInUseError before delete when deployment list is unavailable and status shows references', async () => {
-    mockListAllLLMInferenceServices.mockRejectedValue(new Error('Forbidden'));
-    getGenericErrorCode.mockReturnValue(403);
-    mockK8sGetResource.mockResolvedValue({
-      ...defaultConfig,
-      status: {
-        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
-      },
-    });
-
-    await expect(
-      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
-    ).rejects.toBeInstanceOf(ConfigInUseError);
-
-    expect(mockK8sDeleteResource).not.toHaveBeenCalled();
+    expect(mockK8sGetResource).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/llmd-serving/src/api/__tests__/deleteLlmInferenceServiceConfigIfUnreferenced.spec.ts
+++ b/packages/llmd-serving/src/api/__tests__/deleteLlmInferenceServiceConfigIfUnreferenced.spec.ts
@@ -1,0 +1,235 @@
+import { k8sDeleteResource, k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { mockLLMInferenceServiceK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceK8sResource';
+import { ROUTING_CONFIG_REF_ANNOTATION } from '../../const';
+import { listAllLLMInferenceServices } from '../LLMInferenceService';
+import {
+  ConfigInUseError,
+  deleteLlmInferenceServiceConfigIfUnreferenced,
+} from '../LLMInferenceServiceConfigs';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sDeleteResource: jest.fn(),
+  k8sGetResource: jest.fn(),
+}));
+
+jest.mock('../LLMInferenceService', () => ({
+  listAllLLMInferenceServices: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/api/errorUtils', () => ({
+  getGenericErrorCode: jest.fn(),
+}));
+
+const mockListAllLLMInferenceServices = jest.mocked(listAllLLMInferenceServices);
+const mockK8sDeleteResource = jest.mocked(k8sDeleteResource);
+const mockK8sGetResource = jest.mocked(k8sGetResource);
+const { getGenericErrorCode } = jest.requireMock('@odh-dashboard/internal/api/errorUtils');
+
+const defaultConfig = mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' });
+
+describe('deleteLlmInferenceServiceConfigIfUnreferenced', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListAllLLMInferenceServices.mockResolvedValue([]);
+    mockK8sGetResource.mockResolvedValue(defaultConfig);
+    getGenericErrorCode.mockReturnValue(undefined);
+  });
+
+  it('should throw ConfigInUseError when status.referencedBy is populated and deployment list is unavailable', async () => {
+    mockListAllLLMInferenceServices.mockRejectedValue(new Error('Forbidden'));
+    getGenericErrorCode.mockReturnValue(403);
+    mockK8sGetResource.mockResolvedValue({
+      ...defaultConfig,
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    });
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).rejects.toBeInstanceOf(ConfigInUseError);
+
+    expect(mockK8sDeleteResource).not.toHaveBeenCalled();
+  });
+
+  it('should allow delete when status.referencedBy is stale but no deployments reference the config', async () => {
+    mockK8sGetResource.mockResolvedValue({
+      ...defaultConfig,
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    });
+    mockK8sDeleteResource.mockResolvedValue({
+      kind: 'Status',
+      status: 'Success',
+      code: 200,
+      message: '',
+      reason: '',
+    });
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).resolves.toBe('deleted');
+  });
+
+  it('should throw ConfigInUseError when a deployment references the config', async () => {
+    mockListAllLLMInferenceServices.mockResolvedValue([
+      mockLLMInferenceServiceK8sResource({
+        name: 'deployment-a',
+        additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
+      }),
+    ]);
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).rejects.toBeInstanceOf(ConfigInUseError);
+
+    expect(mockK8sDeleteResource).not.toHaveBeenCalled();
+  });
+
+  it('should delete the config when it is not referenced', async () => {
+    mockK8sDeleteResource.mockResolvedValue({
+      kind: 'Status',
+      status: 'Success',
+      code: 200,
+      message: '',
+      reason: '',
+    });
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).resolves.toBe('deleted');
+  });
+
+  it('should still attempt delete when deployment list is forbidden and status is unreferenced', async () => {
+    mockListAllLLMInferenceServices.mockRejectedValue(new Error('Forbidden'));
+    getGenericErrorCode.mockReturnValue(403);
+    mockK8sDeleteResource.mockResolvedValue({
+      kind: 'Status',
+      status: 'Success',
+      code: 200,
+      message: '',
+      reason: '',
+    });
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).resolves.toBe('deleted');
+  });
+
+  it('should throw ConfigInUseError before delete when a deployment still references the config', async () => {
+    mockListAllLLMInferenceServices.mockResolvedValue([
+      mockLLMInferenceServiceK8sResource({
+        name: 'my-deployment',
+        additionalAnnotations: { [ROUTING_CONFIG_REF_ANNOTATION]: 'router-config' },
+      }),
+    ]);
+    mockK8sGetResource.mockResolvedValue({
+      ...defaultConfig,
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    });
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).rejects.toBeInstanceOf(ConfigInUseError);
+
+    expect(mockK8sDeleteResource).not.toHaveBeenCalled();
+  });
+
+  it('should treat terminating delete responses as success when the config is not referenced', async () => {
+    mockK8sDeleteResource.mockResolvedValue({
+      kind: 'LLMInferenceServiceConfig',
+      apiVersion: 'serving.kserve.io/v1alpha2',
+      metadata: {
+        name: 'router-config',
+        namespace: 'opendatahub',
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+        finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
+      },
+      spec: {},
+    });
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).resolves.toBe('deleted');
+  });
+
+  it('should allow delete when config is terminating with stale referencedBy after deployment removal', async () => {
+    mockK8sGetResource.mockResolvedValue({
+      ...defaultConfig,
+      metadata: {
+        ...defaultConfig.metadata,
+        deletionTimestamp: '2026-08-05T12:00:00Z',
+        finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
+      },
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    });
+    mockK8sDeleteResource.mockResolvedValue({
+      kind: 'Status',
+      status: 'Success',
+      code: 200,
+      message: '',
+      reason: '',
+    });
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).resolves.toBe('deleted');
+  });
+
+  it('should return blocked-pending when deployment list is unavailable and config remains referenced after delete', async () => {
+    mockListAllLLMInferenceServices.mockRejectedValue(new Error('Forbidden'));
+    getGenericErrorCode.mockReturnValue(403);
+    mockK8sGetResource
+      .mockResolvedValueOnce({
+        ...defaultConfig,
+        status: {
+          referencedBy: [],
+        },
+      })
+      .mockResolvedValueOnce({
+        ...defaultConfig,
+        metadata: {
+          ...defaultConfig.metadata,
+          deletionTimestamp: '2026-08-05T12:00:00Z',
+          finalizers: ['serving.kserve.io/llmisvcconfig-finalizer'],
+        },
+        status: {
+          referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+        },
+      });
+    mockK8sDeleteResource.mockResolvedValue({
+      kind: 'Status',
+      status: 'Success',
+      code: 200,
+      message: '',
+      reason: '',
+    });
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).resolves.toBe('blocked-pending');
+  });
+
+  it('should throw ConfigInUseError before delete when deployment list is unavailable and status shows references', async () => {
+    mockListAllLLMInferenceServices.mockRejectedValue(new Error('Forbidden'));
+    getGenericErrorCode.mockReturnValue(403);
+    mockK8sGetResource.mockResolvedValue({
+      ...defaultConfig,
+      status: {
+        referencedBy: [{ name: 'my-deployment', namespace: 'test-project' }],
+      },
+    });
+
+    await expect(
+      deleteLlmInferenceServiceConfigIfUnreferenced('router-config', 'opendatahub', 'routing'),
+    ).rejects.toBeInstanceOf(ConfigInUseError);
+
+    expect(mockK8sDeleteResource).not.toHaveBeenCalled();
+  });
+});

--- a/packages/llmd-serving/src/settings/LlmInferenceServiceConfigAccessGate.tsx
+++ b/packages/llmd-serving/src/settings/LlmInferenceServiceConfigAccessGate.tsx
@@ -9,6 +9,9 @@ import { LLMInferenceServiceConfigModel } from '../types';
  * Gates routes that manage `LLMInferenceServiceConfig` resources behind the create
  * and patch permissions their CRUD actions require, rendering NotFound otherwise.
  *
+ * Delete permission is enforced per-row via SSAR on the kebab Delete action; users
+ * without delete access can still view and edit configurations they can patch.
+ *
  * The accelerator, topology, and routing configuration pages are all backed by this
  * same resource — they differ only by label selector — so they share this gate.
  */

--- a/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationRow.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationRow.tsx
@@ -53,7 +53,7 @@ const RoutingConfigurationRow: React.FC<RoutingConfigurationRowProps> = ({
         isDanger: true,
       },
     ],
-    verbModelAccess('delete', LLMInferenceServiceConfigModel),
+    verbModelAccess('delete', LLMInferenceServiceConfigModel, config.metadata.namespace),
   );
 
   return (

--- a/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationRow.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationRow.tsx
@@ -7,8 +7,10 @@ import {
   getDescriptionFromK8sResource,
 } from '@odh-dashboard/k8s-core';
 import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
+import { useKebabAccessAllowed, verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR';
 import {
   type LLMInferenceServiceConfigKind,
+  LLMInferenceServiceConfigModel,
   TopologyTypeLabels,
   DASHBOARD_RESOURCE_LABEL,
   getConfigSupportedTopologies,
@@ -41,6 +43,18 @@ const RoutingConfigurationRow: React.FC<RoutingConfigurationRowProps> = ({
   const enabled = isConfigEnabled(config);
   const isDashboardCreated =
     config.metadata.labels?.[DASHBOARD_RESOURCE_LABEL] === 'true' && !preInstalled;
+
+  const deleteKebabItems = useKebabAccessAllowed(
+    [
+      { isSeparator: true },
+      {
+        title: 'Delete',
+        onClick: () => onDelete(config),
+        isDanger: true,
+      },
+    ],
+    verbModelAccess('delete', LLMInferenceServiceConfigModel),
+  );
 
   return (
     <Tr data-testid={`routing-config-row-${configName}`}>
@@ -84,12 +98,7 @@ const RoutingConfigurationRow: React.FC<RoutingConfigurationRowProps> = ({
                     title: 'Duplicate',
                     onClick: () => navigate(`duplicate/${configName}`),
                   },
-                  { isSeparator: true },
-                  {
-                    title: 'Delete',
-                    onClick: () => onDelete(config),
-                    isDanger: true,
-                  },
+                  ...deleteKebabItems,
                 ]
               : [
                   {

--- a/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationsTable.tsx
@@ -3,17 +3,15 @@ import { Button, EmptyState, EmptyStateBody, ToolbarItem } from '@patternfly/rea
 import { CubesIcon } from '@patternfly/react-icons';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard delete confirmation wrapper
 import DeleteModal from '@odh-dashboard/internal/pages/projects/components/DeleteModal';
-import { Table, SortableData, TrackingOutcome } from '@odh-dashboard/ui-core';
+import { Table, SortableData } from '@odh-dashboard/ui-core';
 import { useNavigate } from 'react-router';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
-import { k8sDeleteResource, K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
-import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import useNotification from '@odh-dashboard/internal/utilities/useNotification';
 import RoutingConfigurationRow, { getSupportedTopologiesLabel } from './RoutingConfigurationRow';
-import { type LLMInferenceServiceConfigKind, LLMInferenceServiceConfigModel } from '../../types';
+import { type LLMInferenceServiceConfigKind } from '../../types';
 import { isConfigEnabled, isConfigEffectivelyEnabled } from '../../utils';
 import { patchLLMInferenceServiceConfig } from '../../api/LLMInferenceServiceConfigs';
-import { fireRoutingConfigDeleted } from '../../tracking/llmdTrackingConstants';
+import { useDeleteLlmInferenceServiceConfig } from '../useDeleteLlmInferenceServiceConfig';
 
 export const columns: SortableData<LLMInferenceServiceConfigKind>[] = [
   {
@@ -47,11 +45,10 @@ type RoutingConfigurationsTableProps = {
 
 const RoutingConfigurationsTable: React.FC<RoutingConfigurationsTableProps> = ({ configs }) => {
   const navigate = useNavigate();
-  const { dashboardNamespace } = useDashboardNamespace();
   const notification = useNotification();
   const [togglingConfigs, setTogglingConfigs] = React.useState<Record<string, boolean>>({});
-  const [deleteConfig, setDeleteConfig] = React.useState<LLMInferenceServiceConfigKind>();
-  const [isDeleting, setIsDeleting] = React.useState(false);
+  const { deleteConfig, setDeleteConfig, isDeleting, error, handleDelete, closeDeleteModal } =
+    useDeleteLlmInferenceServiceConfig('routing');
 
   const handleToggleEnabled = async (config: LLMInferenceServiceConfigKind) => {
     const configName = config.metadata.name;
@@ -81,35 +78,6 @@ const RoutingConfigurationsTable: React.FC<RoutingConfigurationsTableProps> = ({
       );
     } finally {
       setTogglingConfigs((prev) => ({ ...prev, [configName]: false }));
-    }
-  };
-
-  const handleDelete = async () => {
-    if (!deleteConfig) {
-      return;
-    }
-    setIsDeleting(true);
-    try {
-      await k8sDeleteResource<typeof LLMInferenceServiceConfigModel, K8sStatus>({
-        model: LLMInferenceServiceConfigModel,
-        queryOptions: {
-          name: deleteConfig.metadata.name,
-          ns: dashboardNamespace,
-        },
-      });
-      fireRoutingConfigDeleted({ outcome: TrackingOutcome.submit, success: true });
-      setDeleteConfig(undefined);
-    } catch (e) {
-      notification.error(
-        'Error deleting configuration',
-        e instanceof Error ? e.message : 'Unknown error',
-      );
-      fireRoutingConfigDeleted({
-        outcome: TrackingOutcome.submit,
-        success: false,
-      });
-    } finally {
-      setIsDeleting(false);
     }
   };
 
@@ -158,14 +126,11 @@ const RoutingConfigurationsTable: React.FC<RoutingConfigurationsTableProps> = ({
       {deleteConfig && (
         <DeleteModal
           title="Delete llm-d routing configuration?"
-          onClose={() => {
-            fireRoutingConfigDeleted({ outcome: TrackingOutcome.cancel });
-            setDeleteConfig(undefined);
-            setIsDeleting(false);
-          }}
+          onClose={closeDeleteModal}
           submitButtonLabel="Delete routing configuration"
           onDelete={handleDelete}
           deleting={isDeleting}
+          error={error}
           deleteName={getDisplayNameFromK8sResource(deleteConfig)}
         >
           This action cannot be undone.

--- a/packages/llmd-serving/src/settings/routingConfigs/__tests__/RoutingConfigurationsTable.spec.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/__tests__/RoutingConfigurationsTable.spec.tsx
@@ -21,6 +21,14 @@ jest.mock('@odh-dashboard/internal/utilities/useNotification', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('@odh-dashboard/internal/concepts/userSSAR', () => {
+  const actual = jest.requireActual('@odh-dashboard/internal/concepts/userSSAR');
+  return {
+    ...actual,
+    useKebabAccessAllowed: (actions: unknown[]) => actions,
+  };
+});
+
 jest.mock('../../../api/LLMInferenceServiceConfigs', () => ({
   patchLLMInferenceServiceConfig: jest.fn(),
   deleteLlmInferenceServiceConfigIfUnreferenced: jest.fn(),

--- a/packages/llmd-serving/src/settings/routingConfigs/__tests__/RoutingConfigurationsTable.spec.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/__tests__/RoutingConfigurationsTable.spec.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useNavigate } from 'react-router';
+import useNotification from '@odh-dashboard/internal/utilities/useNotification';
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { deleteLlmInferenceServiceConfigIfUnreferenced } from '../../../api/LLMInferenceServiceConfigs';
+import { CONFIG_DELETION_PENDING_MESSAGE, CONFIG_IN_USE_ERROR_MESSAGE } from '../../../utils';
+import RoutingConfigurationsTable from '../RoutingConfigurationsTable';
+
+jest.mock('react-router', () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/redux/selectors/project', () => ({
+  useDashboardNamespace: jest.fn(() => ({ dashboardNamespace: 'opendatahub' })),
+}));
+
+jest.mock('@odh-dashboard/internal/utilities/useNotification', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../api/LLMInferenceServiceConfigs', () => ({
+  patchLLMInferenceServiceConfig: jest.fn(),
+  deleteLlmInferenceServiceConfigIfUnreferenced: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/pages/projects/components/DeleteModal', () => {
+  const MockDeleteModal: React.FC<{
+    onDelete: () => void;
+    onClose: () => void;
+    deleteName: string;
+    error?: Error;
+  }> = ({ onDelete, onClose, deleteName, error }) => (
+    <div data-testid="delete-modal">
+      <span data-testid="delete-name">{deleteName}</span>
+      {error && <div data-testid="delete-error">{error.message}</div>}
+      <button data-testid="confirm-delete" onClick={onDelete}>
+        Confirm Delete
+      </button>
+      <button data-testid="cancel-delete" onClick={onClose}>
+        Cancel
+      </button>
+    </div>
+  );
+  return { __esModule: true, default: MockDeleteModal };
+});
+
+const mockDeleteLlmInferenceServiceConfigIfUnreferenced = jest.mocked(
+  deleteLlmInferenceServiceConfigIfUnreferenced,
+);
+const mockUseNotification = jest.mocked(useNotification);
+
+describe('RoutingConfigurationsTable', () => {
+  const mockNotification = {
+    error: jest.fn(),
+    success: jest.fn(),
+    info: jest.fn(),
+    warning: jest.fn(),
+  };
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useNavigate).mockReturnValue(mockNavigate);
+    mockUseNotification.mockReturnValue(mockNotification as ReturnType<typeof useNotification>);
+  });
+
+  const openDeleteModal = () => {
+    const kebab = screen.getByRole('button', { name: /kebab toggle/i });
+    fireEvent.click(kebab);
+    const deleteAction = screen.getByRole('menuitem', { name: /delete/i });
+    fireEvent.click(deleteAction);
+  };
+
+  it('should close the delete modal on successful deletion', async () => {
+    mockDeleteLlmInferenceServiceConfigIfUnreferenced.mockResolvedValue('deleted');
+
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      name: 'test-config',
+      displayName: 'Test Config',
+    });
+
+    render(<RoutingConfigurationsTable configs={[config]} />);
+
+    openDeleteModal();
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+
+    await waitFor(() => {
+      expect(mockDeleteLlmInferenceServiceConfigIfUnreferenced).toHaveBeenCalledWith(
+        'test-config',
+        'opendatahub',
+        'routing',
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show an inline error when the config is in use', async () => {
+    mockDeleteLlmInferenceServiceConfigIfUnreferenced.mockRejectedValue(
+      new Error(CONFIG_IN_USE_ERROR_MESSAGE),
+    );
+
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      name: 'test-config',
+      displayName: 'Test Config',
+    });
+
+    render(<RoutingConfigurationsTable configs={[config]} />);
+
+    openDeleteModal();
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-error')).toHaveTextContent(CONFIG_IN_USE_ERROR_MESSAGE);
+    });
+
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+    expect(mockNotification.warning).not.toHaveBeenCalled();
+  });
+
+  it('should keep the modal open when deletion is blocked by a finalizer', async () => {
+    mockDeleteLlmInferenceServiceConfigIfUnreferenced.mockResolvedValue('blocked-pending');
+
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      name: 'test-config',
+      displayName: 'Test Config',
+    });
+
+    render(<RoutingConfigurationsTable configs={[config]} />);
+
+    openDeleteModal();
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-error')).toHaveTextContent(CONFIG_DELETION_PENDING_MESSAGE);
+    });
+
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+    expect(mockNotification.warning).not.toHaveBeenCalled();
+  });
+
+  it('should show an inline error when delete request fails', async () => {
+    mockDeleteLlmInferenceServiceConfigIfUnreferenced.mockRejectedValue(new Error('Network error'));
+
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      name: 'test-config',
+      displayName: 'Test Config',
+    });
+
+    render(<RoutingConfigurationsTable configs={[config]} />);
+
+    openDeleteModal();
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-error')).toHaveTextContent('Network error');
+    });
+
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+  });
+});

--- a/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationRow.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationRow.tsx
@@ -49,7 +49,7 @@ const TopologyConfigurationRow: React.FC<TopologyConfigurationRowProps> = ({
         isDanger: true,
       },
     ],
-    verbModelAccess('delete', LLMInferenceServiceConfigModel),
+    verbModelAccess('delete', LLMInferenceServiceConfigModel, config.metadata.namespace),
   );
 
   return (

--- a/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationRow.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationRow.tsx
@@ -7,8 +7,10 @@ import {
   getDescriptionFromK8sResource,
 } from '@odh-dashboard/k8s-core';
 import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
+import { useKebabAccessAllowed, verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR';
 import {
   type LLMInferenceServiceConfigKind,
+  LLMInferenceServiceConfigModel,
   TopologyTypeLabels,
   DASHBOARD_RESOURCE_LABEL,
   getConfigTopologyType,
@@ -37,6 +39,18 @@ const TopologyConfigurationRow: React.FC<TopologyConfigurationRowProps> = ({
   const topologyType = getConfigTopologyType(config);
   const isDashboardCreated =
     config.metadata.labels?.[DASHBOARD_RESOURCE_LABEL] === 'true' && !preInstalled;
+
+  const deleteKebabItems = useKebabAccessAllowed(
+    [
+      { isSeparator: true },
+      {
+        title: 'Delete',
+        onClick: () => onDelete(config),
+        isDanger: true,
+      },
+    ],
+    verbModelAccess('delete', LLMInferenceServiceConfigModel),
+  );
 
   return (
     <Tr data-testid={`topology-config-row-${configName}`}>
@@ -80,12 +94,7 @@ const TopologyConfigurationRow: React.FC<TopologyConfigurationRowProps> = ({
                     title: 'Duplicate',
                     onClick: () => navigate(`duplicate/${configName}`),
                   },
-                  { isSeparator: true },
-                  {
-                    title: 'Delete',
-                    onClick: () => onDelete(config),
-                    isDanger: true,
-                  },
+                  ...deleteKebabItems,
                 ]
               : [
                   {

--- a/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationsTable.tsx
@@ -12,23 +12,20 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard delete confirmation wrapper
 import DeleteModal from '@odh-dashboard/internal/pages/projects/components/DeleteModal';
-import { Table, SortableData, TrackingOutcome } from '@odh-dashboard/ui-core';
+import { Table, SortableData } from '@odh-dashboard/ui-core';
 import { useNavigate } from 'react-router';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
-import { k8sDeleteResource, K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
-import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import useNotification from '@odh-dashboard/internal/utilities/useNotification';
 import TopologyConfigurationRow from './TopologyConfigurationRow';
 import {
   type LLMInferenceServiceConfigKind,
-  LLMInferenceServiceConfigModel,
   TopologyType,
   TopologyTypeLabels,
   getConfigTopologyType,
 } from '../../types';
 import { isConfigEnabled, isConfigEffectivelyEnabled } from '../../utils';
 import { patchLLMInferenceServiceConfig } from '../../api/LLMInferenceServiceConfigs';
-import { fireTopologyConfigDeleted } from '../../tracking/llmdTrackingConstants';
+import { useDeleteLlmInferenceServiceConfig } from '../useDeleteLlmInferenceServiceConfig';
 
 const getTopologyTypeLabel = (config: LLMInferenceServiceConfigKind): string => {
   const type = getConfigTopologyType(config);
@@ -66,12 +63,11 @@ type TopologyConfigurationsTableProps = {
 
 const TopologyConfigurationsTable: React.FC<TopologyConfigurationsTableProps> = ({ configs }) => {
   const navigate = useNavigate();
-  const { dashboardNamespace } = useDashboardNamespace();
   const notification = useNotification();
   const [isAddDropdownOpen, setIsAddDropdownOpen] = React.useState(false);
   const [togglingConfigs, setTogglingConfigs] = React.useState<Record<string, boolean>>({});
-  const [deleteConfig, setDeleteConfig] = React.useState<LLMInferenceServiceConfigKind>();
-  const [isDeleting, setIsDeleting] = React.useState(false);
+  const { deleteConfig, setDeleteConfig, isDeleting, error, handleDelete, closeDeleteModal } =
+    useDeleteLlmInferenceServiceConfig('topology');
 
   const topologyTypes = Object.values(TopologyType);
   const primaryTopologyType = TopologyType.SINGLE_NODE;
@@ -106,37 +102,6 @@ const TopologyConfigurationsTable: React.FC<TopologyConfigurationsTableProps> = 
     } finally {
       setTogglingConfigs((prev) => ({ ...prev, [configName]: false }));
     }
-  };
-
-  const handleDelete = () => {
-    if (!deleteConfig) {
-      return;
-    }
-    setIsDeleting(true);
-    k8sDeleteResource<typeof LLMInferenceServiceConfigModel, K8sStatus>({
-      model: LLMInferenceServiceConfigModel,
-      queryOptions: {
-        name: deleteConfig.metadata.name,
-        ns: dashboardNamespace,
-      },
-    })
-      .then(() => {
-        fireTopologyConfigDeleted({ outcome: TrackingOutcome.submit, success: true });
-        setDeleteConfig(undefined);
-      })
-      .catch((e: unknown) => {
-        notification.error(
-          'Error deleting configuration',
-          e instanceof Error ? e.message : 'Unknown error',
-        );
-        fireTopologyConfigDeleted({
-          outcome: TrackingOutcome.submit,
-          success: false,
-        });
-      })
-      .finally(() => {
-        setIsDeleting(false);
-      });
   };
 
   const toolbarContent = (
@@ -215,14 +180,11 @@ const TopologyConfigurationsTable: React.FC<TopologyConfigurationsTableProps> = 
       {deleteConfig && (
         <DeleteModal
           title="Delete llm-d topology configuration?"
-          onClose={() => {
-            fireTopologyConfigDeleted({ outcome: TrackingOutcome.cancel });
-            setDeleteConfig(undefined);
-            setIsDeleting(false);
-          }}
+          onClose={closeDeleteModal}
           submitButtonLabel="Delete topology configuration"
           onDelete={handleDelete}
           deleting={isDeleting}
+          error={error}
           deleteName={getDisplayNameFromK8sResource(deleteConfig)}
         >
           This action cannot be undone.

--- a/packages/llmd-serving/src/settings/topologyConfigs/__tests__/TopologyConfigurationsTable.spec.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/__tests__/TopologyConfigurationsTable.spec.tsx
@@ -22,6 +22,14 @@ jest.mock('@odh-dashboard/internal/utilities/useNotification', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('@odh-dashboard/internal/concepts/userSSAR', () => {
+  const actual = jest.requireActual('@odh-dashboard/internal/concepts/userSSAR');
+  return {
+    ...actual,
+    useKebabAccessAllowed: (actions: unknown[]) => actions,
+  };
+});
+
 jest.mock('../../../api/LLMInferenceServiceConfigs', () => ({
   patchLLMInferenceServiceConfig: jest.fn(),
   deleteLlmInferenceServiceConfigIfUnreferenced: jest.fn(),

--- a/packages/llmd-serving/src/settings/topologyConfigs/__tests__/TopologyConfigurationsTable.spec.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/__tests__/TopologyConfigurationsTable.spec.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useNavigate } from 'react-router';
+import useNotification from '@odh-dashboard/internal/utilities/useNotification';
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { deleteLlmInferenceServiceConfigIfUnreferenced } from '../../../api/LLMInferenceServiceConfigs';
+import { CONFIG_DELETION_PENDING_MESSAGE, CONFIG_IN_USE_ERROR_MESSAGE } from '../../../utils';
+import { TopologyType } from '../../../types';
+import TopologyConfigurationsTable from '../TopologyConfigurationsTable';
+
+jest.mock('react-router', () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/redux/selectors/project', () => ({
+  useDashboardNamespace: jest.fn(() => ({ dashboardNamespace: 'opendatahub' })),
+}));
+
+jest.mock('@odh-dashboard/internal/utilities/useNotification', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../api/LLMInferenceServiceConfigs', () => ({
+  patchLLMInferenceServiceConfig: jest.fn(),
+  deleteLlmInferenceServiceConfigIfUnreferenced: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/pages/projects/components/DeleteModal', () => {
+  const MockDeleteModal: React.FC<{
+    onDelete: () => void;
+    onClose: () => void;
+    deleteName: string;
+    error?: Error;
+  }> = ({ onDelete, onClose, deleteName, error }) => (
+    <div data-testid="delete-modal">
+      <span data-testid="delete-name">{deleteName}</span>
+      {error && <div data-testid="delete-error">{error.message}</div>}
+      <button data-testid="confirm-delete" onClick={onDelete}>
+        Confirm Delete
+      </button>
+      <button data-testid="cancel-delete" onClick={onClose}>
+        Cancel
+      </button>
+    </div>
+  );
+  return { __esModule: true, default: MockDeleteModal };
+});
+
+const mockDeleteLlmInferenceServiceConfigIfUnreferenced = jest.mocked(
+  deleteLlmInferenceServiceConfigIfUnreferenced,
+);
+const mockUseNotification = jest.mocked(useNotification);
+
+describe('TopologyConfigurationsTable', () => {
+  const mockNotification = {
+    error: jest.fn(),
+    success: jest.fn(),
+    info: jest.fn(),
+    warning: jest.fn(),
+  };
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useNavigate).mockReturnValue(mockNavigate);
+    mockUseNotification.mockReturnValue(mockNotification as ReturnType<typeof useNotification>);
+  });
+
+  const openDeleteModal = () => {
+    const kebab = screen.getByRole('button', { name: /kebab toggle/i });
+    fireEvent.click(kebab);
+    const deleteAction = screen.getByRole('menuitem', { name: /delete/i });
+    fireEvent.click(deleteAction);
+  };
+
+  it('should close the delete modal on successful deletion', async () => {
+    mockDeleteLlmInferenceServiceConfigIfUnreferenced.mockResolvedValue('deleted');
+
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      name: 'test-topo-config',
+      displayName: 'Test Topo Config',
+      topologyType: TopologyType.SINGLE_NODE,
+    });
+
+    render(<TopologyConfigurationsTable configs={[config]} />);
+
+    openDeleteModal();
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+
+    await waitFor(() => {
+      expect(mockDeleteLlmInferenceServiceConfigIfUnreferenced).toHaveBeenCalledWith(
+        'test-topo-config',
+        'opendatahub',
+        'topology',
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show an inline error when the config is in use', async () => {
+    mockDeleteLlmInferenceServiceConfigIfUnreferenced.mockRejectedValue(
+      new Error(CONFIG_IN_USE_ERROR_MESSAGE),
+    );
+
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      name: 'test-topo-config',
+      displayName: 'Test Topo Config',
+      topologyType: TopologyType.SINGLE_NODE,
+    });
+
+    render(<TopologyConfigurationsTable configs={[config]} />);
+
+    openDeleteModal();
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-error')).toHaveTextContent(CONFIG_IN_USE_ERROR_MESSAGE);
+    });
+
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+  });
+
+  it('should keep the modal open when deletion is blocked by a finalizer', async () => {
+    mockDeleteLlmInferenceServiceConfigIfUnreferenced.mockResolvedValue('blocked-pending');
+
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      name: 'test-topo-config',
+      displayName: 'Test Topo Config',
+      topologyType: TopologyType.SINGLE_NODE,
+    });
+
+    render(<TopologyConfigurationsTable configs={[config]} />);
+
+    openDeleteModal();
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-error')).toHaveTextContent(CONFIG_DELETION_PENDING_MESSAGE);
+    });
+
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+    expect(mockNotification.warning).not.toHaveBeenCalled();
+  });
+
+  it('should show an inline error when delete request fails', async () => {
+    mockDeleteLlmInferenceServiceConfigIfUnreferenced.mockRejectedValue(new Error('Network error'));
+
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      name: 'test-topo-config',
+      displayName: 'Test Topo Config',
+      topologyType: TopologyType.SINGLE_NODE,
+    });
+
+    render(<TopologyConfigurationsTable configs={[config]} />);
+
+    openDeleteModal();
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-error')).toHaveTextContent('Network error');
+    });
+
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+  });
+});

--- a/packages/llmd-serving/src/settings/useDeleteLlmInferenceServiceConfig.ts
+++ b/packages/llmd-serving/src/settings/useDeleteLlmInferenceServiceConfig.ts
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import { deleteLlmInferenceServiceConfigIfUnreferenced } from '../api/LLMInferenceServiceConfigs';
+import type { LLMInferenceServiceConfigKind } from '../types';
+import {
+  fireRoutingConfigDeleted,
+  fireTopologyConfigDeleted,
+} from '../tracking/llmdTrackingConstants';
+import { CONFIG_DELETION_PENDING_MESSAGE, type LlmConfigRefType } from '../utils';
+
+type UseDeleteLlmInferenceServiceConfigResult = {
+  deleteConfig: LLMInferenceServiceConfigKind | undefined;
+  setDeleteConfig: React.Dispatch<React.SetStateAction<LLMInferenceServiceConfigKind | undefined>>;
+  isDeleting: boolean;
+  error: Error | undefined;
+  handleDelete: () => Promise<void>;
+  closeDeleteModal: () => void;
+};
+
+export const useDeleteLlmInferenceServiceConfig = (
+  refType: LlmConfigRefType,
+): UseDeleteLlmInferenceServiceConfigResult => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const [deleteConfig, setDeleteConfig] = React.useState<LLMInferenceServiceConfigKind>();
+  const [isDeleting, setIsDeleting] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+
+  const fireConfigDeleted =
+    refType === 'routing' ? fireRoutingConfigDeleted : fireTopologyConfigDeleted;
+
+  const closeDeleteModal = () => {
+    fireConfigDeleted({ outcome: TrackingOutcome.cancel });
+    setDeleteConfig(undefined);
+    setIsDeleting(false);
+    setError(undefined);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteConfig) {
+      return;
+    }
+
+    setIsDeleting(true);
+    setError(undefined);
+
+    try {
+      const outcome = await deleteLlmInferenceServiceConfigIfUnreferenced(
+        deleteConfig.metadata.name,
+        dashboardNamespace,
+        refType,
+      );
+
+      if (outcome === 'blocked-pending') {
+        setError(new Error(CONFIG_DELETION_PENDING_MESSAGE));
+        fireConfigDeleted({ outcome: TrackingOutcome.submit, success: false });
+        return;
+      }
+
+      fireConfigDeleted({ outcome: TrackingOutcome.submit, success: true });
+      setDeleteConfig(undefined);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error('Unknown error'));
+      fireConfigDeleted({ outcome: TrackingOutcome.submit, success: false });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return {
+    deleteConfig,
+    setDeleteConfig,
+    isDeleting,
+    error,
+    handleDelete,
+    closeDeleteModal,
+  };
+};

--- a/packages/llmd-serving/src/types.ts
+++ b/packages/llmd-serving/src/types.ts
@@ -158,6 +158,14 @@ export type LLMInferenceServiceConfigKind = K8sResourceCommon & {
     };
   };
   spec?: LLMInferenceServiceSpec;
+  status?: {
+    referencedBy?: {
+      name?: string;
+      namespace?: string;
+      kind?: string;
+      apiVersion?: string;
+    }[];
+  };
 };
 export const isLLMInferenceServiceConfig = (
   resource?: K8sResourceCommon,

--- a/packages/llmd-serving/src/utils.ts
+++ b/packages/llmd-serving/src/utils.ts
@@ -1,7 +1,19 @@
 import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { isUnsupportedUnaccepted } from '@odh-dashboard/model-serving/concepts/versions';
-import { WELL_KNOWN_ANNOTATION, DISABLED_ANNOTATION, DASHBOARD_RESOURCE_LABEL } from './const';
-import type { LLMInferenceServiceConfigKind } from './types';
+import {
+  WELL_KNOWN_ANNOTATION,
+  DISABLED_ANNOTATION,
+  DASHBOARD_RESOURCE_LABEL,
+  ROUTING_CONFIG_REF_ANNOTATION,
+  TOPOLOGY_CONFIG_REF_ANNOTATION,
+} from './const';
+import type { LLMInferenceServiceConfigKind, LLMInferenceServiceKind } from './types';
+
+export const CONFIG_IN_USE_ERROR_MESSAGE =
+  'This configuration is currently in use by a deployment. Remove the deployment before deleting this configuration.';
+
+export const CONFIG_DELETION_PENDING_MESSAGE =
+  'This configuration is in use by a deployment. It will remain in a terminating state until that deployment is removed.';
 
 export const isConfigObject = (value: unknown): value is LLMInferenceServiceConfigKind =>
   typeof value === 'object' &&
@@ -104,3 +116,93 @@ export const cleanlyDuplicateConfig = (
     },
   };
 };
+
+const KSERVE_CONFIG_FINALIZER = 'serving.kserve.io/llmisvcconfig-finalizer';
+
+export const isDeletionBlockedByFinalizer = (result: unknown): boolean =>
+  isConfigObject(result) &&
+  !!result.metadata.deletionTimestamp &&
+  !!result.metadata.finalizers?.includes(KSERVE_CONFIG_FINALIZER);
+
+export type LlmConfigRefType = 'routing' | 'topology';
+
+const getConfigRefAnnotation = (refType: LlmConfigRefType) =>
+  refType === 'routing' ? ROUTING_CONFIG_REF_ANNOTATION : TOPOLOGY_CONFIG_REF_ANNOTATION;
+
+const MAX_K8S_NAME_LENGTH = 253;
+
+const getLocalTopologyConfigName = (deploymentName: string, configName: string): string => {
+  const prefix = `${deploymentName}-`;
+  if (configName.startsWith(prefix)) {
+    return configName;
+  }
+  return `${prefix}${configName}`.slice(0, MAX_K8S_NAME_LENGTH).replace(/-+$/, '');
+};
+
+export const isConfigReferencedInStatus = (config: LLMInferenceServiceConfigKind): boolean =>
+  (config.status?.referencedBy?.length ?? 0) > 0;
+
+export const isConfigInUse = (
+  config: LLMInferenceServiceConfigKind,
+  deployments: LLMInferenceServiceKind[] | null,
+  configName: string,
+  refType: LlmConfigRefType,
+): boolean => {
+  if (deployments) {
+    return getDeploymentsReferencingConfig(deployments, configName, refType).length > 0;
+  }
+
+  return isConfigReferencedInStatus(config);
+};
+
+export const isDeletionPendingDueToReferences = (
+  result: unknown,
+  deployments: LLMInferenceServiceKind[] | null,
+  configName: string,
+  refType: LlmConfigRefType,
+): boolean =>
+  isDeletionBlockedByFinalizer(result) &&
+  isConfigObject(result) &&
+  isConfigInUse(result, deployments, configName, refType);
+
+export const isDeploymentReferencingConfig = (
+  deployment: LLMInferenceServiceKind,
+  configName: string,
+  refType: LlmConfigRefType,
+): boolean => {
+  const annotationRef = deployment.metadata.annotations?.[getConfigRefAnnotation(refType)];
+  if (annotationRef === configName) {
+    return true;
+  }
+
+  if (
+    refType === 'topology' &&
+    annotationRef === getLocalTopologyConfigName(deployment.metadata.name, configName)
+  ) {
+    return true;
+  }
+
+  if (deployment.spec.baseRefs?.some((ref) => ref.name === configName)) {
+    return true;
+  }
+
+  if (
+    refType === 'topology' &&
+    deployment.spec.baseRefs?.some(
+      (ref) => ref.name === getLocalTopologyConfigName(deployment.metadata.name, configName),
+    )
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+export const getDeploymentsReferencingConfig = (
+  deployments: LLMInferenceServiceKind[],
+  configName: string,
+  refType: LlmConfigRefType,
+): LLMInferenceServiceKind[] =>
+  deployments.filter((deployment) =>
+    isDeploymentReferencingConfig(deployment, configName, refType),
+  );

--- a/packages/llmd-serving/src/utils.ts
+++ b/packages/llmd-serving/src/utils.ts
@@ -1,13 +1,7 @@
 import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { isUnsupportedUnaccepted } from '@odh-dashboard/model-serving/concepts/versions';
-import {
-  WELL_KNOWN_ANNOTATION,
-  DISABLED_ANNOTATION,
-  DASHBOARD_RESOURCE_LABEL,
-  ROUTING_CONFIG_REF_ANNOTATION,
-  TOPOLOGY_CONFIG_REF_ANNOTATION,
-} from './const';
-import type { LLMInferenceServiceConfigKind, LLMInferenceServiceKind } from './types';
+import { WELL_KNOWN_ANNOTATION, DISABLED_ANNOTATION, DASHBOARD_RESOURCE_LABEL } from './const';
+import type { LLMInferenceServiceConfigKind } from './types';
 
 export const CONFIG_IN_USE_ERROR_MESSAGE =
   'This configuration is currently in use by a deployment. Remove the deployment before deleting this configuration.';
@@ -126,83 +120,10 @@ export const isDeletionBlockedByFinalizer = (result: unknown): boolean =>
 
 export type LlmConfigRefType = 'routing' | 'topology';
 
-const getConfigRefAnnotation = (refType: LlmConfigRefType) =>
-  refType === 'routing' ? ROUTING_CONFIG_REF_ANNOTATION : TOPOLOGY_CONFIG_REF_ANNOTATION;
-
-const MAX_K8S_NAME_LENGTH = 253;
-
-const getLocalTopologyConfigName = (deploymentName: string, configName: string): string => {
-  const prefix = `${deploymentName}-`;
-  if (configName.startsWith(prefix)) {
-    return configName;
-  }
-  return `${prefix}${configName}`.slice(0, MAX_K8S_NAME_LENGTH).replace(/-+$/, '');
-};
-
 export const isConfigReferencedInStatus = (config: LLMInferenceServiceConfigKind): boolean =>
   (config.status?.referencedBy?.length ?? 0) > 0;
 
-export const isConfigInUse = (
-  config: LLMInferenceServiceConfigKind,
-  deployments: LLMInferenceServiceKind[] | null,
-  configName: string,
-  refType: LlmConfigRefType,
-): boolean => {
-  if (deployments) {
-    return getDeploymentsReferencingConfig(deployments, configName, refType).length > 0;
-  }
-
-  return isConfigReferencedInStatus(config);
-};
-
-export const isDeletionPendingDueToReferences = (
-  result: unknown,
-  deployments: LLMInferenceServiceKind[] | null,
-  configName: string,
-  refType: LlmConfigRefType,
-): boolean =>
+export const isDeletionPendingDueToReferences = (result: unknown): boolean =>
   isDeletionBlockedByFinalizer(result) &&
   isConfigObject(result) &&
-  isConfigInUse(result, deployments, configName, refType);
-
-export const isDeploymentReferencingConfig = (
-  deployment: LLMInferenceServiceKind,
-  configName: string,
-  refType: LlmConfigRefType,
-): boolean => {
-  const annotationRef = deployment.metadata.annotations?.[getConfigRefAnnotation(refType)];
-  if (annotationRef === configName) {
-    return true;
-  }
-
-  if (
-    refType === 'topology' &&
-    annotationRef === getLocalTopologyConfigName(deployment.metadata.name, configName)
-  ) {
-    return true;
-  }
-
-  if (deployment.spec.baseRefs?.some((ref) => ref.name === configName)) {
-    return true;
-  }
-
-  if (
-    refType === 'topology' &&
-    deployment.spec.baseRefs?.some(
-      (ref) => ref.name === getLocalTopologyConfigName(deployment.metadata.name, configName),
-    )
-  ) {
-    return true;
-  }
-
-  return false;
-};
-
-export const getDeploymentsReferencingConfig = (
-  deployments: LLMInferenceServiceKind[],
-  configName: string,
-  refType: LlmConfigRefType,
-): LLMInferenceServiceKind[] =>
-  deployments.filter((deployment) =>
-    isDeploymentReferencingConfig(deployment, configName, refType),
-  );
+  isConfigReferencedInStatus(result);


### PR DESCRIPTION
<!--- https://issues.redhat.com/browse/RHOAIENG-81276 -->

https://issues.redhat.com/browse/RHOAIENG-81276

## Description

Fixes silent delete failures when removing llm-d **routing** or **topology** `LLMInferenceServiceConfig` resources that are still referenced by an `LLMInferenceService` deployment.

**Problem:** KServe's `serving.kserve.io/llmisvcconfig-finalizer` blocks deletion of referenced configs. The dashboard treated a successful delete API response as completion and closed the modal, even when the config remained on the cluster in a terminating/blocked state.

**Solution:**
- Add `deleteLlmInferenceServiceConfigIfUnreferenced` with a pre-delete reference check:
  - Cluster-wide `LLMInferenceService` list (annotations + `spec.baseRefs`)
  - Falls back to `status.referencedBy` when deployment list is forbidden (403)
- Add shared `useDeleteLlmInferenceServiceConfig` hook used by both routing and topology config tables
- Show errors inline in `DeleteModal` (`error` prop) instead of toast notifications
- Post-delete safety net detects a terminating config **only when it is still referenced** (avoids false positives on normal deletes)
- Prefer live deployment list over stale `status.referencedBy` after a referencing deployment is removed

**Key files:**
- `packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts`
- `packages/llmd-serving/src/settings/useDeleteLlmInferenceServiceConfig.ts`
- `packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationsTable.tsx`
- `packages/llmd-serving/src/settings/topologyConfigs/TopologyConfigurationsTable.tsx`
- `packages/llmd-serving/src/utils.ts`

## How Has This Been Tested?

**Automated:**
- `npm run lint` — pass (0 errors in `packages/llmd-serving`)
- `npm run type-check` — pass
- `npm run test-unit` — 411/411 pass

**Manual (ODH Dashboard local dev, llm-d routing configs):**
1. Create a routing config and deploy an LLM-d using it → attempt delete → modal stays open with inline error; row remains
<img width="1213" height="505" alt="Screenshot 2026-08-24 at 3 45 06 PM" src="https://github.com/user-attachments/assets/cfc98bed-14f2-4f82-ae36-a81b3f4fc4a4" />

3. Delete an unreferenced config → row removed; modal closes; no error

https://github.com/user-attachments/assets/8e1d4ab1-93a2-403e-a230-dc1678150496


5. Delete a config after removing the referencing deployment → delete succeeds (live deployment scan ignores stale `status.referencedBy`) - 
6. Verified cluster state with `oc get llminferenceserviceconfig` / `oc get llminferenceservice -A` when debugging reference detection

**Testing instructions:**
1. Go to **Settings → Model deployment settings → Routing configurations**
2. **In-use config:** Create config → deploy LLM-d with it → delete config → expect inline modal error, row stays
3. **Unreferenced config:** Create config (no deployment) → delete → expect success, modal closes
4. **After deployment removal:** Delete referencing deployment → delete config → expect success
7. Repeat key scenarios on **Topology configurations** tab

## Test Impact

**Added unit tests:**
- `src/__tests__/configReferences.spec.ts` — deployment reference detection, `isConfigInUse`, `isDeletionPendingDueToReferences`
- `src/__tests__/isDeletionBlockedByFinalizer.spec.ts` — finalizer detection helpers
- `src/api/__tests__/deleteLlmInferenceServiceConfigIfUnreferenced.spec.ts` — delete API flow (pre-check, 403 fallback, blocked-pending, stale status)
- `src/settings/routingConfigs/__tests__/RoutingConfigurationsTable.spec.tsx` — modal error behavior
- `src/settings/topologyConfigs/__tests__/TopologyConfigurationsTable.spec.tsx` — modal error behavior

No Cypress changes (settings table delete flow covered by unit tests).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safeguards that prevent deleting routing or topology configurations currently in use.
  - Added clear feedback when deletion is blocked, pending, or fails.
  - Added permission-aware delete actions for configuration rows.
  - Added support for listing inference services within a namespace.

- **Bug Fixes**
  - Improved handling of stale references, terminating configurations, and deletion permissions.
  - Standardized deletion behavior across routing and topology configuration screens.

- **Tests**
  - Added coverage for reference detection, deletion safeguards, error states, permissions, and modal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->