### PR TITLE
feat(data-registry): implement volume registration flow

### DIFF
--- a/packages/data-registry/frontend/package-lock.json
+++ b/packages/data-registry/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.9.1",
         "@patternfly/patternfly": "~6.5.1",
         "@patternfly/react-core": "~6.5.1",
         "@patternfly/react-icons": "~6.5.1",
@@ -19,8 +20,10 @@
         "mod-arch-core": "^1.10.1",
         "react": "^18",
         "react-dom": "^18",
+        "react-hook-form": "^7.86.0",
         "react-router": "^7.16.0",
-        "react-router-dom": "^7.16.0"
+        "react-router-dom": "^7.16.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@module-federation/enhanced": "^0.24.1",
@@ -2412,6 +2415,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2440,6 +2460,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2461,6 +2488,116 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.9.1.tgz",
+      "integrity": "sha512-7b7vsbraJxKgjVSA1Nur9tLwj539WGJUBLA7QNvXnFoT2pM5Z7G+6rlukk4B2/QrTZy6huRtH6wKeESPKuIr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@sinclair/typebox": ">=0.25.24",
+        "@standard-schema/spec": "^1.0.0",
+        "@typeschema/main": ">=0.13.7",
+        "@vinejs/vine": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "ajv": "^8.12.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "arktype": "^2.0.0",
+        "ata-validator": "^1.2.0",
+        "class-transformer": ">=0.4.0",
+        "class-validator": ">=0.12.0",
+        "computed-types": "^1.0.0",
+        "effect": "^3.10.3",
+        "fluentvalidation-ts": "^3.0.0",
+        "fp-ts": "^2.7.0",
+        "io-ts": "^2.0.0",
+        "joi": "^17.0.0 || ^18.0.0",
+        "nope-validator": ">=0.12.0",
+        "react-hook-form": "^7.55.0",
+        "superstruct": ">=0.12.0",
+        "typanion": "^3.3.2",
+        "valibot": ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc",
+        "vest": ">=6.0.0",
+        "yup": "^1.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sinclair/typebox": {
+          "optional": true
+        },
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "@typeschema/main": {
+          "optional": true
+        },
+        "@vinejs/vine": {
+          "optional": true
+        },
+        "ajv": {
+          "optional": true
+        },
+        "ajv-errors": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "ata-validator": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        },
+        "computed-types": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "fluentvalidation-ts": {
+          "optional": true
+        },
+        "fp-ts": {
+          "optional": true
+        },
+        "io-ts": {
+          "optional": true
+        },
+        "joi": {
+          "optional": true
+        },
+        "nope-validator": {
+          "optional": true
+        },
+        "superstruct": {
+          "optional": true
+        },
+        "typanion": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "vest": {
+          "optional": true
+        },
+        "yup": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5004,6 +5141,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/core": {
       "version": "1.15.47",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
@@ -6768,16 +6911,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -6800,40 +6943,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-align": {
@@ -10902,6 +11011,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -10929,6 +11055,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
@@ -11431,6 +11564,40 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/file-loader/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/file-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/file-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-loader/node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -11783,6 +11950,33 @@
         "webpack": "^5.11.0"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -11842,6 +12036,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/minimatch": {
       "version": "3.1.5",
@@ -15340,9 +15541,9 @@
       "optional": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -18977,6 +19178,40 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/raw-loader/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/raw-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/raw-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/raw-loader/node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -19069,6 +19304,22 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.86.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.86.0.tgz",
+      "integrity": "sha512-4kbWJrh5jPZt1+YqVcXcGKffGcXV/XVbozknLh0Yjh0KhpoAkus21TAQhzRYqNwFkkObmnSvRlZZ3GT+ehoIrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is-18": {
@@ -19953,23 +20204,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/schema-utils/node_modules/ajv-keywords": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -19982,13 +20216,6 @@
       "peerDependencies": {
         "ajv": "^8.8.2"
       }
-    },
-    "node_modules/schema-utils/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -20321,13 +20548,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/serve/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -22663,6 +22883,40 @@
         }
       }
     },
+    "node_modules/url-loader/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/url-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/url-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/url-loader/node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -23834,6 +24088,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/packages/data-registry/frontend/package.json
+++ b/packages/data-registry/frontend/package.json
@@ -89,6 +89,7 @@
     "webpack-merge": "^6.0.1"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.9.1",
     "@patternfly/patternfly": "~6.5.1",
     "@patternfly/react-core": "~6.5.1",
     "@patternfly/react-icons": "~6.5.1",
@@ -99,8 +100,10 @@
     "mod-arch-core": "^1.10.1",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.86.0",
     "react-router": "^7.16.0",
-    "react-router-dom": "^7.16.0"
+    "react-router-dom": "^7.16.0",
+    "zod": "^4.4.3"
   },
   "optionalDependencies": {
     "@babel/preset-env": "^7.26.9",
@@ -109,11 +112,11 @@
     "@cypress/code-coverage": "^3.14.7",
     "@cypress/webpack-preprocessor": "^6.0.4",
     "@testing-library/cypress": "^10.0.3",
+    "@typescript-eslint/eslint-plugin": "^8.31.1",
+    "@typescript-eslint/parser": "^8.31.1",
     "cypress": "^15.16.0",
     "cypress-axe": "^1.5.0",
     "cypress-high-resolution": "^1.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.31.1",
-    "@typescript-eslint/parser": "^8.31.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-node": "^0.3.7",

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
@@ -52,6 +52,7 @@ const mockVolumesResponse = {
       owner: null,
       'created-at': '2026-01-01',
       'updated-at': null,
+      labels: ['source-docs'],
       properties: { description: 'PDF documents' },
       config: {},
     },
@@ -214,5 +215,150 @@ describe('Registry Table', () => {
     cy.findByTestId('confirm-delete-input').type('empty-collection');
     cy.findByTestId('confirm-delete-button').should('be.enabled').click();
     cy.wait('@deleteCollection');
+  });
+});
+
+describe('Register Volume', () => {
+  beforeEach(() => {
+    initIntercepts();
+  });
+
+  it('should open register data modal', () => {
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+    cy.findByTestId('register-volume-modal').should('exist');
+    cy.contains('Register data').should('exist');
+    cy.contains(
+      'Create a new data asset and configure its source location, metadata, and schema.',
+    ).should('exist');
+  });
+
+  it('should have register button disabled until name and collection are provided', () => {
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+
+    cy.findByTestId('register-volume-submit').should('be.disabled');
+
+    cy.findByTestId('volume-name-input').type('my-volume');
+    cy.findByTestId('register-volume-submit').should('be.disabled');
+
+    cy.findByTestId('volume-collection-toggle').click();
+    cy.contains('analytics').click();
+    cy.findByTestId('register-volume-submit').should('be.enabled');
+  });
+
+  it('should submit volume with all fields', () => {
+    cy.intercept('POST', `${REGISTRY_API}/test-project/namespaces/analytics/volumes`, {
+      statusCode: 200,
+      body: {
+        name: 'new-volume',
+        'catalog-name': 'test-project',
+        'schema-name': 'analytics',
+        'volume-type': 'documents',
+        'storage-location': '/data/docs',
+        labels: ['production'],
+        properties: {
+          description: 'Test volume',
+          purpose: 'ML training',
+          license: 'apache-2.0',
+          maturity: 'production',
+          pii_status: 'none',
+        },
+        config: {},
+      },
+    }).as('createVolume');
+
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+
+    cy.findByTestId('volume-name-input').type('new-volume');
+    cy.findByTestId('volume-description-input').type('Test volume');
+
+    cy.findByTestId('volume-format-toggle').click();
+    cy.contains('Documents').click();
+
+    cy.findByTestId('volume-collection-toggle').click();
+    cy.contains('analytics').click();
+
+    cy.findByTestId('volume-path-input').clear();
+    cy.findByTestId('volume-path-input').type('/data/docs');
+
+    cy.findByTestId('volume-purpose-input').type('ML training');
+
+    cy.findByTestId('volume-license-toggle').click();
+    cy.contains('Apache 2.0').click();
+
+    cy.findByTestId('volume-maturity-toggle').click();
+    cy.contains('Production').click();
+
+    cy.findByTestId('volume-pii-toggle').click();
+    cy.contains('None').click();
+
+    cy.findByTestId('register-volume-submit').click();
+
+    cy.wait('@createVolume').then((interception) => {
+      expect(interception.request.body).to.deep.include({
+        name: 'new-volume',
+        content_type: 'documents',
+        description: 'Test volume',
+        location: '/data/docs',
+      });
+      expect(interception.request.body.properties).to.deep.include({
+        purpose: 'ML training',
+        license: 'apache-2.0',
+        maturity: 'production',
+        pii_status: 'none',
+      });
+    });
+
+    cy.findByTestId('register-volume-modal').should('not.exist');
+  });
+
+  it('should display error on 409 conflict', () => {
+    cy.intercept('POST', `${REGISTRY_API}/test-project/namespaces/analytics/volumes`, {
+      statusCode: 409,
+      body: {
+        error: { message: 'Volume already exists', type: 'AlreadyExistsException', code: 409 },
+      },
+    }).as('createVolumeConflict');
+
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+
+    cy.findByTestId('volume-name-input').type('existing-volume');
+    cy.findByTestId('volume-collection-toggle').click();
+    cy.contains('analytics').click();
+
+    cy.findByTestId('register-volume-submit').click();
+
+    cy.wait('@createVolumeConflict');
+    cy.contains('Error registering volume').should('exist');
+    cy.findByTestId('register-volume-modal').should('exist');
+  });
+
+  it('should close modal and reset form on cancel', () => {
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+
+    cy.findByTestId('volume-name-input').type('test-volume');
+    cy.contains('Cancel').click();
+    cy.findByTestId('register-volume-modal').should('not.exist');
+
+    cy.findByTestId('register-data-button').click();
+    cy.findByTestId('volume-name-input').should('have.value', '');
+  });
+
+  it('should show asset type as disabled Unstructured', () => {
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+    cy.findByTestId('asset-type-toggle').should('have.class', 'pf-m-disabled');
+    cy.findByTestId('asset-type-toggle').should('contain.text', 'Unstructured');
+  });
+
+  it('should show "Create new collection" in collection dropdown', () => {
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+    cy.findByTestId('volume-collection-toggle').click();
+    cy.contains('Create new collection').should('exist');
   });
 });

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
@@ -233,18 +233,14 @@ describe('Register Volume', () => {
     ).should('exist');
   });
 
