### PR TITLE
test(e2e): add Kueue model deployment lifecycle Cypress test

### DIFF
--- a/packages/cypress/cypress/fixtures/resources/hardwareProfile/kueue_model_serving_profile.yaml
+++ b/packages/cypress/cypress/fixtures/resources/hardwareProfile/kueue_model_serving_profile.yaml
@@ -1,0 +1,29 @@
+apiVersion: infrastructure.opendatahub.io/v1
+kind: HardwareProfile
+metadata:
+  name: ${hardwareProfileName}
+  namespace: ${hardwareProfileNamespace}
+  annotations:
+    opendatahub.io/dashboard-feature-visibility: '["model-serving"]'
+    opendatahub.io/disabled: 'false'
+    opendatahub.io/display-name: ${displayName}
+spec:
+  displayName: ${displayName}
+  enabled: true
+  identifiers:
+    - defaultCount: 2
+      displayName: CPU
+      identifier: cpu
+      maxCount: 4
+      minCount: 1
+      resourceType: CPU
+    - defaultCount: 8Gi
+      displayName: Memory
+      identifier: memory
+      maxCount: 16Gi
+      minCount: 4Gi
+      resourceType: Memory
+  scheduling:
+    type: Queue
+    kueue:
+      localQueueName: ${localQueueName}

--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -690,6 +690,10 @@ class ModelServingRow extends TableRow {
     return this.find().find(`[data-label="Last deployed"]`);
   }
 
+  findStatusSubtitle() {
+    return this.find().findByTestId('deployment-status-subtitle');
+  }
+
   findConfirmStopModal() {
     return cy.findByTestId('stop-model-modal');
   }
@@ -1254,19 +1258,16 @@ class ModelServingWizard extends Wizard {
     cy.findByRole('option', { name }).click();
   }
 
