### PR TITLE
Allow deployments to stop with a deleted hardware profile, and inject updated values when restarts

### DIFF
--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -7,6 +7,7 @@ import {
   K8sStatus,
   k8sUpdateResource,
   k8sPatchResource,
+  Patch,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { InferenceServiceModel, PodModel } from '#~/api/models';
 import {
@@ -315,6 +316,7 @@ export const deleteInferenceService = (
 export const patchInferenceServiceStoppedStatus = (
   inferenceService: InferenceServiceKind,
   stoppedStatus: 'true' | 'false',
+  extraPatches: Patch[] = [],
 ): Promise<InferenceServiceKind> =>
   k8sPatchResource({
     model: InferenceServiceModel,
@@ -328,5 +330,6 @@ export const patchInferenceServiceStoppedStatus = (
         path: '/metadata/annotations/serving.kserve.io~1stop',
         value: stoppedStatus,
       },
+      ...extraPatches,
     ],
   });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getExistingHardwareProfileData,
   assemblePodSpecOptions,
   applyHardwareProfileConfig,
+  getUpdatedHardwareProfilePatches,
 } from '#~/concepts/hardwareProfiles/utils';
 import { HardwareProfileKind } from '#~/k8sTypes';
 import {
@@ -18,6 +19,7 @@ import {
 } from '#~/types';
 import { UseHardwareProfileConfigResult } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { NOTEBOOK_HARDWARE_PROFILE_PATHS } from '#~/concepts/notebooks/const.ts';
+import { HardwareProfileBindingState } from '#~/concepts/hardwareProfiles/const';
 
 global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
 
@@ -676,5 +678,28 @@ describe('applyHardwareProfileConfig', () => {
     expect((result as any).metadata?.annotations?.['opendatahub.io/hardware-profile-name']).toBe(
       'custom-path-test',
     );
+  });
+});
+
+describe('getUpdatedHardwareProfilePatches', () => {
+  it('should only remove paths present on the resource', () => {
+    const patches = getUpdatedHardwareProfilePatches(
+      {
+        state: HardwareProfileBindingState.UPDATED,
+        profile: mockHardwareProfile({ resourceVersion: '999' }),
+      },
+      mockNotebookK8sResource({}),
+      NOTEBOOK_HARDWARE_PROFILE_PATHS,
+    );
+
+    expect(patches).toStrictEqual([
+      { op: 'remove', path: '/spec/template/spec/containers/0/resources' },
+      { op: 'remove', path: '/spec/template/spec/tolerations' },
+      {
+        op: 'replace',
+        path: '/metadata/annotations/opendatahub.io~1hardware-profile-resource-version',
+        value: '999',
+      },
+    ]);
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -1,5 +1,6 @@
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import { mockNotebookK8sResource } from '#~/__mocks__';
+import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
 import {
   getProfileScore,
   sortIdentifiers,
@@ -7,6 +8,7 @@ import {
   getExistingHardwareProfileData,
   assemblePodSpecOptions,
   applyHardwareProfileConfig,
+  getDeletedHardwareProfilePatches,
   getUpdatedHardwareProfilePatches,
 } from '#~/concepts/hardwareProfiles/utils';
 import { HardwareProfileKind } from '#~/k8sTypes';
@@ -19,7 +21,11 @@ import {
 } from '#~/types';
 import { UseHardwareProfileConfigResult } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { NOTEBOOK_HARDWARE_PROFILE_PATHS } from '#~/concepts/notebooks/const.ts';
-import { HardwareProfileBindingState } from '#~/concepts/hardwareProfiles/const';
+import {
+  HardwareProfileBindingState,
+  INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS,
+  REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH,
+} from '#~/concepts/hardwareProfiles/const';
 
 global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
 
@@ -682,24 +688,100 @@ describe('applyHardwareProfileConfig', () => {
 });
 
 describe('getUpdatedHardwareProfilePatches', () => {
-  it('should only remove paths present on the resource', () => {
-    const patches = getUpdatedHardwareProfilePatches(
-      {
-        state: HardwareProfileBindingState.UPDATED,
-        profile: mockHardwareProfile({ resourceVersion: '999' }),
-      },
-      mockNotebookK8sResource({}),
-      NOTEBOOK_HARDWARE_PROFILE_PATHS,
-    );
+  const updatedState = {
+    state: HardwareProfileBindingState.UPDATED,
+    profile: mockHardwareProfile({ resourceVersion: '999' }),
+  };
+  const replaceResourceVersion = {
+    op: 'replace',
+    path: '/metadata/annotations/opendatahub.io~1hardware-profile-resource-version',
+    value: '999',
+  };
+  const profileWithoutResourceVersion = mockHardwareProfile({});
+  delete profileWithoutResourceVersion.metadata.resourceVersion;
 
-    expect(patches).toStrictEqual([
-      { op: 'remove', path: '/spec/template/spec/containers/0/resources' },
-      { op: 'remove', path: '/spec/template/spec/tolerations' },
-      {
-        op: 'replace',
-        path: '/metadata/annotations/opendatahub.io~1hardware-profile-resource-version',
-        value: '999',
-      },
+  it.each([
+    {
+      kind: 'notebook',
+      cr: mockNotebookK8sResource({}),
+      paths: NOTEBOOK_HARDWARE_PROFILE_PATHS,
+      removed: ['/spec/template/spec/containers/0/resources', '/spec/template/spec/tolerations'],
+    },
+    {
+      kind: 'inference service',
+      cr: mockInferenceServiceK8sResource({
+        resources: { requests: { cpu: '1', memory: '2Gi' }, limits: { cpu: '1', memory: '2Gi' } },
+        nodeSelector: { 'nvidia.com/gpu.present': 'true' },
+      }),
+      paths: INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS,
+      removed: ['/spec/predictor/model/resources', '/spec/predictor/nodeSelector'],
+    },
+  ])('should only remove the paths a $kind actually sets', ({ cr, paths, removed }) => {
+    expect(getUpdatedHardwareProfilePatches(updatedState, cr, paths)).toStrictEqual([
+      ...removed.map((path) => ({ op: 'remove', path })),
+      replaceResourceVersion,
     ]);
+  });
+
+  it.each([
+    {
+      when: 'the binding state is null',
+      bindingState: null,
+      paths: NOTEBOOK_HARDWARE_PROFILE_PATHS,
+    },
+    {
+      when: 'the profile has not been updated',
+      bindingState: { state: HardwareProfileBindingState.DELETED, profile: undefined },
+      paths: NOTEBOOK_HARDWARE_PROFILE_PATHS,
+    },
+    { when: 'the resource paths are unknown', bindingState: updatedState, paths: undefined },
+    {
+      when: 'the profile has no resource version',
+      bindingState: {
+        state: HardwareProfileBindingState.UPDATED,
+        profile: profileWithoutResourceVersion,
+      },
+      paths: NOTEBOOK_HARDWARE_PROFILE_PATHS,
+    },
+  ])('should return no patches when $when', ({ bindingState, paths }) => {
+    expect(
+      getUpdatedHardwareProfilePatches(bindingState, mockNotebookK8sResource({}), paths),
+    ).toStrictEqual([]);
+  });
+});
+
+describe('getDeletedHardwareProfilePatches', () => {
+  const deletedState = { state: HardwareProfileBindingState.DELETED, profile: undefined };
+
+  it('should remove the dangling annotations when the profile has been deleted', () => {
+    expect(
+      getDeletedHardwareProfilePatches(
+        deletedState,
+        mockInferenceServiceK8sResource({ hardwareProfileName: 'deleted-profile' }),
+      ),
+    ).toStrictEqual(REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH);
+  });
+
+  it.each([
+    {
+      when: 'the resource has no annotation to remove',
+      bindingState: deletedState,
+      cr: mockInferenceServiceK8sResource({}),
+    },
+    {
+      when: 'the profile has not been deleted',
+      bindingState: {
+        state: HardwareProfileBindingState.UPDATED,
+        profile: mockHardwareProfile({}),
+      },
+      cr: mockInferenceServiceK8sResource({ hardwareProfileName: 'small-profile' }),
+    },
+    {
+      when: 'the binding state is null',
+      bindingState: null,
+      cr: mockInferenceServiceK8sResource({ hardwareProfileName: 'small-profile' }),
+    },
+  ])('should return no patches when $when', ({ bindingState, cr }) => {
+    expect(getDeletedHardwareProfilePatches(bindingState, cr)).toStrictEqual([]);
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/const.ts
+++ b/frontend/src/concepts/hardwareProfiles/const.ts
@@ -85,3 +85,6 @@ export const INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS: CrPathConfig = {
   tolerationsPath: 'spec.predictor.tolerations',
   nodeSelectorPath: 'spec.predictor.nodeSelector',
 };
+
+export const HARDWARE_PROFILE_RESOURCE_VERSION_PATH =
+  '/metadata/annotations/opendatahub.io~1hardware-profile-resource-version';

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -19,6 +19,7 @@ import {
 import {
   HardwareProfileBindingState,
   REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH,
+  HARDWARE_PROFILE_RESOURCE_VERSION_PATH,
 } from '#~/concepts/hardwareProfiles/const';
 import {
   HardwarePodSpecOptions,
@@ -319,4 +320,21 @@ export const applyHardwareProfileConfig = <T extends K8sResourceCommon>(
     }
   }
   return result;
+};
+
+export const getUpdatedHardwareProfilePatches = <T extends K8sResourceCommon>(
+  bindingState: HardwareProfileBindingStateInfo | null,
+  cr: T,
+  paths?: CrPathConfig,
+): Patch[] => {
+  const { resourceVersion } = bindingState?.profile?.metadata ?? {};
+
+  return bindingState?.state === HardwareProfileBindingState.UPDATED && paths && resourceVersion
+    ? [
+        ...[paths.containerResourcesPath, paths.tolerationsPath, paths.nodeSelectorPath]
+          .filter((path) => get(cr, path) !== undefined)
+          .map((path): Patch => ({ op: 'remove', path: `/${path.split('.').join('/')}` })),
+        { op: 'replace', path: HARDWARE_PROFILE_RESOURCE_VERSION_PATH, value: resourceVersion },
+      ]
+    : [];
 };

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -18,6 +18,9 @@ import useStopModalPreference from '#~/pages/modelServing/useStopModalPreference
 import ModelServingStopModal from '#~/pages/modelServing/ModelServingStopModal';
 import { useInferenceServiceStatus } from '#~/pages/modelServing/useInferenceServiceStatus.ts';
 import { useModelDeploymentNotification } from '#~/pages/modelServing/screens/projects/useModelDeploymentNotification';
+import { useHardwareProfileBindingState } from '#~/concepts/hardwareProfiles/useHardwareProfileBindingState';
+import { getDeletedHardwareProfilePatches } from '#~/concepts/hardwareProfiles/utils';
+import { MODEL_SERVING_VISIBILITY } from '#~/concepts/hardwareProfiles/const';
 import InferenceServiceEndpoint from './InferenceServiceEndpoint';
 import InferenceServiceProject from './InferenceServiceProject';
 import InferenceServiceStatus from './InferenceServiceStatus';
@@ -67,25 +70,45 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
     inferenceService.metadata.name,
   );
 
+  const [bindingStateInfo] = useHardwareProfileBindingState(
+    inferenceService,
+    MODEL_SERVING_VISIBILITY,
+  );
+  const deletedHardwareProfilePatches = React.useMemo(
+    () => getDeletedHardwareProfilePatches(bindingStateInfo, inferenceService),
+    [bindingStateInfo, inferenceService],
+  );
+
   const onStart = React.useCallback(() => {
     setIsStarting(true);
-    patchInferenceServiceStoppedStatus(inferenceService, 'false')
+    patchInferenceServiceStoppedStatus(inferenceService, 'false', deletedHardwareProfilePatches)
       .then(() => {
         refresh();
         watchDeployment();
       })
       .catch(() => setIsStarting(false));
-  }, [inferenceService, refresh, setIsStarting, watchDeployment]);
+  }, [inferenceService, refresh, setIsStarting, watchDeployment, deletedHardwareProfilePatches]);
 
   const onStop = React.useCallback(() => {
     if (dontShowModalValue) {
       setIsStarting(false);
       setIsStopping(true);
-      patchInferenceServiceStoppedStatus(inferenceService, 'true').then(refresh);
+      patchInferenceServiceStoppedStatus(
+        inferenceService,
+        'true',
+        deletedHardwareProfilePatches,
+      ).then(refresh);
     } else {
       setOpenConfirm(true);
     }
-  }, [dontShowModalValue, inferenceService, refresh, setIsStarting, setIsStopping]);
+  }, [
+    dontShowModalValue,
+    inferenceService,
+    refresh,
+    setIsStarting,
+    setIsStopping,
+    deletedHardwareProfilePatches,
+  ]);
 
   return (
     <>
@@ -208,7 +231,11 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
             if (confirmStatus) {
               setIsStarting(false);
               setIsStopping(true);
-              patchInferenceServiceStoppedStatus(inferenceService, 'true').then(refresh);
+              patchInferenceServiceStoppedStatus(
+                inferenceService,
+                'true',
+                deletedHardwareProfilePatches,
+              ).then(refresh);
             }
           }}
         />

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -76,7 +76,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
     inferenceService.metadata.name,
   );
 
-  const [bindingStateInfo] = useHardwareProfileBindingState(
+  const [bindingStateInfo, bindingStateLoaded, bindingStateError] = useHardwareProfileBindingState(
     inferenceService,
     MODEL_SERVING_VISIBILITY,
   );
@@ -119,11 +119,9 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
     if (dontShowModalValue) {
       setIsStarting(false);
       setIsStopping(true);
-      patchInferenceServiceStoppedStatus(
-        inferenceService,
-        'true',
-        deletedHardwareProfilePatches,
-      ).then(refresh);
+      patchInferenceServiceStoppedStatus(inferenceService, 'true', deletedHardwareProfilePatches)
+        .then(refresh)
+        .catch(() => setIsStopping(false));
     } else {
       setOpenConfirm(true);
     }
@@ -220,6 +218,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
           }}
           onStart={onStart}
           onStop={onStop}
+          isDisabled={!bindingStateLoaded && !bindingStateError}
           isDisabledWhileStarting={false}
         />
       </Td>
@@ -261,7 +260,9 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
                 inferenceService,
                 'true',
                 deletedHardwareProfilePatches,
-              ).then(refresh);
+              )
+                .then(refresh)
+                .catch(() => setIsStopping(false));
             }
           }}
         />

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -19,8 +19,14 @@ import ModelServingStopModal from '#~/pages/modelServing/ModelServingStopModal';
 import { useInferenceServiceStatus } from '#~/pages/modelServing/useInferenceServiceStatus.ts';
 import { useModelDeploymentNotification } from '#~/pages/modelServing/screens/projects/useModelDeploymentNotification';
 import { useHardwareProfileBindingState } from '#~/concepts/hardwareProfiles/useHardwareProfileBindingState';
