### PR TITLE
feat(notebooks): add contract tests for workspaces BFF (RHOAIENG-58841)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,6 +174,7 @@ jobs:
             packages/model-registry/upstream/bff/go.sum
             packages/gen-ai/bff/go.sum
             packages/mlflow/bff/go.sum
+            packages/notebooks/upstream/workspaces/backend/go.sum
             distributions/core-bff/bff/go.sum
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -14193,8 +14193,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -35660,8 +35662,10 @@
       "version": "0.0.0",
       "devDependencies": {
         "@odh-dashboard/app-config": "*",
+        "@odh-dashboard/contract-tests": "*",
         "@odh-dashboard/eslint-config": "*",
-        "@odh-dashboard/tsconfig": "*"
+        "@odh-dashboard/tsconfig": "*",
+        "cross-env": "*"
       }
     },
     "packages/observability": {

--- a/packages/contract-tests/scripts/run-go-bff-consumer.sh
+++ b/packages/contract-tests/scripts/run-go-bff-consumer.sh
@@ -200,7 +200,11 @@ log_info "Starting Mock BFF server on port $PORT..."
 
 BFF_BINARY="$(mktemp -d)/bff-test"
 log_info "Building Mock BFF binary..."
-go build -o "$BFF_BINARY" ./cmd
+if [[ -n "${BFF_GO_BUILD_TAGS:-}" ]]; then
+  go build -tags "$BFF_GO_BUILD_TAGS" -o "$BFF_BINARY" ./cmd
+else
+  go build -o "$BFF_BINARY" ./cmd
+fi
 
 log_info "Starting Mock BFF server"
 GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn \

--- a/packages/notebooks/contract-tests/__tests__/testNotebooksContract.test.ts
+++ b/packages/notebooks/contract-tests/__tests__/testNotebooksContract.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ */
+import { ContractApiClient, loadOpenAPISchema } from '@odh-dashboard/contract-tests';
+
+const CONTRACT_USER_HEADERS = {
+  'kubeflow-userid': 'dev-user@example.com',
+  'kubeflow-groups': 'system:masters',
+};
+
+type SwaggerDocument = Record<string, unknown> & {
+  definitions?: Record<string, unknown>;
+};
+
+/** Resolve Swagger 2.0 #/definitions/* refs for AJV contract validation. */
+function resolveSwagger2Definition(
+  swagger: SwaggerDocument,
+  definitionName: string,
+): Record<string, unknown> {
+  const definition = swagger.definitions?.[definitionName];
+  if (!definition || typeof definition !== 'object') {
+    throw new Error(`Missing swagger definition: ${definitionName}`);
+  }
+  return resolveSwagger2Refs(swagger, definition) as Record<string, unknown>;
+}
+
+function resolveSwagger2Refs(swagger: SwaggerDocument, node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map((entry) => resolveSwagger2Refs(swagger, entry));
+  }
+  if (!node || typeof node !== 'object') {
+    return node;
+  }
+
+  const obj = node as Record<string, unknown>;
+  const ref = obj.$ref;
+  if (typeof ref === 'string' && ref.startsWith('#/definitions/')) {
+    const definitionName = ref.slice('#/definitions/'.length);
+    const target = swagger.definitions?.[definitionName];
+    if (!target) {
+      throw new Error(`Unresolved swagger definition ref: ${ref}`);
+    }
+    return resolveSwagger2Refs(swagger, target);
+  }
+
+  const resolved: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    resolved[key] = resolveSwagger2Refs(swagger, value);
+  }
+  return resolved;
+}
+
+describe('Notebooks Workspaces API Contract Tests', () => {
+  const baseUrl = process.env.CONTRACT_MOCK_BFF_URL || 'http://localhost:8080';
+  const apiClient = new ContractApiClient({
+    baseUrl,
+    defaultHeaders: CONTRACT_USER_HEADERS,
+  });
+
+  const apiSchema = loadOpenAPISchema(
+    'upstream/workspaces/backend/openapi/swagger.json',
+  ) as SwaggerDocument;
+
+  describe('Health Check Endpoint', () => {
+    it('should return health status', async () => {
+      const result = await apiClient.get('/api/v1/healthcheck');
+      expect(result).toMatchContract(
+        resolveSwagger2Definition(apiSchema, 'health_check.HealthCheck'),
+        {
+          ref: '#',
+          status: 200,
+        },
+      );
+    });
+  });
+
+  describe('User Endpoint', () => {
+    it('should return current user settings', async () => {
+      const result = await apiClient.get('/api/v1/user');
+      expect(result).toMatchContract(resolveSwagger2Definition(apiSchema, 'api.UserEnvelope'), {
+        ref: '#',
+        status: 200,
+      });
+    });
+  });
+
+  describe('Namespaces Endpoint', () => {
+    it('should list namespaces', async () => {
+      const result = await apiClient.get('/api/v1/namespaces');
+      expect(result).toMatchContract(
+        resolveSwagger2Definition(apiSchema, 'api.NamespaceListEnvelope'),
+        {
+          ref: '#',
+          status: 200,
+        },
+      );
+    });
+  });
+});