-  selectPotentiallyDisabledProfile(profileDisplayName: string): void {
+  selectPotentiallyDisabledProfile(profileDisplayName: string, profileName?: string): void {
     const dropdown = this.findHardProfileSelection();
 
     dropdown.then(($el) => {
       if ($el.prop('disabled')) {
-        // If disabled, verify it contains the base profile name
-        const nameToCheck = profileDisplayName;
-        cy.wrap($el).contains(nameToCheck).should('exist');
-        cy.log(`Dropdown is disabled with value: ${nameToCheck}`);
+        cy.wrap($el).contains(profileDisplayName).should('exist');
+        cy.log(`Dropdown is disabled with value: ${profileDisplayName}`);
       } else {
-        // If enabled, proceed with selection as before using the full display name
         dropdown.click();
-        cy.findByTestId(`${profileDisplayName}`).click();
+        cy.findByTestId(profileName || profileDisplayName).click();
       }
     });
   }

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelDeploymentKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelDeploymentKueueLifecycle.cy.ts
@@ -1,8 +1,8 @@
 import {
-  deleteOpenShiftProject,
-  createOpenShiftProject,
+  recreateOpenShiftProject,
+  deleteOpenShiftProjectBestEffort,
 } from '../../../../utils/oc_commands/project';
-import { retryableBefore } from '../../../../utils/retryableHooks';
+import { retryableBefore, wasSetupPerformed } from '../../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../../utils/uuidGenerator';
 import {
   setupKueueModelDeploymentResources,
@@ -13,11 +13,13 @@ import {
   cleanupKueueWorkbenchResources,
   type KueueWorkbenchConfig,
 } from '../../../../utils/oc_commands/kueueWorkbench';
+import { projectDetails, projectListPage } from '../../../../pages/projects';
 import {
   modelServingGlobal,
   modelServingSection,
   modelServingWizard,
 } from '../../../../pages/modelServing';
+import { LDAP_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { ModelLocationSelectOption, ModelTypeLabel } from '../../../../utils/modelServingConstants';
 
 const describeAdminOnly = Cypress.env('IS_NON_ADMIN_RUN') ? describe.skip : describe;
@@ -67,31 +69,63 @@ const buildKueueConfig = (
   memoryQuota,
 });
 
-const waitForModelServerTabReady = (timeout = TAB_READY_TIMEOUT) => {
-  cy.findByTestId('section-model-server', { timeout }).should('exist');
-  cy.findByTestId('section-model-server').within(() => {
-    cy.get('.pf-v6-l-bullseye, .pf-l-bullseye', { timeout }).should('not.exist');
-    cy.get(
-      '[data-testid="deploy-button"], [data-testid="kserve-select-button"], [data-testid="deployments-table"], [data-testid="empty-state-title"]',
-      { timeout },
-    ).should('be.visible');
+const assertModelServingAvailable = () => {
+  cy.get('body').then(($body) => {
+    if ($body.text().includes('administrator must first select a model serving platform')) {
+      throw new Error(
+        'Model serving platform is not enabled on this cluster. Enable single-model (KServe) serving under Settings → Model serving before running this test.',
+      );
+    }
+    if ($body.find('[data-testid="unauthorized-error"]').length > 0) {
+      throw new Error('Current user is not authorized to view model deployments for this project.');
+    }
   });
 };
 
-const openModelServerTab = (ctx: TestContext, reloadForPlatformLabel = false) => {
+/** Fresh projects must pick KServe before Deploy is available — same as other model E2E specs. */
+const selectKservePlatformIfNeeded = () => {
+  cy.get('body').then(($body) => {
+    if ($body.find('[data-testid="kserve-select-button"]').length > 0) {
+      projectDetails.findSelectPlatformButton('kserve').should('be.visible').click();
+    }
+  });
+};
+
+const waitForDeployModelButton = (timeout = TAB_READY_TIMEOUT) => {
+  cy.findByTestId('section-model-server', { timeout }).should('exist');
+  assertModelServingAvailable();
+  selectKservePlatformIfNeeded();
+  modelServingGlobal.findDeployModelButton().should('be.visible', { timeout });
+};
+
+const waitForDeploymentsTable = (timeout = TAB_READY_TIMEOUT) => {
+  cy.findByTestId('section-model-server', { timeout }).should('exist');
+  assertModelServingAvailable();
+  modelServingSection.findDeploymentsTable().should('be.visible', { timeout });
+};
+
+/** First visit: same navigation pattern as testDeployLLMDServing / testWorkbenchKueueLifecycle. */
+const openModelServerTabForDeploy = (ctx: TestContext) => {
+  cy.visitWithLogin('/?devFeatureFlags=true', LDAP_ADMIN_USER);
+  projectListPage.navigate();
+  projectListPage.filterProjectByName(ctx.projectName);
+  projectListPage.findProjectLink(ctx.projectName).click();
+  projectDetails.findSectionTab(FIXTURE.sectionTab).click();
+  waitForDeployModelButton();
+};
+
+/** Revisit after a model exists — wait for the deployments table, not the deploy empty state. */
+const openModelServerTabForVerification = (ctx: TestContext) => {
   cy.visitWithLogin(
     `/projects/${ctx.projectName}?section=${FIXTURE.sectionTab}&devFeatureFlags=true`,
+    LDAP_ADMIN_USER,
   );
-  waitForModelServerTabReady();
-  if (reloadForPlatformLabel) {
-    cy.reload();
-    waitForModelServerTabReady();
-  }
+  waitForDeploymentsTable();
 };
 
 const deployModelViaWizard = (ctx: TestContext, modelName: string) => {
   cy.get('body').type('{esc}');
-  waitForModelServerTabReady();
+  waitForDeployModelButton();
   modelServingGlobal.findDeployModelButton().should('be.visible').click();
 
   modelServingWizard.findModelLocationSelectOption(ModelLocationSelectOption.URI).click();
@@ -166,8 +200,7 @@ const setupProject = (
     projectName: `${FIXTURE.projectName}-${projectSuffix}-${uuid}`,
     testData: buildKueueConfig(uuid, cpuQuota, memoryQuota),
   };
-  return deleteOpenShiftProject(ctx.projectName, { wait: true, ignoreNotFound: true })
-    .then(() => createOpenShiftProject(ctx.projectName))
+  return recreateOpenShiftProject(ctx.projectName)
     .then(() => setupKueueModelDeploymentResources(ctx.testData, ctx.projectName))
     .then(() => ctx);
 };
@@ -199,18 +232,21 @@ describeAdminOnly('Model deployment Kueue status tests', () => {
     );
 
     after(() => {
+      if (!wasSetupPerformed()) {
+        return;
+      }
       cleanupKueueWorkbenchResources(ctx.testData, ctx.projectName);
-      deleteOpenShiftProject(ctx.projectName, { wait: false, ignoreNotFound: true });
+      deleteOpenShiftProjectBestEffort(ctx.projectName);
     });
 
     it(
       'Verify model deployment shows Inadmissible when ClusterQueue quota is zero',
       { tags: TEST_TAGS },
       () => {
-        openModelServerTab(ctx, true);
+        openModelServerTabForDeploy(ctx);
         deployModelViaWizard(ctx, modelName);
         pollUntilAnyWorkloadMessageMatches(ctx.projectName, INADMISSIBLE_MESSAGE);
-        openModelServerTab(ctx);
+        openModelServerTabForVerification(ctx);
         verifyKueueStatusAndResourcesModal(ctx, modelName, FIXTURE.inadmissibleStatus, false);
       },
     );
@@ -231,21 +267,24 @@ describeAdminOnly('Model deployment Kueue status tests', () => {
     );
 
     after(() => {
+      if (!wasSetupPerformed()) {
+        return;
+      }
       cleanupKueueWorkbenchResources(ctx.testData, ctx.projectName);
-      deleteOpenShiftProject(ctx.projectName, { wait: false, ignoreNotFound: true });
+      deleteOpenShiftProjectBestEffort(ctx.projectName);
     });
 
     it(
       'Verify model deployment shows Queued when ClusterQueue quota is consumed by another deployment',
       { tags: TEST_TAGS },
       () => {
-        openModelServerTab(ctx, true);
+        openModelServerTabForDeploy(ctx);
         deployModelViaWizard(ctx, firstModelName);
         pollUntilWorkloadAdmitted(ctx.projectName, { maxAttempts: 120, pollIntervalMs: 5000 });
-        openModelServerTab(ctx);
+        openModelServerTabForVerification(ctx);
         deployModelViaWizard(ctx, secondModelName);
         pollUntilAnyWorkloadMessageMatches(ctx.projectName, QUEUED_MESSAGE);
-        openModelServerTab(ctx);
+        openModelServerTabForVerification(ctx);
         verifyKueueStatusAndResourcesModal(ctx, secondModelName, FIXTURE.queuedStatus, true);
       },
     );

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelDeploymentKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelDeploymentKueueLifecycle.cy.ts
@@ -1,0 +1,253 @@
+import {
+  deleteOpenShiftProject,
+  createOpenShiftProject,
+} from '../../../../utils/oc_commands/project';
+import { retryableBefore } from '../../../../utils/retryableHooks';
+import { generateTestUUID } from '../../../../utils/uuidGenerator';
+import {
+  setupKueueModelDeploymentResources,
+  pollUntilWorkloadAdmitted,
+  pollUntilAnyWorkloadMessageMatches,
+} from '../../../../utils/oc_commands/kueueModelDeployment';
+import {
+  cleanupKueueWorkbenchResources,
+  type KueueWorkbenchConfig,
+} from '../../../../utils/oc_commands/kueueWorkbench';
+import {
+  modelServingGlobal,
+  modelServingSection,
+  modelServingWizard,
+} from '../../../../pages/modelServing';
+import { ModelLocationSelectOption, ModelTypeLabel } from '../../../../utils/modelServingConstants';
+
+const describeAdminOnly = Cypress.env('IS_NON_ADMIN_RUN') ? describe.skip : describe;
+const TAB_READY_TIMEOUT = 120000;
+const QUEUE_POSITION_REGEX = /\d+(st|nd|rd|th) in/;
+const INADMISSIBLE_MESSAGE = /> maximum capacity \(0\)/i;
+const QUEUED_MESSAGE = /insufficient unused quota/i;
+const TEST_TAGS = ['@Kueue', '@Dashboard', '@ModelServing', '@Featureflagged', '@NonConcurrent'];
+
+const FIXTURE = {
+  projectName: 'kueue-md-proj',
+  flavorName: 'lifecycle-model-flavor',
+  clusterQueueName: 'lifecycle-model-cluster-queue',
+  localQueueName: 'lifecycle-model-queue',
+  hardwareProfileName: 'kueue-lifecycle-model-hp',
+  hardwareProfileDisplayName: 'Kueue Lifecycle Model Profile',
+  inadmissibleCpuQuota: 0,
+  inadmissibleMemoryQuota: 0,
+  inadmissibleStatus: 'Inadmissible',
+  queuedCpuQuota: 3,
+  queuedMemoryQuota: 9,
+  queuedStatus: 'Queued',
+  waitingForQuotaMessage: 'Waiting for quota',
+  sectionTab: 'model-server',
+  modelLocationURI: 'hf://facebook/opt-125m',
+  servingRuntime: 'vLLM CPU (x86) ServingRuntime for KServe',
+  deploymentMethod: 'legacy' as const,
+  connectionNameSuffix: '-connection',
+};
+
+type TestContext = {
+  testData: KueueWorkbenchConfig;
+  projectName: string;
+};
+
+const buildKueueConfig = (
+  uuid: string,
+  cpuQuota: number,
+  memoryQuota: number,
+): KueueWorkbenchConfig => ({
+  flavorName: `${FIXTURE.flavorName}-${uuid}`,
+  clusterQueueName: `${FIXTURE.clusterQueueName}-${uuid}`,
+  localQueueName: `${FIXTURE.localQueueName}-${uuid}`,
+  hardwareProfileName: `${FIXTURE.hardwareProfileName}-${uuid}`,
+  hardwareProfileDisplayName: `${FIXTURE.hardwareProfileDisplayName} ${uuid}`,
+  cpuQuota,
+  memoryQuota,
+});
+
+const waitForModelServerTabReady = (timeout = TAB_READY_TIMEOUT) => {
+  cy.findByTestId('section-model-server', { timeout }).should('exist');
+  cy.findByTestId('section-model-server').within(() => {
+    cy.get('.pf-v6-l-bullseye, .pf-l-bullseye', { timeout }).should('not.exist');
+    cy.get(
+      '[data-testid="deploy-button"], [data-testid="kserve-select-button"], [data-testid="deployments-table"], [data-testid="empty-state-title"]',
+      { timeout },
+    ).should('be.visible');
+  });
+};
+
+const openModelServerTab = (ctx: TestContext, reloadForPlatformLabel = false) => {
+  cy.visitWithLogin(
+    `/projects/${ctx.projectName}?section=${FIXTURE.sectionTab}&devFeatureFlags=true`,
+  );
+  waitForModelServerTabReady();
+  if (reloadForPlatformLabel) {
+    cy.reload();
+    waitForModelServerTabReady();
+  }
+};
+
+const deployModelViaWizard = (ctx: TestContext, modelName: string) => {
+  cy.get('body').type('{esc}');
+  waitForModelServerTabReady();
+  modelServingGlobal.findDeployModelButton().should('be.visible').click();
+
+  modelServingWizard.findModelLocationSelectOption(ModelLocationSelectOption.URI).click();
+  modelServingWizard.findUrilocationInput().clear().type(FIXTURE.modelLocationURI);
+  modelServingWizard.findSaveConnectionCheckbox().should('be.checked');
+  modelServingWizard
+    .findSaveConnectionInput()
+    .clear()
+    .type(`${modelName}${FIXTURE.connectionNameSuffix}`);
+  modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
+  modelServingWizard.findNextButton().should('be.enabled').click();
+
+  modelServingWizard.findModelDeploymentNameInput().clear().type(modelName);
+  modelServingWizard.findResourceNameButton().click();
+  modelServingWizard.findResourceNameInput().should('be.visible');
+  modelServingWizard.selectDeploymentMethodByKey(FIXTURE.deploymentMethod);
+  modelServingWizard.selectPotentiallyDisabledProfile(
+    ctx.testData.hardwareProfileDisplayName,
+    ctx.testData.hardwareProfileName,
+  );
+  modelServingWizard
+    .findHardProfileSelection()
+    .should('contain.text', ctx.testData.hardwareProfileDisplayName);
+  modelServingWizard.selectServingRuntimeOption(FIXTURE.servingRuntime);
+  modelServingWizard.findNextButton().should('be.enabled').click();
+  modelServingWizard.findNextButton().click();
+  modelServingWizard.findSubmitButton().click();
+
+  modelServingSection
+    .getKServeRow(modelName)
+    .find()
+    .findByTestId('deployed-model-name', { timeout: TAB_READY_TIMEOUT })
+    .should('contain.text', modelName);
+};
+
+const verifyKueueStatusAndResourcesModal = (
+  ctx: TestContext,
+  modelName: string,
+  expectedStatus: string,
+  expectWaitingForQuota: boolean,
+) => {
+  const row = modelServingSection.getKServeRow(modelName);
+  row.findStatusLabel(expectedStatus, TAB_READY_TIMEOUT);
+
+  if (expectWaitingForQuota) {
+    row.findStatusSubtitle().should(($el) => {
+      const text = $el.text();
+      expect(
+        text.includes(FIXTURE.waitingForQuotaMessage) || QUEUE_POSITION_REGEX.test(text),
+      ).to.eq(true);
+    });
+  } else {
+    row.findStatusSubtitle().invoke('text').should('match', QUEUE_POSITION_REGEX);
+  }
+
+  row.findStatusLabel().click();
+  cy.findByTestId('deployment-status-modal').should('be.visible');
+  cy.findByTestId('deployment-status-resources-tab').click();
+  cy.findByTestId('cluster-queue-section').should('be.visible');
+  cy.findByTestId('queue-value').should('contain.text', ctx.testData.clusterQueueName);
+  cy.findByTestId('quotas-section').should('be.visible');
+  cy.findByTestId('deployment-status-modal').find('[aria-label="Close"]').click();
+};
+
+const setupProject = (
+  projectSuffix: string,
+  uuid: string,
+  cpuQuota: number,
+  memoryQuota: number,
+): Cypress.Chainable<TestContext> => {
+  const ctx: TestContext = {
+    projectName: `${FIXTURE.projectName}-${projectSuffix}-${uuid}`,
+    testData: buildKueueConfig(uuid, cpuQuota, memoryQuota),
+  };
+  return deleteOpenShiftProject(ctx.projectName, { wait: true, ignoreNotFound: true })
+    .then(() => createOpenShiftProject(ctx.projectName))
+    .then(() => setupKueueModelDeploymentResources(ctx.testData, ctx.projectName))
+    .then(() => ctx);
+};
+
+describeAdminOnly('Model deployment Kueue status tests', () => {
+  beforeEach(() => {
+    cy.on('uncaught:exception', (err) => {
+      if (err.message.includes("Cannot read properties of undefined (reading 'data')")) {
+        return false;
+      }
+      return undefined;
+    });
+  });
+
+  describe('Inadmissible with zero quota', () => {
+    let ctx: TestContext;
+    const uuid = generateTestUUID();
+    const modelName = `kueue-md-inad-${uuid}`;
+
+    retryableBefore(() =>
+      setupProject(
+        'inad',
+        uuid,
+        FIXTURE.inadmissibleCpuQuota,
+        FIXTURE.inadmissibleMemoryQuota,
+      ).then((projectCtx) => {
+        ctx = projectCtx;
+      }),
+    );
+
+    after(() => {
+      cleanupKueueWorkbenchResources(ctx.testData, ctx.projectName);
+      deleteOpenShiftProject(ctx.projectName, { wait: false, ignoreNotFound: true });
+    });
+
+    it(
+      'Verify model deployment shows Inadmissible when ClusterQueue quota is zero',
+      { tags: TEST_TAGS },
+      () => {
+        openModelServerTab(ctx, true);
+        deployModelViaWizard(ctx, modelName);
+        pollUntilAnyWorkloadMessageMatches(ctx.projectName, INADMISSIBLE_MESSAGE);
+        openModelServerTab(ctx);
+        verifyKueueStatusAndResourcesModal(ctx, modelName, FIXTURE.inadmissibleStatus, false);
+      },
+    );
+  });
+
+  describe('Queued when quota is fully consumed', () => {
+    let ctx: TestContext;
+    const uuid = generateTestUUID();
+    const firstModelName = `kueue-md-q1-${uuid}`;
+    const secondModelName = `kueue-md-q2-${uuid}`;
+
+    retryableBefore(() =>
+      setupProject('queued', uuid, FIXTURE.queuedCpuQuota, FIXTURE.queuedMemoryQuota).then(
+        (projectCtx) => {
+          ctx = projectCtx;
+        },
+      ),
+    );
+
+    after(() => {
+      cleanupKueueWorkbenchResources(ctx.testData, ctx.projectName);
+      deleteOpenShiftProject(ctx.projectName, { wait: false, ignoreNotFound: true });
+    });
+
+    it(
+      'Verify model deployment shows Queued when ClusterQueue quota is consumed by another deployment',
+      { tags: TEST_TAGS },
+      () => {
+        openModelServerTab(ctx, true);
+        deployModelViaWizard(ctx, firstModelName);
+        pollUntilWorkloadAdmitted(ctx.projectName, { maxAttempts: 120, pollIntervalMs: 5000 });
+        openModelServerTab(ctx);
+        deployModelViaWizard(ctx, secondModelName);
+        pollUntilAnyWorkloadMessageMatches(ctx.projectName, QUEUED_MESSAGE);
+        openModelServerTab(ctx);
+        verifyKueueStatusAndResourcesModal(ctx, secondModelName, FIXTURE.queuedStatus, true);
+      },
+    );
+  });
+});

--- a/packages/cypress/cypress/utils/oc_commands/kueueModelDeployment.ts
+++ b/packages/cypress/cypress/utils/oc_commands/kueueModelDeployment.ts
@@ -1,0 +1,99 @@
+import { applyOpenShiftYaml, type PollOptions } from './baseCommands';
+import {
+  addKueueLabelToNamespace,
+  createKueueWorkbenchResources,
+  type KueueWorkbenchConfig,
+} from './kueueWorkbench';
+import type { CommandLineResult } from '../../types';
+
+const applicationNamespace = Cypress.env('APPLICATIONS_NAMESPACE');
+
+const pollOcStdout = (
+  command: string,
+  isDone: (stdout: string) => boolean,
+  waitingMessage: string,
+  failureMessage: (stdout: string, stderr: string, elapsed: string) => string,
+  { maxAttempts = 60, pollIntervalMs = 5000 }: PollOptions = {},
+): Cypress.Chainable<string> => {
+  const startTime = Date.now();
+
+  const check = (attemptNumber = 1): Cypress.Chainable<string> =>
+    cy.exec(command, { failOnNonZeroExit: false }).then((result) => {
+      const stdout = result.stdout.trim();
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+      if (isDone(stdout)) {
+        return cy.wrap(stdout);
+      }
+
+      if (attemptNumber >= maxAttempts) {
+        throw new Error(failureMessage(stdout, result.stderr.trim(), elapsed));
+      }
+
+      cy.log(`${waitingMessage} (attempt ${attemptNumber}/${maxAttempts}, elapsed: ${elapsed}s)`);
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      return cy.wait(pollIntervalMs).then(() => check(attemptNumber + 1));
+    });
+
+  return check();
+};
+
+const createKueueModelServingHardwareProfile = (
+  config: KueueWorkbenchConfig,
+): Cypress.Chainable<CommandLineResult> =>
+  cy.fixture('resources/hardwareProfile/kueue_model_serving_profile.yaml').then((yamlTemplate) => {
+    const variables = {
+      hardwareProfileName: config.hardwareProfileName,
+      hardwareProfileNamespace: applicationNamespace,
+      displayName: config.hardwareProfileDisplayName,
+      localQueueName: config.localQueueName,
+    };
+
+    let yamlContent = yamlTemplate;
+    Object.keys(variables).forEach((key) => {
+      const regex = new RegExp(`\\$\\{${key}\\}`, 'g');
+      yamlContent = yamlContent.replace(regex, String(variables[key as keyof typeof variables]));
+    });
+
+    return applyOpenShiftYaml(yamlContent, applicationNamespace);
+  });
+
+export const setupKueueModelDeploymentResources = (
+  config: KueueWorkbenchConfig,
+  namespace: string,
+): Cypress.Chainable<CommandLineResult> =>
+  addKueueLabelToNamespace(namespace)
+    .then(() =>
+      cy.exec(`oc label namespace ${namespace} modelmesh-enabled=false --overwrite`, {
+        failOnNonZeroExit: false,
+      }),
+    )
+    .then(() => createKueueWorkbenchResources(config, namespace))
+    .then(() => createKueueModelServingHardwareProfile(config));
+
+export const pollUntilWorkloadAdmitted = (
+  namespace: string,
+  options?: PollOptions,
+): Cypress.Chainable<string> =>
+  pollOcStdout(
+    `oc get workloads.kueue.x-k8s.io -n ${namespace} -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Admitted")].status}{"\\n"}{end}'`,
+    (stdout) => stdout.includes('True'),
+    `Waiting for Kueue Workload admission in ${namespace}`,
+    (stdout, stderr, elapsed) =>
+      `Kueue Workload not admitted in ${namespace} (${elapsed}s). stdout: "${stdout}", stderr: "${stderr}"`,
+    options,
+  );
+
+export const pollUntilAnyWorkloadMessageMatches = (
+  namespace: string,
+  messagePattern: RegExp,
+  options?: PollOptions,
+): Cypress.Chainable<string> =>
+  pollOcStdout(
+    `oc get workloads -n ${namespace} -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="QuotaReserved")].message}{"\\n"}{end}'`,
+    (stdout) => !!stdout && messagePattern.test(stdout),
+    `Waiting for Kueue Workload message in ${namespace}`,
+    (stdout, stderr, elapsed) =>
+      `Kueue Workload message did not match ${messagePattern} in ${namespace} (${elapsed}s). messages: "${stdout}", stderr: "${stderr}"`,
+    options,
+  );

--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -74,6 +74,47 @@ export const deleteOpenShiftProject = (
   });
 };
 
+/** Deletes a project without waiting; logs failures but does not throw (for after hooks). */
+export const deleteOpenShiftProjectBestEffort = (
+  projectName: string,
+): Cypress.Chainable<CommandLineResult> =>
+  cy
+    .exec(`oc delete project ${projectName} --wait=false --ignore-not-found`, {
+      failOnNonZeroExit: false,
+    })
+    .then((result) => {
+      if (result.exitCode !== 0) {
+        cy.log(
+          `WARNING: best-effort delete of ${projectName} returned exit ${result.exitCode}: ${result.stderr}`,
+        );
+      }
+      return cy.wrap(result);
+    });
+
+/** Deletes any existing project, waits until it is gone, then creates a fresh one. */
+export const recreateOpenShiftProject = (
+  projectName: string,
+): Cypress.Chainable<CommandLineResult> => {
+  const waitUntilGone = (attempt = 1): Cypress.Chainable<void> =>
+    verifyOpenShiftProjectExists(projectName).then((exists): Cypress.Chainable<void> => {
+      if (!exists) {
+        return cy.wrap(undefined as void);
+      }
+      if (attempt >= 60) {
+        throw new Error(`Project ${projectName} still exists after cleanup`);
+      }
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      return cy.wait(2000).then(() => waitUntilGone(attempt + 1));
+    });
+
+  return cy
+    .exec(`oc delete project ${projectName} --wait=false --ignore-not-found`, {
+      failOnNonZeroExit: false,
+    })
+    .then(() => waitUntilGone())
+    .then(() => createOpenShiftProject(projectName));
+};
+
 /**
  * Assign a role to a user for an specific Project
  *


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-85482

## Description

Adds Cypress E2E for Kueue **model deployment status** ([RHOAIENG-85482](https://issues.redhat.com/browse/RHOAIENG-85482)) — **Inadmissible** and **Queued** only.

- **Inadmissible:** zero-quota ClusterQueue → deploy → assert status, queue position, status modal Resources tab
- **Queued:** 3 CPU / 9Gi quota → first deploy admits → second deploy → assert Queued + modal

Setup: Kueue project + model-serving HP (`scheduling.type: Queue`), wizard deploy (`hf://facebook/opt-125m`, vLLM CPU). Skipped when `IS_NON_ADMIN_RUN` is set.

## How Has This Been Tested?

- `eslint` on changed Cypress files
- Live run on **dash-e2e-rhoai** as `ldap-admin1` — both tests passed

```bash
export CY_TEST_CONFIG=/path/to/test-variables.yml
oc login -u ldap-admin1 --server=<OCP_API_URL>
cd frontend
npm run cypress:run -- --spec ../packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelDeploymentKueueLifecycle.cy.ts
```

## Test Impact
<img width="1459" height="700" alt="Screenshot 2026-08-27 at 3 08 23 PM" src="https://github.com/user-attachments/assets/e0fb5312-912f-45df-a384-a4fcc8866712" />


New spec: `testModelDeploymentKueueLifecycle.cy.ts`  
Tags: `@Kueue`, `@Dashboard`, `@ModelServing`, `@Featureflagged`, `@NonConcurrent`

## Request review criteria

- [x] Manually tested on cluster
- [x] Testing instructions added
- [x] Tests added
- [x] Follows [Best Practices](/docs/best-practices.md)
- [ ] Tested with PR image before merge
CJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring hardware profiles for Kueue-managed model serving.
  * Added end-to-end coverage for model deployments that are blocked by unavailable quota or queued until resources become available.
  * Deployment status checks now include status subtitles and support selecting enabled or disabled hardware profiles.

* **Tests**
  * Added automated validation for workload admission, queue status, resource quotas, and deployment lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-85482]: https://redhat.atlassian.net/browse/RHOAIENG-85482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