### PR TITLE
fix(notebooks): enable TLS for standalone notebooks-ui module federation

### DIFF
--- a/manifests/modules/notebooks/deployment.yaml
+++ b/manifests/modules/notebooks/deployment.yaml
@@ -59,6 +59,23 @@ spec:
                   items:
                     - key: service-ca.crt
                       path: service-ca.crt
+        - name: proxy-tls
+          secret:
+            secretName: notebooks-proxy-tls
+        - name: odh-trusted-ca-cert
+          configMap:
+            name: odh-trusted-ca-bundle
+            optional: true
+            items:
+              - key: ca-bundle.crt
+                path: odh-trusted-ca-bundle.crt
+        - name: odh-ca-cert
+          configMap:
+            name: odh-trusted-ca-bundle
+            optional: true
+            items:
+              - key: odh-ca-bundle.crt
+                path: odh-ca-bundle.crt
       containers:
         - name: notebooks-ui
           image: notebooks-ui-image
@@ -67,7 +84,7 @@ spec:
             httpGet:
               path: /api/v1/healthcheck
               port: 9043
-              scheme: HTTP
+              scheme: HTTPS
             initialDelaySeconds: 30
             timeoutSeconds: 15
             periodSeconds: 30
@@ -77,7 +94,7 @@ spec:
             httpGet:
               path: /api/v1/healthcheck
               port: 9043
-              scheme: HTTP
+              scheme: HTTPS
             initialDelaySeconds: 15
             timeoutSeconds: 15
             periodSeconds: 30
@@ -98,12 +115,33 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: proxy-tls
+              mountPath: /etc/tls/private
+              readOnly: true
+            - name: odh-trusted-ca-cert
+              mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+              subPath: odh-trusted-ca-bundle.crt
+              readOnly: true
+            - name: odh-trusted-ca-cert
+              mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+              subPath: odh-trusted-ca-bundle.crt
+              readOnly: true
+            - name: odh-ca-cert
+              mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+              subPath: odh-ca-bundle.crt
+              readOnly: true
+            - name: odh-ca-cert
+              mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+              subPath: odh-ca-bundle.crt
+              readOnly: true
             - name: modules-sa-token
               mountPath: /var/run/secrets/kubernetes.io/serviceaccount
               readOnly: true
-          env:
-            - name: PORT
-              value: "9043"
+          args:
+            - '--port=9043'
+            - '--cert-file=/etc/tls/private/tls.crt'
+            - '--key-file=/etc/tls/private/tls.key'
+            - '--static-assets-dir=/static'
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true

--- a/manifests/modules/notebooks/service.yaml
+++ b/manifests/modules/notebooks/service.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: odh-dashboard-notebooks-ui
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: notebooks-proxy-tls
+    service.beta.kubernetes.io/backend-protocol: HTTPS
 spec:
   selector:
     deployment: notebooks-ui

--- a/packages/notebooks/package.json
+++ b/packages/notebooks/package.json
@@ -24,7 +24,7 @@
     "name": "notebooks",
     "remoteEntry": "/remoteEntry.js",
     "authorize": true,
-    "tls": false,
+    "tls": true,
     "proxy": [
       {
         "path": "/notebooks/api",


### PR DESCRIPTION
Add OpenShift serving-cert wiring in standalone manifests and set module-federation tls: true. BFF TLS support lives in opendatahub-io/workbenches (fix/backend-tls-federation) and will be synced via the notebooks subtree.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
JIRA: https://redhat.atlassian.net/browse/RHOAIENG-88028

On fresh RHOAI installs, the notebooks plugin fails to load via module federation because the operator sets tls: true for the notebooks entry in federation-config, but notebooks-ui was deployed to serve HTTP only. rhods-dashboard logs show:

ERR_SSL_PACKET_LENGTH_TOO_LONG
Module federation service 'notebooks' is unavailable
This PR adds the dashboard-side TLS wiring for the standalone notebooks module, aligned with gen-ai/maas/mlflow manifests. No changes under packages/notebooks/upstream/ — BFF TLS is implemented in [opendatahub-io/workbenches](https://github.com/opendatahub-io/workbenches) and will arrive via subtree sync.

Depends-on: https://github.com/opendatahub-io/workbenches/pull/25


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Prerequisites: workbenches TLS PR merged + notebooks-ui image built with TLS BFF support.

- Deploy/reconcile dashboard with this PR’s manifests.
- Confirm OpenShift creates notebooks-proxy-tls secret for odh-dashboard-notebooks-ui Service.
- Confirm notebooks-ui pod is Ready (HTTPS probes on /api/v1/healthcheck).
- Check rhods-dashboard logs — no ERR_SSL_PACKET_LENGTH_TOO_LONG for /_mf/notebooks/remoteEntry.js.
- Hard-refresh browser — Workspaces / Workspace Kinds visible under AI Hub when workbenchesV2: true.
- Confirm no manual federation-config patch is required (notebooks.tls stays true).

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Manifest-only change plus package.json federation metadata. No new unit tests. Validation is cluster/integration testing with the updated notebooks-ui image.


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled HTTPS for the notebooks interface.
  * Added automatic TLS certificate provisioning and secure service configuration.
  * Updated health checks to verify HTTPS availability.
  * Enabled TLS in the notebooks module-federation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->