### PR TITLE
add kueue project modal for clusterqueue

### DIFF
--- a/frontend/src/api/k8s/__tests__/localQueues.spec.ts
+++ b/frontend/src/api/k8s/__tests__/localQueues.spec.ts
@@ -2,7 +2,7 @@ import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
 import { LocalQueueModel } from '@odh-dashboard/k8s-core/api/models';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
 import { LocalQueueKind } from '#~/k8sTypes';
-import { listLocalQueues } from '#~/api/k8s/localQueues';
+import { listAllLocalQueues, listLocalQueues } from '#~/api/k8s/localQueues';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sListResourceItems: jest.fn(),
@@ -35,5 +35,18 @@ describe('listLocalQueues', () => {
       model: LocalQueueModel,
       queryOptions: { ns: 'test-project' },
     });
+  });
+});
+
+describe('listAllLocalQueues', () => {
+  it('should fetch and return localqueues across all namespaces', async () => {
+    k8sListResourceItemsMock.mockResolvedValue([mockedLocalQueue]);
+    const result = await listAllLocalQueues();
+    expect(k8sListResourceItemsMock).toHaveBeenCalledWith({
+      model: LocalQueueModel,
+      queryOptions: {},
+    });
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([mockedLocalQueue]);
   });
 });

--- a/frontend/src/api/k8s/localQueues.ts
+++ b/frontend/src/api/k8s/localQueues.ts
@@ -15,3 +15,13 @@ export const listLocalQueues = async (
     queryOptions,
   });
 };
+
+export const listAllLocalQueues = async (labelSelector?: string): Promise<LocalQueueKind[]> => {
+  const queryOptions = {
+    ...(labelSelector && { queryParams: { labelSelector } }),
+  };
+  return k8sListResourceItems<LocalQueueKind>({
+    model: LocalQueueModel,
+    queryOptions,
+  });
+};

