### PR TITLE
modal for project not in kueue

### DIFF
--- a/packages/gpuaas/src/components/InfrastructureKueueHelpLink.tsx
+++ b/packages/gpuaas/src/components/InfrastructureKueueHelpLink.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { Button, Content, Popover } from '@patternfly/react-core';
+import NonKueueManagedProjectsModal from './NonKueueManagedProjectsModal';
+import {
+  KUEUE_HELP_LINK_TEXT,
+  KUEUE_HELP_POPOVER_BODY,
+  KUEUE_HELP_VIEW_PROJECTS_LINK,
+} from '../const';
+import useNonKueueManagedProjects from '../hooks/useNonKueueManagedProjects';
+
+const InfrastructureKueueHelpLink: React.FC = () => {
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const { projects, loaded, error } = useNonKueueManagedProjects();
+
+  const closePopover = (event: MouseEvent | KeyboardEvent) => {
+    setIsPopoverOpen(false);
+    if (event instanceof KeyboardEvent) {
+      requestAnimationFrame(() => triggerRef.current?.focus());
+    }
+  };
+
+  const openModal = () => {
+    setIsPopoverOpen(false);
+    setIsModalOpen(true);
+  };
+
+  return (
+    <>
+      <Popover
+        isVisible={isPopoverOpen}
+        shouldOpen={() => setIsPopoverOpen(true)}
+        shouldClose={closePopover}
+        showClose
+        withFocusTrap={false}
+        bodyContent={
+          <>
+            <Content component="p">{KUEUE_HELP_POPOVER_BODY}</Content>
+            <Button
+              variant="link"
+              isInline
+              onClick={openModal}
+              data-testid="view-non-kueue-managed-projects-link"
+            >
+              {KUEUE_HELP_VIEW_PROJECTS_LINK}
+            </Button>
+          </>
+        }
+      >
+        <Button
+          ref={triggerRef}
+          variant="link"
+          isInline
+          data-testid="infrastructure-kueue-help-link"
+        >
+          {KUEUE_HELP_LINK_TEXT}
+        </Button>
+      </Popover>
+      {isModalOpen && (
+        <NonKueueManagedProjectsModal
+          projects={projects}
+          loaded={loaded}
+          error={error}
+          onClose={() => setIsModalOpen(false)}
+        />
+      )}
+    </>
+  );
+};
+
+export default InfrastructureKueueHelpLink;

