### PR TITLE
Restore Ability to Delete an External Model

### DIFF
--- a/packages/cypress/cypress/tests/mocked/maas/maasExternalModels.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/maas/maasExternalModels.cy.ts
@@ -10,6 +10,7 @@ import {
   externalModelPathModal,
   externalModelProviderUrlModal,
   externalModelsPage,
+  deleteExternalModelModal,
 } from '../../../pages/modelsAsAService';
 import { mockExternalModels, mockMaasNamespaces } from '../../../utils/maasUtils';
 
@@ -211,31 +212,31 @@ describe('External Models Page', () => {
       externalModelsPage.findRows().should('have.length', 4);
     });
 
-    // it('should delete an external model', () => {
-    //   cy.interceptOdh(
-    //     'DELETE /maas/api/v1/externalmodel/:namespace/:name',
-    //     { path: { namespace: TEST_PROJECT, name: 'gpt-4o-external' } },
-    //     { data: null },
-    //   ).as('deleteExternalModel');
+    it('should delete an external model', () => {
+      cy.interceptOdh(
+        'DELETE /maas/api/v1/externalmodel/:namespace/:name',
+        { path: { namespace: TEST_PROJECT, name: 'gpt-4o-external' } },
+        { data: null },
+      ).as('deleteExternalModel');
 
-    //   externalModelsPage.getRow('GPT-4o External').findKebabAction('Delete').click();
-    //   deleteExternalModelModal.shouldShowResourceName('GPT-4o External');
-    //   deleteExternalModelModal.findInput().type('GPT-4o External');
-    //   deleteExternalModelModal.findSubmitButton().should('be.enabled');
+      externalModelsPage.getRow('GPT-4o External').findKebabAction('Delete').click();
+      deleteExternalModelModal.shouldShowResourceName('GPT-4o External');
+      deleteExternalModelModal.findInput().type('GPT-4o External');
+      deleteExternalModelModal.findSubmitButton().should('be.enabled');
 
-    //   cy.interceptOdh(
-    //     'GET /maas/api/v1/externalmodel',
-    //     { query: { namespace: TEST_PROJECT } },
-    //     {
-    //       data: mockExternalModels().filter((model) => model.name !== 'gpt-4o-external'),
-    //     },
-    //   ).as('listExternalModels');
+      cy.interceptOdh(
+        'GET /maas/api/v1/externalmodel',
+        { query: { namespace: TEST_PROJECT } },
+        {
+          data: mockExternalModels().filter((model) => model.name !== 'gpt-4o-external'),
+        },
+      ).as('listExternalModels');
 
-    //   deleteExternalModelModal.findSubmitButton().click();
-    //   cy.wait('@deleteExternalModel');
-    //   cy.wait('@listExternalModels');
-    //   externalModelsPage.findRows().should('have.length', 3);
-    //   externalModelsPage.findTable().should('not.contain', 'GPT-4o External');
-    // });
+      deleteExternalModelModal.findSubmitButton().click();
+      cy.wait('@deleteExternalModel');
+      cy.wait('@listExternalModels');
+      externalModelsPage.findRows().should('have.length', 3);
+      externalModelsPage.findTable().should('not.contain', 'GPT-4o External');
+    });
   });
 });

--- a/packages/maas/frontend/src/app/pages/external-models/AllExternalModelsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/AllExternalModelsPage.tsx
@@ -3,6 +3,7 @@ import { Navigate, useParams } from 'react-router-dom';
 import { ApplicationsPage } from '@odh-dashboard/ui-core';
 import { useNamespaceSelector } from 'mod-arch-core';
 import { useListExternalModels } from '~/app/hooks/useListExternalModels';