--- a/packages/gpuaas/src/components/KueueProjectsModal.tsx
+++ b/packages/gpuaas/src/components/KueueProjectsModal.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+/* eslint-disable @odh-dashboard/no-restricted-imports */
+import {
+  Alert,
+  Bullseye,
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  SearchInput,
+  Spinner,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { DashboardEmptyTableView, Table } from '@odh-dashboard/ui-core';
+/* eslint-enable @odh-dashboard/no-restricted-imports */
+import KueueProjectsModalRow from './KueueProjectsModalRow';
+import {
+  KUEUE_PROJECTS_MODAL_DESCRIPTION,
+  KUEUE_PROJECTS_MODAL_TITLE,
+  kueueProjectsColumns,
+} from './kueueProjectsModalConst';
+import useKueueProjectsForClusterQueue from '../hooks/useKueueProjectsForClusterQueue';
+
+export type KueueProjectsModalProps = {
+  clusterQueueName: string;
+  onClose: () => void;
+};
+
+const KueueProjectsModal: React.FC<KueueProjectsModalProps> = ({ clusterQueueName, onClose }) => {
+  const [filterText, setFilterText] = React.useState('');
+  const { data: projects, loaded, error } = useKueueProjectsForClusterQueue(clusterQueueName);
+
+  const filteredProjects = React.useMemo(() => {
+    const normalized = filterText.trim().toLowerCase();
+    if (!normalized) {
+      return projects;
+    }
+
+    return projects.filter((project) => project.name.toLowerCase().includes(normalized));
+  }, [filterText, projects]);
+
+  const onClearFilters = React.useCallback(() => {
+    setFilterText('');
+  }, []);
+
+  const modalBody = error ? (
+    <Alert
+      isInline
+      variant="danger"
+      title="Error loading Kueue projects"
+      data-testid="kueue-projects-error-alert"
+    >
+      {error.message}
+    </Alert>
+  ) : !loaded ? (
+    <Bullseye data-testid="kueue-projects-loading">
+      <Spinner />
+    </Bullseye>
+  ) : (
+    <Table
+      data-testid="kueue-projects-table"
+      aria-label="Kueue projects table"
+      variant="compact"
+      enablePagination="compact"
+      defaultSortColumn={0}
+      data={filteredProjects}
+      columns={kueueProjectsColumns}
+      toolbarContent={
+        <ToolbarGroup>
+          <ToolbarItem>
+            <SearchInput
+              aria-label="Find by name"
+              placeholder="Find by name"
+              value={filterText}
+              onChange={(_event, value) => setFilterText(value)}
+              onClear={() => setFilterText('')}
+              data-testid="kueue-projects-name-filter"
+            />
+          </ToolbarItem>
+        </ToolbarGroup>
+      }
+      emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
+      onClearFilters={onClearFilters}
+      rowRenderer={(project) => <KueueProjectsModalRow key={project.name} project={project} />}
+    />
+  );
+
+  return (
+    <Modal
+      isOpen
+      variant="medium"
+      onClose={onClose}
+      data-testid="kueue-projects-modal"
+      aria-labelledby="kueue-projects-modal-title"
+    >
+      <ModalHeader
+        title={KUEUE_PROJECTS_MODAL_TITLE}
+        labelId="kueue-projects-modal-title"
+        description={KUEUE_PROJECTS_MODAL_DESCRIPTION}
+      />
+      <ModalBody>{modalBody}</ModalBody>
+      <ModalFooter>
+        <Button data-testid="kueue-projects-close-button" variant="primary" onClick={onClose}>
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default KueueProjectsModal;

--- a/packages/gpuaas/src/components/KueueProjectsModalRow.tsx
+++ b/packages/gpuaas/src/components/KueueProjectsModalRow.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { Label, Truncate } from '@patternfly/react-core';
+import { Td, Tr } from '@patternfly/react-table';
+import { KUEUE_MANAGED_STATUS_LABEL } from './kueueProjectsModalConst';
+import type { KueueProject } from '../types';
+
+type KueueProjectsModalRowProps = {
+  project: KueueProject;
+};
+
+const KueueProjectsModalRow: React.FC<KueueProjectsModalRowProps> = ({ project }) => (
+  <Tr data-testid={`kueue-projects-row-${project.name}`}>
+    <Td dataLabel="Name">
+      <Truncate content={project.name} />
+    </Td>
+    <Td dataLabel="Status">
+      <Label color="green" isCompact data-testid="kueue-managed-status-label">
+        {KUEUE_MANAGED_STATUS_LABEL}
+      </Label>
+    </Td>
+  </Tr>
+);
+
+export default KueueProjectsModalRow;

--- a/packages/gpuaas/src/components/__tests__/KueueProjectsModal.spec.tsx
+++ b/packages/gpuaas/src/components/__tests__/KueueProjectsModal.spec.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import KueueProjectsModal from '../KueueProjectsModal';
+import useKueueProjectsForClusterQueue from '../../hooks/useKueueProjectsForClusterQueue';
+
+jest.mock('../../hooks/useKueueProjectsForClusterQueue', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const useKueueProjectsForClusterQueueMock = jest.mocked(useKueueProjectsForClusterQueue);
+
+describe('KueueProjectsModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useKueueProjectsForClusterQueueMock.mockReturnValue({
+      data: [{ name: 'legacy-jobs' }, { name: 'alpha-team' }, { name: 'beta-workloads' }],
+      loaded: true,
+      error: undefined,
+      refresh: jest.fn(),
+    });
+  });
+
+  it('renders title, description, and project rows', () => {
+    render(<KueueProjectsModal clusterQueueName="gpu-cq" onClose={jest.fn()} />);
+
+    expect(screen.getByText('Kueue projects')).toBeInTheDocument();
+    expect(screen.getByText('Kueue projects using this cluster queue.')).toBeInTheDocument();
+    expect(screen.getByTestId('kueue-projects-row-legacy-jobs')).toBeInTheDocument();
+    expect(screen.getByTestId('kueue-projects-row-alpha-team')).toBeInTheDocument();
+    expect(useKueueProjectsForClusterQueueMock).toHaveBeenCalledWith('gpu-cq');
+  });
+
+  it('shows loading state while projects are loading', () => {
+    useKueueProjectsForClusterQueueMock.mockReturnValue({
+      data: [],
+      loaded: false,
+      error: undefined,
+      refresh: jest.fn(),
+    });
+
+    render(<KueueProjectsModal clusterQueueName="gpu-cq" onClose={jest.fn()} />);
+
+    expect(screen.getByTestId('kueue-projects-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('kueue-projects-table')).not.toBeInTheDocument();
+  });
+
+  it('filters projects by name', async () => {
+    const user = userEvent.setup();
+    render(<KueueProjectsModal clusterQueueName="gpu-cq" onClose={jest.fn()} />);
+
+    const searchInput = screen.getByPlaceholderText('Find by name');
+    await user.type(searchInput, 'alpha');
+
+    expect(screen.getByTestId('kueue-projects-row-alpha-team')).toBeInTheDocument();
+    expect(screen.queryByTestId('kueue-projects-row-legacy-jobs')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when Close is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<KueueProjectsModal clusterQueueName="gpu-cq" onClose={onClose} />);
+
+    await user.click(screen.getByTestId('kueue-projects-close-button'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gpuaas/src/components/__tests__/KueueProjectsModal.spec.tsx
+++ b/packages/gpuaas/src/components/__tests__/KueueProjectsModal.spec.tsx
@@ -47,6 +47,23 @@ describe('KueueProjectsModal', () => {
     expect(screen.queryByTestId('kueue-projects-table')).not.toBeInTheDocument();
   });
 
+  it('shows error state when loading projects fails', () => {
+    useKueueProjectsForClusterQueueMock.mockReturnValue({
+      data: [],
+      loaded: true,
+      error: new Error('Failed to fetch local queues'),
+      refresh: jest.fn(),
+    });
+
+    render(<KueueProjectsModal clusterQueueName="gpu-cq" onClose={jest.fn()} />);
+
+    expect(screen.getByTestId('kueue-projects-error-alert')).toBeInTheDocument();
+    expect(screen.getByText('Error loading Kueue projects')).toBeInTheDocument();
+    expect(screen.getByText('Failed to fetch local queues')).toBeInTheDocument();
+    expect(screen.queryByTestId('kueue-projects-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('kueue-projects-loading')).not.toBeInTheDocument();
+  });
+
   it('filters projects by name', async () => {
     const user = userEvent.setup();
     render(<KueueProjectsModal clusterQueueName="gpu-cq" onClose={jest.fn()} />);

--- a/packages/gpuaas/src/components/kueueProjectsModalConst.ts
+++ b/packages/gpuaas/src/components/kueueProjectsModalConst.ts
@@ -1,0 +1,27 @@
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports -- shared table types from ui-core
+import type { SortableData } from '@odh-dashboard/ui-core';
+import type { KueueProject } from '../types';
+
+export const KUEUE_PROJECTS_MODAL_TITLE = 'Kueue projects';
+
+export const KUEUE_PROJECTS_MODAL_DESCRIPTION = 'Kueue projects using this cluster queue.';
+
+export const KUEUE_MANAGED_STATUS_LABEL = 'Kueue-managed';
+
+export const compareKueueProjectsByName = (a: KueueProject, b: KueueProject): number =>
+  a.name.localeCompare(b.name);
+
+export const kueueProjectsColumns: SortableData<KueueProject>[] = [
+  {
+    label: 'Name',
+    field: 'name',
+    width: 50,
+    sortable: compareKueueProjectsByName,
+  },
+  {
+    label: 'Status',
+    field: 'status',
+    width: 50,
+    sortable: false,
+  },
+];

--- a/packages/gpuaas/src/hooks/__tests__/useKueueProjectsForClusterQueue.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useKueueProjectsForClusterQueue.spec.ts
@@ -1,0 +1,71 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { getModelServingProjects } from '@odh-dashboard/internal/api/k8s/projects';
+import { listAllLocalQueues } from '@odh-dashboard/internal/api/k8s/localQueues';
+import useKueueProjectsForClusterQueue from '../useKueueProjectsForClusterQueue';
+
+jest.mock('@odh-dashboard/internal/api/k8s/projects', () => ({
+  getModelServingProjects: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/api/k8s/localQueues', () => ({
+  listAllLocalQueues: jest.fn(),
+}));
+
+const getModelServingProjectsMock = jest.mocked(getModelServingProjects);
+const listAllLocalQueuesMock = jest.mocked(listAllLocalQueues);
+
+describe('useKueueProjectsForClusterQueue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns Kueue-managed data science projects linked to the cluster queue', async () => {
+    listAllLocalQueuesMock.mockResolvedValue([
+      {
+        apiVersion: 'kueue.x-k8s.io/v1beta2',
+        kind: 'LocalQueue',
+        metadata: { name: 'lq-1', namespace: 'legacy-jobs' },
+        spec: { clusterQueue: 'gpu-cq' },
+      },
+      {
+        apiVersion: 'kueue.x-k8s.io/v1beta2',
+        kind: 'LocalQueue',
+        metadata: { name: 'lq-2', namespace: 'other-cq-project' },
+        spec: { clusterQueue: 'other-cq' },
+      },
+    ]);
+    getModelServingProjectsMock.mockResolvedValue([
+      mockProjectK8sResource({ k8sName: 'legacy-jobs', enableKueue: true }),
+      mockProjectK8sResource({ k8sName: 'other-cq-project', enableKueue: true }),
+      mockProjectK8sResource({ k8sName: 'not-kueue-managed', isDSProject: true }),
+    ]);
+
+    const renderResult = testHook(useKueueProjectsForClusterQueue)('gpu-cq');
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current.data).toEqual([{ name: 'legacy-jobs' }]);
+    expect(renderResult.result.current.loaded).toBe(true);
+    expect(renderResult.result.current.error).toBeUndefined();
+  });
+
+  it('excludes projects without the Kueue-managed label', async () => {
+    listAllLocalQueuesMock.mockResolvedValue([
+      {
+        apiVersion: 'kueue.x-k8s.io/v1beta2',
+        kind: 'LocalQueue',
+        metadata: { name: 'lq-1', namespace: 'legacy-jobs' },
+        spec: { clusterQueue: 'gpu-cq' },
+      },
+    ]);
+    getModelServingProjectsMock.mockResolvedValue([
+      mockProjectK8sResource({ k8sName: 'legacy-jobs', enableKueue: false }),
+    ]);
+
+    const renderResult = testHook(useKueueProjectsForClusterQueue)('gpu-cq');
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current.data).toEqual([]);
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+});

--- a/packages/gpuaas/src/hooks/useKueueProjectsForClusterQueue.ts
+++ b/packages/gpuaas/src/hooks/useKueueProjectsForClusterQueue.ts
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import useFetch, { FetchStateObject, NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetch';
+import { KnownLabels } from '@odh-dashboard/k8s-core';
+import { getModelServingProjects } from '@odh-dashboard/internal/api/k8s/projects';
+import { listAllLocalQueues } from '@odh-dashboard/internal/api/k8s/localQueues';
+import type { KueueProject } from '../types';
+
+const isKueueManagedProject = (
+  project: Awaited<ReturnType<typeof getModelServingProjects>>[number],
+): boolean => project.metadata.labels?.[KnownLabels.KUEUE_MANAGED] === 'true';
+
+const resolveKueueProjectsForClusterQueue = async (
+  clusterQueueName: string,
+): Promise<KueueProject[]> => {
+  const [localQueues, projects] = await Promise.all([
+    listAllLocalQueues(),
+    getModelServingProjects(),
+  ]);
+
+  const namespacesForClusterQueue = new Set(
+    localQueues
+      .filter((localQueue) => localQueue.spec.clusterQueue === clusterQueueName)
+      .map((localQueue) => localQueue.metadata?.namespace)
+      .filter((namespace): namespace is string => Boolean(namespace)),
+  );
+
+  return projects
+    .filter(
+      (project) =>
+        namespacesForClusterQueue.has(project.metadata.name) && isKueueManagedProject(project),
+    )
+    .map((project) => ({ name: project.metadata.name }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+};
+
+const useKueueProjectsForClusterQueue = (
+  clusterQueueName?: string,
+): FetchStateObject<KueueProject[]> =>
+  useFetch<KueueProject[]>(
+    React.useCallback(() => {
+      if (!clusterQueueName) {
+        return Promise.reject(new NotReadyError('No cluster queue name'));
+      }
+
+      return resolveKueueProjectsForClusterQueue(clusterQueueName);
+    }, [clusterQueueName]),
+    [],
+    { initialPromisePurity: true },
+  );
+
+export default useKueueProjectsForClusterQueue;

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -25,3 +25,7 @@ export type CQDcgmResult = {
   computePercentage: number | null | undefined;
   memoryPercentage: number | null | undefined;
 };
+
+export type KueueProject = {
+  name: string;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-88145
## Description
Adds a Kueue projects modal for viewing projects associated with a ClusterQueue.

The modal:
- Loads LocalQueues across all namespaces.
- Finds projects linked to the selected ClusterQueue.
- Displays Kueue-managed projects in a table.
- Supports sorting, searching, pagination, loading, error, and empty states.

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
<img width="879" height="724" alt="kueue-enabled" src="https://github.com/user-attachments/assets/bb34d7c3-badd-4169-b1d3-06da21df0723" />

## How Has This Been Tested?

Manually tested by temporarily adding the Kueue projects modal to the Infrastructure page with `clusterQueueName="default"`.

Verified that:
- The modal opens and closes correctly.
- LocalQueues are loaded across namespaces.
- Projects associated with the ClusterQueue are displayed.
- Search, sorting, pagination, loading, and empty states work as expected.
- The modal correctly displays `kueue-managed` from the test cluster.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
- Added unit tests for LocalQueue retrieval.
- Added hook tests for ClusterQueue-to-project filtering.

<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a modal for viewing projects associated with a Kueue cluster queue.
  * Added project filtering, sorting, pagination, loading, and error states.
  * Project rows now display names and Kueue-managed status.
  * Added support for retrieving projects across all namespaces.

* **Bug Fixes**
  * Improved handling when a cluster queue is unavailable or unspecified.

* **Tests**
  * Added coverage for project loading, filtering, sorting, display, and modal interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->