### PR TITLE
feat(notebooks): add TLS server support to workbenches BFF

### DIFF
--- a/packages/notebooks/upstream/workspaces/backend/cmd/main.go
+++ b/packages/notebooks/upstream/workspaces/backend/cmd/main.go
@@ -50,6 +50,7 @@ import (
 func main() {
 	// Define command line flags
 	cfg := &config.EnvConfig{}
+	var certFile, keyFile string
 	flag.IntVar(&cfg.Port,
 		"port",
 		getEnvAsInt("PORT", 4000),
@@ -130,6 +131,8 @@ func main() {
 		getEnvAsStr("STATIC_ASSETS_DIR", "/static"),
 		"Directory containing frontend static assets",
 	)
+	flag.StringVar(&certFile, "cert-file", getEnvAsStr("CERT_FILE", ""), "Path to TLS certificate file")
+	flag.StringVar(&keyFile, "key-file", getEnvAsStr("KEY_FILE", ""), "Path to TLS key file")
 
 	flag.Parse()
 
@@ -202,7 +205,7 @@ func main() {
 		logger.Error("failed to create app", "error", err)
 		os.Exit(1)
 	}
-	svr, err := server.NewServer(app, logger)
+	svr, err := server.NewServer(app, logger, certFile, keyFile)
 	if err != nil {
 		logger.Error("failed to create server", "error", err)
 		os.Exit(1)

--- a/packages/notebooks/upstream/workspaces/backend/internal/server/server.go
+++ b/packages/notebooks/upstream/workspaces/backend/internal/server/server.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -39,9 +40,15 @@ type Server struct {
 	logger   *slog.Logger
 	listener net.Listener
 	server   *http.Server
+	certFile string
+	keyFile  string
 }
 
-func NewServer(app *api.App, logger *slog.Logger) (*Server, error) {
+func NewServer(app *api.App, logger *slog.Logger, certFile, keyFile string) (*Server, error) {
+	if (certFile == "") != (keyFile == "") {
+		return nil, fmt.Errorf("cert-file and key-file must be provided together")
+	}
+
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", app.Config.Port))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create listener: %w", err)
@@ -61,6 +68,8 @@ func NewServer(app *api.App, logger *slog.Logger) (*Server, error) {
 		logger:   logger,
 		listener: listener,
 		server:   svc,
+		certFile: certFile,
+		keyFile:  keyFile,
 	}
 
 	return svr, nil
@@ -88,8 +97,18 @@ func (s *Server) Start(ctx context.Context) error {
 		close(serverShutdown)
 	}()
 
-	s.logger.Info("starting server", "addr", s.server.Addr)
-	if err := s.server.Serve(s.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	tlsEnabled := s.certFile != "" && s.keyFile != ""
+	s.logger.Info("starting server", "addr", s.server.Addr, "tls", tlsEnabled)
+	var err error
+	if tlsEnabled {
+		s.server.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS13,
+		}
+		err = s.server.ServeTLS(s.listener, s.certFile, s.keyFile)
+	} else {
+		err = s.server.Serve(s.listener)
+	}
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 

--- a/packages/notebooks/upstream/workspaces/backend/internal/server/server_test.go
+++ b/packages/notebooks/upstream/workspaces/backend/internal/server/server_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewServerRejectsPartialTLSConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		certFile string
+		keyFile  string
+	}{
+		{name: "cert only", certFile: "/tls/tls.crt", keyFile: ""},
+		{name: "key only", certFile: "", keyFile: "/tls/tls.key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewServer(nil, nil, tt.certFile, tt.keyFile)
+			if err == nil {
+				t.Fatal("expected error for partial TLS config, got nil")
+			}
+			if !strings.Contains(err.Error(), "must be provided together") {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-88028

## Description

Cherry-picks [opendatahub-io/workbenches#25](https://github.com/opendatahub-io/workbenches/pull/25) into `packages/notebooks/upstream/workspaces/backend`.

The ODH/RHOAI dashboard operator configures module federation with `tls: true` for all standalone BFF modules. Other modules (gen-ai, maas, mlflow, etc.) terminate TLS in-process using OpenShift serving certificates. The workbenches BFF only served plain HTTP, which caused federation to fail with `ERR_SSL_PACKET_LENGTH_TOO_LONG` when rhods-dashboard proxied `/_mf/notebooks/remoteEntry.js` over HTTPS.

This adds optional TLS support to the workspaces BFF, matching the pattern used by other ODH federated BFFs:
- New flags: `--cert-file` and `--key-file` (with `CERT_FILE` / `KEY_FILE` env fallbacks)
- When both are set, the server uses `ServeTLS` with TLS 1.3 minimum
- When unset, behavior is unchanged (plain HTTP for local dev)

## How Has This Been Tested?

Ran the existing and newly-added Go test suite for the affected package, and verified the backend builds and vets cleanly.

```
go build ./...
go vet ./...
go test ./internal/server/...
```

## Test Impact

Upstream PR includes a new `server_test.go` covering TLS and non-TLS server startup paths, carried over as part of this sync.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled secure TLS communication for the notebooks module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->