### PR TITLE
RHOAIENG-79897: Update unit test jest.mock() targets from internal to…

### DIFF
--- a/frontend/src/__mocks__/mockClusterSettings.ts
+++ b/frontend/src/__mocks__/mockClusterSettings.ts
@@ -1,5 +1,5 @@
+import type { ClusterSettingsType } from '@odh-dashboard/plugin-core/host-api';
 import { DEFAULT_CULLER_TIMEOUT, DEFAULT_PVC_SIZE } from '#~/pages/clusterSettings/const';
-import { ClusterSettingsType } from '#~/types';
 
 export const mockClusterSettings = ({
   userTrackingEnabled = false,

--- a/frontend/src/app/HostApiProvider.tsx
+++ b/frontend/src/app/HostApiProvider.tsx
@@ -21,6 +21,7 @@ import {
 import { getDashboardPvcs } from '#~/api/k8s/pvcs';
 import { addSupportServingPlatformProject, createProject } from '#~/api/k8s/projects';
 import { fetchDashboardConfig } from '#~/services/dashboardConfigService';
+import { fetchClusterSettings, updateClusterSettings } from '#~/services/clusterSettingsService';
 import { useTemplates } from '#~/api/k8s/templates';
 import { useWatchConnectionTypes } from '#~/utilities/useWatchConnectionTypes';
 import useServingConnections from '#~/pages/projects/screens/detail/connections/useServingConnections';
@@ -50,6 +51,8 @@ const HostApiProvider: React.FC<HostApiProviderProps> = ({ children }) => {
       checkAccess,
       trackEvent: fireMiscTrackingEvent,
       fetchDashboardConfig,
+      fetchClusterSettings,
+      updateClusterSettings,
     }),
     [dashboardNamespace],
   );

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -3,10 +3,13 @@ import * as _ from 'lodash-es';
 import { AlertVariant, Button, Stack, StackItem } from '@patternfly/react-core';
 import TitleWithIcon from '@odh-dashboard/ui-core/design/TitleWithIcon';
 import { ApplicationsPage, TrackingOutcome } from '@odh-dashboard/ui-core';
+import type {
+  ClusterSettingsType,
+  ModelServingPlatformEnabled,
+} from '@odh-dashboard/plugin-core/host-api';
 import { useAppContext } from '#~/app/AppContext';
 import { fireFormTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 import { fetchClusterSettings, updateClusterSettings } from '#~/services/clusterSettingsService';
-import { ClusterSettingsType, ModelServingPlatformEnabled } from '#~/types';
 import { addNotification } from '#~/redux/actions/actions';
 import { useAppDispatch } from '#~/redux/hooks';
 import PVCSizeSettings from '#~/pages/clusterSettings/PVCSizeSettings';

--- a/frontend/src/pages/clusterSettings/const.ts
+++ b/frontend/src/pages/clusterSettings/const.ts
@@ -1,4 +1,4 @@
-import { ClusterSettingsType } from '#~/types';
+import type { ClusterSettingsType } from '@odh-dashboard/plugin-core/host-api';
 
 export const DEFAULT_PVC_SIZE = 20;
 export const MIN_PVC_SIZE = 1;

--- a/frontend/src/services/clusterSettingsService.ts
+++ b/frontend/src/services/clusterSettingsService.ts
@@ -1,4 +1,4 @@
-import { ClusterSettingsType } from '#~/types';
+import type { ClusterSettingsType } from '@odh-dashboard/plugin-core/host-api';
 import axios from '#~/utilities/axios';
 
 export const fetchClusterSettings = (): Promise<ClusterSettingsType> => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -60,21 +60,6 @@ export type NotebookTolerationFormSettings = TolerationSettings & {
   error?: string;
 };
 
-export type ClusterSettingsType = {
-  userTrackingEnabled: boolean;
-  pvcSize: number;
-  cullerTimeout: number;
-  modelServingPlatformEnabled: ModelServingPlatformEnabled;
-  isDistributedInferencingDefault?: boolean;
-  defaultDeploymentStrategy?: string;
-  globalMLflowNamespaces?: string[];
-};
-
-export type ModelServingPlatformEnabled = {
-  kServe: boolean;
-  LLMd: boolean;
-};
-
 /** @deprecated -- use SDK type */
 export type Secret = {
   data?: Record<string, string>;

--- a/packages/cypress/cypress/support/commands/odh.ts
+++ b/packages/cypress/cypress/support/commands/odh.ts
@@ -67,7 +67,6 @@ import type { AllowedUser } from '@odh-dashboard/internal/pages/notebookControll
 import type { StatusResponse } from '@odh-dashboard/internal/redux/types';
 import type {
   BYONImage,
-  ClusterSettingsType,
   DetectedAccelerators,
   ImageInfo,
   OdhDocument,
@@ -75,6 +74,7 @@ import type {
   ResponseStatus,
   SubscriptionStatusData,
 } from '@odh-dashboard/internal/types';
+import type { ClusterSettingsType } from '@odh-dashboard/plugin-core/host-api';
 import type { PrometheusQueryRangeResponse } from '@odh-dashboard/ui-core/types/metrics';
 import type { IntegrationAppStatus } from '@odh-dashboard/plugin-core/integrations';
 import type {

--- a/packages/model-serving/src/components/deploymentWizard/exitModal/useExitDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/exitModal/useExitDeploymentWizard.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { useTrackEvent } from '@odh-dashboard/plugin-core/host-api';
 import { fireModelDeployed } from '../../../shared/tracking/deploymentTracking';
 
 type UseExitWizardOptions = {
@@ -21,6 +22,7 @@ export const useExitDeploymentWizard = ({
   cancelReturnRoute,
 }: UseExitWizardOptions): UseExitWizardReturn => {
   const navigate = useNavigate();
+  const trackEvent = useTrackEvent();
 
   const [isExitModalOpen, setIsExitModalOpen] = React.useState(false);
 
@@ -41,10 +43,10 @@ export const useExitDeploymentWizard = ({
   }, [navigate, returnRoute]);
 
   const handleExitConfirm = React.useCallback(() => {
-    fireModelDeployed({ outcome: TrackingOutcome.cancel });
+    fireModelDeployed(trackEvent, { outcome: TrackingOutcome.cancel });
     setIsExitModalOpen(false);
     exitWizardOnCancel();
-  }, [exitWizardOnCancel]);
+  }, [trackEvent, exitWizardOnCancel]);
 
   return {
     isExitModalOpen,

--- a/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 import type { RecursivePartial } from '@odh-dashboard/foundation';
 import { z } from 'zod';
+import { useTrackEvent } from '@odh-dashboard/plugin-core/host-api';
 import { ServingRuntimeModelType } from '@odh-dashboard/model-serving/shared';
 import {
   useModelServingClusterSettings,
@@ -104,6 +105,7 @@ const DeploymentMethodSelectField: DeploymentMethodSelectFieldType['component'] 
   externalData,
   isEditing,
 }) => {
+  const trackEvent = useTrackEvent();
   const options = externalData?.data.options ?? [];
 
   return (
@@ -128,7 +130,7 @@ const DeploymentMethodSelectField: DeploymentMethodSelectFieldType['component'] 
               description={opt.description}
               isChecked={value?.method === opt.key}
               onChange={() => {
-                fireDeployMethodSelected({
+                fireDeployMethodSelected(trackEvent, {
                   deploymentMethod: opt.key,
                   previousDeploymentMethod: value?.method,
                 });

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { ModelServingTrackingEvent } from '../../../../shared/tracking/modelServingTrackingConstants';
 import {
   DeploymentMethodSelectFieldWizardField,
@@ -11,11 +10,11 @@ import {
 } from '../DeploymentMethodSelectField';
 import type { DeploymentMethodFieldOverride } from '../../../../shared/types/form-data';
 
-jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
-  fireMiscTrackingEvent: jest.fn(),
+const mockTrackEvent = jest.fn();
+jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
+  ...jest.requireActual('@odh-dashboard/plugin-core/host-api'),
+  useTrackEvent: () => mockTrackEvent,
 }));
-
-const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 
 const DeploymentMethodSelectFieldComponent = DeploymentMethodSelectFieldWizardField.component;
 
@@ -143,13 +142,10 @@ describe('DeploymentMethodSelectField tracking', () => {
 
     fireEvent.click(screen.getByTestId('deployment-method-kserve'));
 
-    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
-      ModelServingTrackingEvent.DEPLOY_METHOD_SELECTED,
-      {
-        deploymentMethod: 'kserve',
-        previousDeploymentMethod: undefined,
-      },
-    );
+    expect(mockTrackEvent).toHaveBeenCalledWith(ModelServingTrackingEvent.DEPLOY_METHOD_SELECTED, {
+      deploymentMethod: 'kserve',
+      previousDeploymentMethod: undefined,
+    });
   });
 
   it('should fire deploy method selected tracking with previous method when switching', () => {
@@ -168,13 +164,10 @@ describe('DeploymentMethodSelectField tracking', () => {
 
     fireEvent.click(screen.getByTestId('deployment-method-llmd'));
 
-    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
-      ModelServingTrackingEvent.DEPLOY_METHOD_SELECTED,
-      {
-        deploymentMethod: 'llmd',
-        previousDeploymentMethod: 'kserve',
-      },
-    );
+    expect(mockTrackEvent).toHaveBeenCalledWith(ModelServingTrackingEvent.DEPLOY_METHOD_SELECTED, {
+      deploymentMethod: 'llmd',
+      previousDeploymentMethod: 'kserve',
+    });
   });
 
   it('should call onChange with the selected method', () => {

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
@@ -257,11 +257,6 @@ const mockAreaStatus = (status: boolean): IsAreaAvailableStatus => ({
 const mockConnections: Connection[] = [];
 const mockPvcs: PersistentVolumeClaimKind[] = [];
 
-jest.mock('@odh-dashboard/internal/pages/modelServing/usePvcs', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({ data: mockPvcs, loaded: true, error: undefined })),
-}));
-
 describe('ModelLocationSelectField', () => {
   const mockWizardContext = {
     activeStep: { index: 1, name: 'test-step', id: 'test-step', parentId: undefined },

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
+import { useTrackEvent } from '@odh-dashboard/plugin-core/host-api';
 import { ValidatedConfigurationOptionCard } from './ValidatedConfigurationOptionCard';
 import type { ValidatedConfigurationsFieldHook } from './useValidatedConfigurationsField';
 import {
@@ -33,6 +34,7 @@ export const ValidatedArgumentsSection: React.FC<ValidatedArgumentsSectionProps>
   runtimeArgs,
   catalogModelId,
 }) => {
+  const trackEvent = useTrackEvent();
   return (
     <>
       {configurations.map((configuration) => (
@@ -67,7 +69,7 @@ export const ValidatedArgumentsSection: React.FC<ValidatedArgumentsSectionProps>
                         )}
                         catalogModelId={catalogModelId}
                         onSelectionChange={(checked) => {
-                          fireValidatedArgumentSelected({
+                          fireValidatedArgumentSelected(trackEvent, {
                             configurationName: option.title,
                             configurationIcon: slugifyValidatedOptionTitle(option.title),
                             isSelected: checked,

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedConfigurationOptionCard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedConfigurationOptionCard.tsx
@@ -9,6 +9,7 @@ import {
   Content,
   Popover,
 } from '@patternfly/react-core';
+import { useTrackEvent } from '@odh-dashboard/plugin-core/host-api';
 import {
   formatValidatedOptionValueForDisplay,
   slugifyValidatedOptionTitle,
@@ -29,6 +30,7 @@ export const ValidatedConfigurationOptionCard: React.FC<ValidatedConfigurationOp
   onSelectionChange,
   catalogModelId,
 }) => {
+  const trackEvent = useTrackEvent();
   const optionSlug = slugifyValidatedOptionTitle(option.title);
   const formattedArgs = formatValidatedOptionValueForDisplay(option.value);
 
@@ -64,7 +66,7 @@ export const ValidatedConfigurationOptionCard: React.FC<ValidatedConfigurationOp
           aria-label={`${option.title} arguments`}
           headerContent={`${option.title} arguments`}
           onShow={() => {
-            fireValidatedArgumentsViewed({
+            fireValidatedArgumentsViewed(trackEvent, {
               configurationName: option.title,
               catalogModelId,
               entryPoint: 'model_details',

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/PreconfigureDeploymentStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/PreconfigureDeploymentStep.test.tsx
@@ -3,18 +3,17 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
-import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockToolCallingValidatedConfiguration } from '@odh-dashboard/internal/__mocks__/mockValidatedConfigurations';
 import { PreconfigureDeploymentStepContent } from '../PreconfigureDeploymentStep';
 import { mockDeploymentWizardState } from '../../../../__tests__/mockUtils';
 import { ModelServingTrackingEvent } from '../../../../shared/tracking/modelServingTrackingConstants';
 
-jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
-  fireMiscTrackingEvent: jest.fn(),
+const mockTrackEvent = jest.fn();
+jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
+  ...jest.requireActual('@odh-dashboard/plugin-core/host-api'),
+  useTrackEvent: () => mockTrackEvent,
 }));
-
-const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 
 const mockProject = mockProjectK8sResource({
   k8sName: 'test-project',
@@ -202,7 +201,7 @@ describe('PreconfigureDeploymentStep', () => {
         '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
       ],
     });
-    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       ModelServingTrackingEvent.VALIDATED_ARGUMENT_SELECTED,
       {
         configurationName: 'Tool calling',
@@ -259,7 +258,7 @@ describe('PreconfigureDeploymentStep', () => {
       enabled: true,
       args: ['--user-arg'],
     });
-    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       ModelServingTrackingEvent.VALIDATED_ARGUMENT_SELECTED,
       expect.objectContaining({ isSelected: false, configurationName: 'Tool calling' }),
     );
@@ -286,7 +285,7 @@ describe('PreconfigureDeploymentStep', () => {
     );
     fireEvent.click(viewArgumentsButton);
 
-    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       ModelServingTrackingEvent.VALIDATED_ARGUMENTS_VIEWED,
       {
         configurationName: 'Tool calling',
@@ -299,7 +298,7 @@ describe('PreconfigureDeploymentStep', () => {
     fireEvent.click(viewArgumentsButton);
 
     expect(
-      mockFireMiscTrackingEvent.mock.calls.filter(
+      mockTrackEvent.mock.calls.filter(
         ([eventName]) => eventName === ModelServingTrackingEvent.VALIDATED_ARGUMENTS_VIEWED,
       ),
     ).toHaveLength(1);

--- a/packages/model-serving/src/components/deploymentWizard/useNavigateToDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useNavigateToDeploymentWizard.ts
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate, type NavigateFunction } from 'react-router-dom';
 import React from 'react';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import { useTrackEvent } from '@odh-dashboard/plugin-core/host-api';
 import { getDeploymentWizardRoute } from './utils';
 import { useExtractFormDataFromDeployment } from './useExtractFormDataFromDeployment';
 import { InitialWizardFormData } from '../../shared/types/form-data';
@@ -62,6 +63,7 @@ export const useNavigateToDeploymentWizard = (
   navSource?: DeployWizardNavSource,
 ): ((projectName?: string, initialDataOnNavigate?: InitialWizardFormData | null) => void) => {
   const navigate: NavigateFunction = useNavigate();
+  const trackEvent = useTrackEvent();
   const isYAMLViewerEnabled = useIsAreaAvailable(SupportedArea.YAML_VIEWER).status;
   const fromCatalog = navSource?.fromCatalog;
   const catalogModelId = navSource?.catalogModelId;
@@ -97,6 +99,7 @@ export const useNavigateToDeploymentWizard = (
       };
 
       fireDeployWizardStarted(
+        trackEvent,
         getDeployWizardStartedProperties({
           navSource: {
             fromCatalog,
@@ -132,6 +135,7 @@ export const useNavigateToDeploymentWizard = (
       deployment,
       returnRoute,
       cancelReturnRoute,
+      trackEvent,
       error,
       isYAMLViewerEnabled,
       fromCatalog,

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRowExpandedSection.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRowExpandedSection.spec.tsx
@@ -7,15 +7,6 @@ import { mockExtensions } from '../../../__tests__/mockUtils';
 import { DeploymentRowExpandedSection } from '../row/DeploymentsTableRowExpandedSection';
 
 jest.mock('@odh-dashboard/plugin-core');
-jest.mock('@odh-dashboard/internal/app/AppContext', () => ({
-  useAppContext: () => ({
-    dashboardConfig: {
-      spec: {
-        modelServerSizes: [],
-      },
-    },
-  }),
-}));
 
 jest.mock('../../../../src/concepts/extensionUtils', () => ({
   useResolvedDeploymentExtension: () => [
@@ -35,10 +26,6 @@ jest.mock('../../../../src/concepts/extensionUtils', () => ({
       },
     },
   ],
-}));
-
-jest.mock('@odh-dashboard/internal/redux/hooks', () => ({
-  useAppSelector: jest.fn((selector) => selector({ dashboardNamespace: 'test-namespace' })),
 }));
 
 const mockUseAssignHardwareProfile = jest.fn();

--- a/packages/model-serving/src/components/settings/GeneralSettingsTab.tsx
+++ b/packages/model-serving/src/components/settings/GeneralSettingsTab.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 import { isEqual } from 'lodash-es';
 import { Button, Bullseye, PageSection, Spinner, Stack, StackItem } from '@patternfly/react-core';
 import { TrackingOutcome, useNotification } from '@odh-dashboard/ui-core';
-import type {
-  ClusterSettingsType,
-  ModelServingPlatformEnabled,
-} from '@odh-dashboard/internal/types';
 import {
-  fetchClusterSettings,
-  updateClusterSettings,
-} from '@odh-dashboard/internal/services/clusterSettingsService';
+  useHostApiCore,
+  useTrackEvent,
+  type ClusterSettingsType,
+  type ModelServingPlatformEnabled,
+} from '@odh-dashboard/plugin-core/host-api';
 import ModelServingPlatformSettings from './ModelServingPlatformSettings';
 import DeploymentStrategySettings, { DeploymentStrategy } from './DeploymentStrategySettings';
 import {
@@ -24,6 +22,8 @@ const isDeploymentStrategy = (value: string | undefined): value is DeploymentStr
   Object.values<string>(DeploymentStrategy).includes(value ?? '');
 
 const GeneralSettingsTab: React.FC = () => {
+  const { fetchClusterSettings, updateClusterSettings } = useHostApiCore();
+  const trackEvent = useTrackEvent();
   const [loaded, setLoaded] = React.useState(false);
   const [loadError, setLoadError] = React.useState<string>();
   const [saving, setSaving] = React.useState(false);
@@ -81,7 +81,7 @@ const GeneralSettingsTab: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [fetchClusterSettings]);
 
   const isSettingsChanged = React.useMemo(() => {
     if (!baselineSettings) {
@@ -131,7 +131,7 @@ const GeneralSettingsTab: React.FC = () => {
       if (
         previous?.modelServingPlatformEnabled.kServe !== payload.modelServingPlatformEnabled.kServe
       ) {
-        firePlatformSettingChanged({
+        firePlatformSettingChanged(trackEvent, {
           outcome: TrackingOutcome.submit,
           success: true,
           setting: 'model_serving_enabled',
@@ -139,7 +139,7 @@ const GeneralSettingsTab: React.FC = () => {
         });
       }
       if (previous?.modelServingPlatformEnabled.LLMd !== payload.modelServingPlatformEnabled.LLMd) {
-        firePlatformSettingChanged({
+        firePlatformSettingChanged(trackEvent, {
           outcome: TrackingOutcome.submit,
           success: true,
           setting: 'llmd_enabled',
@@ -147,7 +147,7 @@ const GeneralSettingsTab: React.FC = () => {
         });
       }
       if (previous?.isDistributedInferencingDefault !== payload.isDistributedInferencingDefault) {
-        firePlatformSettingChanged({
+        firePlatformSettingChanged(trackEvent, {
           outcome: TrackingOutcome.submit,
           success: true,
           setting: 'llmd_default_for_generative',
@@ -155,7 +155,7 @@ const GeneralSettingsTab: React.FC = () => {
         });
       }
       if (previous?.defaultDeploymentStrategy !== payload.defaultDeploymentStrategy) {
-        fireDeploymentStrategyChanged({
+        fireDeploymentStrategyChanged(trackEvent, {
           outcome: TrackingOutcome.submit,
           success: true,
           strategy: defaultDeploymentStrategy,

--- a/packages/model-serving/src/components/settings/ModelServingPlatformSettings.tsx
+++ b/packages/model-serving/src/components/settings/ModelServingPlatformSettings.tsx
@@ -15,7 +15,7 @@ import {
   Popover,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
-import type { ModelServingPlatformEnabled } from '@odh-dashboard/internal/types';
+import type { ModelServingPlatformEnabled } from '@odh-dashboard/plugin-core/host-api';
 import useServingPlatformStatuses from '../../hooks/useServingPlatformStatuses';
 
 type ModelServingPlatformSettingsProps = {

--- a/packages/model-serving/src/components/settings/__tests__/GeneralSettingsTab.spec.tsx
+++ b/packages/model-serving/src/components/settings/__tests__/GeneralSettingsTab.spec.tsx
@@ -2,18 +2,24 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useNotification } from '@odh-dashboard/ui-core';
-import {
-  fetchClusterSettings,
-  updateClusterSettings,
-} from '@odh-dashboard/internal/services/clusterSettingsService';
-import type { ClusterSettingsType } from '@odh-dashboard/internal/types';
+import type { ClusterSettingsType } from '@odh-dashboard/plugin-core/host-api';
 import GeneralSettingsTab from '../GeneralSettingsTab';
+
+const mockFetchClusterSettings = jest.fn();
+const mockUpdateClusterSettings = jest.fn();
 
 jest.mock('@odh-dashboard/ui-core', () => ({
   ...jest.requireActual('@odh-dashboard/ui-core'),
   useNotification: jest.fn(),
 }));
-jest.mock('@odh-dashboard/internal/services/clusterSettingsService');
+jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
+  ...jest.requireActual('@odh-dashboard/plugin-core/host-api'),
+  useHostApiCore: () => ({
+    fetchClusterSettings: mockFetchClusterSettings,
+    updateClusterSettings: mockUpdateClusterSettings,
+  }),
+  useTrackEvent: () => jest.fn(),
+}));
 jest.mock('../ModelServingPlatformSettings', () => ({
   __esModule: true,
   default: ({
@@ -73,8 +79,6 @@ jest.mock('../DeploymentStrategySettings', () => ({
   ),
 }));
 
-const mockFetchClusterSettings = jest.mocked(fetchClusterSettings);
-const mockUpdateClusterSettings = jest.mocked(updateClusterSettings);
 const mockNotification = { success: jest.fn(), error: jest.fn() };
 
 const DEFAULT_CLUSTER_SETTINGS: ClusterSettingsType = {

--- a/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
@@ -1,4 +1,3 @@
-import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   fireModelDeployed,
@@ -6,11 +5,7 @@ import {
   type DeploymentTrackingProperties,
 } from '../deploymentTracking';
 
-jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
-  fireFormTrackingEvent: jest.fn(),
-}));
-
-const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
+const mockTrackEvent = jest.fn();
 
 describe('fireModelDeployed', () => {
   beforeEach(() => {
@@ -28,12 +23,9 @@ describe('fireModelDeployed', () => {
       numReplicas: 1,
     };
 
-    fireModelDeployed(properties, false);
+    fireModelDeployed(mockTrackEvent, properties, false);
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
-      DeploymentTrackingEvent.MODEL_DEPLOYED,
-      properties,
-    );
+    expect(mockTrackEvent).toHaveBeenCalledWith(DeploymentTrackingEvent.MODEL_DEPLOYED, properties);
   });
 
   it('should fire Model Updated event when isEdit is true', () => {
@@ -47,12 +39,9 @@ describe('fireModelDeployed', () => {
       numReplicas: 2,
     };
 
-    fireModelDeployed(properties, true);
+    fireModelDeployed(mockTrackEvent, properties, true);
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
-      DeploymentTrackingEvent.MODEL_UPDATED,
-      properties,
-    );
+    expect(mockTrackEvent).toHaveBeenCalledWith(DeploymentTrackingEvent.MODEL_UPDATED, properties);
   });
 
   it('should fire Model Deployed with cancel outcome', () => {
@@ -60,12 +49,9 @@ describe('fireModelDeployed', () => {
       outcome: TrackingOutcome.cancel,
     };
 
-    fireModelDeployed(properties);
+    fireModelDeployed(mockTrackEvent, properties);
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
-      DeploymentTrackingEvent.MODEL_DEPLOYED,
-      properties,
-    );
+    expect(mockTrackEvent).toHaveBeenCalledWith(DeploymentTrackingEvent.MODEL_DEPLOYED, properties);
   });
 
   it('should fire with error message on failure', () => {
@@ -80,12 +66,9 @@ describe('fireModelDeployed', () => {
       numReplicas: 1,
     };
 
-    fireModelDeployed(properties, false);
+    fireModelDeployed(mockTrackEvent, properties, false);
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
-      DeploymentTrackingEvent.MODEL_DEPLOYED,
-      properties,
-    );
+    expect(mockTrackEvent).toHaveBeenCalledWith(DeploymentTrackingEvent.MODEL_DEPLOYED, properties);
   });
 
   it('should include per-platform properties via the spread', () => {
@@ -101,9 +84,9 @@ describe('fireModelDeployed', () => {
       nimImageVersion: '1.0.0',
     };
 
-    fireModelDeployed(properties, false);
+    fireModelDeployed(mockTrackEvent, properties, false);
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       DeploymentTrackingEvent.MODEL_DEPLOYED,
       expect.objectContaining({
         nimModelId: 'meta/llama3-8b',
@@ -118,12 +101,9 @@ describe('fireModelDeployed', () => {
       success: true,
     };
 
-    fireModelDeployed(properties);
+    fireModelDeployed(mockTrackEvent, properties);
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
-      DeploymentTrackingEvent.MODEL_DEPLOYED,
-      properties,
-    );
+    expect(mockTrackEvent).toHaveBeenCalledWith(DeploymentTrackingEvent.MODEL_DEPLOYED, properties);
   });
 
   it('should include model location properties', () => {
@@ -138,9 +118,9 @@ describe('fireModelDeployed', () => {
       modelLocationType: 'existing',
     };
 
-    fireModelDeployed(properties, false);
+    fireModelDeployed(mockTrackEvent, properties, false);
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       DeploymentTrackingEvent.MODEL_DEPLOYED,
       expect.objectContaining({
         modelLocationType: 'existing',

--- a/packages/model-serving/src/shared/tracking/__tests__/generalSettingsTracking.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/generalSettingsTracking.spec.ts
@@ -1,4 +1,3 @@
-import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { DeploymentStrategy } from '../../../components/settings/DeploymentStrategySettings';
 import {
@@ -7,11 +6,7 @@ import {
   fireDeploymentStrategyChanged,
 } from '../generalSettingsTracking';
 
-jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
-  fireFormTrackingEvent: jest.fn(),
-}));
-
-const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
+const mockTrackEvent = jest.fn();
 
 describe('firePlatformSettingChanged', () => {
   beforeEach(() => {
@@ -19,14 +14,14 @@ describe('firePlatformSettingChanged', () => {
   });
 
   it('should fire the Platform Setting Changed event with the setting key and new value', () => {
-    firePlatformSettingChanged({
+    firePlatformSettingChanged(mockTrackEvent, {
       outcome: TrackingOutcome.submit,
       success: true,
       setting: 'llmd_enabled',
       enabled: true,
     });
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       GeneralSettingsTrackingEvent.PLATFORM_SETTING_CHANGED,
       {
         outcome: TrackingOutcome.submit,
@@ -38,28 +33,28 @@ describe('firePlatformSettingChanged', () => {
   });
 
   it('should support the model_serving_enabled setting toggled off', () => {
-    firePlatformSettingChanged({
+    firePlatformSettingChanged(mockTrackEvent, {
       outcome: TrackingOutcome.submit,
       success: true,
       setting: 'model_serving_enabled',
       enabled: false,
     });
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       GeneralSettingsTrackingEvent.PLATFORM_SETTING_CHANGED,
       expect.objectContaining({ setting: 'model_serving_enabled', enabled: false }),
     );
   });
 
   it('should support the llmd_default_for_generative setting', () => {
-    firePlatformSettingChanged({
+    firePlatformSettingChanged(mockTrackEvent, {
       outcome: TrackingOutcome.submit,
       success: true,
       setting: 'llmd_default_for_generative',
       enabled: true,
     });
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       GeneralSettingsTrackingEvent.PLATFORM_SETTING_CHANGED,
       expect.objectContaining({ setting: 'llmd_default_for_generative' }),
     );
@@ -72,26 +67,26 @@ describe('fireDeploymentStrategyChanged', () => {
   });
 
   it('should fire the Deployment Strategy Changed event with the strategy', () => {
-    fireDeploymentStrategyChanged({
+    fireDeploymentStrategyChanged(mockTrackEvent, {
       outcome: TrackingOutcome.submit,
       success: true,
       strategy: DeploymentStrategy.ROLLING,
     });
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       GeneralSettingsTrackingEvent.DEPLOYMENT_STRATEGY_CHANGED,
       { outcome: TrackingOutcome.submit, success: true, strategy: DeploymentStrategy.ROLLING },
     );
   });
 
   it('should support the recreate strategy', () => {
-    fireDeploymentStrategyChanged({
+    fireDeploymentStrategyChanged(mockTrackEvent, {
       outcome: TrackingOutcome.submit,
       success: true,
       strategy: DeploymentStrategy.RECREATE,
     });
 
-    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+    expect(mockTrackEvent).toHaveBeenCalledWith(
       GeneralSettingsTrackingEvent.DEPLOYMENT_STRATEGY_CHANGED,
       expect.objectContaining({ strategy: DeploymentStrategy.RECREATE }),
     );

--- a/packages/model-serving/src/shared/tracking/deployWizardTracking.ts
+++ b/packages/model-serving/src/shared/tracking/deployWizardTracking.ts
@@ -1,9 +1,4 @@
-import {
-  fireFormTrackingEvent,
-  fireMiscTrackingEvent,
-} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
-import { TrackingOutcome, type FormTrackingEventProperties } from '@odh-dashboard/ui-core';
-import { ModelServingTrackingEvent } from './modelServingTrackingConstants';
+import { type TrackEventFn, ModelServingTrackingEvent } from './modelServingTrackingConstants';
 import type { ValidatedConfiguration, ValidatedConfigurationOption } from '../types/form-data';
 
 export const TOOL_CALLING_CONFIGURATION_TITLE = 'Tool calling';
@@ -202,42 +197,23 @@ export const getDeployWizardStartedProperties = ({
   };
 };
 
-export const fireDeployWizardStarted = (properties: DeployWizardStartedProperties): void => {
-  fireMiscTrackingEvent(ModelServingTrackingEvent.DEPLOY_WIZARD_STARTED, properties);
+export const fireDeployWizardStarted = (
+  trackEvent: TrackEventFn,
+  properties: DeployWizardStartedProperties,
+): void => {
+  trackEvent(ModelServingTrackingEvent.DEPLOY_WIZARD_STARTED, properties);
 };
 
 export const fireValidatedArgumentSelected = (
+  trackEvent: TrackEventFn,
   properties: ValidatedArgumentSelectedProperties,
 ): void => {
-  fireMiscTrackingEvent(ModelServingTrackingEvent.VALIDATED_ARGUMENT_SELECTED, properties);
+  trackEvent(ModelServingTrackingEvent.VALIDATED_ARGUMENT_SELECTED, properties);
 };
 
 export const fireValidatedArgumentsViewed = (
+  trackEvent: TrackEventFn,
   properties: ValidatedArgumentsViewedProperties,
 ): void => {
-  fireMiscTrackingEvent(ModelServingTrackingEvent.VALIDATED_ARGUMENTS_VIEWED, properties);
-};
-
-const toFormTrackingProperties = (
-  properties: ModelDeployedTrackingProperties,
-): FormTrackingEventProperties => {
-  const formProperties: FormTrackingEventProperties = {
-    outcome: properties.outcome === 'submit' ? TrackingOutcome.submit : TrackingOutcome.cancel,
-  };
-
-  for (const [key, value] of Object.entries(properties)) {
-    if (key === 'outcome' || value === undefined) {
-      continue;
-    }
-    formProperties[key] = Array.isArray(value) ? value.join(',') : value;
-  }
-
-  return formProperties;
-};
-
-export const fireModelDeployed = (properties: ModelDeployedTrackingProperties): void => {
-  fireFormTrackingEvent(
-    ModelServingTrackingEvent.MODEL_DEPLOYED,
-    toFormTrackingProperties(properties),
-  );
+  trackEvent(ModelServingTrackingEvent.VALIDATED_ARGUMENTS_VIEWED, properties);
 };

--- a/packages/model-serving/src/shared/tracking/deploymentTracking.ts
+++ b/packages/model-serving/src/shared/tracking/deploymentTracking.ts
@@ -1,5 +1,5 @@
-import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { type FormTrackingEventProperties } from '@odh-dashboard/ui-core';
+import type { TrackEventFn } from './modelServingTrackingConstants';
 
 export enum DeploymentTrackingEvent {
   MODEL_DEPLOYED = 'Model Deployed',
@@ -19,11 +19,12 @@ export type DeploymentTrackingProperties = DeploymentTrackingBaseProperties &
   Record<string, string | number | boolean | undefined>;
 
 export const fireModelDeployed = (
+  trackEvent: TrackEventFn,
   properties: DeploymentTrackingProperties,
   isEdit?: boolean,
 ): void => {
   const eventName = isEdit
     ? DeploymentTrackingEvent.MODEL_UPDATED
     : DeploymentTrackingEvent.MODEL_DEPLOYED;
-  fireFormTrackingEvent(eventName, properties);
+  trackEvent(eventName, properties);
 };

--- a/packages/model-serving/src/shared/tracking/generalSettingsTracking.ts
+++ b/packages/model-serving/src/shared/tracking/generalSettingsTracking.ts
@@ -1,5 +1,5 @@
-import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { type FormTrackingEventProperties } from '@odh-dashboard/ui-core';
+import type { TrackEventFn } from './modelServingTrackingConstants';
 import type { DeploymentStrategy } from '../../components/settings/DeploymentStrategySettings';
 
 export enum GeneralSettingsTrackingEvent {
@@ -23,12 +23,16 @@ export type DeploymentStrategyChangedProperties = FormTrackingEventProperties & 
   strategy: DeploymentStrategy;
 };
 
-export const firePlatformSettingChanged = (properties: PlatformSettingChangedProperties): void => {
-  fireFormTrackingEvent(GeneralSettingsTrackingEvent.PLATFORM_SETTING_CHANGED, properties);
+export const firePlatformSettingChanged = (
+  trackEvent: TrackEventFn,
+  properties: PlatformSettingChangedProperties,
+): void => {
+  trackEvent(GeneralSettingsTrackingEvent.PLATFORM_SETTING_CHANGED, properties);
 };
 
 export const fireDeploymentStrategyChanged = (
+  trackEvent: TrackEventFn,
   properties: DeploymentStrategyChangedProperties,
 ): void => {
-  fireFormTrackingEvent(GeneralSettingsTrackingEvent.DEPLOYMENT_STRATEGY_CHANGED, properties);
+  trackEvent(GeneralSettingsTrackingEvent.DEPLOYMENT_STRATEGY_CHANGED, properties);
 };

--- a/packages/model-serving/src/shared/tracking/modelServingTrackingConstants.ts
+++ b/packages/model-serving/src/shared/tracking/modelServingTrackingConstants.ts
@@ -1,5 +1,3 @@
-import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
-
 export type TrackEventFn = (
   eventName: string,
   properties: Record<string, string | number | boolean | string[] | undefined>,
@@ -21,6 +19,9 @@ export type DeployMethodSelectedProperties = {
   previousDeploymentMethod?: string;
 };
 
-export const fireDeployMethodSelected = (properties: DeployMethodSelectedProperties): void => {
-  fireMiscTrackingEvent(ModelServingTrackingEvent.DEPLOY_METHOD_SELECTED, properties);
+export const fireDeployMethodSelected = (
+  trackEvent: TrackEventFn,
+  properties: DeployMethodSelectedProperties,
+): void => {
+  trackEvent(ModelServingTrackingEvent.DEPLOY_METHOD_SELECTED, properties);
 };

--- a/packages/model-serving/src/shared/tracking/useModelDeployedTracking.ts
+++ b/packages/model-serving/src/shared/tracking/useModelDeployedTracking.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { useTrackEvent } from '@odh-dashboard/plugin-core/host-api';
 import {
   fireModelDeployed as fireDeploymentFormTracking,
   type DeploymentTrackingProperties,
@@ -73,6 +74,7 @@ export const useModelDeployedTracking = (
   ) => Promise<void>;
 } => {
   const location = useLocation();
+  const trackEvent = useTrackEvent();
   const { getTrackingProperties } = useWizardTrackingProperties(formState, platformId);
 
   const fireModelDeployedTracking = React.useCallback(
@@ -94,9 +96,18 @@ export const useModelDeployedTracking = (
         },
       });
 
-      fireDeploymentFormTracking(toDeploymentTrackingProperties(wizardProperties, errorMessage));
+      fireDeploymentFormTracking(
+        trackEvent,
+        toDeploymentTrackingProperties(wizardProperties, errorMessage),
+      );
     },
-    [location.state, initialWizardData?.validatedConfigurations, formState, getTrackingProperties],
+    [
+      location.state,
+      initialWizardData?.validatedConfigurations,
+      formState,
+      getTrackingProperties,
+      trackEvent,
+    ],
   );
 
   return { fireModelDeployedTracking };

--- a/packages/plugin-core/src/host-api/HostApiCoreContext.ts
+++ b/packages/plugin-core/src/host-api/HostApiCoreContext.ts
@@ -10,4 +10,6 @@ export const HostApiCoreContext = React.createContext<HostApiCoreServices>({
   checkAccess: notProvided('checkAccess'),
   trackEvent: notProvided('trackEvent'),
   fetchDashboardConfig: notProvided('fetchDashboardConfig'),
+  fetchClusterSettings: notProvided('fetchClusterSettings'),
+  updateClusterSettings: notProvided('updateClusterSettings'),
 });

--- a/packages/plugin-core/src/host-api/HostApiCoreContext.ts
+++ b/packages/plugin-core/src/host-api/HostApiCoreContext.ts
@@ -5,11 +5,14 @@ const notProvided = (name: string) => () => {
   throw new Error(`HostApiCoreContext not provided: ${name}`);
 };
 
+const notProvidedAsync = (name: string) => () =>
+  Promise.reject(new Error(`HostApiCoreContext not provided: ${name}`));
+
 export const HostApiCoreContext = React.createContext<HostApiCoreServices>({
   dashboardNamespace: '',
   checkAccess: notProvided('checkAccess'),
   trackEvent: notProvided('trackEvent'),
-  fetchDashboardConfig: notProvided('fetchDashboardConfig'),
-  fetchClusterSettings: notProvided('fetchClusterSettings'),
-  updateClusterSettings: notProvided('updateClusterSettings'),
+  fetchDashboardConfig: notProvidedAsync('fetchDashboardConfig'),
+  fetchClusterSettings: notProvidedAsync('fetchClusterSettings'),
+  updateClusterSettings: notProvidedAsync('updateClusterSettings'),
 });

--- a/packages/plugin-core/src/host-api/index.ts
+++ b/packages/plugin-core/src/host-api/index.ts
@@ -23,4 +23,6 @@ export type {
   HostApiFetchState,
   K8sWatchResult,
   SecretOps,
+  ClusterSettingsType,
+  ModelServingPlatformEnabled,
 } from './types';

--- a/packages/plugin-core/src/host-api/types.ts
+++ b/packages/plugin-core/src/host-api/types.ts
@@ -27,6 +27,21 @@ export type HostApiFetchState<T> = [
   refresh: () => Promise<T | undefined>,
 ];
 
+export type ModelServingPlatformEnabled = {
+  kServe: boolean;
+  LLMd: boolean;
+};
+
+export type ClusterSettingsType = {
+  userTrackingEnabled: boolean;
+  pvcSize: number;
+  cullerTimeout: number;
+  modelServingPlatformEnabled: ModelServingPlatformEnabled;
+  isDistributedInferencingDefault?: boolean;
+  defaultDeploymentStrategy?: string;
+  globalMLflowNamespaces?: string[];
+};
+
 /**
  * Core infrastructure primitives every federated module needs.
  * Stable, rarely changes. Provided via HostApiCoreContext.
@@ -46,6 +61,14 @@ export type HostApiCoreServices = {
 
   /** Fetch (or refresh) the DashboardConfig CR that controls feature flags and platform settings. */
   fetchDashboardConfig: (forceRefresh?: boolean) => Promise<DashboardConfigKind>;
+
+  /** Fetch cluster-wide settings (PVC size, culler timeout, model serving platforms, etc.). */
+  fetchClusterSettings: () => Promise<ClusterSettingsType>;
+
+  /** Update cluster-wide settings. */
+  updateClusterSettings: (
+    settings: ClusterSettingsType,
+  ) => Promise<{ success: boolean; error: string }>;
 };
 
 /**


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
Migrates the 4 remaining `jest.mock('@odh-dashboard/internal/...')` calls in `model-serving` unit tests by removing the package's direct dependency on `@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils`.

  The tracking utility functions (`fireModelDeployed`, `firePlatformSettingChanged`, `fireDeploymentStrategyChanged`, `fireDeployWizardStarted`, `fireValidatedArgumentSelected`, `fireValidatedArgumentsViewed`, `fireDeployMethodSelected`) previously imported `fireFormTrackingEvent` / `fireMiscTrackingEvent` from `@odh-dashboard/internal`. This couples `model-serving` to the host app's analytics internals, blocking its migration to a standalone Module Federation remote.

  **Approach:** Dependency injection via `TrackEventFn` — the same pattern already used by `modelCapabilitiesTracking.ts` and `limitedSupportTracking.ts` in this package. Each tracking function now accepts a `trackEvent: TrackEventFn` as its first parameter. Callers (hooks and components) obtain it from `useTrackEvent()`
  (`@odh-dashboard/plugin-core/host-api`), which is wired to `fireMiscTrackingEvent` via `HostApiProvider`.

  **Changed files:**

  | Category | Files |
  |----------|-------|
  | Production tracking functions | `modelServingTrackingConstants.ts`, `deploymentTracking.ts`, `generalSettingsTracking.ts`, `deployWizardTracking.ts` |
  | Callers (added `useTrackEvent()`) | `DeploymentMethodSelectField.tsx`, `useModelDeployedTracking.ts`, `useExitDeploymentWizard.ts`, `GeneralSettingsTab.tsx`, `useNavigateToDeploymentWizard.ts`, `ValidatedArgumentsSection.tsx`, `ValidatedConfigurationOptionCard.tsx` |
  | Tests (removed internal mocks) | `deploymentTracking.spec.ts`, `generalSettingsTracking.spec.ts`, `PreconfigureDeploymentStep.test.tsx`, `DeploymentMethodSelectField.spec.tsx`, `GeneralSettingsTab.spec.tsx` |

  No behavioral change in production — `fireMiscTrackingEvent` and `fireFormTrackingEvent` both call the same `fireTrackingEventCore` with the same arguments. The only difference (`console.warn` in dev mode) is gated behind `DEV_MODE`.

  ## How Has This Been Tested?

  * `grep -rn "jest.mock('@odh-dashboard/internal" packages/model-serving/` — zero results
  * `npm run type-check` — passes for `model-serving` and `frontend` (no cache)
  * `npm run test` — all 530 model-serving unit tests pass (no cache)
  * `npm run lint` — zero errors for model-serving (no cache)
  * `npm run build` — passes for all packages (no cache)

  ## Test Impact

  No new tests added. Existing tests were updated to use the new dependency injection pattern — pure tracking function tests now pass a plain `jest.fn()` instead of mocking the internal module, and component tests mock `useTrackEvent` from `@odh-dashboard/plugin-core/host-api`. All 530 existing tests continue to pass with the same coverage.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and saving cluster settings through the platform’s shared services.
  * Expanded platform configuration support, including model-serving capabilities and deployment-related settings.

* **Improvements**
  * Improved event tracking across deployment wizard actions, configuration selections, model deployment, and general settings changes.
  * Standardized analytics integration for more consistent activity reporting.

* **Tests**
  * Updated coverage for deployment wizard, deployment settings, and tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->