### PR TITLE
fix: Remove inaccessible elasticstack.slack.com URL

### DIFF
--- a/manifests/rhoai/shared/apps/elastic/elastic-app.yaml
+++ b/manifests/rhoai/shared/apps/elastic/elastic-app.yaml
@@ -57,7 +57,7 @@ spec:
 
     - Elasticsearch can be deployed where your apps are: on-prem, your cloud provider of choice, or air-gapped environments.
 
-    - Enjoy being part of a worldwide community of developers where inspiration and support are never far away. Find the Elastic community on [Slack](https://elasticstack.slack.com), our [discuss](https://discuss.elastic.co/) forums, or social media.
+    - Enjoy being part of a worldwide community of developers where inspiration and support are never far away. Find the Elastic community on our [discuss](https://discuss.elastic.co/) forums or social media.
 
     ## Quick links
 


### PR DESCRIPTION
Removes the private Slack workspace link that was causing 403 Forbidden errors in test validation. Users can still access community support via the public discuss.elastic.co forum.