### PR TITLE
feat(nim): prioritize NVIDIA hardware profiles in NIM wizard

### DIFF
--- a/packages/hardware-profiles/shared/HardwareProfileFormSection.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileFormSection.tsx
@@ -33,6 +33,7 @@ type HardwareProfileFormSectionProps<T extends HardwarePodSpecOptions> = {
   visibleIn?: HardwareProfileFeatureVisibility[];
   podSpecOptionsState: HardwarePodSpecOptionsState<T>;
   isHardwareProfileSupported?: (profile: HardwareProfileKind) => boolean;
+  isHardwareProfilePreferred?: (profile: HardwareProfileKind) => boolean;
   isLocalQueueMissing?: boolean;
 };
 
@@ -42,6 +43,7 @@ const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSp
   isEditing,
   visibleIn = [],
   isHardwareProfileSupported = () => false,
+  isHardwareProfilePreferred,
   isLocalQueueMissing = false,
 }) => {
   const {
@@ -110,6 +112,7 @@ const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSp
                 !project ? [[], true, undefined] : projectScopedHardwareProfiles
               }
               isHardwareProfileSupported={isHardwareProfileSupported}
+              isHardwareProfilePreferred={isHardwareProfilePreferred}
               initialHardwareProfile={initialHardwareProfile}
               onChange={onProfileSelect}
               allowExistingSettings={isEditing && !initialHardwareProfile}

--- a/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
@@ -33,6 +33,7 @@ import {
   getHardwareProfileDisplayName,
   isHardwareProfileEnabled,
   orderHardwareProfiles,
+  prioritizeHardwareProfiles,
 } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
 import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
@@ -93,6 +94,7 @@ type HardwareProfileSelectProps = {
   allowExistingSettings: boolean;
   hardwareProfileConfig: HardwareProfileConfig;
   isHardwareProfileSupported: (profile: HardwareProfileKind) => boolean;
+  isHardwareProfilePreferred?: (profile: HardwareProfileKind) => boolean;
   onChange: (profile: HardwareProfileKind | undefined) => void;
   project?: string;
   selectionIndicator?: React.ReactNode;
@@ -113,6 +115,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
   allowExistingSettings = false,
   hardwareProfileConfig,
   isHardwareProfileSupported,
+  isHardwareProfilePreferred,
   onChange,
   project,
 }) => {
@@ -130,6 +133,20 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
   const hardwareProfileOrder = React.useMemo(
     () => dashboardConfig?.spec.hardwareProfileOrder || [],
     [dashboardConfig?.spec.hardwareProfileOrder],
+  );
+
+  const orderProfiles = React.useCallback(
+    (profiles: HardwareProfileKind[]) => {
+      if (isHardwareProfilePreferred) {
+        return prioritizeHardwareProfiles(
+          profiles,
+          isHardwareProfilePreferred,
+          hardwareProfileOrder,
+        );
+      }
+      return orderHardwareProfiles(profiles, hardwareProfileOrder);
+    },
+    [hardwareProfileOrder, isHardwareProfilePreferred],
   );
 
   const projectForKueue = React.useMemo(() => {
@@ -161,13 +178,12 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
   );
 
   const options = React.useMemo(() => {
-    const enabledProfiles = orderHardwareProfiles(
+    const enabledProfiles = orderProfiles(
       filterProfilesByKueue(
         hardwareProfiles.filter(isHardwareProfileEnabled),
         kueueFilteringState,
         availableLocalQueueNames,
       ),
-      hardwareProfileOrder,
     );
 
     if (initialHardwareProfile && !enabledProfiles.includes(initialHardwareProfile)) {
@@ -249,7 +265,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     isQueueMissing,
     availableLocalQueueNames,
     kueueFilteringState,
-    hardwareProfileOrder,
+    orderProfiles,
   ]);
 
   const renderMenuItem = (
@@ -326,7 +342,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     ) {
       filteredProfiles.push(initialHardwareProfile);
     }
-    return orderHardwareProfiles(filteredProfiles, hardwareProfileOrder).filter((profile) =>
+    return orderProfiles(filteredProfiles).filter((profile) =>
       getHardwareProfileDisplayName(profile)
         .toLocaleLowerCase()
         .includes(searchHardwareProfile.toLocaleLowerCase()),

--- a/packages/hardware-profiles/shared/index.ts
+++ b/packages/hardware-profiles/shared/index.ts
@@ -64,6 +64,10 @@ export {
   applyHardwareProfileConfig,
   getLocalQueueLabel,
 } from './utils';
+export {
+  isNvidiaHardwareProfile,
+  prioritizeHardwareProfiles,
+} from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
 
 // Components
 export { default as HardwareProfileBindingStateLabel } from './HardwareProfileBindingStateLabel';

--- a/packages/hardware-profiles/shared/index.ts
+++ b/packages/hardware-profiles/shared/index.ts
@@ -65,6 +65,7 @@ export {
   getLocalQueueLabel,
 } from './utils';
 export {
+  isHardwareProfileWithAcceleratorPrefix,
   isNvidiaHardwareProfile,
   prioritizeHardwareProfiles,
 } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';

--- a/packages/hardware-profiles/src/pages/__tests__/utils.spec.ts
+++ b/packages/hardware-profiles/src/pages/__tests__/utils.spec.ts
@@ -16,6 +16,7 @@ import {
   filterRecognizedVisibility,
   getClusterQueueNameFromLocalQueues,
   isHardwareProfileIdentifierValid,
+  isHardwareProfileWithAcceleratorPrefix,
   isNvidiaHardwareProfile,
   prioritizeHardwareProfiles,
   validateProfileWarning,
@@ -542,6 +543,44 @@ describe('filterRecognizedVisibility', () => {
 
   it('should return an empty array when given an empty array', () => {
     expect(filterRecognizedVisibility([])).toEqual([]);
+  });
+});
+
+describe('isHardwareProfileWithAcceleratorPrefix', () => {
+  it('should return true when profile has a matching accelerator identifier prefix', () => {
+    const profile = mockHardwareProfile({
+      name: 'nvidia-profile',
+      identifiers: [
+        {
+          displayName: 'GPU',
+          identifier: 'nvidia.com/gpu',
+          minCount: 1,
+          maxCount: 4,
+          defaultCount: 1,
+          resourceType: IdentifierResourceType.ACCELERATOR,
+        },
+      ],
+    });
+
+    expect(isHardwareProfileWithAcceleratorPrefix(profile, 'nvidia.com/')).toBe(true);
+  });
+
+  it('should return false when profile has no matching accelerator identifier prefix', () => {
+    const profile = mockHardwareProfile({
+      name: 'amd-profile',
+      identifiers: [
+        {
+          displayName: 'GPU',
+          identifier: 'amd.com/gpu',
+          minCount: 1,
+          maxCount: 4,
+          defaultCount: 1,
+          resourceType: IdentifierResourceType.ACCELERATOR,
+        },
+      ],
+    });
+
+    expect(isHardwareProfileWithAcceleratorPrefix(profile, 'nvidia.com/')).toBe(false);
   });
 });
 

--- a/packages/hardware-profiles/src/pages/__tests__/utils.spec.ts
+++ b/packages/hardware-profiles/src/pages/__tests__/utils.spec.ts
@@ -16,6 +16,8 @@ import {
   filterRecognizedVisibility,
   getClusterQueueNameFromLocalQueues,
   isHardwareProfileIdentifierValid,
+  isNvidiaHardwareProfile,
+  prioritizeHardwareProfiles,
   validateProfileWarning,
 } from '../utils';
 
@@ -540,5 +542,74 @@ describe('filterRecognizedVisibility', () => {
 
   it('should return an empty array when given an empty array', () => {
     expect(filterRecognizedVisibility([])).toEqual([]);
+  });
+});
+
+describe('isNvidiaHardwareProfile', () => {
+  it('should return true for profiles with an NVIDIA accelerator identifier', () => {
+    const profile = mockHardwareProfile({
+      name: 'nvidia-profile',
+      identifiers: [
+        {
+          displayName: 'GPU',
+          identifier: 'nvidia.com/gpu',
+          minCount: 1,
+          maxCount: 4,
+          defaultCount: 1,
+          resourceType: IdentifierResourceType.ACCELERATOR,
+        },
+      ],
+    });
+
+    expect(isNvidiaHardwareProfile(profile)).toBe(true);
+  });
+
+  it('should return false for profiles without an NVIDIA accelerator identifier', () => {
+    const profile = mockHardwareProfile({
+      name: 'cpu-only-profile',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '2',
+          defaultCount: '1',
+          resourceType: IdentifierResourceType.CPU,
+        },
+      ],
+    });
+
+    expect(isNvidiaHardwareProfile(profile)).toBe(false);
+  });
+});
+
+describe('prioritizeHardwareProfiles', () => {
+  it('should place preferred profiles before non-preferred profiles', () => {
+    const nvidiaProfile = mockHardwareProfile({
+      name: 'nvidia-profile',
+      identifiers: [
+        {
+          displayName: 'GPU',
+          identifier: 'nvidia.com/gpu',
+          minCount: 1,
+          maxCount: 4,
+          defaultCount: 1,
+          resourceType: IdentifierResourceType.ACCELERATOR,
+        },
+      ],
+    });
+    const smallProfile = mockHardwareProfile({ name: 'small-profile' });
+    const largeProfile = mockHardwareProfile({ name: 'large-profile' });
+
+    const result = prioritizeHardwareProfiles(
+      [smallProfile, largeProfile, nvidiaProfile],
+      isNvidiaHardwareProfile,
+    );
+
+    expect(result.map((profile) => profile.metadata.name)).toEqual([
+      'nvidia-profile',
+      'large-profile',
+      'small-profile',
+    ]);
   });
 });

--- a/packages/hardware-profiles/src/pages/utils.ts
+++ b/packages/hardware-profiles/src/pages/utils.ts
@@ -228,12 +228,18 @@ export const alphaSortHardwareProfilesByName = (
   return profiles.toSorted((a, b) => collator.compare(a.metadata.name, b.metadata.name));
 };
 
-export const isNvidiaHardwareProfile = (profile: HardwareProfileKind): boolean =>
+export const isHardwareProfileWithAcceleratorPrefix = (
+  profile: HardwareProfileKind,
+  acceleratorPrefix: string,
+): boolean =>
   profile.spec.identifiers?.some(
     (identifier) =>
       identifier.resourceType === IdentifierResourceType.ACCELERATOR &&
-      identifier.identifier.startsWith('nvidia.com/'),
+      identifier.identifier.startsWith(acceleratorPrefix),
   ) ?? false;
+
+export const isNvidiaHardwareProfile = (profile: HardwareProfileKind): boolean =>
+  isHardwareProfileWithAcceleratorPrefix(profile, 'nvidia.com/');
 
 export const orderHardwareProfiles = (
   profiles: HardwareProfileKind[],

--- a/packages/hardware-profiles/src/pages/utils.ts
+++ b/packages/hardware-profiles/src/pages/utils.ts
@@ -228,6 +228,13 @@ export const alphaSortHardwareProfilesByName = (
   return profiles.toSorted((a, b) => collator.compare(a.metadata.name, b.metadata.name));
 };
 
+export const isNvidiaHardwareProfile = (profile: HardwareProfileKind): boolean =>
+  profile.spec.identifiers?.some(
+    (identifier) =>
+      identifier.resourceType === IdentifierResourceType.ACCELERATOR &&
+      identifier.identifier.startsWith('nvidia.com/'),
+  ) ?? false;
+
 export const orderHardwareProfiles = (
   profiles: HardwareProfileKind[],
   hardwareProfileOrder: string[] = [],
@@ -248,6 +255,17 @@ export const orderHardwareProfiles = (
     });
   }
   return alphaSortHardwareProfilesByName(profiles);
+};
+
+export const prioritizeHardwareProfiles = (
+  profiles: HardwareProfileKind[],
+  isPreferred: (profile: HardwareProfileKind) => boolean,
+  hardwareProfileOrder: string[] = [],
+): HardwareProfileKind[] => {
+  const ordered = orderHardwareProfiles(profiles, hardwareProfileOrder);
+  const preferred = ordered.filter(isPreferred);
+  const rest = ordered.filter((profile) => !isPreferred(profile));
+  return [...preferred, ...rest];
 };
 
 export const getClusterQueueNameFromLocalQueues = (

--- a/packages/model-serving/src/__tests__/mockUtils.ts
+++ b/packages/model-serving/src/__tests__/mockUtils.ts
@@ -247,6 +247,7 @@ export const mockDeploymentWizardState = (
         isExternalRouteVisible: true,
         shouldAutoCheckTokens: false,
       },
+      computedOverrides: {},
       dispatch: jest.fn(),
       fields: [] as WizardField[],
     } as UseModelDeploymentWizardState,

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelServingHardwareProfileSection.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelServingHardwareProfileSection.tsx
@@ -8,16 +8,18 @@ import type {
   HardwarePodSpecOptionsState,
   PodSpecOptions,
 } from '@odh-dashboard/hardware-profiles/shared';
+import type { HardwareProfileKind } from '@odh-dashboard/k8s-core';
 
 type ModelServingHardwareProfileSectionComponentProps = {
   hardwareProfileConfig: UseHardwareProfileConfigResult;
   project?: string;
   isEditing?: boolean;
+  isHardwareProfilePreferred?: (profile: HardwareProfileKind) => boolean;
 };
 
 export const ModelServingHardwareProfileSection: React.FC<
   ModelServingHardwareProfileSectionComponentProps
-> = ({ hardwareProfileConfig, project, isEditing = false }) => {
+> = ({ hardwareProfileConfig, project, isEditing = false, isHardwareProfilePreferred }) => {
   const podSpecOptionsState: HardwarePodSpecOptionsState<PodSpecOptions> = React.useMemo(
     () => ({
       hardwareProfile: hardwareProfileConfig,
@@ -36,6 +38,7 @@ export const ModelServingHardwareProfileSection: React.FC<
       podSpecOptionsState={podSpecOptionsState}
       isEditing={isEditing}
       isHardwareProfileSupported={() => true}
+      isHardwareProfilePreferred={isHardwareProfilePreferred}
       visibleIn={MODEL_SERVING_VISIBILITY}
     />
   );

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Form, FormSection, Spinner } from '@patternfly/react-core';
-import { isNvidiaHardwareProfile } from '@odh-dashboard/hardware-profiles/shared';
+import { isHardwareProfileWithAcceleratorPrefix } from '@odh-dashboard/hardware-profiles/shared';
+import type { HardwareProfileKind } from '@odh-dashboard/k8s-core';
 import K8sNameDescriptionField from '@odh-dashboard/ui-core/components/K8sNameDescriptionField';
 import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import ProjectSection from '../fields/ProjectSection';
@@ -10,7 +11,6 @@ import { NumReplicasField } from '../fields/NumReplicasField';
 import { GenericFieldRenderer } from '../fields/GenericFieldRenderer';
 import { ExternalDataMap } from '../ExternalDataLoader';
 import { isNonSingleNodeTopologyActive } from '../topologyUtils';
-import { ModelLocationType } from '../../../shared/types/form-data';
 
 const EXPLICIT_TOPOLOGY_FIELD_IDS = [
   'llmd-serving/topology-type',
@@ -32,7 +32,15 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
   hideProjectSection,
 }) => {
   const hideHwp = isNonSingleNodeTopologyActive(wizardState.state);
-  const isNimWizard = wizardState.state.modelLocationData.data?.type === ModelLocationType.NIM;
+  const preferredAccelerator = wizardState.computedOverrides.hardwareProfile?.preferredAccelerator;
+
+  const isHardwareProfilePreferred = React.useMemo(
+    (): ((profile: HardwareProfileKind) => boolean) | undefined =>
+      preferredAccelerator
+        ? (profile) => isHardwareProfileWithAcceleratorPrefix(profile, preferredAccelerator)
+        : undefined,
+    [preferredAccelerator],
+  );
 
   const modelDeploymentExtensionFields = React.useMemo(
     () =>
@@ -91,7 +99,7 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
             project={projectName}
             hardwareProfileConfig={wizardState.state.hardwareProfileConfig}
             isEditing={wizardState.initialData?.isEditing}
-            isHardwareProfilePreferred={isNimWizard ? isNvidiaHardwareProfile : undefined}
+            isHardwareProfilePreferred={isHardwareProfilePreferred}
           />
         )}
         {wizardState.state.modelFormatState.isVisible && (

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Form, FormSection, Spinner } from '@patternfly/react-core';
+import { isNvidiaHardwareProfile } from '@odh-dashboard/hardware-profiles/shared';
 import K8sNameDescriptionField from '@odh-dashboard/ui-core/components/K8sNameDescriptionField';
 import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import ProjectSection from '../fields/ProjectSection';
@@ -9,6 +10,7 @@ import { NumReplicasField } from '../fields/NumReplicasField';
 import { GenericFieldRenderer } from '../fields/GenericFieldRenderer';
 import { ExternalDataMap } from '../ExternalDataLoader';
 import { isNonSingleNodeTopologyActive } from '../topologyUtils';
+import { ModelLocationType } from '../../../shared/types/form-data';
 
 const EXPLICIT_TOPOLOGY_FIELD_IDS = [
   'llmd-serving/topology-type',
@@ -30,6 +32,7 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
   hideProjectSection,
 }) => {
   const hideHwp = isNonSingleNodeTopologyActive(wizardState.state);
+  const isNimWizard = wizardState.state.modelLocationData.data?.type === ModelLocationType.NIM;
 
   const modelDeploymentExtensionFields = React.useMemo(
     () =>
@@ -88,6 +91,7 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
             project={projectName}
             hardwareProfileConfig={wizardState.state.hardwareProfileConfig}
             isEditing={wizardState.initialData?.isEditing}
+            isHardwareProfilePreferred={isNimWizard ? isNvidiaHardwareProfile : undefined}
           />
         )}
         {wizardState.state.modelFormatState.isVisible && (

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
@@ -35,6 +35,7 @@ import {
   type InitialWizardFormData,
   type WizardField,
   type WizardFormData,
+  type WizardStateOverrides,
 } from '../../shared/types/form-data';
 
 export type UseModelDeploymentWizardState = WizardFormData & {
@@ -49,6 +50,7 @@ export type UseModelDeploymentWizardState = WizardFormData & {
     isExternalRouteVisible: boolean;
     shouldAutoCheckTokens: boolean;
   };
+  computedOverrides: WizardStateOverrides;
   dispatch: React.Dispatch<WizardFormAction>;
   fields: WizardField<unknown>[];
 };
@@ -233,6 +235,7 @@ export const useModelDeploymentWizard = (
   return {
     initialData,
     state: stateWithOverrides,
+    computedOverrides,
     dispatch,
     fields,
     loaded: {

--- a/packages/model-serving/src/shared/types/form-data.ts
+++ b/packages/model-serving/src/shared/types/form-data.ts
@@ -246,6 +246,10 @@ export type WizardStateOverrides = {
     selection?: { name: string; namespace?: string };
     hiddenOptions?: { name: string; namespace?: string }[];
   };
+  hardwareProfile?: {
+    /** Accelerator identifier prefix used to prioritize matching hardware profiles. */
+    preferredAccelerator?: string;
+  };
 };
 
 export type WizardField<

--- a/packages/nim-serving/src/constants.ts
+++ b/packages/nim-serving/src/constants.ts
@@ -6,6 +6,8 @@ export const NIM_LEGACY_ID = 'nvidia-nim';
 /** Platform id for NIMService deployments managed by the k8s-nim-operator. */
 export const NIM_SERVICE_ID = 'nvidia-nim-service';
 export const NIM_MODEL_TYPE = 'NVIDIA NIM';
+/** Prefix for NVIDIA accelerator identifiers on hardware profiles (gpu, mig, etc.). */
+export const NVIDIA_ACCELERATOR_PREFIX = 'nvidia.com/';
 
 export const KSERVE_CONTAINER_NAME = 'kserve-container';
 export const NIM_CACHE_MOUNT_PATH = '/mnt/models/cache';

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -8,6 +8,7 @@ import type { ProjectSectionType } from '@odh-dashboard/model-serving/shared/wiz
 import type { WizardField } from '@odh-dashboard/model-serving/shared/types/form-data';
 import { NIMModelLocationKey } from '@odh-dashboard/model-serving/shared/wizard-fields';
 import { TemplateKind } from '@odh-dashboard/k8s-core';
+import { getNIMHardwareProfileFieldOverrides } from './nimHardwareProfileOverrides';
 import useNIMAccountStatus, { NIMAccountStatus } from '../../../api/accounts/hooks';
 import NIMSettingsLink from '../../projectSettings/NIMSettingsLink';
 import { useNIMImages, type NIMImagesData } from '../../../api/images/hooks';
@@ -278,6 +279,7 @@ export const NIMImageFieldWizardField: NIMImageFieldType = {
       existingFieldData ?? { repository: '', tag: '' },
     validationSchema: nimImageFieldSchema,
     resolveDependencies: (formData) => ({ project: formData.project }),
+    getFieldOverrides: getNIMHardwareProfileFieldOverrides,
   },
   component: NIMImageFieldComponent,
   externalDataHook: useNIMImageFieldExternalData,

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimHardwareProfileOverrides.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimHardwareProfileOverrides.spec.ts
@@ -1,0 +1,10 @@
+import { getNIMHardwareProfileFieldOverrides } from '../nimHardwareProfileOverrides';
+import { NVIDIA_ACCELERATOR_PREFIX } from '../../../../constants';
+
+describe('getNIMHardwareProfileFieldOverrides', () => {
+  it('should prioritize NVIDIA accelerator hardware profiles', () => {
+    expect(getNIMHardwareProfileFieldOverrides()).toEqual({
+      hardwareProfile: { preferredAccelerator: NVIDIA_ACCELERATOR_PREFIX },
+    });
+  });
+});

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimHardwareProfileOverrides.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimHardwareProfileOverrides.ts
@@ -1,0 +1,6 @@
+import type { WizardStateOverrides } from '@odh-dashboard/model-serving/shared/types/form-data';
+import { NVIDIA_ACCELERATOR_PREFIX } from '../../../constants';
+
+export const getNIMHardwareProfileFieldOverrides = (): WizardStateOverrides => ({
+  hardwareProfile: { preferredAccelerator: NVIDIA_ACCELERATOR_PREFIX },
+});


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-82818

## Description

NIM deployments only work with NVIDIA GPUs, but the hardware profile dropdown in the deployment wizard listed profiles in default alphabetical order — making NVIDIA profiles harder to find.

This change prioritizes NVIDIA hardware profiles at the top of the hardware profile selector when the NIM wizard is active (`ModelLocationType.NIM`):

- Adds `isNvidiaHardwareProfile` to detect profiles with an `nvidia.com/*` accelerator identifier (covers `nvidia.com/gpu` and MIG variants).
- Adds `prioritizeHardwareProfiles` to reorder profiles while preserving existing alpha / dashboard `hardwareProfileOrder` sorting within each group.
- Extends `HardwareProfileSelect` and `HardwareProfileFormSection` with an optional `isHardwareProfilePreferred` callback.
- Wires NIM-specific preference in `ModelDeploymentStep` via `ModelServingHardwareProfileSection`.

KServe and other wizard flows are unchanged.

## How Has This Been Tested?
<img width="1409" height="440" alt="Screenshot 2026-08-26 at 12 23 29 PM" src="https://github.com/user-attachments/assets/0619cd26-8749-47f8-a8a2-d6ebe0238f71" />

- Ran `npx turbo run lint --filter=@odh-dashboard/hardware-profiles --filter=@odh-dashboard/model-serving` — passed (pre-existing warnings only).
- Added unit tests for `isNvidiaHardwareProfile` and `prioritizeHardwareProfiles` in `packages/hardware-profiles/src/pages/__tests__/utils.spec.ts`.
- Manual testing in the NIM deployment wizard is recommended: open the hardware profile dropdown and confirm NVIDIA GPU profiles appear before CPU-only / non-NVIDIA profiles.

## Test Impact

- **Unit tests added:** `isNvidiaHardwareProfile` and `prioritizeHardwareProfiles` coverage in `packages/hardware-profiles/src/pages/__tests__/utils.spec.ts`.
- **Cypress:** No new Cypress tests. NIM wizard profile ordering could be covered in `packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts` as a follow-up.
- **Note:** `hardware-profiles` does not currently have its own `test-unit` script; confirm the new tests are picked up by CI or wire a runner for that package.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hardware profile selections can now prioritize profiles matching the deployment’s preferred accelerator.
  * NVIDIA-compatible hardware profiles are automatically prioritized for NIM deployments.
  * Deployment wizard state now exposes computed field overrides.

* **Tests**
  * Added coverage for accelerator detection, profile prioritization, and NIM hardware profile preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->