+import { ExternalModel } from '~/app/types/external-models';
 import EmptyExternalModelsPage from './EmptyExternalModelsPage';
 import NoProjectsPage from './NoProjectsPage';
 import {
@@ -15,6 +16,7 @@ import { ExternalModelsTable } from './ExternalModelsTable';
 import ExternalModelsToolBar from './ExternalModelsToolBar';
 import ExternalModelsProjectSelector from './ExternalModelsProjectSelector';
 import { filterExternalModelsByKeyword } from './utils';
+import DeleteExternalModelModal from './DeleteExternalModelModal';
 
 const AllExternalModelsPage: React.FC = () => {
   const { namespace: urlNamespace } = useParams<{ namespace?: string }>();
@@ -42,7 +44,10 @@ const AllExternalModelsPage: React.FC = () => {
   const fallbackNamespace = preferredNamespace?.name ?? namespaces[0]?.name;
   const resolvedNamespace = validUrlNamespace ?? fallbackNamespace;
 
-  const [externalModels, loaded, error] = useListExternalModels(resolvedNamespace || '');
+  const [externalModels, loaded, error, refresh] = useListExternalModels(resolvedNamespace || '');
+  const [deleteExternalModel, setDeleteExternalModel] = React.useState<ExternalModel | undefined>(
+    undefined,
+  );
 
   const filteredExternalModels = React.useMemo(
     () =>
@@ -76,6 +81,7 @@ const AllExternalModelsPage: React.FC = () => {
           <ExternalModelsTable
             externalModels={filteredExternalModels}
             onClearFilters={onClearFilters}
+            setDeleteExternalModel={setDeleteExternalModel}
             toolbarContent={
               <ExternalModelsToolBar filterData={filterData} onFilterUpdate={onFilterUpdate} />
             }
@@ -84,6 +90,17 @@ const AllExternalModelsPage: React.FC = () => {
                 <EmptyExternalModelsPage />
               )
             }
+          />
+        )}
+        {deleteExternalModel && (
+          <DeleteExternalModelModal
+            externalModel={deleteExternalModel}
+            onClose={(deleted) => {
+              setDeleteExternalModel(undefined);
+              if (deleted) {
+                refresh();
+              }
+            }}
           />
         )}
       </ApplicationsPage>

--- a/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTable.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTable.tsx
@@ -9,6 +9,7 @@ type ExternalModelsTableProps = {
   onClearFilters: () => void;
   toolbarContent: React.ReactElement;
   emptyTableView: React.ReactNode;
+  setDeleteExternalModel: (externalModel: ExternalModel) => void;
 };
 
 export const ExternalModelsTable: React.FC<ExternalModelsTableProps> = ({
@@ -16,6 +17,7 @@ export const ExternalModelsTable: React.FC<ExternalModelsTableProps> = ({
   onClearFilters,
   toolbarContent,
   emptyTableView,
+  setDeleteExternalModel,
 }): React.ReactNode => (
   <Table
     data-testid="external-models-table"
@@ -30,6 +32,7 @@ export const ExternalModelsTable: React.FC<ExternalModelsTableProps> = ({
         key={externalModel.name}
         externalModel={externalModel}
         rowIndex={rowIndex}
+        setDeleteExternalModel={setDeleteExternalModel}
       />
     )}
     emptyTableView={emptyTableView ?? <DashboardEmptyTableView onClearFilters={onClearFilters} />}

--- a/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ResourceTr } from '@odh-dashboard/ui-core';
 import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
-import { Tbody, Td, Tr } from '@patternfly/react-table';
+import { ActionsColumn, Tbody, Td, Tr } from '@patternfly/react-table';
 import { Button, Flex, FlexItem, Label, Stack, StackItem } from '@patternfly/react-core';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { PhaseResourceType } from '~/app/utilities/phaseLabelUtils';
@@ -33,11 +33,13 @@ const enum ToggleLocation {
 type ExternalModelTableRowProps = {
   externalModel: ExternalModel;
   rowIndex: number;
+  setDeleteExternalModel: (externalModel: ExternalModel) => void;
 };
 
 const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
   externalModel,
   rowIndex,
+  setDeleteExternalModel,
 }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [hasOverflow, setHasOverflow] = React.useState(false);
@@ -224,6 +226,20 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
     </Td>
   );
 
+  const actionsCell = (
+    <Td isActionCell>
+      <ActionsColumn
+        data-testid="external-model-actions"
+        items={[
+          {
+            title: 'Delete',
+            onClick: () => setDeleteExternalModel(externalModel),
+          },
+        ]}
+      />
+    </Td>
+  );
+
   return (
     <>
       <Tbody isExpanded={isExpanded} data-testid="external-model-row">
@@ -239,6 +255,7 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
           {nameCell}
           {externalProviderCell}
           {phaseCell}
+          {actionsCell}
         </ResourceTr>
         <Tr isExpanded={isExpanded}>
           <Td colSpan={externalModelsColumns.length + 1}>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-88475](https://redhat.atlassian.net/browse/RHOAIENG-88475)


## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Reverts #8730

Re-adds ability to delete external model

the actions column and delete modal are back:

https://github.com/user-attachments/assets/2d91b14e-e7e7-4775-b980-d9ff3d0474f5



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

deleted an external model, you can apply this yaml to make a dummy deleteable one on the dashboard maas cluster:
```
apiVersion: inference.opendatahub.io/v1alpha1
kind: ExternalModel
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"inference.opendatahub.io/v1alpha1","kind":"ExternalModel","metadata":{"annotations":{},"name":"bbr-anthropic","namespace":"bbr-e2e"},"spec":{"externalProviderRefs":[{"apiFormat":"messages","path":"/v1/messages","ref":{"name":"bbr-anthropic"},"targetModel":"claude-sonnet-4-5-20241022"}]}}
    openshift.io/description: An Anthropic based model to test the new BBR feature.
    openshift.io/display-name: yaml external model
  name: yaml-model
  namespace: bbr-e2e
spec:
  externalProviderRefs:
    - apiFormat: messages
      path: /v1/messages
      ref:
        name: bbr-anthropic
      targetModel: claude-sonnet-4-5-20241022
      weight: 1
```

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
uncommented out the mock test for deleting the external model

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-88475]: https://redhat.atlassian.net/browse/RHOAIENG-88475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete external models directly from the external-models table.
  * Added a confirmation dialog displaying the selected model and requiring confirmation before deletion.
  * The model list refreshes automatically after a successful deletion.

* **Tests**
  * Added end-to-end coverage confirming external-model deletion and removal from the table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->