-  it('should have register button disabled until name and collection are provided', () => {
+  it('should show validation errors when submitting without required fields', () => {
     visitWithData();
     cy.findByTestId('register-data-button').click();
 
-    cy.findByTestId('register-volume-submit').should('be.disabled');
+    cy.findByTestId('register-volume-submit').click();
 
-    cy.findByTestId('volume-name-input').type('my-volume');
-    cy.findByTestId('register-volume-submit').should('be.disabled');
-
-    cy.findByTestId('volume-collection-toggle').click();
-    cy.contains('analytics').click();
-    cy.findByTestId('register-volume-submit').should('be.enabled');
+    cy.contains('Asset name is required').should('exist');
+    cy.contains('Collection is required').should('exist');
   });
 
   it('should submit volume with all fields', () => {

--- a/packages/data-registry/frontend/src/__tests__/unit/components/RegisterVolumeModal.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/RegisterVolumeModal.spec.tsx
@@ -51,37 +51,48 @@ describe('RegisterVolumeModal', () => {
     ).toBeTruthy();
   });
 
-  it('should have register button disabled when name is empty', () => {
+  it('should show validation error when submitting without name', async () => {
     render(<RegisterVolumeModal {...defaultProps} />);
 
     const submitButton = screen.getByTestId('register-volume-submit');
-    expect(submitButton).toHaveProperty('disabled', true);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Asset name is required')).toBeTruthy();
+    });
+
+    expect(mockCreateVolume).not.toHaveBeenCalled();
   });
 
-  it('should have register button disabled when collection is not selected', () => {
+  it('should show validation error when submitting without collection', async () => {
     render(<RegisterVolumeModal {...defaultProps} />);
 
     const nameInput = screen.getByTestId('volume-name-input');
     fireEvent.change(nameInput, { target: { value: 'test-volume' } });
+    fireEvent.blur(nameInput);
 
     const submitButton = screen.getByTestId('register-volume-submit');
-    expect(submitButton).toHaveProperty('disabled', true);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Collection is required')).toBeTruthy();
+    });
+
+    expect(mockCreateVolume).not.toHaveBeenCalled();
   });
 
-  it('should enable register button when name and collection are provided', () => {
+  it('should show validation error for invalid name format', async () => {
     render(<RegisterVolumeModal {...defaultProps} />);
 
     const nameInput = screen.getByTestId('volume-name-input');
-    fireEvent.change(nameInput, { target: { value: 'test-volume' } });
+    fireEvent.change(nameInput, { target: { value: 'INVALID_NAME!' } });
+    fireEvent.blur(nameInput);
 
-    const collectionToggle = screen.getByTestId('volume-collection-toggle');
-    fireEvent.click(collectionToggle);
-
-    const collectionOption = screen.getByText('collection-1');
-    fireEvent.click(collectionOption);
-
-    const submitButton = screen.getByTestId('register-volume-submit');
-    expect(submitButton).toHaveProperty('disabled', false);
+    await waitFor(() => {
+      expect(
+        screen.getByText('Name must contain only lowercase letters, numbers, and hyphens'),
+      ).toBeTruthy();
+    });
   });
 
   it('should submit volume with correct data', async () => {

--- a/packages/data-registry/frontend/src/__tests__/unit/components/RegisterVolumeModal.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/RegisterVolumeModal.spec.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import RegisterVolumeModal from '~/app/components/RegisterVolumeModal';
+import * as dataRegistryApi from '~/app/api/dataRegistry';
+
+jest.mock('~/app/api/dataRegistry');
+
+const mockCreateVolume = jest.mocked(dataRegistryApi.createVolume);
+
+describe('RegisterVolumeModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    project: 'test-project',
+    collections: ['collection-1', 'collection-2'],
+    onCreated: jest.fn(),
+    onManageCollections: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render modal with all form fields', () => {
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    expect(screen.getByText('Register data')).toBeTruthy();
+    expect(screen.getByTestId('volume-name-input')).toBeTruthy();
+    expect(screen.getByTestId('volume-description-input')).toBeTruthy();
+    expect(screen.getByTestId('asset-type-toggle')).toBeTruthy();
+    expect(screen.getByTestId('volume-format-toggle')).toBeTruthy();
+    expect(screen.getByTestId('volume-collection-toggle')).toBeTruthy();
+    expect(screen.getByTestId('volume-path-input')).toBeTruthy();
+  });
+
+  it('should render section descriptions', () => {
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    expect(
+      screen.getByText(
+        'Provide general identification and classification details for this data asset.',
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Specify where the data is stored by selecting a connection or providing path details.',
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText('Define operational metadata, compliance levels, and discoverability tags.'),
+    ).toBeTruthy();
+  });
+
+  it('should have register button disabled when name is empty', () => {
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    const submitButton = screen.getByTestId('register-volume-submit');
+    expect(submitButton).toHaveProperty('disabled', true);
+  });
+
+  it('should have register button disabled when collection is not selected', () => {
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    const nameInput = screen.getByTestId('volume-name-input');
+    fireEvent.change(nameInput, { target: { value: 'test-volume' } });
+
+    const submitButton = screen.getByTestId('register-volume-submit');
+    expect(submitButton).toHaveProperty('disabled', true);
+  });
+
+  it('should enable register button when name and collection are provided', () => {
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    const nameInput = screen.getByTestId('volume-name-input');
+    fireEvent.change(nameInput, { target: { value: 'test-volume' } });
+
+    const collectionToggle = screen.getByTestId('volume-collection-toggle');
+    fireEvent.click(collectionToggle);
+
+    const collectionOption = screen.getByText('collection-1');
+    fireEvent.click(collectionOption);
+
+    const submitButton = screen.getByTestId('register-volume-submit');
+    expect(submitButton).toHaveProperty('disabled', false);
+  });
+
+  it('should submit volume with correct data', async () => {
+    mockCreateVolume.mockResolvedValue({
+      name: 'test-volume',
+      'catalog-name': 'test-project',
+      'schema-name': 'collection-1',
+      'volume-type': 'other',
+      'storage-location': '/data/path',
+    });
+
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    const nameInput = screen.getByTestId('volume-name-input');
+    fireEvent.change(nameInput, { target: { value: 'test-volume' } });
+
+    const descriptionInput = screen.getByTestId('volume-description-input');
+    fireEvent.change(descriptionInput, { target: { value: 'Test description' } });
+
+    const collectionToggle = screen.getByTestId('volume-collection-toggle');
+    fireEvent.click(collectionToggle);
+    const collectionOption = screen.getByText('collection-1');
+    fireEvent.click(collectionOption);
+
+    const pathInput = screen.getByTestId('volume-path-input');
+    fireEvent.change(pathInput, { target: { value: '/data/path' } });
+
+    const submitButton = screen.getByTestId('register-volume-submit');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockCreateVolume).toHaveBeenCalledWith('test-project', 'collection-1', {
+        name: 'test-volume',
+        // eslint-disable-next-line camelcase
+        content_type: 'other',
+        description: 'Test description',
+        location: '/data/path',
+      });
+    });
+
+    expect(defaultProps.onCreated).toHaveBeenCalled();
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('should display error message on submission failure', async () => {
+    mockCreateVolume.mockRejectedValue(new Error('API error 409: Volume already exists'));
+
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    const nameInput = screen.getByTestId('volume-name-input');
+    fireEvent.change(nameInput, { target: { value: 'existing-volume' } });
+
+    const collectionToggle = screen.getByTestId('volume-collection-toggle');
+    fireEvent.click(collectionToggle);
+    const collectionOption = screen.getByText('collection-1');
+    fireEvent.click(collectionOption);
+
+    const submitButton = screen.getByTestId('register-volume-submit');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Error registering volume')).toBeTruthy();
+      expect(screen.getByText('API error 409: Volume already exists')).toBeTruthy();
+    });
+
+    expect(defaultProps.onCreated).not.toHaveBeenCalled();
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+  });
+
+  it('should reset form fields on close', () => {
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    const nameInput = screen.getByTestId('volume-name-input');
+    fireEvent.change(nameInput, { target: { value: 'test-volume' } });
+
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('should show "Create new collection" in collection dropdown', () => {
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    const collectionToggle = screen.getByTestId('volume-collection-toggle');
+    fireEvent.click(collectionToggle);
+
+    expect(screen.getByText('Create new collection')).toBeTruthy();
+  });
+
+  it('should not include default path "/" in request', async () => {
+    mockCreateVolume.mockResolvedValue({
+      name: 'minimal-volume',
+      'catalog-name': 'test-project',
+      'schema-name': 'collection-1',
+      'volume-type': 'documents',
+      'storage-location': '',
+    });
+
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    const nameInput = screen.getByTestId('volume-name-input');
+    fireEvent.change(nameInput, { target: { value: 'minimal-volume' } });
+
+    const formatToggle = screen.getByTestId('volume-format-toggle');
+    fireEvent.click(formatToggle);
+    const formatOption = screen.getByText('Documents');
+    fireEvent.click(formatOption);
+
+    const collectionToggle = screen.getByTestId('volume-collection-toggle');
+    fireEvent.click(collectionToggle);
+    const collectionOption = screen.getByText('collection-1');
+    fireEvent.click(collectionOption);
+
+    const submitButton = screen.getByTestId('register-volume-submit');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockCreateVolume).toHaveBeenCalledWith('test-project', 'collection-1', {
+        name: 'minimal-volume',
+        // eslint-disable-next-line camelcase
+        content_type: 'documents',
+      });
+    });
+  });
+
+  it('should show asset type as disabled with Unstructured value', () => {
+    render(<RegisterVolumeModal {...defaultProps} />);
+
+    const assetTypeToggle = screen.getByTestId('asset-type-toggle');
+    expect(assetTypeToggle.textContent).toBe('Unstructured');
+    expect(assetTypeToggle.className).toContain('pf-m-disabled');
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
@@ -38,6 +38,7 @@ const renderTable = (props?: Partial<React.ComponentProps<typeof RegistryTable>>
         error={undefined}
         labels={mockLabels}
         onManageCollections={jest.fn()}
+        onRegisterData={jest.fn()}
         {...props}
       />
     </MemoryRouter>,

--- a/packages/data-registry/frontend/src/__tests__/unit/hooks/useAssets.spec.ts
+++ b/packages/data-registry/frontend/src/__tests__/unit/hooks/useAssets.spec.ts
@@ -71,6 +71,49 @@ describe('useAssets', () => {
     expect(assets[0].labels).toEqual(['production']);
   });
 
+  it('should map volume labels from API response', async () => {
+    mockFetchCollections.mockResolvedValue({ namespaces: [['col1']] });
+    mockFetchAssets.mockResolvedValue({ assets: [] });
+    mockFetchVolumes.mockResolvedValue({
+      volumes: [
+        {
+          name: 'labeled-volume',
+          'catalog-name': 'project',
+          'schema-name': 'col1',
+          'volume-type': 'documents',
+          'storage-location': '/data',
+          labels: ['production', 'ml-data'],
+          properties: { description: 'Volume with labels' },
+          config: {},
+        },
+        {
+          name: 'unlabeled-volume',
+          'catalog-name': 'project',
+          'schema-name': 'col1',
+          'volume-type': 'images',
+          'storage-location': '/images',
+          properties: {},
+          config: {},
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useAssets('test-project'));
+
+    await waitFor(() => {
+      expect(result.current[1]).toBe(true);
+    });
+
+    const assets = result.current[0];
+    expect(assets).toHaveLength(2);
+
+    const labeled = assets.find((a) => a.name === 'labeled-volume');
+    expect(labeled?.labels).toEqual(['production', 'ml-data']);
+
+    const unlabeled = assets.find((a) => a.name === 'unlabeled-volume');
+    expect(unlabeled?.labels).toEqual([]);
+  });
+
   it('should handle API errors', async () => {
     mockFetchCollections.mockRejectedValue(new Error('Network error'));
 

--- a/packages/data-registry/frontend/src/app/api/dataRegistry.ts
+++ b/packages/data-registry/frontend/src/app/api/dataRegistry.ts
@@ -4,6 +4,8 @@ import {
   ListNamespacesResponse,
   NamespaceResponse,
   CreateNamespaceRequest,
+  CreateVolumeRequest,
+  VolumeInfo,
   LabelListResponse,
 } from '~/app/types';
 import { URL_PREFIX, BFF_API_VERSION } from '~/app/utilities/const';
@@ -74,6 +76,19 @@ export const fetchAssets = (project: string, collection: string): Promise<AssetL
 
 export const fetchVolumes = (project: string, collection: string): Promise<ListVolumesResponse> =>
   fetchJSON(registryUrl(`/${project}/namespaces/${collection}/volumes`));
+
+export const createVolume = async (
+  project: string,
+  collection: string,
+  data: CreateVolumeRequest,
+): Promise<VolumeInfo> => {
+  const response = await fetchRequest(
+    registryUrl(`/${project}/namespaces/${collection}/volumes`),
+    'POST',
+    data,
+  );
+  return response.json();
+};
 
 // Labels
 

--- a/packages/data-registry/frontend/src/app/components/RegisterVolumeModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegisterVolumeModal.tsx
@@ -21,6 +21,8 @@ import {
   LabelGroup,
   Popover,
   Icon,
+  Flex,
+  FlexItem,
 } from '@patternfly/react-core';
 import { PlusCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { createVolume } from '~/app/api/dataRegistry';
@@ -87,8 +89,9 @@ const RegisterVolumeModal: React.FC<RegisterVolumeModalProps> = ({
   const [license, setLicense] = React.useState('');
   const [maturity, setMaturity] = React.useState('');
   const [piiStatus, setPiiStatus] = React.useState('');
+  const customPropertyIdRef = React.useRef(0);
   const [customProperties, setCustomProperties] = React.useState<
-    Array<{ key: string; value: string }>
+    Array<{ id: number; key: string; value: string }>
   >([]);
   const [isFormatOpen, setIsFormatOpen] = React.useState(false);
   const [isCollectionOpen, setIsCollectionOpen] = React.useState(false);
@@ -114,7 +117,9 @@ const RegisterVolumeModal: React.FC<RegisterVolumeModalProps> = ({
   }, []);
 
   const handleAddCustomProperty = React.useCallback(() => {
-    setCustomProperties((prev) => [...prev, { key: '', value: '' }]);
+    const id = customPropertyIdRef.current;
+    customPropertyIdRef.current += 1;
+    setCustomProperties((prev) => [...prev, { id, key: '', value: '' }]);
   }, []);
 
   const handleRemoveCustomProperty = React.useCallback((index: number) => {
@@ -597,28 +602,36 @@ const RegisterVolumeModal: React.FC<RegisterVolumeModalProps> = ({
                 Add key/value pair
               </Button>
               {customProperties.map((prop, index) => (
-                <div key={index} className="pf-v6-u-display-flex pf-v6-u-gap-md pf-v6-u-mb-md">
-                  <TextInput
-                    value={prop.key}
-                    onChange={(_event, value) => handleCustomPropertyChange(index, 'key', value)}
-                    placeholder="Key"
-                    data-testid={`custom-property-key-${index}`}
-                  />
-                  <TextInput
-                    value={prop.value}
-                    onChange={(_event, value) => handleCustomPropertyChange(index, 'value', value)}
-                    placeholder="Value"
-                    data-testid={`custom-property-value-${index}`}
-                  />
-                  <Button
-                    variant="plain"
-                    onClick={() => handleRemoveCustomProperty(index)}
-                    aria-label="Remove property"
-                    data-testid={`custom-property-remove-${index}`}
-                  >
-                    Remove
-                  </Button>
-                </div>
+                <Flex key={prop.id} gap={{ default: 'gapMd' }} className="pf-v6-u-mb-md">
+                  <FlexItem grow={{ default: 'grow' }}>
+                    <TextInput
+                      value={prop.key}
+                      onChange={(_event, value) => handleCustomPropertyChange(index, 'key', value)}
+                      placeholder="Key"
+                      data-testid={`custom-property-key-${index}`}
+                    />
+                  </FlexItem>
+                  <FlexItem grow={{ default: 'grow' }}>
+                    <TextInput
+                      value={prop.value}
+                      onChange={(_event, value) =>
+                        handleCustomPropertyChange(index, 'value', value)
+                      }
+                      placeholder="Value"
+                      data-testid={`custom-property-value-${index}`}
+                    />
+                  </FlexItem>
+                  <FlexItem>
+                    <Button
+                      variant="plain"
+                      onClick={() => handleRemoveCustomProperty(index)}
+                      aria-label="Remove property"
+                      data-testid={`custom-property-remove-${index}`}
+                    >
+                      Remove
+                    </Button>
+                  </FlexItem>
+                </Flex>
               ))}
             </FormGroup>
           </FormSection>

--- a/packages/data-registry/frontend/src/app/components/RegisterVolumeModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegisterVolumeModal.tsx
@@ -6,27 +6,22 @@ import {
   ModalFooter,
   Button,
   Form,
-  FormGroup,
-  FormSection,
-  TextInput,
-  TextArea,
   Alert,
-  Select,
-  SelectOption,
-  SelectList,
-  MenuToggle,
-  MenuToggleElement,
   Content,
-  Label,
-  LabelGroup,
-  Popover,
-  Icon,
-  Flex,
-  FlexItem,
 } from '@patternfly/react-core';
-import { PlusCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { useForm, FormProvider } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { createVolume } from '~/app/api/dataRegistry';
 import { CreateVolumeRequest } from '~/app/types';
+import {
+  registerVolumeSchema,
+  registerVolumeDefaults,
+  RegisterVolumeFormData,
+} from '~/app/schemas/registerVolume.schema';
+import AssetDetailsSection from './register-volume/AssetDetailsSection';
+import DataLocationSection from './register-volume/DataLocationSection';
+import PropertiesSection from './register-volume/PropertiesSection';
+import CustomPropertiesSection from './register-volume/CustomPropertiesSection';
 
 type RegisterVolumeModalProps = {
   isOpen: boolean;
@@ -37,36 +32,45 @@ type RegisterVolumeModalProps = {
   onManageCollections: () => void;
 };
 
-const FORMAT_OPTIONS = [
-  { key: 'documents', label: 'Documents', description: 'Text, PDFs, and office files' },
-  { key: 'images', label: 'Images', description: 'Photos, graphics, and medical scans' },
-  { key: 'audio', label: 'Audio', description: 'Speech, music, and sound recordings' },
-  { key: 'video', label: 'Video', description: 'Clips, recordings, and video streams' },
-  { key: 'binary', label: 'Binary', description: 'Models, code, and compressed archives' },
-  { key: 'other', label: 'Other', description: 'Custom or uncategorized formats' },
-];
-
-const LICENSE_OPTIONS = [
-  { key: 'internal-use', label: 'Internal use' },
-  { key: 'cc-by-4.0', label: 'CC BY 4.0' },
-  { key: 'apache-2.0', label: 'Apache 2.0' },
-  { key: 'proprietary', label: 'Proprietary' },
-  { key: 'restricted', label: 'Restricted' },
-];
-
-const MATURITY_OPTIONS = [
-  { key: 'experimental', label: 'Experimental' },
-  { key: 'staging', label: 'Staging' },
-  { key: 'production', label: 'Production' },
-  { key: 'deprecated', label: 'Deprecated' },
-];
-
-const PII_OPTIONS = [
-  { key: 'none', label: 'None' },
-  { key: 'contains-pii', label: 'Contains PII' },
-  { key: 'contains-sensitive', label: 'Contains sensitive' },
-  { key: 'anonymized', label: 'Anonymized' },
-];
+const buildRequest = (data: RegisterVolumeFormData): CreateVolumeRequest => {
+  const request: CreateVolumeRequest = {
+    name: data.name.trim(),
+    // eslint-disable-next-line camelcase
+    content_type: data.format,
+  };
+  if (data.description) {
+    request.description = data.description;
+  }
+  if (data.path && data.path !== '/') {
+    request.location = data.path;
+  }
+  if (data.labels.length > 0) {
+    request.labels = data.labels;
+  }
+  const properties: Record<string, string> = {};
+  if (data.purpose) {
+    properties.purpose = data.purpose;
+  }
+  if (data.license) {
+    properties.license = data.license;
+  }
+  if (data.maturity) {
+    properties.maturity = data.maturity;
+  }
+  if (data.piiStatus) {
+    // eslint-disable-next-line camelcase
+    properties.pii_status = data.piiStatus;
+  }
+  data.customProperties.forEach((prop) => {
+    if (prop.key && prop.value) {
+      properties[prop.key] = prop.value;
+    }
+  });
+  if (Object.keys(properties).length > 0) {
+    request.properties = properties;
+  }
+  return request;
+};
 
 const RegisterVolumeModal: React.FC<RegisterVolumeModalProps> = ({
   isOpen,
@@ -76,157 +80,38 @@ const RegisterVolumeModal: React.FC<RegisterVolumeModalProps> = ({
   onCreated,
   onManageCollections,
 }) => {
-  const [name, setName] = React.useState('');
-  const [description, setDescription] = React.useState('');
-  const [format, setFormat] = React.useState('other');
-  const [collection, setCollection] = React.useState('');
-  const [labels, setLabels] = React.useState<string[]>([]);
-  const [isAddingLabel, setIsAddingLabel] = React.useState(false);
-  const [newLabel, setNewLabel] = React.useState('');
-  const [connection, setConnection] = React.useState('');
-  const [path, setPath] = React.useState('/');
-  const [purpose, setPurpose] = React.useState('');
-  const [license, setLicense] = React.useState('');
-  const [maturity, setMaturity] = React.useState('');
-  const [piiStatus, setPiiStatus] = React.useState('');
-  const customPropertyIdRef = React.useRef(0);
-  const [customProperties, setCustomProperties] = React.useState<
-    Array<{ id: number; key: string; value: string }>
-  >([]);
-  const [isFormatOpen, setIsFormatOpen] = React.useState(false);
-  const [isCollectionOpen, setIsCollectionOpen] = React.useState(false);
-  const [isConnectionOpen, setIsConnectionOpen] = React.useState(false);
-  const [isLicenseOpen, setIsLicenseOpen] = React.useState(false);
-  const [isMaturityOpen, setIsMaturityOpen] = React.useState(false);
-  const [isPiiOpen, setIsPiiOpen] = React.useState(false);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState('');
 
-  const selectedFormat = FORMAT_OPTIONS.find((f) => f.key === format);
-
-  const handleAddLabel = React.useCallback(() => {
-    if (newLabel.trim() && !labels.includes(newLabel.trim())) {
-      setLabels((prev) => [...prev, newLabel.trim()]);
-      setNewLabel('');
-      setIsAddingLabel(false);
-    }
-  }, [newLabel, labels]);
-
-  const handleRemoveLabel = React.useCallback((label: string) => {
-    setLabels((prev) => prev.filter((l) => l !== label));
-  }, []);
-
-  const handleAddCustomProperty = React.useCallback(() => {
-    const id = customPropertyIdRef.current;
-    customPropertyIdRef.current += 1;
-    setCustomProperties((prev) => [...prev, { id, key: '', value: '' }]);
-  }, []);
-
-  const handleRemoveCustomProperty = React.useCallback((index: number) => {
-    setCustomProperties((prev) => prev.filter((_, i) => i !== index));
-  }, []);
-
-  const handleCustomPropertyChange = React.useCallback(
-    (index: number, field: 'key' | 'value', value: string) => {
-      setCustomProperties((prev) =>
-        prev.map((prop, i) => (i === index ? { ...prop, [field]: value } : prop)),
-      );
-    },
-    [],
-  );
-
-  const resetForm = React.useCallback(() => {
-    setName('');
-    setDescription('');
-    setFormat('other');
-    setCollection('');
-    setLabels([]);
-    setIsAddingLabel(false);
-    setNewLabel('');
-    setConnection('');
-    setPath('/');
-    setPurpose('');
-    setLicense('');
-    setMaturity('');
-    setPiiStatus('');
-    setCustomProperties([]);
-    setError('');
-  }, []);
-
-  const handleSubmit = React.useCallback(async () => {
-    if (!name.trim() || !collection) {
-      return;
-    }
-    setIsSubmitting(true);
-    setError('');
-    try {
-      const requestData: CreateVolumeRequest = {
-        name: name.trim(),
-        // eslint-disable-next-line camelcase
-        content_type: format,
-      };
-      if (description) {
-        requestData.description = description;
-      }
-      if (path && path !== '/') {
-        requestData.location = path;
-      }
-      if (labels.length > 0) {
-        requestData.labels = labels;
-      }
-      const properties: Record<string, string> = {};
-      if (purpose) {
-        properties.purpose = purpose;
-      }
-      if (license) {
-        properties.license = license;
-      }
-      if (maturity) {
-        properties.maturity = maturity;
-      }
-      if (piiStatus) {
-        // eslint-disable-next-line camelcase
-        properties.pii_status = piiStatus;
-      }
-      customProperties.forEach((prop) => {
-        if (prop.key && prop.value) {
-          properties[prop.key] = prop.value;
-        }
-      });
-      if (Object.keys(properties).length > 0) {
-        requestData.properties = properties;
-      }
-      await createVolume(project, collection, requestData);
-      resetForm();
-      onCreated();
-      onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to register volume');
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [
-    name,
-    description,
-    format,
-    collection,
-    labels,
-    path,
-    purpose,
-    license,
-    maturity,
-    piiStatus,
-    customProperties,
-    project,
-    resetForm,
-    onCreated,
-    onClose,
-  ]);
+  const form = useForm<RegisterVolumeFormData>({
+    resolver: zodResolver(registerVolumeSchema),
+    defaultValues: registerVolumeDefaults,
+    mode: 'onBlur',
+  });
 
   const handleClose = React.useCallback(() => {
-    resetForm();
+    form.reset(registerVolumeDefaults);
+    setError('');
     onClose();
-  }, [resetForm, onClose]);
+  }, [form, onClose]);
+
+  const handleSubmit = React.useCallback(
+    async (data: RegisterVolumeFormData) => {
+      setIsSubmitting(true);
+      setError('');
+      try {
+        await createVolume(project, data.collection, buildRequest(data));
+        form.reset(registerVolumeDefaults);
+        onCreated();
+        onClose();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to register volume');
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [project, form, onCreated, onClose],
+  );
 
   return (
     <Modal
@@ -249,399 +134,23 @@ const RegisterVolumeModal: React.FC<RegisterVolumeModalProps> = ({
             {error}
           </Alert>
         ) : null}
-        <Form>
-          {/* ── Data asset details ── */}
-          <FormSection title="Data asset details" titleElement="h2">
-            <Content component="p">
-              Provide general identification and classification details for this data asset.
-            </Content>
-
-            <FormGroup label="Asset name" isRequired fieldId="volume-name">
-              <TextInput
-                id="volume-name"
-                value={name}
-                onChange={(_event, value) => setName(value)}
-                isRequired
-                data-testid="volume-name-input"
-              />
-            </FormGroup>
-
-            <FormGroup label="Asset description" fieldId="volume-description">
-              <TextArea
-                id="volume-description"
-                value={description}
-                onChange={(_event, value) => setDescription(value)}
-                data-testid="volume-description-input"
-              />
-            </FormGroup>
-
-            <FormGroup
-              label="Asset type"
-              isRequired
-              fieldId="asset-type"
-              labelHelp={
-                <Popover bodyContent="Only unstructured data volumes are supported in this release.">
-                  <Icon aria-label="Asset type info" role="button">
-                    <OutlinedQuestionCircleIcon />
-                  </Icon>
-                </Popover>
-              }
-            >
-              <MenuToggle isDisabled isFullWidth data-testid="asset-type-toggle">
-                Unstructured
-              </MenuToggle>
-            </FormGroup>
-
-            <FormGroup label="Format" fieldId="volume-format">
-              <Select
-                isOpen={isFormatOpen}
-                selected={format}
-                onSelect={(_event, value) => {
-                  setFormat(String(value));
-                  setIsFormatOpen(false);
-                }}
-                onOpenChange={setIsFormatOpen}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    onClick={() => setIsFormatOpen((prev) => !prev)}
-                    isExpanded={isFormatOpen}
-                    isFullWidth
-                    data-testid="volume-format-toggle"
-                  >
-                    {selectedFormat?.label || 'Select format'}
-                  </MenuToggle>
-                )}
-              >
-                <SelectList>
-                  {FORMAT_OPTIONS.map((option) => (
-                    <SelectOption
-                      key={option.key}
-                      value={option.key}
-                      description={option.description}
-                    >
-                      {option.label}
-                    </SelectOption>
-                  ))}
-                </SelectList>
-              </Select>
-            </FormGroup>
-
-            <FormGroup label="Collection" fieldId="volume-collection">
-              <Content component="p">
-                Assign this asset to collections to help group your data. To manage collections for
-                the entire project, go to{' '}
-                <Button variant="link" isInline onClick={onManageCollections}>
-                  Manage collections
-                </Button>
-                .
-              </Content>
-              <Select
-                isOpen={isCollectionOpen}
-                selected={collection}
-                onSelect={(_event, value) => {
-                  if (value === '__create_new__') {
-                    setIsCollectionOpen(false);
-                    onManageCollections();
-                    return;
-                  }
-                  setCollection(String(value));
-                  setIsCollectionOpen(false);
-                }}
-                onOpenChange={setIsCollectionOpen}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    onClick={() => setIsCollectionOpen((prev) => !prev)}
-                    isExpanded={isCollectionOpen}
-                    isFullWidth
-                    data-testid="volume-collection-toggle"
-                  >
-                    {collection || 'Select collection'}
-                  </MenuToggle>
-                )}
-              >
-                <SelectList>
-                  {collections.map((coll) => (
-                    <SelectOption key={coll} value={coll}>
-                      {coll}
-                    </SelectOption>
-                  ))}
-                  <SelectOption key="__create_new__" value="__create_new__">
-                    <Button variant="link" isInline icon={<PlusCircleIcon />}>
-                      Create new collection
-                    </Button>
-                  </SelectOption>
-                </SelectList>
-              </Select>
-            </FormGroup>
-
-            <FormGroup label="Labels" fieldId="volume-labels">
-              <Content component="p">
-                Add labels to help organize and filter this asset. To manage labels for the entire
-                project, go to{' '}
-                <Button variant="link" isInline isDisabled>
-                  Manage labels
-                </Button>
-                .
-              </Content>
-              {labels.length > 0 ? (
-                <LabelGroup numLabels={5}>
-                  {labels.map((label) => (
-                    <Label key={label} onClose={() => handleRemoveLabel(label)}>
-                      {label}
-                    </Label>
-                  ))}
-                </LabelGroup>
-              ) : null}
-              {isAddingLabel ? (
-                <TextInput
-                  id="volume-labels-input"
-                  value={newLabel}
-                  onChange={(_event, value) => setNewLabel(value)}
-                  placeholder="Enter label name"
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      handleAddLabel();
-                    }
-                    if (e.key === 'Escape') {
-                      setIsAddingLabel(false);
-                      setNewLabel('');
-                    }
-                  }}
-                  onBlur={() => {
-                    if (newLabel.trim()) {
-                      handleAddLabel();
-                    } else {
-                      setIsAddingLabel(false);
-                    }
-                  }}
-                  autoFocus
-                  data-testid="volume-labels-input"
-                />
-              ) : null}
-              <Button
-                variant="link"
-                icon={<PlusCircleIcon />}
-                onClick={() => setIsAddingLabel(true)}
-                data-testid="add-label-button"
-              >
-                Add label
-              </Button>
-            </FormGroup>
-          </FormSection>
-
-          {/* ── Data location ── */}
-          <FormSection title="Data location" titleElement="h2">
-            <Content component="p">
-              Specify where the data is stored by selecting a connection or providing path details.
-            </Content>
-
-            <FormGroup label="Connection" fieldId="volume-connection">
-              <Select
-                isOpen={isConnectionOpen}
-                selected={connection}
-                onSelect={(_event, value) => {
-                  setConnection(String(value));
-                  setIsConnectionOpen(false);
-                }}
-                onOpenChange={setIsConnectionOpen}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    onClick={() => setIsConnectionOpen((prev) => !prev)}
-                    isExpanded={isConnectionOpen}
-                    isFullWidth
-                    data-testid="volume-connection-toggle"
-                  >
-                    {connection || 'Select a connection'}
-                  </MenuToggle>
-                )}
-              >
-                <SelectList>
-                  <SelectOption value="" isDisabled>
-                    No connections available
-                  </SelectOption>
-                </SelectList>
-              </Select>
-            </FormGroup>
-
-            <FormGroup label="Path" fieldId="volume-path">
-              <TextInput
-                id="volume-path"
-                value={path}
-                onChange={(_event, value) => setPath(value)}
-                data-testid="volume-path-input"
-              />
-            </FormGroup>
-          </FormSection>
-
-          {/* ── Properties ── */}
-          <FormSection title="Properties" titleElement="h2">
-            <Content component="p">
-              Define operational metadata, compliance levels, and discoverability tags.
-            </Content>
-
-            <FormGroup label="Purpose" fieldId="volume-purpose">
-              <TextInput
-                id="volume-purpose"
-                value={purpose}
-                onChange={(_event, value) => setPurpose(value)}
-                placeholder="e.g. ML training, fraud detection"
-                data-testid="volume-purpose-input"
-              />
-            </FormGroup>
-
-            <FormGroup label="License" fieldId="volume-license">
-              <Select
-                isOpen={isLicenseOpen}
-                selected={license}
-                onSelect={(_event, value) => {
-                  setLicense(String(value));
-                  setIsLicenseOpen(false);
-                }}
-                onOpenChange={setIsLicenseOpen}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    onClick={() => setIsLicenseOpen((prev) => !prev)}
-                    isExpanded={isLicenseOpen}
-                    isFullWidth
-                    data-testid="volume-license-toggle"
-                  >
-                    {LICENSE_OPTIONS.find((o) => o.key === license)?.label || 'Select license'}
-                  </MenuToggle>
-                )}
-              >
-                <SelectList>
-                  {LICENSE_OPTIONS.map((o) => (
-                    <SelectOption key={o.key} value={o.key}>
-                      {o.label}
-                    </SelectOption>
-                  ))}
-                </SelectList>
-              </Select>
-            </FormGroup>
-
-            <FormGroup label="Maturity" fieldId="volume-maturity">
-              <Select
-                isOpen={isMaturityOpen}
-                selected={maturity}
-                onSelect={(_event, value) => {
-                  setMaturity(String(value));
-                  setIsMaturityOpen(false);
-                }}
-                onOpenChange={setIsMaturityOpen}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    onClick={() => setIsMaturityOpen((prev) => !prev)}
-                    isExpanded={isMaturityOpen}
-                    isFullWidth
-                    data-testid="volume-maturity-toggle"
-                  >
-                    {MATURITY_OPTIONS.find((o) => o.key === maturity)?.label || 'Select maturity'}
-                  </MenuToggle>
-                )}
-              >
-                <SelectList>
-                  {MATURITY_OPTIONS.map((o) => (
-                    <SelectOption key={o.key} value={o.key}>
-                      {o.label}
-                    </SelectOption>
-                  ))}
-                </SelectList>
-              </Select>
-            </FormGroup>
-
-            <FormGroup label="PII status" fieldId="volume-pii">
-              <Select
-                isOpen={isPiiOpen}
-                selected={piiStatus}
-                onSelect={(_event, value) => {
-                  setPiiStatus(String(value));
-                  setIsPiiOpen(false);
-                }}
-                onOpenChange={setIsPiiOpen}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    onClick={() => setIsPiiOpen((prev) => !prev)}
-                    isExpanded={isPiiOpen}
-                    isFullWidth
-                    data-testid="volume-pii-toggle"
-                  >
-                    {PII_OPTIONS.find((o) => o.key === piiStatus)?.label || 'Select PII status'}
-                  </MenuToggle>
-                )}
-              >
-                <SelectList>
-                  {PII_OPTIONS.map((o) => (
-                    <SelectOption key={o.key} value={o.key}>
-                      {o.label}
-                    </SelectOption>
-                  ))}
-                </SelectList>
-              </Select>
-            </FormGroup>
-          </FormSection>
-
-          {/* ── Custom properties ── */}
-          <FormSection title="Custom properties" titleElement="h2">
-            <FormGroup fieldId="volume-custom-properties">
-              <Content component="p">
-                Add key/value pair annotations to attach metadata to this asset.
-              </Content>
-              <Button
-                variant="link"
-                icon={<PlusCircleIcon />}
-                onClick={handleAddCustomProperty}
-                data-testid="add-custom-property"
-              >
-                Add key/value pair
-              </Button>
-              {customProperties.map((prop, index) => (
-                <Flex key={prop.id} gap={{ default: 'gapMd' }} className="pf-v6-u-mb-md">
-                  <FlexItem grow={{ default: 'grow' }}>
-                    <TextInput
-                      value={prop.key}
-                      onChange={(_event, value) => handleCustomPropertyChange(index, 'key', value)}
-                      placeholder="Key"
-                      data-testid={`custom-property-key-${index}`}
-                    />
-                  </FlexItem>
-                  <FlexItem grow={{ default: 'grow' }}>
-                    <TextInput
-                      value={prop.value}
-                      onChange={(_event, value) =>
-                        handleCustomPropertyChange(index, 'value', value)
-                      }
-                      placeholder="Value"
-                      data-testid={`custom-property-value-${index}`}
-                    />
-                  </FlexItem>
-                  <FlexItem>
-                    <Button
-                      variant="plain"
-                      onClick={() => handleRemoveCustomProperty(index)}
-                      aria-label="Remove property"
-                      data-testid={`custom-property-remove-${index}`}
-                    >
-                      Remove
-                    </Button>
-                  </FlexItem>
-                </Flex>
-              ))}
-            </FormGroup>
-          </FormSection>
-        </Form>
+        <FormProvider {...form}>
+          <Form>
+            <AssetDetailsSection
+              collections={collections}
+              onManageCollections={onManageCollections}
+            />
+            <DataLocationSection />
+            <PropertiesSection />
+            <CustomPropertiesSection />
+          </Form>
+        </FormProvider>
       </ModalBody>
       <ModalFooter>
         <Button
           variant="primary"
-          onClick={handleSubmit}
-          isDisabled={!name.trim() || !collection || isSubmitting}
+          onClick={form.handleSubmit(handleSubmit)}
+          isDisabled={isSubmitting}
           isLoading={isSubmitting}
           data-testid="register-volume-submit"
         >

--- a/packages/data-registry/frontend/src/app/components/RegisterVolumeModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegisterVolumeModal.tsx
@@ -1,0 +1,645 @@
+import React from 'react';
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Form,
+  FormGroup,
+  FormSection,
+  TextInput,
+  TextArea,
+  Alert,
+  Select,
+  SelectOption,
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+  Content,
+  Label,
+  LabelGroup,
+  Popover,
+  Icon,
+} from '@patternfly/react-core';
+import { PlusCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { createVolume } from '~/app/api/dataRegistry';
+import { CreateVolumeRequest } from '~/app/types';
+
+type RegisterVolumeModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  project: string;
+  collections: string[];
+  onCreated: () => void;
+  onManageCollections: () => void;
+};
+
+const FORMAT_OPTIONS = [
+  { key: 'documents', label: 'Documents', description: 'Text, PDFs, and office files' },
+  { key: 'images', label: 'Images', description: 'Photos, graphics, and medical scans' },
+  { key: 'audio', label: 'Audio', description: 'Speech, music, and sound recordings' },
+  { key: 'video', label: 'Video', description: 'Clips, recordings, and video streams' },
+  { key: 'binary', label: 'Binary', description: 'Models, code, and compressed archives' },
+  { key: 'other', label: 'Other', description: 'Custom or uncategorized formats' },
+];
+
+const LICENSE_OPTIONS = [
+  { key: 'internal-use', label: 'Internal use' },
+  { key: 'cc-by-4.0', label: 'CC BY 4.0' },
+  { key: 'apache-2.0', label: 'Apache 2.0' },
+  { key: 'proprietary', label: 'Proprietary' },
+  { key: 'restricted', label: 'Restricted' },
+];
+
+const MATURITY_OPTIONS = [
+  { key: 'experimental', label: 'Experimental' },
+  { key: 'staging', label: 'Staging' },
+  { key: 'production', label: 'Production' },
+  { key: 'deprecated', label: 'Deprecated' },
+];
+
+const PII_OPTIONS = [
+  { key: 'none', label: 'None' },
+  { key: 'contains-pii', label: 'Contains PII' },
+  { key: 'contains-sensitive', label: 'Contains sensitive' },
+  { key: 'anonymized', label: 'Anonymized' },
+];
+
+const RegisterVolumeModal: React.FC<RegisterVolumeModalProps> = ({
+  isOpen,
+  onClose,
+  project,
+  collections,
+  onCreated,
+  onManageCollections,
+}) => {
+  const [name, setName] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [format, setFormat] = React.useState('other');
+  const [collection, setCollection] = React.useState('');
+  const [labels, setLabels] = React.useState<string[]>([]);
+  const [isAddingLabel, setIsAddingLabel] = React.useState(false);
+  const [newLabel, setNewLabel] = React.useState('');
+  const [connection, setConnection] = React.useState('');
+  const [path, setPath] = React.useState('/');
+  const [purpose, setPurpose] = React.useState('');
+  const [license, setLicense] = React.useState('');
+  const [maturity, setMaturity] = React.useState('');
+  const [piiStatus, setPiiStatus] = React.useState('');
+  const [customProperties, setCustomProperties] = React.useState<
+    Array<{ key: string; value: string }>
+  >([]);
+  const [isFormatOpen, setIsFormatOpen] = React.useState(false);
+  const [isCollectionOpen, setIsCollectionOpen] = React.useState(false);
+  const [isConnectionOpen, setIsConnectionOpen] = React.useState(false);
+  const [isLicenseOpen, setIsLicenseOpen] = React.useState(false);
+  const [isMaturityOpen, setIsMaturityOpen] = React.useState(false);
+  const [isPiiOpen, setIsPiiOpen] = React.useState(false);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [error, setError] = React.useState('');
+
+  const selectedFormat = FORMAT_OPTIONS.find((f) => f.key === format);
+
+  const handleAddLabel = React.useCallback(() => {
+    if (newLabel.trim() && !labels.includes(newLabel.trim())) {
+      setLabels((prev) => [...prev, newLabel.trim()]);
+      setNewLabel('');
+      setIsAddingLabel(false);
+    }
+  }, [newLabel, labels]);
+
+  const handleRemoveLabel = React.useCallback((label: string) => {
+    setLabels((prev) => prev.filter((l) => l !== label));
+  }, []);
+
+  const handleAddCustomProperty = React.useCallback(() => {
+    setCustomProperties((prev) => [...prev, { key: '', value: '' }]);
+  }, []);
+
+  const handleRemoveCustomProperty = React.useCallback((index: number) => {
+    setCustomProperties((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleCustomPropertyChange = React.useCallback(
+    (index: number, field: 'key' | 'value', value: string) => {
+      setCustomProperties((prev) =>
+        prev.map((prop, i) => (i === index ? { ...prop, [field]: value } : prop)),
+      );
+    },
+    [],
+  );
+
+  const resetForm = React.useCallback(() => {
+    setName('');
+    setDescription('');
+    setFormat('other');
+    setCollection('');
+    setLabels([]);
+    setIsAddingLabel(false);
+    setNewLabel('');
+    setConnection('');
+    setPath('/');
+    setPurpose('');
+    setLicense('');
+    setMaturity('');
+    setPiiStatus('');
+    setCustomProperties([]);
+    setError('');
+  }, []);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (!name.trim() || !collection) {
+      return;
+    }
+    setIsSubmitting(true);
+    setError('');
+    try {
+      const requestData: CreateVolumeRequest = {
+        name: name.trim(),
+        // eslint-disable-next-line camelcase
+        content_type: format,
+      };
+      if (description) {
+        requestData.description = description;
+      }
+      if (path && path !== '/') {
+        requestData.location = path;
+      }
+      if (labels.length > 0) {
+        requestData.labels = labels;
+      }
+      const properties: Record<string, string> = {};
+      if (purpose) {
+        properties.purpose = purpose;
+      }
+      if (license) {
+        properties.license = license;
+      }
+      if (maturity) {
+        properties.maturity = maturity;
+      }
+      if (piiStatus) {
+        // eslint-disable-next-line camelcase
+        properties.pii_status = piiStatus;
+      }
+      customProperties.forEach((prop) => {
+        if (prop.key && prop.value) {
+          properties[prop.key] = prop.value;
+        }
+      });
+      if (Object.keys(properties).length > 0) {
+        requestData.properties = properties;
+      }
+      await createVolume(project, collection, requestData);
+      resetForm();
+      onCreated();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to register volume');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    name,
+    description,
+    format,
+    collection,
+    labels,
+    path,
+    purpose,
+    license,
+    maturity,
+    piiStatus,
+    customProperties,
+    project,
+    resetForm,
+    onCreated,
+    onClose,
+  ]);
+
+  const handleClose = React.useCallback(() => {
+    resetForm();
+    onClose();
+  }, [resetForm, onClose]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      variant="medium"
+      data-testid="register-volume-modal"
+    >
+      <ModalHeader
+        title="Register data"
+        description={
+          <Content component="p">
+            Create a new data asset and configure its source location, metadata, and schema.
+          </Content>
+        }
+      />
+      <ModalBody>
+        {error ? (
+          <Alert variant="danger" isInline title="Error registering volume">
+            {error}
+          </Alert>
+        ) : null}
+        <Form>
+          {/* ── Data asset details ── */}
+          <FormSection title="Data asset details" titleElement="h2">
+            <Content component="p">
+              Provide general identification and classification details for this data asset.
+            </Content>
+
+            <FormGroup label="Asset name" isRequired fieldId="volume-name">
+              <TextInput
+                id="volume-name"
+                value={name}
+                onChange={(_event, value) => setName(value)}
+                isRequired
+                data-testid="volume-name-input"
+              />
+            </FormGroup>
+
+            <FormGroup label="Asset description" fieldId="volume-description">
+              <TextArea
+                id="volume-description"
+                value={description}
+                onChange={(_event, value) => setDescription(value)}
+                data-testid="volume-description-input"
+              />
+            </FormGroup>
+
+            <FormGroup
+              label="Asset type"
+              isRequired
+              fieldId="asset-type"
+              labelHelp={
+                <Popover bodyContent="Only unstructured data volumes are supported in this release.">
+                  <Icon aria-label="Asset type info" role="button">
+                    <OutlinedQuestionCircleIcon />
+                  </Icon>
+                </Popover>
+              }
+            >
+              <MenuToggle isDisabled isFullWidth data-testid="asset-type-toggle">
+                Unstructured
+              </MenuToggle>
+            </FormGroup>
+
+            <FormGroup label="Format" fieldId="volume-format">
+              <Select
+                isOpen={isFormatOpen}
+                selected={format}
+                onSelect={(_event, value) => {
+                  setFormat(String(value));
+                  setIsFormatOpen(false);
+                }}
+                onOpenChange={setIsFormatOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsFormatOpen((prev) => !prev)}
+                    isExpanded={isFormatOpen}
+                    isFullWidth
+                    data-testid="volume-format-toggle"
+                  >
+                    {selectedFormat?.label || 'Select format'}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  {FORMAT_OPTIONS.map((option) => (
+                    <SelectOption
+                      key={option.key}
+                      value={option.key}
+                      description={option.description}
+                    >
+                      {option.label}
+                    </SelectOption>
+                  ))}
+                </SelectList>
+              </Select>
+            </FormGroup>
+
+            <FormGroup label="Collection" fieldId="volume-collection">
+              <Content component="p">
+                Assign this asset to collections to help group your data. To manage collections for
+                the entire project, go to{' '}
+                <Button variant="link" isInline onClick={onManageCollections}>
+                  Manage collections
+                </Button>
+                .
+              </Content>
+              <Select
+                isOpen={isCollectionOpen}
+                selected={collection}
+                onSelect={(_event, value) => {
+                  if (value === '__create_new__') {
+                    setIsCollectionOpen(false);
+                    onManageCollections();
+                    return;
+                  }
+                  setCollection(String(value));
+                  setIsCollectionOpen(false);
+                }}
+                onOpenChange={setIsCollectionOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsCollectionOpen((prev) => !prev)}
+                    isExpanded={isCollectionOpen}
+                    isFullWidth
+                    data-testid="volume-collection-toggle"
+                  >
+                    {collection || 'Select collection'}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  {collections.map((coll) => (
+                    <SelectOption key={coll} value={coll}>
+                      {coll}
+                    </SelectOption>
+                  ))}
+                  <SelectOption key="__create_new__" value="__create_new__">
+                    <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                      Create new collection
+                    </Button>
+                  </SelectOption>
+                </SelectList>
+              </Select>
+            </FormGroup>
+
+            <FormGroup label="Labels" fieldId="volume-labels">
+              <Content component="p">
+                Add labels to help organize and filter this asset. To manage labels for the entire
+                project, go to{' '}
+                <Button variant="link" isInline isDisabled>
+                  Manage labels
+                </Button>
+                .
+              </Content>
+              {labels.length > 0 ? (
+                <LabelGroup numLabels={5}>
+                  {labels.map((label) => (
+                    <Label key={label} onClose={() => handleRemoveLabel(label)}>
+                      {label}
+                    </Label>
+                  ))}
+                </LabelGroup>
+              ) : null}
+              {isAddingLabel ? (
+                <TextInput
+                  id="volume-labels-input"
+                  value={newLabel}
+                  onChange={(_event, value) => setNewLabel(value)}
+                  placeholder="Enter label name"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleAddLabel();
+                    }
+                    if (e.key === 'Escape') {
+                      setIsAddingLabel(false);
+                      setNewLabel('');
+                    }
+                  }}
+                  onBlur={() => {
+                    if (newLabel.trim()) {
+                      handleAddLabel();
+                    } else {
+                      setIsAddingLabel(false);
+                    }
+                  }}
+                  autoFocus
+                  data-testid="volume-labels-input"
+                />
+              ) : null}
+              <Button
+                variant="link"
+                icon={<PlusCircleIcon />}
+                onClick={() => setIsAddingLabel(true)}
+                data-testid="add-label-button"
+              >
+                Add label
+              </Button>
+            </FormGroup>
+          </FormSection>
+
+          {/* ── Data location ── */}
+          <FormSection title="Data location" titleElement="h2">
+            <Content component="p">
+              Specify where the data is stored by selecting a connection or providing path details.
+            </Content>
+
+            <FormGroup label="Connection" fieldId="volume-connection">
+              <Select
+                isOpen={isConnectionOpen}
+                selected={connection}
+                onSelect={(_event, value) => {
+                  setConnection(String(value));
+                  setIsConnectionOpen(false);
+                }}
+                onOpenChange={setIsConnectionOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsConnectionOpen((prev) => !prev)}
+                    isExpanded={isConnectionOpen}
+                    isFullWidth
+                    data-testid="volume-connection-toggle"
+                  >
+                    {connection || 'Select a connection'}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  <SelectOption value="" isDisabled>
+                    No connections available
+                  </SelectOption>
+                </SelectList>
+              </Select>
+            </FormGroup>
+
+            <FormGroup label="Path" fieldId="volume-path">
+              <TextInput
+                id="volume-path"
+                value={path}
+                onChange={(_event, value) => setPath(value)}
+                data-testid="volume-path-input"
+              />
+            </FormGroup>
+          </FormSection>
+
+          {/* ── Properties ── */}
+          <FormSection title="Properties" titleElement="h2">
+            <Content component="p">
+              Define operational metadata, compliance levels, and discoverability tags.
+            </Content>
+
+            <FormGroup label="Purpose" fieldId="volume-purpose">
+              <TextInput
+                id="volume-purpose"
+                value={purpose}
+                onChange={(_event, value) => setPurpose(value)}
+                placeholder="e.g. ML training, fraud detection"
+                data-testid="volume-purpose-input"
+              />
+            </FormGroup>
+
+            <FormGroup label="License" fieldId="volume-license">
+              <Select
+                isOpen={isLicenseOpen}
+                selected={license}
+                onSelect={(_event, value) => {
+                  setLicense(String(value));
+                  setIsLicenseOpen(false);
+                }}
+                onOpenChange={setIsLicenseOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsLicenseOpen((prev) => !prev)}
+                    isExpanded={isLicenseOpen}
+                    isFullWidth
+                    data-testid="volume-license-toggle"
+                  >
+                    {LICENSE_OPTIONS.find((o) => o.key === license)?.label || 'Select license'}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  {LICENSE_OPTIONS.map((o) => (
+                    <SelectOption key={o.key} value={o.key}>
+                      {o.label}
+                    </SelectOption>
+                  ))}
+                </SelectList>
+              </Select>
+            </FormGroup>
+
+            <FormGroup label="Maturity" fieldId="volume-maturity">
+              <Select
+                isOpen={isMaturityOpen}
+                selected={maturity}
+                onSelect={(_event, value) => {
+                  setMaturity(String(value));
+                  setIsMaturityOpen(false);
+                }}
+                onOpenChange={setIsMaturityOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsMaturityOpen((prev) => !prev)}
+                    isExpanded={isMaturityOpen}
+                    isFullWidth
+                    data-testid="volume-maturity-toggle"
+                  >
+                    {MATURITY_OPTIONS.find((o) => o.key === maturity)?.label || 'Select maturity'}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  {MATURITY_OPTIONS.map((o) => (
+                    <SelectOption key={o.key} value={o.key}>
+                      {o.label}
+                    </SelectOption>
+                  ))}
+                </SelectList>
+              </Select>
+            </FormGroup>
+
+            <FormGroup label="PII status" fieldId="volume-pii">
+              <Select
+                isOpen={isPiiOpen}
+                selected={piiStatus}
+                onSelect={(_event, value) => {
+                  setPiiStatus(String(value));
+                  setIsPiiOpen(false);
+                }}
+                onOpenChange={setIsPiiOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsPiiOpen((prev) => !prev)}
+                    isExpanded={isPiiOpen}
+                    isFullWidth
+                    data-testid="volume-pii-toggle"
+                  >
+                    {PII_OPTIONS.find((o) => o.key === piiStatus)?.label || 'Select PII status'}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  {PII_OPTIONS.map((o) => (
+                    <SelectOption key={o.key} value={o.key}>
+                      {o.label}
+                    </SelectOption>
+                  ))}
+                </SelectList>
+              </Select>
+            </FormGroup>
+          </FormSection>
+
+          {/* ── Custom properties ── */}
+          <FormSection title="Custom properties" titleElement="h2">
+            <FormGroup fieldId="volume-custom-properties">
+              <Content component="p">
+                Add key/value pair annotations to attach metadata to this asset.
+              </Content>
+              <Button
+                variant="link"
+                icon={<PlusCircleIcon />}
+                onClick={handleAddCustomProperty}
+                data-testid="add-custom-property"
+              >
+                Add key/value pair
+              </Button>
+              {customProperties.map((prop, index) => (
+                <div key={index} className="pf-v6-u-display-flex pf-v6-u-gap-md pf-v6-u-mb-md">
+                  <TextInput
+                    value={prop.key}
+                    onChange={(_event, value) => handleCustomPropertyChange(index, 'key', value)}
+                    placeholder="Key"
+                    data-testid={`custom-property-key-${index}`}
+                  />
+                  <TextInput
+                    value={prop.value}
+                    onChange={(_event, value) => handleCustomPropertyChange(index, 'value', value)}
+                    placeholder="Value"
+                    data-testid={`custom-property-value-${index}`}
+                  />
+                  <Button
+                    variant="plain"
+                    onClick={() => handleRemoveCustomProperty(index)}
+                    aria-label="Remove property"
+                    data-testid={`custom-property-remove-${index}`}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              ))}
+            </FormGroup>
+          </FormSection>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          onClick={handleSubmit}
+          isDisabled={!name.trim() || !collection || isSubmitting}
+          isLoading={isSubmitting}
+          data-testid="register-volume-submit"
+        >
+          Register
+        </Button>
+        <Button variant="link" onClick={handleClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default RegisterVolumeModal;

--- a/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
@@ -35,6 +35,7 @@ type RegistryTableProps = {
   error: Error | undefined;
   labels: string[];
   onManageCollections: () => void;
+  onRegisterData: () => void;
 };
 
 type FilterCategory = 'labels' | 'assetType' | 'format';
@@ -104,6 +105,7 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
   error,
   labels,
   onManageCollections,
+  onRegisterData,
 }) => {
   const [searchText, setSearchText] = React.useState('');
   const [filterCategory, setFilterCategory] = React.useState<FilterCategory>('labels');
@@ -379,6 +381,12 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
                 }}
                 data-testid="asset-search"
               />
+            </ToolbarItem>
+            {/* Register data button */}
+            <ToolbarItem>
+              <Button variant="primary" onClick={onRegisterData} data-testid="register-data-button">
+                Register data
+              </Button>
             </ToolbarItem>
             {/* Kebab */}
             <ToolbarItem>

--- a/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
@@ -58,6 +58,7 @@ const FORMAT_LABELS: Record<
   audio: { text: 'Unstructured', color: 'orange' },
   video: { text: 'Unstructured', color: 'orange' },
   binary: { text: 'Unstructured', color: 'orange' },
+  other: { text: 'Unstructured', color: 'orange' },
 };
 
 const UNSTRUCTURED_FORMATS = [
@@ -66,6 +67,7 @@ const UNSTRUCTURED_FORMATS = [
   'audio',
   'video',
   'binary',
+  'other',
   'application/pdf',
   'pdf',
 ];

--- a/packages/data-registry/frontend/src/app/components/register-volume/AssetDetailsSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-volume/AssetDetailsSection.tsx
@@ -1,0 +1,305 @@
+import React from 'react';
+import {
+  FormGroup,
+  FormSection,
+  TextInput,
+  TextArea,
+  Select,
+  SelectOption,
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+  Content,
+  Label,
+  LabelGroup,
+  Popover,
+  Icon,
+  Button,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import { PlusCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Controller, useFormContext } from 'react-hook-form';
+import { RegisterVolumeFormData } from '~/app/schemas/registerVolume.schema';
+
+const FORMAT_OPTIONS = [
+  { key: 'documents', label: 'Documents', description: 'Text, PDFs, and office files' },
+  { key: 'images', label: 'Images', description: 'Photos, graphics, and medical scans' },
+  { key: 'audio', label: 'Audio', description: 'Speech, music, and sound recordings' },
+  { key: 'video', label: 'Video', description: 'Clips, recordings, and video streams' },
+  { key: 'binary', label: 'Binary', description: 'Models, code, and compressed archives' },
+  { key: 'other', label: 'Other', description: 'Custom or uncategorized formats' },
+];
+
+type AssetDetailsSectionProps = {
+  collections: string[];
+  onManageCollections: () => void;
+};
+
+const AssetDetailsSection: React.FC<AssetDetailsSectionProps> = ({
+  collections,
+  onManageCollections,
+}) => {
+  const {
+    control,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useFormContext<RegisterVolumeFormData>();
+
+  const labels = watch('labels');
+  const [isFormatOpen, setIsFormatOpen] = React.useState(false);
+  const [isCollectionOpen, setIsCollectionOpen] = React.useState(false);
+  const [isAddingLabel, setIsAddingLabel] = React.useState(false);
+  const [newLabel, setNewLabel] = React.useState('');
+
+  const handleAddLabel = React.useCallback(() => {
+    if (newLabel.trim() && !labels.includes(newLabel.trim())) {
+      setValue('labels', [...labels, newLabel.trim()]);
+      setNewLabel('');
+      setIsAddingLabel(false);
+    }
+  }, [newLabel, labels, setValue]);
+
+  const handleRemoveLabel = React.useCallback(
+    (label: string) => {
+      setValue(
+        'labels',
+        labels.filter((l) => l !== label),
+      );
+    },
+    [labels, setValue],
+  );
+
+  return (
+    <FormSection title="Data asset details" titleElement="h2">
+      <Content component="p">
+        Provide general identification and classification details for this data asset.
+      </Content>
+
+      <Controller
+        name="name"
+        control={control}
+        render={({ field }) => (
+          <FormGroup label="Asset name" isRequired fieldId="volume-name">
+            <TextInput
+              id="volume-name"
+              {...field}
+              isRequired
+              validated={errors.name ? 'error' : 'default'}
+              data-testid="volume-name-input"
+            />
+            {errors.name ? (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="error">{errors.name.message}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            ) : null}
+          </FormGroup>
+        )}
+      />
+
+      <Controller
+        name="description"
+        control={control}
+        render={({ field }) => (
+          <FormGroup label="Asset description" fieldId="volume-description">
+            <TextArea
+              id="volume-description"
+              {...field}
+              validated={errors.description ? 'error' : 'default'}
+              data-testid="volume-description-input"
+            />
+            {errors.description ? (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="error">{errors.description.message}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            ) : null}
+          </FormGroup>
+        )}
+      />
+
+      <FormGroup
+        label="Asset type"
+        isRequired
+        fieldId="asset-type"
+        labelHelp={
+          <Popover bodyContent="Only unstructured data volumes are supported in this release.">
+            <Icon aria-label="Asset type info" role="button">
+              <OutlinedQuestionCircleIcon />
+            </Icon>
+          </Popover>
+        }
+      >
+        <MenuToggle isDisabled isFullWidth data-testid="asset-type-toggle">
+          Unstructured
+        </MenuToggle>
+      </FormGroup>
+
+      <Controller
+        name="format"
+        control={control}
+        render={({ field }) => (
+          <FormGroup label="Format" fieldId="volume-format">
+            <Select
+              isOpen={isFormatOpen}
+              selected={field.value}
+              onSelect={(_event, value) => {
+                field.onChange(String(value));
+                setIsFormatOpen(false);
+              }}
+              onOpenChange={setIsFormatOpen}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsFormatOpen((prev) => !prev)}
+                  isExpanded={isFormatOpen}
+                  isFullWidth
+                  data-testid="volume-format-toggle"
+                >
+                  {FORMAT_OPTIONS.find((f) => f.key === field.value)?.label || 'Select format'}
+                </MenuToggle>
+              )}
+            >
+              <SelectList>
+                {FORMAT_OPTIONS.map((option) => (
+                  <SelectOption
+                    key={option.key}
+                    value={option.key}
+                    description={option.description}
+                  >
+                    {option.label}
+                  </SelectOption>
+                ))}
+              </SelectList>
+            </Select>
+          </FormGroup>
+        )}
+      />
+
+      <Controller
+        name="collection"
+        control={control}
+        render={({ field }) => (
+          <FormGroup label="Collection" fieldId="volume-collection">
+            <Content component="p">
+              Assign this asset to collections to help group your data. To manage collections for
+              the entire project, go to{' '}
+              <Button variant="link" isInline onClick={onManageCollections}>
+                Manage collections
+              </Button>
+              .
+            </Content>
+            <Select
+              isOpen={isCollectionOpen}
+              selected={field.value}
+              onSelect={(_event, value) => {
+                if (value === '__create_new__') {
+                  setIsCollectionOpen(false);
+                  onManageCollections();
+                  return;
+                }
+                field.onChange(String(value));
+                setIsCollectionOpen(false);
+              }}
+              onOpenChange={setIsCollectionOpen}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsCollectionOpen((prev) => !prev)}
+                  isExpanded={isCollectionOpen}
+                  isFullWidth
+                  data-testid="volume-collection-toggle"
+                >
+                  {field.value || 'Select collection'}
+                </MenuToggle>
+              )}
+            >
+              <SelectList>
+                {collections.map((coll) => (
+                  <SelectOption key={coll} value={coll}>
+                    {coll}
+                  </SelectOption>
+                ))}
+                <SelectOption key="__create_new__" value="__create_new__">
+                  <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                    Create new collection
+                  </Button>
+                </SelectOption>
+              </SelectList>
+            </Select>
+            {errors.collection ? (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="error">{errors.collection.message}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            ) : null}
+          </FormGroup>
+        )}
+      />
+
+      <FormGroup label="Labels" fieldId="volume-labels">
+        <Content component="p">
+          Add labels to help organize and filter this asset. To manage labels for the entire
+          project, go to{' '}
+          <Button variant="link" isInline isDisabled>
+            Manage labels
+          </Button>
+          .
+        </Content>
+        {labels.length > 0 ? (
+          <LabelGroup numLabels={5}>
+            {labels.map((label) => (
+              <Label key={label} onClose={() => handleRemoveLabel(label)}>
+                {label}
+              </Label>
+            ))}
+          </LabelGroup>
+        ) : null}
+        {isAddingLabel ? (
+          <TextInput
+            id="volume-labels-input"
+            aria-label="New label name"
+            value={newLabel}
+            onChange={(_event, value) => setNewLabel(value)}
+            placeholder="Enter label name"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleAddLabel();
+              }
+              if (e.key === 'Escape') {
+                setIsAddingLabel(false);
+                setNewLabel('');
+              }
+            }}
+            onBlur={() => {
+              if (newLabel.trim()) {
+                handleAddLabel();
+              } else {
+                setIsAddingLabel(false);
+              }
+            }}
+            autoFocus
+            data-testid="volume-labels-input"
+          />
+        ) : null}
+        <Button
+          variant="link"
+          icon={<PlusCircleIcon />}
+          onClick={() => setIsAddingLabel(true)}
+          data-testid="add-label-button"
+        >
+          Add label
+        </Button>
+      </FormGroup>
+    </FormSection>
+  );
+};
+
+export default AssetDetailsSection;

--- a/packages/data-registry/frontend/src/app/components/register-volume/CustomPropertiesSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-volume/CustomPropertiesSection.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {
+  FormGroup,
+  FormSection,
+  TextInput,
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { RegisterVolumeFormData } from '~/app/schemas/registerVolume.schema';
+
+const CustomPropertiesSection: React.FC = () => {
+  const { control, register } = useFormContext<RegisterVolumeFormData>();
+  const { fields, append, remove } = useFieldArray({ control, name: 'customProperties' });
+
+  return (
+    <FormSection title="Custom properties" titleElement="h2">
+      <FormGroup fieldId="volume-custom-properties">
+        <Content component="p">
+          Add key/value pair annotations to attach metadata to this asset.
+        </Content>
+        <Button
+          variant="link"
+          icon={<PlusCircleIcon />}
+          onClick={() => append({ id: Date.now(), key: '', value: '' })}
+          data-testid="add-custom-property"
+        >
+          Add key/value pair
+        </Button>
+        {fields.map((field, index) => (
+          <Flex key={field.id} gap={{ default: 'gapMd' }} className="pf-v6-u-mb-md">
+            <FlexItem grow={{ default: 'grow' }}>
+              <TextInput
+                {...register(`customProperties.${index}.key`)}
+                placeholder="Key"
+                data-testid={`custom-property-key-${index}`}
+              />
+            </FlexItem>
+            <FlexItem grow={{ default: 'grow' }}>
+              <TextInput
+                {...register(`customProperties.${index}.value`)}
+                placeholder="Value"
+                data-testid={`custom-property-value-${index}`}
+              />
+            </FlexItem>
+            <FlexItem>
+              <Button
+                variant="plain"
+                onClick={() => remove(index)}
+                aria-label="Remove property"
+                data-testid={`custom-property-remove-${index}`}
+              >
+                Remove
+              </Button>
+            </FlexItem>
+          </Flex>
+        ))}
+      </FormGroup>
+    </FormSection>
+  );
+};
+
+export default CustomPropertiesSection;

--- a/packages/data-registry/frontend/src/app/components/register-volume/DataLocationSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-volume/DataLocationSection.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {
+  FormGroup,
+  FormSection,
+  TextInput,
+  Select,
+  SelectOption,
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+  Content,
+} from '@patternfly/react-core';
+import { Controller, useFormContext } from 'react-hook-form';
+import { RegisterVolumeFormData } from '~/app/schemas/registerVolume.schema';
+
+const DataLocationSection: React.FC = () => {
+  const { control } = useFormContext<RegisterVolumeFormData>();
+  const [isConnectionOpen, setIsConnectionOpen] = React.useState(false);
+
+  return (
+    <FormSection title="Data location" titleElement="h2">
+      <Content component="p">
+        Specify where the data is stored by selecting a connection or providing path details.
+      </Content>
+
+      <Controller
+        name="connection"
+        control={control}
+        render={({ field }) => (
+          <FormGroup label="Connection" fieldId="volume-connection">
+            <Select
+              isOpen={isConnectionOpen}
+              selected={field.value}
+              onSelect={(_event, value) => {
+                field.onChange(String(value));
+                setIsConnectionOpen(false);
+              }}
+              onOpenChange={setIsConnectionOpen}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsConnectionOpen((prev) => !prev)}
+                  isExpanded={isConnectionOpen}
+                  isFullWidth
+                  data-testid="volume-connection-toggle"
+                >
+                  {field.value || 'Select a connection'}
+                </MenuToggle>
+              )}
+            >
+              <SelectList>
+                <SelectOption value="" isDisabled>
+                  No connections available
+                </SelectOption>
+              </SelectList>
+            </Select>
+          </FormGroup>
+        )}
+      />
+
+      <Controller
+        name="path"
+        control={control}
+        render={({ field }) => (
+          <FormGroup label="Path" fieldId="volume-path">
+            <TextInput id="volume-path" {...field} data-testid="volume-path-input" />
+          </FormGroup>
+        )}
+      />
+    </FormSection>
+  );
+};
+
+export default DataLocationSection;

--- a/packages/data-registry/frontend/src/app/components/register-volume/PropertiesSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-volume/PropertiesSection.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import {
+  FormGroup,
+  FormSection,
+  TextInput,
+  Select,
+  SelectOption,
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+  Content,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import { Controller, useFormContext } from 'react-hook-form';
+import { RegisterVolumeFormData } from '~/app/schemas/registerVolume.schema';
+
+const LICENSE_OPTIONS = [
+  { key: 'internal-use', label: 'Internal use' },
+  { key: 'cc-by-4.0', label: 'CC BY 4.0' },
+  { key: 'apache-2.0', label: 'Apache 2.0' },
+  { key: 'proprietary', label: 'Proprietary' },
+  { key: 'restricted', label: 'Restricted' },
+];
+
+const MATURITY_OPTIONS = [
+  { key: 'experimental', label: 'Experimental' },
+  { key: 'staging', label: 'Staging' },
+  { key: 'production', label: 'Production' },
+  { key: 'deprecated', label: 'Deprecated' },
+];
+
+const PII_OPTIONS = [
+  { key: 'none', label: 'None' },
+  { key: 'contains-pii', label: 'Contains PII' },
+  { key: 'contains-sensitive', label: 'Contains sensitive' },
+  { key: 'anonymized', label: 'Anonymized' },
+];
+
+type SelectFieldProps = {
+  name: 'license' | 'maturity' | 'piiStatus';
+  label: string;
+  fieldId: string;
+  testId: string;
+  options: { key: string; label: string }[];
+  placeholder: string;
+};
+
+const SelectField: React.FC<SelectFieldProps> = ({
+  name,
+  label,
+  fieldId,
+  testId,
+  options,
+  placeholder,
+}) => {
+  const { control } = useFormContext<RegisterVolumeFormData>();
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field }) => (
+        <FormGroup label={label} fieldId={fieldId}>
+          <Select
+            isOpen={isOpen}
+            selected={field.value}
+            onSelect={(_event, value) => {
+              field.onChange(String(value));
+              setIsOpen(false);
+            }}
+            onOpenChange={setIsOpen}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsOpen((prev) => !prev)}
+                isExpanded={isOpen}
+                isFullWidth
+                data-testid={testId}
+              >
+                {options.find((o) => o.key === field.value)?.label || placeholder}
+              </MenuToggle>
+            )}
+          >
+            <SelectList>
+              {options.map((o) => (
+                <SelectOption key={o.key} value={o.key}>
+                  {o.label}
+                </SelectOption>
+              ))}
+            </SelectList>
+          </Select>
+        </FormGroup>
+      )}
+    />
+  );
+};
+
+const PropertiesSection: React.FC = () => {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<RegisterVolumeFormData>();
+
+  return (
+    <FormSection title="Properties" titleElement="h2">
+      <Content component="p">
+        Define operational metadata, compliance levels, and discoverability tags.
+      </Content>
+
+      <Controller
+        name="purpose"
+        control={control}
+        render={({ field }) => (
+          <FormGroup label="Purpose" fieldId="volume-purpose">
+            <TextInput
+              id="volume-purpose"
+              {...field}
+              placeholder="e.g. ML training, fraud detection"
+              validated={errors.purpose ? 'error' : 'default'}
+              data-testid="volume-purpose-input"
+            />
+            {errors.purpose ? (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="error">{errors.purpose.message}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            ) : null}
+          </FormGroup>
+        )}
+      />
+
+      <SelectField
+        name="license"
+        label="License"
+        fieldId="volume-license"
+        testId="volume-license-toggle"
+        options={LICENSE_OPTIONS}
+        placeholder="Select license"
+      />
+
+      <SelectField
+        name="maturity"
+        label="Maturity"
+        fieldId="volume-maturity"
+        testId="volume-maturity-toggle"
+        options={MATURITY_OPTIONS}
+        placeholder="Select maturity"
+      />
+
+      <SelectField
+        name="piiStatus"
+        label="PII status"
+        fieldId="volume-pii"
+        testId="volume-pii-toggle"
+        options={PII_OPTIONS}
+        placeholder="Select PII status"
+      />
+    </FormSection>
+  );
+};
+
+export default PropertiesSection;