--- a/packages/gpuaas/src/components/NonKueueManagedProjectsModal.tsx
+++ b/packages/gpuaas/src/components/NonKueueManagedProjectsModal.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+/* eslint-disable @odh-dashboard/no-restricted-imports */
+import {
+  Alert,
+  Bullseye,
+  Button,
+  Label,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  SearchInput,
+  Spinner,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { Tr, Td } from '@patternfly/react-table';
+import { DashboardEmptyTableView, Table } from '@odh-dashboard/ui-core';
+import type { SortableData } from '@odh-dashboard/ui-core';
+/* eslint-enable @odh-dashboard/no-restricted-imports */
+import { getDisplayNameFromK8sResource, type ProjectKind } from '@odh-dashboard/k8s-core';
+import {
+  NON_KUEUE_PROJECTS_MODAL_DESCRIPTION,
+  NON_KUEUE_PROJECTS_MODAL_TITLE,
+  NON_KUEUE_PROJECT_STATUS_LABEL,
+} from '../const';
+
+type NonKueueManagedProjectsModalProps = {
+  projects: ProjectKind[];
+  loaded: boolean;
+  error?: Error;
+  onClose: () => void;
+};
+
+const columns: SortableData<ProjectKind>[] = [
+  {
+    field: 'name',
+    label: 'Name',
+    sortable: (a, b) =>
+      getDisplayNameFromK8sResource(a).localeCompare(getDisplayNameFromK8sResource(b)),
+  },
+  {
+    field: 'status',
+    label: 'Status',
+    sortable: false,
+  },
+];
+
+const NonKueueManagedProjectsModal: React.FC<NonKueueManagedProjectsModalProps> = ({
+  projects,
+  loaded,
+  error,
+  onClose,
+}) => {
+  const [filterText, setFilterText] = React.useState('');
+
+  const filteredProjects = React.useMemo(() => {
+    const normalized = filterText.trim().toLowerCase();
+    if (!normalized) {
+      return projects;
+    }
+
+    return projects.filter((project) => {
+      const displayName = getDisplayNameFromK8sResource(project).toLowerCase();
+      const name = project.metadata.name.toLowerCase();
+      return displayName.includes(normalized) || name.includes(normalized);
+    });
+  }, [filterText, projects]);
+
+  const onClearFilters = React.useCallback(() => {
+    setFilterText('');
+  }, []);
+
+  return (
+    <Modal
+      isOpen
+      variant="medium"
+      onClose={onClose}
+      data-testid="non-kueue-managed-projects-modal"
+      aria-labelledby="non-kueue-managed-projects-modal-title"
+    >
+      <ModalHeader
+        title={NON_KUEUE_PROJECTS_MODAL_TITLE}
+        labelId="non-kueue-managed-projects-modal-title"
+        description={NON_KUEUE_PROJECTS_MODAL_DESCRIPTION}
+      />
+      <ModalBody>
+        {error && (
+          <Alert
+            className="pf-v6-u-mb-md"
+            data-testid="non-kueue-managed-projects-error"
+            variant="danger"
+            isInline
+            title={error.message}
+          />
+        )}
+        {!loaded ? (
+          <Bullseye className="pf-v6-u-p-lg" data-testid="non-kueue-managed-projects-loading">
+            <Spinner />
+          </Bullseye>
+        ) : (
+          <Table
+            data-testid="non-kueue-managed-projects-table"
+            aria-label="Projects not managed by Kueue table"
+            variant="compact"
+            enablePagination="compact"
+            data={filteredProjects}
+            columns={columns}
+            toolbarContent={
+              <ToolbarGroup>
+                <ToolbarItem>
+                  <SearchInput
+                    aria-label="Find by name"
+                    placeholder="Find by name"
+                    value={filterText}
+                    onChange={(_event, value) => setFilterText(value)}
+                    onClear={() => setFilterText('')}
+                    data-testid="non-kueue-managed-projects-search"
+                  />
+                </ToolbarItem>
+              </ToolbarGroup>
+            }
+            emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
+            onClearFilters={onClearFilters}
+            rowRenderer={(project) => (
+              <Tr key={project.metadata.uid ?? project.metadata.name}>
+                <Td dataLabel="Name">{getDisplayNameFromK8sResource(project)}</Td>
+                <Td dataLabel="Status">
+                  <Label color="grey">{NON_KUEUE_PROJECT_STATUS_LABEL}</Label>
+                </Td>
+              </Tr>
+            )}
+          />
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          data-testid="non-kueue-managed-projects-close-button"
+          variant="primary"
+          onClick={onClose}
+        >
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default NonKueueManagedProjectsModal;

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -1,3 +1,15 @@
+export const INFRASTRUCTURE_PAGE_DESCRIPTION =
+  'View accelerator utilization, cluster queue cohort configuration, and workload details.';
+
+export const KUEUE_HELP_LINK_TEXT = "Not seeing what you're looking for?";
+export const KUEUE_HELP_POPOVER_BODY =
+  "This page shows data from projects managed by Kueue. Projects without a local queue aren't part of queue-based resource management.";
+export const KUEUE_HELP_VIEW_PROJECTS_LINK = 'View projects not managed by Kueue';
+export const NON_KUEUE_PROJECTS_MODAL_TITLE = 'Projects not managed by Kueue';
+export const NON_KUEUE_PROJECTS_MODAL_DESCRIPTION =
+  'Data from the following projects is not displayed on the Infrastructure page because they do not use Kueue for workload admission.';
+export const NON_KUEUE_PROJECT_STATUS_LABEL = 'not Kueue-managed';
+
 export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
 
 export const TREND_REFRESH_INTERVAL = 5 * 60 * 1000;

--- a/packages/gpuaas/src/hooks/useNonKueueManagedProjects.ts
+++ b/packages/gpuaas/src/hooks/useNonKueueManagedProjects.ts
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import type { ProjectKind } from '@odh-dashboard/k8s-core';
+import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
+import { getNonKueueManagedDataScienceProjects } from '../utils/kueueProjects';
+
+type UseNonKueueManagedProjectsResult = {
+  projects: ProjectKind[];
+  loaded: boolean;
+  error: Error | undefined;
+};
+
+const useNonKueueManagedProjects = (): UseNonKueueManagedProjectsResult => {
+  const [allProjects, loaded, error] = useProjects();
+
+  const projects = React.useMemo(
+    () => getNonKueueManagedDataScienceProjects(allProjects),
+    [allProjects],
+  );
+
+  return { projects, loaded, error };
+};
+
+export default useNonKueueManagedProjects;

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -22,7 +22,12 @@ import {
 } from '@patternfly/react-core';
 import { ClusterIcon, MicrochipIcon, SyncAltIcon } from '@patternfly/react-icons';
 import { relativeTime } from '@odh-dashboard/internal/utilities/time';
-import { INFRASTRUCTURE_SECTIONS, INFRASTRUCTURE_TABS } from '../const';
+import {
+  INFRASTRUCTURE_PAGE_DESCRIPTION,
+  INFRASTRUCTURE_SECTIONS,
+  INFRASTRUCTURE_TABS,
+} from '../const';
+import InfrastructureKueueHelpLink from '../components/InfrastructureKueueHelpLink';
 import { GPUAAS_EVENTS, type PageViewedProperties } from '../tracking/gpuaasTrackingConstants';
 import ClusterSummaryCards from '../components/ClusterSummaryCards';
 import HardwareUsageSection from '../components/HardwareUsageSection';
@@ -113,7 +118,17 @@ const InfrastructurePage: React.FC = () => {
   return (
     <ApplicationsPage
       title="Infrastructure"
-      description="Current accelerator allocation and quota consumption for this cluster. Cluster queues are grouped into cohorts to share resources."
+      description={
+        <>
+          {INFRASTRUCTURE_PAGE_DESCRIPTION}
+          {isKueueAvailable && (
+            <>
+              {' '}
+              <InfrastructureKueueHelpLink />
+            </>
+          )}
+        </>
+      }
       loaded
       empty={false}
       provideChildrenPadding

--- a/packages/gpuaas/src/utils/__tests__/kueueProjects.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/kueueProjects.spec.ts
@@ -1,0 +1,59 @@
+import { KnownLabels } from '@odh-dashboard/k8s-core';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import {
+  getNonKueueManagedDataScienceProjects,
+  isNonKueueManagedDataScienceProject,
+} from '../kueueProjects';
+
+describe('kueueProjects', () => {
+  const kueueManagedProject = mockProjectK8sResource({
+    k8sName: 'kueue-project',
+    enableKueue: true,
+  });
+  const nonKueueDsProject = mockProjectK8sResource({
+    k8sName: 'legacy-batch',
+    enableKueue: false,
+  });
+  const nonDsProject = mockProjectK8sResource({
+    k8sName: 'system-project',
+    isDSProject: false,
+    enableKueue: false,
+  });
+
+  describe('isNonKueueManagedDataScienceProject', () => {
+    it('should return true for data science projects without the Kueue managed label', () => {
+      expect(isNonKueueManagedDataScienceProject(nonKueueDsProject)).toBe(true);
+    });
+
+    it('should return false for Kueue-managed data science projects', () => {
+      expect(isNonKueueManagedDataScienceProject(kueueManagedProject)).toBe(false);
+    });
+
+    it('should return false for projects without the dashboard label', () => {
+      expect(isNonKueueManagedDataScienceProject(nonDsProject)).toBe(false);
+    });
+
+    it('should return false when the Kueue managed label is not true', () => {
+      const project = mockProjectK8sResource({ k8sName: 'false-label-project' });
+      project.metadata.labels = {
+        ...project.metadata.labels,
+        [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        [KnownLabels.KUEUE_MANAGED]: 'false',
+      };
+
+      expect(isNonKueueManagedDataScienceProject(project)).toBe(true);
+    });
+  });
+
+  describe('getNonKueueManagedDataScienceProjects', () => {
+    it('should return only non-Kueue-managed data science projects', () => {
+      expect(
+        getNonKueueManagedDataScienceProjects([
+          kueueManagedProject,
+          nonKueueDsProject,
+          nonDsProject,
+        ]).map((project) => project.metadata.name),
+      ).toEqual(['legacy-batch']);
+    });
+  });
+});

--- a/packages/gpuaas/src/utils/kueueProjects.ts
+++ b/packages/gpuaas/src/utils/kueueProjects.ts
@@ -1,0 +1,7 @@
+import { isAiProject, KnownLabels, type ProjectKind } from '@odh-dashboard/k8s-core';
+
+export const isNonKueueManagedDataScienceProject = (project: ProjectKind): boolean =>
+  isAiProject(project) && project.metadata.labels?.[KnownLabels.KUEUE_MANAGED] !== 'true';
+
+export const getNonKueueManagedDataScienceProjects = (projects: ProjectKind[]): ProjectKind[] =>
+  projects.filter(isNonKueueManagedDataScienceProject);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79840
## Description
Adds a modal for viewing Data Science Projects that are not managed by Kueue.

The Infrastructure page now:
- Displays a Kueue help link and popover.
- Provides a link to view projects that are not managed by Kueue.
- Loads and filters non-Kueue-managed Data Science Projects.
- Displays project names and their Kueue management status in a searchable, paginated table.
- Handles loading, error, and empty states.

https://github.com/user-attachments/assets/b2d1594b-168e-4b11-955d-3ff1ceab8399


<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Manual testing instructions:

1. Open the GPU infrastructure page.
2. Locate the Kueue information link.
3. Open the help popover.
4. Select “View projects”.
5. Verify that the modal displays non-Kueue-managed Data Science Projects.
6. Verify project search and pagination.
7. Verify loading, error, and empty states.
8. Verify that closing the modal returns to the infrastructure page.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added unit tests for Kueue project filtering:

- Includes Data Science Projects without the Kueue-managed label.
- Excludes Kueue-managed projects.
- Excludes projects without the Dashboard resource label.
- Treats a Kueue label value other than `"true"` as not managed by Kueue.
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual help on the Infrastructure page for Kueue-managed projects.
  * Added a modal to view projects not managed by Kueue.
  * Added project search, sorting, pagination, status labels, loading states, and error handling.
  * Added an empty-state option to clear filters and improved keyboard focus handling.
* **Tests**
  * Added coverage for identifying and filtering non-Kueue-managed data science projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->