### PR TITLE
fix(e2e): wait for dashboard label and Active before project list lookup

### DIFF
--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -126,7 +126,7 @@ class ProjectListPage {
   }
 
   findProjectLink(projectName: string) {
-    return this.findProjectsTable().findByRole('link', { name: projectName, timeout: 30000 });
+    return this.findProjectsTable().findByRole('link', { name: projectName });
   }
 
   findEmptyResults() {

--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -126,7 +126,7 @@ class ProjectListPage {
   }
 
   findProjectLink(projectName: string) {
-    return this.findProjectsTable().findByRole('link', { name: projectName });
+    return this.findProjectsTable().findByRole('link', { name: projectName, timeout: 30000 });
   }
 
   findEmptyResults() {

--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -1,4 +1,4 @@
-import { pollUntilSuccess } from './baseCommands';
+import { pollUntilSuccess, waitForNamespace } from './baseCommands';
 import type { CommandLineResult, DashboardConfig } from '../../types';
 import { handleOCCommandResult } from '../errorHandling';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
@@ -25,18 +25,53 @@ export const createOpenShiftProject = (
                 stderr: ${result.stderr}`);
       throw new Error(`Command failed with code ${result.exitCode}`);
     }
-    // Add dashboard label immediately after project creation
-    const labelCommand = `oc label namespace ${projectName} opendatahub.io/dashboard=true --overwrite`;
-    return cy.exec(labelCommand, { failOnNonZeroExit: false }).then((labelResult) => {
-      if (labelResult.exitCode !== 0) {
-        cy.log(`WARNING: Failed to add dashboard label to ${projectName}
-                  stdout: ${labelResult.stdout}
-                  stderr: ${labelResult.stderr}`);
-      }
-      return cy.wrap(result);
-    });
+
+    // oc new-project can return before the Namespace object is patchable.
+    // Labeling immediately then treating a failed label as a warning leaves the
+    // project invisible in the dashboard A.I. projects filter.
+    return waitForNamespace(projectName, 30, 1000)
+      .then(() => applyDashboardLabel(projectName))
+      .then(() => waitForProjectReadyForDashboard(projectName))
+      .then(() => cy.wrap(result));
   });
 };
+
+/**
+ * Apply the dashboard label that `isAiProject` / the default projects-table filter require.
+ * Fail the test if the label cannot be applied — a missing label is not recoverable in the UI.
+ */
+const applyDashboardLabel = (projectName: string): Cypress.Chainable<Cypress.Exec> => {
+  const labelCommand = `oc label namespace ${projectName} opendatahub.io/dashboard=true --overwrite`;
+  return cy.exec(labelCommand, { failOnNonZeroExit: false }).then((labelResult) => {
+    if (labelResult.exitCode !== 0) {
+      throw new Error(
+        `Failed to add dashboard label to ${projectName}: ${
+          labelResult.stderr || labelResult.stdout
+        }`,
+      );
+    }
+    return labelResult;
+  });
+};
+
+/**
+ * Wait until the project is visible to the dashboard: dashboard label set and status Active.
+ * The UI watch lists Projects and client-filters to Active + opendatahub.io/dashboard=true.
+ */
+export const waitForProjectReadyForDashboard = (
+  projectName: string,
+): Cypress.Chainable<Cypress.Exec> =>
+  pollUntilSuccess(
+    `oc get namespace ${projectName} -o json | jq -e '.metadata.labels["opendatahub.io/dashboard"] == "true"'`,
+    `dashboard label on namespace ${projectName}`,
+    { maxAttempts: 15, pollIntervalMs: 1000 },
+  ).then(() =>
+    pollUntilSuccess(
+      `oc get project ${projectName} -o json | jq -e '.status.phase == "Active"'`,
+      `project ${projectName} phase Active`,
+      { maxAttempts: 15, pollIntervalMs: 1000 },
+    ),
+  );
 
 /**
  * Delete an OpenShift Project given its name

--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -26,52 +26,27 @@ export const createOpenShiftProject = (
       throw new Error(`Command failed with code ${result.exitCode}`);
     }
 
-    // oc new-project can return before the Namespace object is patchable.
-    // Labeling immediately then treating a failed label as a warning leaves the
-    // project invisible in the dashboard A.I. projects filter.
-    return waitForNamespace(projectName, 30, 1000)
-      .then(() => applyDashboardLabel(projectName))
-      .then(() => waitForProjectReadyForDashboard(projectName))
-      .then(() => cy.wrap(result));
+    // Wait until the namespace is patchable, then require the dashboard label
+    // and Active phase so the A.I. projects filter can see it.
+    return waitForNamespace(projectName, 30, 1000).then(() => {
+      const labelCommand = `oc label namespace ${projectName} opendatahub.io/dashboard=true --overwrite`;
+      return cy.exec(labelCommand, { failOnNonZeroExit: false }).then((labelResult) => {
+        if (labelResult.exitCode !== 0) {
+          throw new Error(
+            `Failed to add dashboard label to ${projectName}: ${
+              labelResult.stderr || labelResult.stdout
+            }`,
+          );
+        }
+        return pollUntilSuccess(
+          `oc get project ${projectName} -o json | jq -e '.metadata.labels["opendatahub.io/dashboard"] == "true" and .status.phase == "Active"'`,
+          `project ${projectName} dashboard-ready`,
+          { maxAttempts: 15, pollIntervalMs: 1000 },
+        ).then(() => cy.wrap(result));
+      });
+    });
   });
 };
-
-/**
- * Apply the dashboard label that `isAiProject` / the default projects-table filter require.
- * Fail the test if the label cannot be applied — a missing label is not recoverable in the UI.
- */
-const applyDashboardLabel = (projectName: string): Cypress.Chainable<Cypress.Exec> => {
-  const labelCommand = `oc label namespace ${projectName} opendatahub.io/dashboard=true --overwrite`;
-  return cy.exec(labelCommand, { failOnNonZeroExit: false }).then((labelResult) => {
-    if (labelResult.exitCode !== 0) {
-      throw new Error(
-        `Failed to add dashboard label to ${projectName}: ${
-          labelResult.stderr || labelResult.stdout
-        }`,
-      );
-    }
-    return labelResult;
-  });
-};
-
-/**
- * Wait until the project is visible to the dashboard: dashboard label set and status Active.
- * The UI watch lists Projects and client-filters to Active + opendatahub.io/dashboard=true.
- */
-export const waitForProjectReadyForDashboard = (
-  projectName: string,
-): Cypress.Chainable<Cypress.Exec> =>
-  pollUntilSuccess(
-    `oc get namespace ${projectName} -o json | jq -e '.metadata.labels["opendatahub.io/dashboard"] == "true"'`,
-    `dashboard label on namespace ${projectName}`,
-    { maxAttempts: 15, pollIntervalMs: 1000 },
-  ).then(() =>
-    pollUntilSuccess(
-      `oc get project ${projectName} -o json | jq -e '.status.phase == "Active"'`,
-      `project ${projectName} phase Active`,
-      { maxAttempts: 15, pollIntervalMs: 1000 },
-    ),
-  );
 
 /**
  * Delete an OpenShift Project given its name

--- a/packages/cypress/cypress/utils/projectChecker.ts
+++ b/packages/cypress/cypress/utils/projectChecker.ts
@@ -5,17 +5,16 @@ import {
 } from './oc_commands/project';
 import { ensureAdminOcSession } from './oc_commands/baseCommands';
 
-export const createAndVerifyProject = (projectName: string): void => {
+export const createAndVerifyProject = (projectName: string): Cypress.Chainable<boolean> =>
   createOpenShiftProject(projectName).then((result) => {
     expect(result.exitCode).to.equal(0);
+    return verifyOpenShiftProjectExists(projectName).then((exists) => {
+      if (!exists) {
+        throw new Error(`Expected project ${projectName} to exist, but it does not.`);
+      }
+      return cy.wrap(true);
+    });
   });
-
-  verifyOpenShiftProjectExists(projectName).then((exists) => {
-    if (!exists) {
-      throw new Error(`Expected project ${projectName} to exist, but it does not.`);
-    }
-  });
-};
 
 // Best-effort cleanup for after() hooks — failures are logged, never thrown.
 export const cleanupTestProject = (projectName: string): void => {
@@ -31,11 +30,11 @@ export const cleanupTestProject = (projectName: string): void => {
   });
 };
 
-export const createCleanProject = (projectName: string): void => {
+export const createCleanProject = (projectName: string): Cypress.Chainable<boolean> =>
   verifyOpenShiftProjectExists(projectName).then((exists) => {
     if (exists) {
       cy.log(`Project ${projectName} already exists. Deleting it.`);
-      deleteOpenShiftProject(projectName, { wait: true }).then(() => {
+      return deleteOpenShiftProject(projectName, { wait: true }).then(() => {
         // Verify the project is actually gone before creating a new one
         // Projects can be in "Terminating" state even after delete --wait returns
         cy.log(`Waiting for project ${projectName} to be fully deleted...`);
@@ -52,14 +51,12 @@ export const createCleanProject = (projectName: string): void => {
             },
           );
         };
-        checkDeleted().then(() => {
+        return checkDeleted().then(() => {
           cy.log(`Creating project ${projectName}`);
-          createAndVerifyProject(projectName);
+          return createAndVerifyProject(projectName);
         });
       });
-    } else {
-      cy.log(`Creating project ${projectName}`);
-      createAndVerifyProject(projectName);
     }
+    cy.log(`Creating project ${projectName}`);
+    return createAndVerifyProject(projectName);
   });
-};


### PR DESCRIPTION
## Description
`oc new-project` can return before the namespace is patchable. Cypress was labeling immediately, treating label failure as a warning, then treating `oc get project` as ready. The projects table defaults to A.I. projects (`opendatahub.io/dashboard=true` + `Active`), so the lookup missed the row.

Wait for the namespace, apply the dashboard label (fail if it cannot), then wait until labeled + Active before returning.

## How Has This Been Tested?
Ran `testProjectEditing.cy.ts` on a live cluster (`dash-e2e-odh`). Create waited for namespace, label, and Active; the projects table found the link. Passed in 32s.

## Test Impact
This is a Cypress helper fix used by project-list specs (`testWorkbenchStatus`, `testFeatureStoreWorkbenchConnect`, `testProjectEditing`). No new specs.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`