--- a/packages/data-registry/frontend/src/app/hooks/useAssets.ts
+++ b/packages/data-registry/frontend/src/app/hooks/useAssets.ts
@@ -35,7 +35,7 @@ const mapVolumeAsset = (volume: VolumeInfo, collection: string): RegistryAsset =
   assetType: 'volume',
   location: volume['storage-location'] || '',
   connectionRef: volume.properties?.['connection-ref'] || '',
-  labels: [],
+  labels: volume.labels || [],
   collection,
 });
 

--- a/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
@@ -21,6 +21,7 @@ import { useAssets } from '~/app/hooks/useAssets';
 import { useLabels } from '~/app/hooks/useLabels';
 import RegistryTable from '~/app/components/RegistryTable';
 import ManageCollectionsModal from '~/app/components/ManageCollectionsModal';
+import RegisterVolumeModal from '~/app/components/RegisterVolumeModal';
 
 // TODO: Replace with isAvailableProject from @odh-dashboard/k8s-core when BFF returns filtered projects
 const HIDDEN_NS_PREFIXES = ['openshift-', 'kube-'];
@@ -31,6 +32,7 @@ const DataRegistryPage: React.FC = () => {
   const requestedProject = searchParams.get('project') || '';
   const [isProjectOpen, setIsProjectOpen] = React.useState(false);
   const [isCollectionsModalOpen, setIsCollectionsModalOpen] = React.useState(false);
+  const [isRegisterModalOpen, setIsRegisterModalOpen] = React.useState(false);
 
   const [namespaces, namespacesLoaded, namespacesError] = useNamespaces();
 
@@ -166,6 +168,7 @@ const DataRegistryPage: React.FC = () => {
                 setIsCollectionsModalOpen(true);
               }
             }}