--- a/packages/notebooks/package.json
+++ b/packages/notebooks/package.json
@@ -9,7 +9,7 @@
     "update-subtree": "package-subtree --package=@odh-dashboard/notebooks",
     "update-subtree-local": "package-subtree-local --package=@odh-dashboard/notebooks",
     "install:module": "npm install --prefix upstream/workspaces/frontend",
-    "test:contract": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client' CONTRACT_MOCK_BFF_HEALTH_ENDPOINT=/api/v1/healthcheck odh-ct-bff-consumer --bff-dir upstream/workspaces/backend",
+    "test:contract": "cross-env BFF_GO_BUILD_TAGS=mockk8s BFF_MOCK_FLAGS='--mock-k8s-client' CONTRACT_MOCK_BFF_HEALTH_ENDPOINT=/api/v1/healthcheck odh-ct-bff-consumer --bff-dir upstream/workspaces/backend",
     "start:dev": "cd upstream/workspaces/frontend && PORT=9105 DEPLOYMENT_MODE=federated npm run start:dev",
     "start:dev:ext": "cd upstream/workspaces/frontend && DEPLOYMENT_MODE=federated PORT=9105 npm run start:dev",
     "start:dev:wait": "wait-on -i 1000 http://localhost:9105"

--- a/packages/notebooks/package.json
+++ b/packages/notebooks/package.json
@@ -15,8 +15,12 @@
     "start:dev:wait": "wait-on -i 1000 http://localhost:9105"
   },
   "subtree": {
+    "DO_NOT_MERGE_SYNCED_FROM_LOCAL": {
+      "branch": "RHOAIENG-58841",
+      "origin_url": "git@github.com:harshad16/kf-notebooks.git"
+    },
     "repo": "https://github.com/opendatahub-io/workbenches.git",
-    "branch": "main",
+    "branch": "RHOAIENG-58841",
     "src": "",
     "target": "upstream",
     "commit": "88f318c4e1346bdd9b5d6acda208411bc344ccbd"

--- a/packages/notebooks/package.json
+++ b/packages/notebooks/package.json
@@ -15,12 +15,8 @@
     "start:dev:wait": "wait-on -i 1000 http://localhost:9105"
   },
   "subtree": {
-    "DO_NOT_MERGE_SYNCED_FROM_LOCAL": {
-      "branch": "RHOAIENG-58841",
-      "origin_url": "git@github.com:harshad16/kf-notebooks.git"
-    },
     "repo": "https://github.com/opendatahub-io/workbenches.git",
-    "branch": "RHOAIENG-58841",
+    "branch": "main",
     "src": "",
     "target": "upstream",
     "commit": "88f318c4e1346bdd9b5d6acda208411bc344ccbd"

--- a/packages/notebooks/package.json
+++ b/packages/notebooks/package.json
@@ -9,6 +9,7 @@
     "update-subtree": "package-subtree --package=@odh-dashboard/notebooks",
     "update-subtree-local": "package-subtree-local --package=@odh-dashboard/notebooks",
     "install:module": "npm install --prefix upstream/workspaces/frontend",
+    "test:contract": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client' CONTRACT_MOCK_BFF_HEALTH_ENDPOINT=/api/v1/healthcheck odh-ct-bff-consumer --bff-dir upstream/workspaces/backend",
     "start:dev": "cd upstream/workspaces/frontend && PORT=9105 DEPLOYMENT_MODE=federated npm run start:dev",
     "start:dev:ext": "cd upstream/workspaces/frontend && DEPLOYMENT_MODE=federated PORT=9105 npm run start:dev",
     "start:dev:wait": "wait-on -i 1000 http://localhost:9105"
@@ -42,7 +43,9 @@
   },
   "devDependencies": {
     "@odh-dashboard/app-config": "*",
+    "@odh-dashboard/contract-tests": "*",
     "@odh-dashboard/eslint-config": "*",
-    "@odh-dashboard/tsconfig": "*"
+    "@odh-dashboard/tsconfig": "*",
+    "cross-env": "*"
   }
 }