-import { getDeletedHardwareProfilePatches } from '#~/concepts/hardwareProfiles/utils';
-import { MODEL_SERVING_VISIBILITY } from '#~/concepts/hardwareProfiles/const';
+import {
+  getDeletedHardwareProfilePatches,
+  getUpdatedHardwareProfilePatches,
+} from '#~/concepts/hardwareProfiles/utils';
+import {
+  MODEL_SERVING_VISIBILITY,
+  INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS,
+} from '#~/concepts/hardwareProfiles/const';
 import InferenceServiceEndpoint from './InferenceServiceEndpoint';
 import InferenceServiceProject from './InferenceServiceProject';
 import InferenceServiceStatus from './InferenceServiceStatus';
@@ -79,15 +85,35 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
     [bindingStateInfo, inferenceService],
   );
 
+  const updatedHardwareProfilePatches = React.useMemo(
+    () =>
+      getUpdatedHardwareProfilePatches(
+        bindingStateInfo,
+        inferenceService,
+        INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS,
+      ),
+    [bindingStateInfo, inferenceService],
+  );
+
   const onStart = React.useCallback(() => {
     setIsStarting(true);
-    patchInferenceServiceStoppedStatus(inferenceService, 'false', deletedHardwareProfilePatches)
+    patchInferenceServiceStoppedStatus(inferenceService, 'false', [
+      ...deletedHardwareProfilePatches,
+      ...updatedHardwareProfilePatches,
+    ])
       .then(() => {
         refresh();
         watchDeployment();
       })
       .catch(() => setIsStarting(false));
-  }, [inferenceService, refresh, setIsStarting, watchDeployment, deletedHardwareProfilePatches]);
+  }, [
+    inferenceService,
+    refresh,
+    setIsStarting,
+    watchDeployment,
+    deletedHardwareProfilePatches,
+    updatedHardwareProfilePatches,
+  ]);
 
   const onStop = React.useCallback(() => {
     if (dontShowModalValue) {

--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -712,6 +712,10 @@ class ModelServingRow extends TableRow {
   findModelResourceKindText() {
     return cy.findByTestId('resource-kind-text');
   }
+
+  findStateActionToggle() {
+    return this.find().findByTestId('state-action-toggle');
+  }
 }
 
 class KServeRow extends ModelServingRow {
@@ -727,10 +731,6 @@ class KServeRow extends ModelServingRow {
 
   findProjectScopedLabel() {
     return this.find().findByTestId('project-scoped-label');
-  }
-
-  findStateActionToggle() {
-    return this.find().findByTestId('state-action-toggle');
   }
 
   findStatusLabel(label?: string, timeout?: number) {

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureDataSet.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureDataSet.cy.ts
@@ -526,7 +526,7 @@ describe('DataSet Details', () => {
     cy.wait('@getDataSetDetails');
 
     featureDataSetDetails.findSourceFeatureService().within(() => {
-      cy.findByText('test-feature-service').click();
+      cy.findByText('test-feature-service').click({ force: true });
     });
 
     cy.url().should(

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -31,6 +31,8 @@ import {
   mockHardwareProfile,
 } from '@odh-dashboard/internal/__mocks__/mockHardwareProfile';
 import { DataScienceStackComponent } from '@odh-dashboard/internal/concepts/areas/types';
+import { ModelStateToggleLabel } from '@odh-dashboard/model-serving/components/deploymentWizard/types';
+import { REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH } from '@odh-dashboard/internal/concepts/hardwareProfiles/const';
 import { deleteModal } from '../../../pages/components/DeleteModal';
 import {
   kserveModalEdit,
@@ -821,6 +823,43 @@ describe('Model Serving Global', () => {
       errorIcon.trigger('mouseenter');
       const errorPopoverTitle = modelRow.findHardwareProfileErrorPopover();
       errorPopoverTitle.should('be.visible');
+    });
+  });
+  describe('Model Serving Deleted Hardware Profile', () => {
+    it('should strip the deleted hardware profile annotations when stopping a deployment', () => {
+      const inferenceService = mockInferenceServiceK8sResource({
+        name: 'test-model',
+        displayName: 'Test Model',
+        hardwareProfileName: 'deleted-profile',
+        hardwareProfileNamespace: 'opendatahub',
+      });
+      initIntercepts({ inferenceServices: [inferenceService] });
+
+      cy.interceptK8s(
+        'PATCH',
+        { model: InferenceServiceModel, ns: 'test-project', name: 'test-model' },
+        inferenceService,
+      ).as('stopModelPatch');
+
+      modelServingGlobal.visit('test-project');
+
+      const modelRow = modelServingGlobal.getDeploymentRow('Test Model');
+      modelRow.findHardwareProfileDeletedLabel().should('be.visible');
+      modelRow.findStateActionToggle().should('have.text', ModelStateToggleLabel.STOP).click();
+      modelRow.findConfirmStopModalButton().click();
+
+      cy.wait('@stopModelPatch').then((interception) => {
+        expect(interception.request.body).to.containSubset([
+          {
+            op: 'add',
+            path: '/metadata/annotations/serving.kserve.io~1stop',
+            value: 'true',
+          },
+        ]);
+        expect(interception.request.body).to.containSubset(
+          REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH,
+        );
+      });
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/manageRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/manageRuns.cy.ts
@@ -61,7 +61,10 @@ describe('Manage runs', () => {
   });
 
   it('navigates to "Compare runs" page when "Compare runs" breadcrumb is clicked', () => {
-    manageRunsPage.findBreadcrumb().findByRole('link', { name: 'Compare runs' }).click();
+    manageRunsPage
+      .findBreadcrumb()
+      .findByRole('link', { name: 'Compare runs' })
+      .click({ force: true });
     cy.location('pathname').should(
       'equal',
       `/develop-train/pipelines/runs/${projectName}/compare-runs`,
@@ -70,7 +73,10 @@ describe('Manage runs', () => {
   });
 
   it('navigates to runs page when the project breadcrumb is clicked', () => {
-    manageRunsPage.findBreadcrumb().findByRole('link', { name: 'Runs in Test project' }).click();
+    manageRunsPage
+      .findBreadcrumb()
+      .findByRole('link', { name: 'Runs in Test project' })
+      .click({ force: true });
     cy.location('pathname').should('equal', `/develop-train/pipelines/runs/${projectName}`);
   });
 

--- a/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
@@ -402,7 +402,11 @@ describe('Pipeline topology', () => {
         pipelineRecurringRunDetails.visit(projectId, mockRecurringRun.recurring_run_id);
 
         pipelineRecurringRunDetails.findDetailsTab().click();
-        pipelineRecurringRunDetails.findDetailItem('Project').findValue().find('a').click();
+        pipelineRecurringRunDetails
+          .findDetailItem('Project')
+          .findValue()
+          .find('a')
+          .click({ force: true });
         verifyRelativeURL(`/projects/${projectId}`);
       });
 

--- a/packages/kserve/src/deploymentStatus.ts
+++ b/packages/kserve/src/deploymentStatus.ts
@@ -5,7 +5,7 @@ import {
   getInferenceServiceStatusMessage,
 } from '@odh-dashboard/internal/concepts/modelServingKServe/kserveStatusUtils';
 import { DeploymentStatus } from '@odh-dashboard/model-serving/extension-points';
-import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sPatchResource, type Patch } from '@openshift/dynamic-plugin-sdk-utils';
 import { InferenceServiceModel } from '@odh-dashboard/internal/api/models/kserve';
 import { getModelDeploymentStoppedStates } from '@odh-dashboard/model-serving/utils';
 import { KServeDeployment } from './deployments';
@@ -13,6 +13,7 @@ import { KServeDeployment } from './deployments';
 export const patchDeploymentStoppedStatus = (
   deployment: KServeDeployment,
   isStopped: boolean,
+  extraPatches: Patch[] = [],
 ): Promise<KServeDeployment['model']> =>
   k8sPatchResource({
     model: InferenceServiceModel,
@@ -26,6 +27,7 @@ export const patchDeploymentStoppedStatus = (
         path: '/metadata/annotations/serving.kserve.io~1stop',
         value: isStopped ? 'true' : 'false',
       },
+      ...extraPatches,
     ],
   });
 

--- a/packages/llmd-serving/src/deployments/status.ts
+++ b/packages/llmd-serving/src/deployments/status.ts
@@ -3,7 +3,7 @@ import {
   ModelDeploymentState,
   ModelStatus,
 } from '@odh-dashboard/internal/pages/modelServing/screens/types';
-import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sPatchResource, type Patch } from '@openshift/dynamic-plugin-sdk-utils';
 import { K8sAPIOptions, PodKind } from '@odh-dashboard/internal/k8sTypes';
 import { checkModelPodStatus } from '@odh-dashboard/internal/concepts/modelServingKServe/kserveStatusUtils';
 import { PodModel } from '@odh-dashboard/internal/api/models/k8s';
@@ -60,6 +60,7 @@ export const getLLMdDeploymentStatus = (
 export const patchDeploymentStoppedStatus = (
   deployment: LLMdDeployment,
   isStopped: boolean,
+  extraPatches: Patch[] = [],
 ): Promise<LLMdDeployment['model']> =>
   k8sPatchResource({
     model: LLMInferenceServiceModel,
@@ -73,6 +74,7 @@ export const patchDeploymentStoppedStatus = (
         path: '/metadata/annotations/serving.kserve.io~1stop',
         value: isStopped ? 'true' : 'false',
       },
+      ...extraPatches,
     ],
   });
 

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -10,7 +10,7 @@ import type {
 // eslint-disable-next-line no-restricted-syntax, @typescript-eslint/consistent-type-imports
 import type { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils';
 import type { ModelServingPodSpecOptionsState } from '@odh-dashboard/internal/concepts/hardwareProfiles/deprecated/useModelServingAcceleratorDeprecatedPodSpecOptionsState';
-import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import type { K8sResourceCommon, Patch } from '@openshift/dynamic-plugin-sdk-utils';
 import type { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import type { ToggleState } from '@odh-dashboard/internal/components/StateActionToggle';
 import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
@@ -267,7 +267,7 @@ export type ModelServingStartStopAction<D extends Deployment = Deployment> = Ext
   {
     platform: D['modelServingPlatformId'];
     patchDeploymentStoppedStatus: CodeRef<
-      (deployment: D, isStopped: boolean) => Promise<D['model']>
+      (deployment: D, isStopped: boolean, extraPatches?: Patch[]) => Promise<D['model']>
     >;
   }
 >;

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -5,8 +5,23 @@ import { MemoryRouter } from 'react-router-dom';
 import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { mockUseAssignHardwareProfileResult } from '@odh-dashboard/internal/__mocks__/mockUseAssignHardwareProfileResult';
 import { useAssignHardwareProfile } from '@odh-dashboard/internal/concepts/hardwareProfiles/useAssignHardwareProfile';
-import { Deployment } from '../../../../extension-points';
+import { useHardwareProfileBindingState } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileBindingState';
+import {
+  HardwareProfileBindingState,
+  INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS,
+  REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH,
+} from '@odh-dashboard/internal/concepts/hardwareProfiles/const';
+import { mockHardwareProfile } from '@odh-dashboard/internal/__mocks__/mockHardwareProfile';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/internal/__mocks__/mockInferenceServiceK8sResource';
+import type { InferenceServiceKind } from '@odh-dashboard/internal/k8sTypes';
+import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import {
+  Deployment,
+  isModelServingStartStopAction,
+  type ModelServingStartStopAction,
+} from '../../../../extension-points';
 import { mockExtensions } from '../../../__tests__/mockUtils';
+import { useDeploymentExtension } from '../../../concepts/extensionUtils';
 import { DeploymentRow } from '../row/DeploymentsTableRow';
 
 jest.mock('@odh-dashboard/plugin-core');
@@ -26,7 +41,7 @@ jest.mock('../../../concepts/useStopModalPreference', () => ({
 
 // Mock the useDeploymentExtension hook
 jest.mock('../../../concepts/extensionUtils', () => ({
-  useDeploymentExtension: () => null,
+  useDeploymentExtension: jest.fn(),
   useResolvedDeploymentExtension: () => [
     {
       properties: {
@@ -64,9 +79,12 @@ jest.mock('../row/DeploymentHardwareProfileCell', () => ({
 jest.mock(
   '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileBindingState',
   () => ({
-    useHardwareProfileBindingState: () => [null, true, undefined],
+    useHardwareProfileBindingState: jest.fn(),
   }),
 );
+
+const mockUseDeploymentExtension = jest.mocked(useDeploymentExtension);
+const mockUseHardwareProfileBindingState = jest.mocked(useHardwareProfileBindingState);
 
 const mockDeployment = (partial: Partial<Deployment> = {}) => ({
   modelServingPlatformId: 'test-platform',
@@ -93,9 +111,12 @@ describe('DeploymentsTableRow', () => {
   let onDelete: jest.Mock;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     onDelete = jest.fn();
     mockExtensions();
     (useAssignHardwareProfile as jest.Mock).mockReturnValue(mockUseAssignHardwareProfileResult());
+    mockUseDeploymentExtension.mockReturnValue(null);
+    mockUseHardwareProfileBindingState.mockReturnValue([null, true, undefined]);
   });
 
   it('should render the basic row', async () => {
@@ -299,6 +320,133 @@ describe('DeploymentsTableRow', () => {
       expect(screen.getByText('https://internal-endpoint.com')).toBeInTheDocument();
       expect(screen.getByTestId('api-protocol-label')).toBeInTheDocument();
       expect(screen.getByTestId('api-protocol-label')).toHaveTextContent('REST');
+    });
+  });
+
+  describe('hardware profile patches', () => {
+    const patchStoppedStatus = jest.fn();
+    const patchDeploymentStoppedStatus = jest.fn();
+
+    const startStopExtension: LoadedExtension<ModelServingStartStopAction> = {
+      type: 'model-serving.deployments-table/start-stop-action',
+      properties: { platform: 'test-platform', patchDeploymentStoppedStatus },
+      pluginName: 'test-plugin',
+      uid: 'start-stop',
+    };
+    const formDataExtension: LoadedExtension<Extension> = {
+      type: 'model-serving.deployment/form-data',
+      properties: {
+        platform: 'test-platform',
+        hardwareProfilePaths: INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS,
+      },
+      pluginName: 'test-plugin',
+      uid: 'form-data',
+    };
+
+    beforeEach(() => {
+      patchStoppedStatus.mockResolvedValue(undefined);
+      patchDeploymentStoppedStatus.mockResolvedValue(patchStoppedStatus);
+      mockUseDeploymentExtension.mockImplementation((guard) =>
+        guard === isModelServingStartStopAction ? startStopExtension : null,
+      );
+      mockExtensions([formDataExtension]);
+    });
+
+    const renderRow = (
+      stoppedStates: { isRunning: boolean; isStopped: boolean },
+      model: InferenceServiceKind,
+    ) =>
+      renderWithRouter(
+        <table>
+          <tbody>
+            <DeploymentRow
+              deployment={{
+                ...mockDeployment({
+                  status: { state: ModelDeploymentState.LOADED, stoppedStates },
+                }),
+                model,
+              }}
+              platformColumns={[]}
+              onDelete={onDelete}
+              rowIndex={0}
+            />
+          </tbody>
+        </table>,
+      );
+
+    it('should send the annotation removals when stopping with a deleted profile', async () => {
+      mockUseHardwareProfileBindingState.mockReturnValue([
+        { state: HardwareProfileBindingState.DELETED, profile: undefined },
+        true,
+        undefined,
+      ]);
+
+      renderRow(
+        { isRunning: true, isStopped: false },
+        mockInferenceServiceK8sResource({ hardwareProfileName: 'deleted-profile' }),
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('state-action-toggle'));
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('stop-model-button'));
+      });
+
+      expect(patchStoppedStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        true,
+        REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH,
+      );
+    });
+
+    it('should strip the stale resource settings when starting with an updated profile', async () => {
+      mockUseHardwareProfileBindingState.mockReturnValue([
+        {
+          state: HardwareProfileBindingState.UPDATED,
+          profile: mockHardwareProfile({ resourceVersion: '999' }),
+        },
+        true,
+        undefined,
+      ]);
+
+      renderRow(
+        { isRunning: false, isStopped: true },
+        mockInferenceServiceK8sResource({
+          hardwareProfileName: 'small-profile',
+          hardwareProfileResourceVersion: '1',
+          resources: { requests: { cpu: '1', memory: '2Gi' }, limits: { cpu: '1', memory: '2Gi' } },
+        }),
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('state-action-toggle'));
+      });
+
+      expect(patchStoppedStatus).toHaveBeenCalledWith(expect.anything(), false, [
+        { op: 'remove', path: '/spec/predictor/model/resources' },
+        {
+          op: 'replace',
+          path: '/metadata/annotations/opendatahub.io~1hardware-profile-resource-version',
+          value: '999',
+        },
+      ]);
+    });
+
+    it('should disable the toggle while the binding state is still loading', () => {
+      mockUseHardwareProfileBindingState.mockReturnValue([null, false, undefined]);
+
+      renderRow({ isRunning: true, isStopped: false }, mockInferenceServiceK8sResource({}));
+
+      expect(screen.getByTestId('state-action-toggle')).toBeDisabled();
+    });
+
+    it('should keep the toggle usable when the profiles cannot be loaded', () => {
+      mockUseHardwareProfileBindingState.mockReturnValue([null, false, new Error('forbidden')]);
+
+      renderRow({ isRunning: true, isStopped: false }, mockInferenceServiceK8sResource({}));
+
+      expect(screen.getByTestId('state-action-toggle')).toBeEnabled();
     });
   });
 });

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -61,6 +61,13 @@ jest.mock('../row/DeploymentHardwareProfileCell', () => ({
   DeploymentHardwareProfileCell: () => <td>Hardware Profile</td>,
 }));
 
+jest.mock(
+  '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileBindingState',
+  () => ({
+    useHardwareProfileBindingState: () => [null, true, undefined],
+  }),
+);
+
 const mockDeployment = (partial: Partial<Deployment> = {}) => ({
   modelServingPlatformId: 'test-platform',
   model: {

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -8,7 +8,10 @@ import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/
 import ResourceNameTooltip from '@odh-dashboard/internal/components/ResourceNameTooltip';
 import StateActionToggle from '@odh-dashboard/internal/components/StateActionToggle';
 import { useHardwareProfileBindingState } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileBindingState';
-import { getDeletedHardwareProfilePatches } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
+import {
+  getDeletedHardwareProfilePatches,
+  getUpdatedHardwareProfilePatches,
+} from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
 import { MODEL_SERVING_VISIBILITY } from '@odh-dashboard/internal/concepts/hardwareProfiles/const';
 import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import { DeploymentHardwareProfileCell } from './DeploymentHardwareProfileCell';
@@ -83,16 +86,31 @@ export const DeploymentRow: React.FC<{
   const hardwareProfilePaths = formDataExtension?.properties.hardwareProfilePaths;
   const pathsLoaded = formDataResolved && !!hardwareProfilePaths;
 
+  const updatedHardwareProfilePatches = React.useMemo(
+    () =>
+      getUpdatedHardwareProfilePatches(bindingStateInfo, deployment.model, hardwareProfilePaths),
+    [bindingStateInfo, deployment.model, hardwareProfilePaths],
+  );
+
   const onStart = React.useCallback(() => {
     if (!startStopActionExtension) return;
     startStopActionExtension.properties
       .patchDeploymentStoppedStatus()
       .then(async (resolvedFunction) => {
-        await resolvedFunction(deployment, false, deletedHardwareProfilePatches);
+        await resolvedFunction(deployment, false, [
+          ...deletedHardwareProfilePatches,
+          ...updatedHardwareProfilePatches,
+        ]);
         // Start watching for deployment status changes
         watchDeployment();
       });
-  }, [deployment, startStopActionExtension, watchDeployment, deletedHardwareProfilePatches]);
+  }, [
+    deployment,
+    startStopActionExtension,
+    watchDeployment,
+    deletedHardwareProfilePatches,
+    updatedHardwareProfilePatches,
+  ]);
 
   const onStop = React.useCallback(() => {
     if (dontShowModalValue) {

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -7,6 +7,9 @@ import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import ResourceNameTooltip from '@odh-dashboard/internal/components/ResourceNameTooltip';
 import StateActionToggle from '@odh-dashboard/internal/components/StateActionToggle';
+import { useHardwareProfileBindingState } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileBindingState';
+import { getDeletedHardwareProfilePatches } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
+import { MODEL_SERVING_VISIBILITY } from '@odh-dashboard/internal/concepts/hardwareProfiles/const';
 import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import { DeploymentHardwareProfileCell } from './DeploymentHardwareProfileCell';
 import { DeploymentRowExpandedSection } from './DeploymentsTableRowExpandedSection';
@@ -56,6 +59,15 @@ export const DeploymentRow: React.FC<{
 
   const { watchDeployment } = useModelDeploymentNotification(deployment);
 
+  const [bindingStateInfo] = useHardwareProfileBindingState(
+    deployment.model,
+    MODEL_SERVING_VISIBILITY,
+  );
+  const deletedHardwareProfilePatches = React.useMemo(
+    () => getDeletedHardwareProfilePatches(bindingStateInfo, deployment.model),
+    [bindingStateInfo, deployment.model],
+  );
+
   const navigateToDeploymentWizard = useNavigateToDeploymentWizard(deployment);
 
   const [formDataExtensions, formDataResolved] = useResolvedExtensions(
@@ -76,21 +88,23 @@ export const DeploymentRow: React.FC<{
     startStopActionExtension.properties
       .patchDeploymentStoppedStatus()
       .then(async (resolvedFunction) => {
-        await resolvedFunction(deployment, false);
+        await resolvedFunction(deployment, false, deletedHardwareProfilePatches);
         // Start watching for deployment status changes
         watchDeployment();
       });
-  }, [deployment, startStopActionExtension, watchDeployment]);
+  }, [deployment, startStopActionExtension, watchDeployment, deletedHardwareProfilePatches]);
 
   const onStop = React.useCallback(() => {
     if (dontShowModalValue) {
       startStopActionExtension?.properties
         .patchDeploymentStoppedStatus()
-        .then((resolvedFunction) => resolvedFunction(deployment, true));
+        .then((resolvedFunction) =>
+          resolvedFunction(deployment, true, deletedHardwareProfilePatches),
+        );
     } else {
       setOpenConfirm(true);
     }
-  }, [dontShowModalValue, deployment, startStopActionExtension]);
+  }, [dontShowModalValue, deployment, startStopActionExtension, deletedHardwareProfilePatches]);
 
   const row = (
     <>
@@ -209,7 +223,9 @@ export const DeploymentRow: React.FC<{
             if (confirmStatus) {
               startStopActionExtension.properties
                 .patchDeploymentStoppedStatus()
-                .then((resolvedFunction) => resolvedFunction(deployment, true));
+                .then((resolvedFunction) =>
+                  resolvedFunction(deployment, true, deletedHardwareProfilePatches),
+                );
             }
           }}
         />

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -62,7 +62,7 @@ export const DeploymentRow: React.FC<{
 
   const { watchDeployment } = useModelDeploymentNotification(deployment);
 
-  const [bindingStateInfo] = useHardwareProfileBindingState(
+  const [bindingStateInfo, bindingStateLoaded, bindingStateError] = useHardwareProfileBindingState(
     deployment.model,
     MODEL_SERVING_VISIBILITY,
   );
@@ -192,6 +192,7 @@ export const DeploymentRow: React.FC<{
               currentState={deployment.status.stoppedStates}
               onStart={onStart}
               onStop={onStop}
+              isDisabled={(!bindingStateLoaded && !bindingStateError) || !formDataResolved}
               isDisabledWhileStarting={false}
             />
           ) : (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-78897
https://redhat.atlassian.net/browse/RHOAIENG-78895

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When a hardware profile bound to a deployment is deleted, the `InferenceService` keeps dangling `opendatahub.io/hardware-profile-name` and `-namespace` annotations. The hardware profile webhook rejects any patch that leaves those annotations in place, including the unrelated stop/start patch, so affected deployments could not be stopped or restarted.


Fixed by patching the hardware profile annotation removal with `patchInferenceServiceStoppedStatus` and `patchDeploymentStoppedStatus`, mirroring the existing workbench fix.

Separately, resources, tolerations and nodeSelector are written into the inference CR when a deployment is created, and the webhook only fills in paths that are absent, it never overwrites values already present. A deployment therefore kept the settings captured at deploy time no matter how many times it was restarted, even though the hardware profile Updated state tells the user that restarting will apply the profile's new settings.

Fixed by stripping those paths on start so the webhook repopulates them from the profile's current values, and bringing the stored resource version up to date so the deployment stops reporting the Updated state. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This should be tested in 3.4.4.
**Deleted hardware profile**
I deployed a model from model catalog, selecting a hardware profile. While it's running, I delete the hardware profile, and then stop the deployment. It should stop successfully. 
**Updated hardware profile**
Deploy a model with a hardware profile whose default and max counts differ. Stop the deployment, edit the profile's CPU/memory, then start it again. It should come back with the profile's new values rather than the ones captured at deploy time.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