+            onRegisterData={() => setIsRegisterModalOpen(true)}
           />
           <ManageCollectionsModal
             isOpen={isCollectionsModalOpen}
@@ -173,6 +176,17 @@ const DataRegistryPage: React.FC = () => {
             project={selectedProject}
             collections={collections}
             onRefresh={handleRefresh}
+          />
+          <RegisterVolumeModal
+            isOpen={isRegisterModalOpen}
+            onClose={() => setIsRegisterModalOpen(false)}
+            project={selectedProject}
+            collections={collectionNames}
+            onCreated={handleRefresh}
+            onManageCollections={() => {
+              setIsRegisterModalOpen(false);
+              setIsCollectionsModalOpen(true);
+            }}
           />
         </>
       )}

--- a/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
@@ -55,12 +55,13 @@ const DataRegistryPage: React.FC = () => {
     assets,
     collectionNames,
   );
-  const [labels] = useLabels(selectedProject);
+  const [labels, , , labelsRefresh] = useLabels(selectedProject);
 
   const handleRefresh = React.useCallback(() => {
     assetsRefresh();
     collectionsRefresh();
-  }, [assetsRefresh, collectionsRefresh]);
+    labelsRefresh();
+  }, [assetsRefresh, collectionsRefresh, labelsRefresh]);
 
   const handleProjectSelect = React.useCallback(
     (_event: React.MouseEvent | undefined, value: string | number | undefined) => {

--- a/packages/data-registry/frontend/src/app/schemas/registerVolume.schema.ts
+++ b/packages/data-registry/frontend/src/app/schemas/registerVolume.schema.ts
@@ -1,0 +1,40 @@
+import * as z from 'zod';
+
+const COLLECTION_NAME_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+export const registerVolumeSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Asset name is required')
+    .max(63, 'Name must be 63 characters or fewer')
+    .regex(COLLECTION_NAME_REGEX, 'Name must contain only lowercase letters, numbers, and hyphens'),
+  description: z.string().max(500, 'Description must be 500 characters or fewer'),
+  format: z.string(),
+  collection: z.string().min(1, 'Collection is required'),
+  labels: z.array(z.string()),
+  connection: z.string(),
+  path: z.string(),
+  purpose: z.string().max(200, 'Purpose must be 200 characters or fewer'),
+  license: z.string(),
+  maturity: z.string(),
+  piiStatus: z.string(),
+  customProperties: z.array(z.object({ id: z.number(), key: z.string(), value: z.string() })),
+});
+
+export type RegisterVolumeFormData = z.infer<typeof registerVolumeSchema>;
+
+export const registerVolumeDefaults: RegisterVolumeFormData = {
+  name: '',
+  description: '',
+  format: 'other',
+  collection: '',
+  labels: [],
+  connection: '',
+  path: '/',
+  purpose: '',
+  license: '',
+  maturity: '',
+  piiStatus: '',
+  customProperties: [],
+};