--- a/packages/notebooks/upstream/workspaces/backend/Dockerfile
+++ b/packages/notebooks/upstream/workspaces/backend/Dockerfile
@@ -22,7 +22,7 @@ COPY backend/internal/ internal/
 COPY backend/openapi/ openapi/
 
 # Build the Go application
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o backend ./cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o backend ./cmd
 
 # Use distroless as minimal base image to package the application binary
 FROM gcr.io/distroless/static:nonroot

--- a/packages/notebooks/upstream/workspaces/backend/Makefile
+++ b/packages/notebooks/upstream/workspaces/backend/Makefile
@@ -94,11 +94,15 @@ swag: SWAGGER
 
 .PHONY: build
 build: fmt vet swag ## Build backend binary.
-	go build -o bin/backend cmd/main.go
+	go build -o bin/backend ./cmd
+
+.PHONY: build-mock
+build-mock: fmt vet swag ## Build backend binary with mock Kubernetes support.
+	go build -tags mockk8s -o bin/backend ./cmd
 
 .PHONY: run
 run: fmt vet swag ## Run a backend from your host.
-	go run ./cmd/main.go --port=$(PORT)
+	go run ./cmd --port=$(PORT)
 
 .PHONY: docker-build
 docker-build:

--- a/packages/notebooks/upstream/workspaces/backend/cmd/main.go
+++ b/packages/notebooks/upstream/workspaces/backend/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strconv"
 
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	application "github.com/kubeflow/notebooks/workspaces/backend/api"
@@ -66,6 +67,26 @@ func main() {
 		"client-burst",
 		getEnvAsInt("CLIENT_BURST", 100),
 		"Maximum Burst configuration passed to rest.Client",
+	)
+	flag.BoolVar(
+		&cfg.MockK8sClient,
+		"mock-k8s-client",
+		false,
+		"Use an in-process envtest Kubernetes API server (for contract tests; requires -tags mockk8s build)",
+	)
+	var contractHarnessAllowedOrigins string
+	flag.StringVar(
+		&contractHarnessAllowedOrigins,
+		"allowed-origins",
+		"",
+		"Ignored: compatibility flag for the ODH contract test harness",
+	)
+	var contractHarnessMockMRClient bool
+	flag.BoolVar(
+		&contractHarnessMockMRClient,
+		"mock-mr-client",
+		false,
+		"Ignored: compatibility flag for the ODH contract test harness",
 	)
 	flag.BoolVar(
 		// TODO: remove before GA
@@ -142,12 +163,34 @@ func main() {
 
 	// Initialize the logger
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	if contractHarnessAllowedOrigins != "" {
+		logger.Warn("--allowed-origins is accepted for ODH harness compatibility but not enforced",
+			"value", contractHarnessAllowedOrigins)
+	}
+	if contractHarnessMockMRClient {
+		logger.Warn("--mock-mr-client is accepted for ODH harness compatibility but has no effect")
+	}
 
-	// Build the Kubernetes client configuration
-	kubeconfig, err := ctrl.GetConfig()
-	if err != nil {
-		logger.Error("failed to get Kubernetes config", "error", err)
-		os.Exit(1)
+	var kubeconfig *rest.Config
+	var err error
+	if cfg.MockK8sClient {
+		var stopMockK8s func() error
+		kubeconfig, stopMockK8s, err = startMockK8s(logger)
+		if err != nil {
+			logger.Error("failed to start envtest Kubernetes API", "error", err)
+			os.Exit(1)
+		}
+		defer func() {
+			if stopErr := stopMockK8s(); stopErr != nil {
+				logger.Error("failed to stop envtest Kubernetes API", "error", stopErr)
+			}
+		}()
+	} else {
+		kubeconfig, err = ctrl.GetConfig()
+		if err != nil {
+			logger.Error("failed to get Kubernetes config", "error", err)
+			os.Exit(1)
+		}
 	}
 	kubeconfig.QPS = float32(cfg.ClientQPS)
 	kubeconfig.Burst = cfg.ClientBurst

--- a/packages/notebooks/upstream/workspaces/backend/cmd/mock_k8s_disabled.go
+++ b/packages/notebooks/upstream/workspaces/backend/cmd/mock_k8s_disabled.go
@@ -1,3 +1,5 @@
+//go:build !mockk8s
+
 /*
 Copyright 2024.
 
@@ -14,29 +16,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package main
 
-type EnvConfig struct {
-	Port int
+import (
+	"errors"
+	"log/slog"
 
-	ClientQPS   float64
-	ClientBurst int
+	"k8s.io/client-go/rest"
+)
 
-	// MockK8sClient starts an in-process envtest API server instead of using the cluster kubeconfig.
-	MockK8sClient bool
-
-	DisableAuth bool
-
-	UserIdHeader string
-	UserIdPrefix string
-	GroupsHeader string
-
-	ProxyUrlPrefix string
-
-	SwaggerEnabled  bool
-	SwaggerHost     string
-	SwaggerBasePath string
-	SwaggerScheme   string
-	// StaticAssetsDir is the directory containing frontend static assets
-	StaticAssetsDir string
+func startMockK8s(_ *slog.Logger) (*rest.Config, func() error, error) {
+	return nil, nil, errors.New("mock Kubernetes support is not compiled into this binary; rebuild with -tags mockk8s")
 }

--- a/packages/notebooks/upstream/workspaces/backend/cmd/mock_k8s_enabled.go
+++ b/packages/notebooks/upstream/workspaces/backend/cmd/mock_k8s_enabled.go
@@ -1,3 +1,5 @@
+//go:build mockk8s
+
 /*
 Copyright 2024.
 
@@ -14,29 +16,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package main
 
-type EnvConfig struct {
-	Port int
+import (
+	"log/slog"
 
-	ClientQPS   float64
-	ClientBurst int
+	"k8s.io/client-go/rest"
 
-	// MockK8sClient starts an in-process envtest API server instead of using the cluster kubeconfig.
-	MockK8sClient bool
+	"github.com/kubeflow/notebooks/workspaces/backend/internal/integrations/kubernetes/testenv"
+)
 
-	DisableAuth bool
-
-	UserIdHeader string
-	UserIdPrefix string
-	GroupsHeader string
-
-	ProxyUrlPrefix string
-
-	SwaggerEnabled  bool
-	SwaggerHost     string
-	SwaggerBasePath string
-	SwaggerScheme   string
-	// StaticAssetsDir is the directory containing frontend static assets
-	StaticAssetsDir string
+func startMockK8s(logger *slog.Logger) (*rest.Config, func() error, error) {
+	cfg, env, err := testenv.Start(logger)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cfg, env.Stop, nil
 }

--- a/packages/notebooks/upstream/workspaces/backend/internal/integrations/kubernetes/testenv/testenv.go
+++ b/packages/notebooks/upstream/workspaces/backend/internal/integrations/kubernetes/testenv/testenv.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testenv
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+const (
+	envTestK8sVersion  = "1.31.0"
+	contractTestUser   = "dev-user@example.com"
+	defaultImageCRDDir = "/crds"
+)
+
+// Environment wraps envtest for contract-test and local mock Kubernetes access.
+type Environment struct {
+	env *envtest.Environment
+}
+
+// Start boots a local Kubernetes API server with Workspace CRDs and cluster-admin access
+// for the default ODH contract-test user.
+func Start(logger *slog.Logger) (*rest.Config, *Environment, error) {
+	binaryAssetsDir := resolveBinaryAssetsDir()
+	crdDir := resolveCRDDirectory()
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{crdDir},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: binaryAssetsDir,
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to start envtest: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		_ = testEnv.Stop()
+		return nil, nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+
+	if err := grantClusterAdmin(context.Background(), clientset, contractTestUser); err != nil {
+		_ = testEnv.Stop()
+		return nil, nil, err
+	}
+
+	if logger != nil {
+		logger.Info("started envtest Kubernetes API for contract tests",
+			slog.String("assets", binaryAssetsDir),
+			slog.String("crdDir", crdDir),
+		)
+	}
+
+	return cfg, &Environment{env: testEnv}, nil
+}
+
+// Stop tears down the envtest control plane.
+func (e *Environment) Stop() error {
+	if e == nil || e.env == nil {
+		return nil
+	}
+	return e.env.Stop()
+}
+
+func resolveBinaryAssetsDir() string {
+	if dir := os.Getenv("KUBEBUILDER_ASSETS"); dir != "" {
+		return dir
+	}
+	if dir := os.Getenv("ENVTEST_ASSETS"); dir != "" {
+		return dir
+	}
+	return filepath.Join("bin", "k8s", fmt.Sprintf("%s-%s-%s", envTestK8sVersion, runtime.GOOS, runtime.GOARCH))
+}
+
+func grantClusterAdmin(ctx context.Context, clientset kubernetes.Interface, username string) error {
+	_, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("contract-test-cluster-admin-%s", sanitizeName(username)),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "User",
+				Name: username,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create cluster-admin binding for contract test user: %w", err)
+	}
+	return nil
+}
+
+func resolveCRDDirectory() string {
+	if dir := os.Getenv("WORKSPACES_CRD_DIR"); dir != "" {
+		return dir
+	}
+	if _, err := os.Stat(defaultImageCRDDir); err == nil {
+		return defaultImageCRDDir
+	}
+	return filepath.Join("..", "controller", "manifests", "kustomize", "base", "crd")
+}
+
+func sanitizeName(value string) string {
+	replacer := func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		default:
+			return '-'
+		}
+	}
+	out := make([]rune, 0, len(value))
+	for _, r := range value {
+		out = append(out, replacer(r))
+	}
+	return strings.Trim(strings.ToLower(string(out)), "-")
+}

--- a/packages/notebooks/upstream/workspaces/backend/internal/integrations/kubernetes/testenv/testenv_test.go
+++ b/packages/notebooks/upstream/workspaces/backend/internal/integrations/kubernetes/testenv/testenv_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testenv
+
+import "testing"
+
+func TestSanitizeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in, want string
+	}{
+		{"dev-user@example.com", "dev-user-example-com"},
+		{"Dev-User@Example.COM", "dev-user-example-com"},
+		{"-leading-and-trailing-", "leading-and-trailing"},
+	}
+	for _, tt := range tests {
+		if got := sanitizeName(tt.in); got != tt.want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestResolveCRDDirectory(t *testing.T) {
+	t.Setenv("WORKSPACES_CRD_DIR", "")
+	if got := resolveCRDDirectory(); got == "" {
+		t.Fatal("resolveCRDDirectory() returned empty path")
+	}
+
+	customDir := t.TempDir()
+	t.Setenv("WORKSPACES_CRD_DIR", customDir)
+	if got := resolveCRDDirectory(); got != customDir {
+		t.Errorf("resolveCRDDirectory() = %q, want %q", got, customDir)
+	}
+}


### PR DESCRIPTION
Wire notebooks into the shared contract-test framework with healthcheck, user, and namespaces endpoint validation. Requires upstream --mock-k8s-client support from workbenches after subtree sync.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Completes the notebooks mod-arch onboarding contract-testing item by wiring @odh-dashboard/notebooks into the shared @odh-dashboard/contract-tests framework.

Changes:

- packages/notebooks/contract-tests/__tests__/testNotebooksContract.test.ts — validates:
   - GET /api/v1/healthcheck
   - GET /api/v1/user
   - GET /api/v1/namespaces
- packages/notebooks/package.json — test:contract script and devDependencies
- .github/workflows/test.yml — Go module cache path for notebooks backend


Contract tests validate responses against upstream/workspaces/backend/openapi/swagger.json (Swagger 2.0), with a small ref resolver for #/definitions/*.

Depends-On: https://github.com/opendatahub-io/workbenches/pull/23


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

rerequisites: Go 1.26+, Node 22+, workbenches changes present in upstream subtree.

1. Sync workbenches (after that PR merges):

```
cd /home/harshad/odh/odh-dashboard
npm run update-subtree-local --workspace=@odh-dashboard/notebooks -- /home/harshad/odh/workbenches main
```

2. Run notebooks contract tests:

```
cd packages/notebooks
npm run test:contract
```

Expected: 3 tests pass (healthcheck, user, namespaces).

3. Full monorepo contract suite (optional):

```
cd /home/harshad/odh/odh-dashboard
npm run test:contract
```

- New consumer contract tests for notebooks (3 cases).
- Notebooks is included in root npm run test:contract via turbo once test:contract exists in package.json.
- No UI changes.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added contract tests for notebook workspace APIs, covering health checks, current-user details, and namespace listing.
  * Added response validation against the API schema and expected successful responses.
  * Improved confidence that notebook workspace services remain compatible with their documented API behavior.
* **Chores**
  * Added a dedicated command for running notebook contract tests with mock settings.
  * Updated test configuration to include Go module dependencies in workflow caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->