### PR TITLE
Deprecating nim odh app

### DIFF
--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -134,6 +134,14 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
     );
   }
 
+  if (isInternalRouteIntegrationsApp(odhApp.spec.internalRoute)) {
+    dropdownItems.push(
+      <DropdownItem key="uninstall" data-testid="uninstall-app" onClick={removeApplication}>
+        Uninstall
+      </DropdownItem>,
+    );
+  }
+
   const launchClasses = css(
     'odh-card__footer__link',
     !odhApp.spec.link && 'm-hidden',
@@ -269,6 +277,7 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
                   <MenuToggle
                     variant="plain"
                     aria-label="Actions"
+                    data-testid="app-actions-toggle"
                     ref={toggleRef}
                     onClick={() => setIsOpen(!isOpen)}
                     isExpanded={isOpen}

--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -8,6 +8,7 @@ import {
   CardBody,
   CardFooter,
   CardHeader,
+  Divider,
   Dropdown,
   DropdownItem,
   DropdownList,
@@ -136,7 +137,13 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
 
   if (isAdmin && isInternalRouteIntegrationsApp(odhApp.spec.internalRoute)) {
     dropdownItems.push(
-      <DropdownItem key="uninstall" data-testid="uninstall-app" onClick={removeApplication}>
+      <Divider key="uninstall-divider" component="li" />,
+      <DropdownItem
+        key="uninstall"
+        data-testid="uninstall-app"
+        isDanger
+        onClick={removeApplication}
+      >
         Uninstall
       </DropdownItem>,
     );

--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -134,7 +134,7 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
     );
   }
 
-  if (isInternalRouteIntegrationsApp(odhApp.spec.internalRoute)) {
+  if (isAdmin && isInternalRouteIntegrationsApp(odhApp.spec.internalRoute)) {
     dropdownItems.push(
       <DropdownItem key="uninstall" data-testid="uninstall-app" onClick={removeApplication}>
         Uninstall

--- a/frontend/src/pages/exploreApplication/ExploreApplications.tsx
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.tsx
@@ -103,6 +103,7 @@ ExploreApplicationsInner.displayName = 'ExploreApplicationsInner';
 const ExploreApplications: React.FC = () => {
   const { components, loaded, loadError } = useWatchComponents(false);
   const mlflowEnabled = useIsAreaAvailable(SupportedArea.MLFLOW).status;
+  const nimWizardEnabled = useIsAreaAvailable(SupportedArea.NIM_WIZARD).status;
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const selectedId = searchParams.get('selectId');
@@ -132,8 +133,9 @@ const ExploreApplications: React.FC = () => {
       _.cloneDeep(components)
         .filter((component) => !component.spec.hidden)
         .filter((component) => component.metadata.name !== 'mlflow' || mlflowEnabled)
+        .filter((component) => component.metadata.name !== 'nvidia-nim' || !nimWizardEnabled)
         .toSorted((a, b) => a.spec.displayName.localeCompare(b.spec.displayName)),
-    [components, mlflowEnabled],
+    [components, mlflowEnabled, nimWizardEnabled],
   );
 
   React.useEffect(() => {

--- a/frontend/src/pages/exploreApplication/ExploreApplications.tsx
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.tsx
@@ -108,11 +108,22 @@ const ExploreApplications: React.FC = () => {
   const [searchParams] = useSearchParams();
   const selectedId = searchParams.get('selectId');
   const [selectedComponent, setSelectedComponent] = React.useState<OdhApplication>();
-  const isEmpty = components.length === 0;
+
+  const exploreComponents = React.useMemo<OdhApplication[]>(
+    () =>
+      _.cloneDeep(components)
+        .filter((component) => !component.spec.hidden)
+        .filter((component) => component.metadata.name !== 'mlflow' || mlflowEnabled)
+        .filter((component) => component.metadata.name !== 'nvidia-nim' || !nimWizardEnabled)
+        .toSorted((a, b) => a.spec.displayName.localeCompare(b.spec.displayName)),
+    [components, mlflowEnabled, nimWizardEnabled],
+  );
+
+  const isEmpty = exploreComponents.length === 0;
 
   const updateSelection = React.useCallback(
     (currentSelectedId?: string | null): void => {
-      const selection = components.find(
+      const selection = exploreComponents.find(
         (c) => c.metadata.name && c.metadata.name === currentSelectedId,
       );
       if (currentSelectedId && selection) {
@@ -125,17 +136,7 @@ const ExploreApplications: React.FC = () => {
       removeQueryArgument(navigate, 'selectId');
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [components],
-  );
-
-  const exploreComponents = React.useMemo<OdhApplication[]>(
-    () =>
-      _.cloneDeep(components)
-        .filter((component) => !component.spec.hidden)
-        .filter((component) => component.metadata.name !== 'mlflow' || mlflowEnabled)
-        .filter((component) => component.metadata.name !== 'nvidia-nim' || !nimWizardEnabled)
-        .toSorted((a, b) => a.spec.displayName.localeCompare(b.spec.displayName)),
-    [components, mlflowEnabled, nimWizardEnabled],
+    [exploreComponents],
   );
 
   React.useEffect(() => {

--- a/packages/cypress/cypress/pages/enabled.ts
+++ b/packages/cypress/cypress/pages/enabled.ts
@@ -13,6 +13,19 @@ class EnabledPage {
     this.shouldHaveEnabledPageSection();
     cy.testA11y();
   }
+
+  findCard(cardName: string) {
+    return cy.findByTestId(`card ${cardName}`);
+  }
+
+  findCardKebab(cardName: string) {
+    return this.findCard(cardName).findByTestId('app-actions-toggle');
+  }
+
+  findUninstallItem(cardName: string) {
+    this.findCardKebab(cardName).click();
+    return cy.findByTestId('uninstall-app');
+  }
 }
 
 export const enabledPage = new EnabledPage();

--- a/packages/cypress/cypress/pages/explore.ts
+++ b/packages/cypress/cypress/pages/explore.ts
@@ -17,6 +17,10 @@ class ExplorePage {
   findCardLocator(cardName: string) {
     return cy.get(`[data-testid="card ${cardName}"] label`);
   }
+
+  findCard(cardName: string) {
+    return cy.findByTestId(`card ${cardName}`);
+  }
 }
 
 export const explorePage = new ExplorePage();

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
@@ -7,6 +7,8 @@ import { mockNimServingRuntimeTemplate } from '@odh-dashboard/model-serving/__mo
 import { mockNimAccount } from '@odh-dashboard/internal/__mocks__/mockNimAccount';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { projectDetailsSettingsTab } from '../../../../pages/projects';
+import { explorePage } from '../../../../pages/explore';
+import { enabledPage } from '../../../../pages/enabled';
 import { NIMAccountModel, ProjectModel, TemplateModel } from '../../../../utils/models';
 import { asProjectEditUser } from '../../../../utils/mockUsers';
 
@@ -79,5 +81,39 @@ describe('NIM Settings Card', () => {
     projectDetailsSettingsTab.visitSettings('test-project');
     projectDetailsSettingsTab.findNIMRemoveButton().should('exist');
     projectDetailsSettingsTab.findNIMReplaceKeyButton().should('exist');
+  });
+});
+
+describe('NIM global app deprecation (nimWizard enabled)', () => {
+  beforeEach(() => {
+    asProjectEditUser();
+  });
+
+  it('should not show the NIM app on the Explore page', () => {
+    initIntercepts();
+    // Control app to prove the page renders and only NIM is filtered out
+    cy.interceptOdh('GET /api/components', null, [
+      mockOdhApplication({ name: 'nvidia-nim' }),
+      mockOdhApplication({
+        name: 'other-app',
+        displayName: 'Other App',
+        internalRoute: undefined,
+      }),
+    ]);
+
+    explorePage.visit();
+    explorePage.findCard('other-app').should('exist');
+    explorePage.findCard('nvidia-nim').should('not.exist');
+  });
+
+  it('should uninstall the NIM app from the Enabled page', () => {
+    initIntercepts();
+    cy.intercept('DELETE', '/api/integrations/nim', { success: true }).as('uninstallNim');
+
+    enabledPage.visit();
+    enabledPage.findCard('nvidia-nim').should('exist');
+    enabledPage.findUninstallItem('nvidia-nim').should('be.visible').click();
+
+    cy.wait('@uninstallNim');
   });
 });

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
@@ -10,7 +10,7 @@ import { projectDetailsSettingsTab } from '../../../../pages/projects';
 import { explorePage } from '../../../../pages/explore';
 import { enabledPage } from '../../../../pages/enabled';
 import { NIMAccountModel, ProjectModel, TemplateModel } from '../../../../utils/models';
-import { asProjectEditUser } from '../../../../utils/mockUsers';
+import { asProductAdminUser, asProjectEditUser } from '../../../../utils/mockUsers';
 
 const initIntercepts = ({
   nimAccountExists = false,
@@ -86,7 +86,7 @@ describe('NIM Settings Card', () => {
 
 describe('NIM global app deprecation (nimWizard enabled)', () => {
   beforeEach(() => {
-    asProjectEditUser();
+    asProductAdminUser();
   });
 
   it('should not show the NIM app on the Explore page', () => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-82817

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Two changes
1. Very simple filter for the nim OdhApp from the explore page if nimWizard is enabled
2. Add an "uninstall" option for an existing enabled nim OdhApp
  - The uninstall is only added if it's an integration app, nim is the only one. So it avoids side effects for other apps
  - For some reason you could only uninstall it if there was a key error

<img width="1488" height="625" alt="image" src="https://github.com/user-attachments/assets/7f44233d-57d4-4587-83c3-8b279f415b06" />
<img width="1497" height="607" alt="Screenshot 2026-08-26 at 4 30 20 PM" src="https://github.com/user-attachments/assets/31e54100-7724-492a-85fb-606b7849019d" />

**UPDATE**
<img width="360" height="340" alt="image" src="https://github.com/user-attachments/assets/2b5db22a-7577-4ec7-a878-bab82f54c739" />


As a non-admin, it won't appear
<img width="1001" height="680" alt="image" src="https://github.com/user-attachments/assets/d8e02549-70c1-4aac-a996-dbd7bb78bf0a" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Enable the global NIM app (with nimWizard false)
2. Go to the enabled apps
3. Click the uninstall button
4. It should uninstall

1. Have the global nim app uninstalled (with nimWizard false)
2. Make sure you see it in the explore page
3. Set nimWizard to true
4. It should disappear

1. Log in as a non admin with it installed
2. It the uninstall shouldn't appear

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Cypress test added to cover the deprecation behavior

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an **Uninstall** action for administrators managing enabled internal integration applications.
- NIM applications are hidden from Explore when NIM Wizard is enabled.
- Other available applications remain visible and selectable.

## Bug Fixes
- Improved application filtering and selection behavior when NIM Wizard is enabled.

## Tests
- Added coverage for NIM application filtering and administrator uninstallation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->