--- a/packages/data-registry/frontend/src/app/types.ts
+++ b/packages/data-registry/frontend/src/app/types.ts
@@ -108,20 +108,6 @@ export type CreateVolumeRequest = {
   properties?: Record<string, string>;
 };
 
-export type CreateAssetRequest = {
-  name: string;
-  format?: string;
-  location?: string;
-  connection_ref?: ConnectionRef | null;
-  description?: string;
-  purpose?: string;
-  license?: string;
-  maturity?: string;
-  pii?: string;
-  owner?: string;
-  labels?: string[];
-};
-
 export type LabelListResponse = {
   labels: string[];
 };

--- a/packages/data-registry/frontend/src/app/types.ts
+++ b/packages/data-registry/frontend/src/app/types.ts
@@ -75,6 +75,7 @@ export type VolumeInfo = {
   owner?: string;
   'created-at'?: string;
   'updated-at'?: string;
+  labels?: string[];
   properties?: Record<string, string>;
   config?: Record<string, string>;
 };
@@ -95,6 +96,30 @@ export type NamespaceResponse = {
 export type CreateNamespaceRequest = {
   namespace: string[];
   properties?: Record<string, string>;
+};
+
+export type CreateVolumeRequest = {
+  name: string;
+  location?: string;
+  content_type?: string;
+  connection_ref?: ConnectionRef | null;
+  description?: string;
+  labels?: string[];
+  properties?: Record<string, string>;
+};
+
+export type CreateAssetRequest = {
+  name: string;
+  format?: string;
+  location?: string;
+  connection_ref?: ConnectionRef | null;
+  description?: string;
+  purpose?: string;
+  license?: string;
+  maturity?: string;
+  pii?: string;
+  owner?: string;
+  labels?: string[];
 };
 
 export type LabelListResponse = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Implements the volume registration form for the Data Registry module. Clicking "Register data" in the registry table toolbar opens a modal with the full registration flow matching the UX prototype:

**Data asset details:**
- Asset name (required), description, asset type (locked to Unstructured with info popover), format dropdown (documents/images/audio/video/binary/other), collection selector with inline "Create new collection" link, and labels with add/remove support.

**Data location:**
- Connection dropdown (placeholder for future implementation), path field.

**Properties:**
- Purpose, license (internal-use/cc-by-4.0/apache-2.0/proprietary/restricted), maturity (experimental/staging/production/deprecated), PII status (none/contains-pii/contains-sensitive/anonymized).

**Custom properties:**
- Key/value pair annotations with add/remove.

On submit, calls `POST /v1/{project}/namespaces/{collection}/volumes` via the BFF. Handles 409 conflict with inline error. On success, closes the modal and refreshes the asset list.

Also fixes `mapVolumeAsset` to map `labels` from the `VolumeInfo` API response (previously hardcoded to `[]`), and adds `labels` to the `VolumeInfo` TypeScript type.

Registration 1
<img width="985" height="1285" alt="image" src="https://github.com/user-attachments/assets/e85f8742-a936-4d7c-b4e8-a57e6ee97c25" />

Registration 2
<img width="985" height="1285" alt="image" src="https://github.com/user-attachments/assets/272e1c82-3111-4890-9317-bd0e58f82119" />

Registration formats
<img width="985" height="1285" alt="image" src="https://github.com/user-attachments/assets/55c6f364-8f11-4abc-a850-2d141dc6bd6c" />

Registration collections
<img width="985" height="1285" alt="image" src="https://github.com/user-attachments/assets/127a5f48-5cb0-4142-b87f-99aec20eebe6" />

License:
<img width="985" height="1285" alt="image" src="https://github.com/user-attachments/assets/188ed08d-1dd8-4609-9a8b-953f250f291d" />

Maturity:
<img width="985" height="1285" alt="image" src="https://github.com/user-attachments/assets/a1978a04-71ec-4063-9ed5-4ac90d66bc25" />

PII:
<img width="985" height="1285" alt="image" src="https://github.com/user-attachments/assets/b62bd4f1-571f-4574-bffd-fd4d3089f288" />

Successful registration:
<img width="2361" height="102" alt="image" src="https://github.com/user-attachments/assets/c33d7fb3-32f4-4b0e-abf2-6761f85617d2" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Manually tested the full registration flow against a live RHOAI cluster with Feast Data Registry running
- Verified volume creation with all fields populated, including labels appearing in the table after creation
- Tested 409 duplicate name error handling
- Tested form validation (disabled submit without name/collection)
- Tested form reset on cancel
- Ran all unit and Cypress tests locally

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

**Unit tests (Jest):** 38 tests across 5 suites
- New: `RegisterVolumeModal.spec.tsx` — 11 tests covering rendering, validation, submission, error handling, form reset, asset type disabled state, "Create new collection" in dropdown
- Updated: `RegistryTable.spec.tsx` — added `onRegisterData` prop to test helper
- New: `useAssets.spec.ts` — added test for volume labels mapping (both present and missing/null)

**Cypress mock tests:** 16 tests (9 existing + 7 new)
- New `Register Volume` describe block: modal open, validation flow, full field submission with payload verification, 409 error display, cancel/reset, asset type disabled, collection dropdown "Create new collection" link


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Register data** action to the data registry.
  * Added a volume registration form with descriptions, labels, metadata, collections, connections, and custom properties.
  * Added validation, success handling, cancellation, and inline error messages.
  * Added options to create a new collection and support for unstructured asset types.

* **Bug Fixes**
  * Preserved volume labels returned by the service.
  * Improved handling of volumes without labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->