### PR TITLE
fix(eval-hub): use configured primary metric for benchmark score display

### DIFF
--- a/packages/eval-hub/frontend/src/app/utilities/__tests__/evaluationUtils.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utilities/__tests__/evaluationUtils.spec.ts
@@ -9,6 +9,7 @@ import {
   getJobBenchmarks,
   getResultScore,
   formatAsPercentage,
+  formatBenchmarkScore,
   formatDate,
   formatDurationCompact,
   isTerminalState,
@@ -290,6 +291,50 @@ describe('formatAsPercentage', () => {
   });
 });
 
+describe('formatBenchmarkScore', () => {
+  /* eslint-disable camelcase */
+  it('should prefer test.primary_score over metrics', () => {
+    expect(
+      formatBenchmarkScore({ id: 'b1', test: { primary_score: 0.8 }, metrics: { acc: 0.5 } }),
+    ).toBe('80%');
+  });
+
+  it('should use primaryMetric parameter when test is absent', () => {
+    expect(
+      formatBenchmarkScore(
+        { id: 'b1', metrics: { attack_success_rate: 0.1, acc: 0.9 } },
+        'attack_success_rate',
+      ),
+    ).toBe('10%');
+  });
+
+  it('should fall back to acc_norm/acc when primaryMetric is not provided', () => {
+    expect(formatBenchmarkScore({ id: 'b1', metrics: { acc_norm: 0.85, acc: 0.7 } })).toBe('85%');
+  });
+
+  it('should fall back to attack_success_rate when acc metrics are absent', () => {
+    expect(formatBenchmarkScore({ id: 'b1', metrics: { attack_success_rate: 0 } })).toBe('0%');
+  });
+
+  it('should return null when no recognized metrics are present', () => {
+    expect(formatBenchmarkScore({ id: 'b1', metrics: { unknown_metric: 0.5 } })).toBeNull();
+  });
+
+  it('should return null when metrics is undefined', () => {
+    expect(formatBenchmarkScore({ id: 'b1' })).toBeNull();
+  });
+
+  it('should skip primaryMetric when its value is not a number', () => {
+    expect(
+      formatBenchmarkScore(
+        { id: 'b1', metrics: { bad_metric: 'not-a-number', acc: 0.6 } },
+        'bad_metric',
+      ),
+    ).toBe('60%');
+  });
+  /* eslint-enable camelcase */
+});
+
 describe('getResultScore', () => {
   it('should return percentage from top-level test score', () => {
     const job = mockEvaluationJob({ score: 0.85 });
@@ -333,10 +378,61 @@ describe('getResultScore', () => {
     expect(getResultScore(job)).toBe('85%');
   });
 
-  it('should return dash when metrics has neither acc_norm nor acc', () => {
+  it('should return dash when metrics has no recognized metric names', () => {
     const job = mockEvaluationJob();
     job.results = { benchmarks: [{ id: 'b1', metrics: { f1_score: 0.9 } }] };
     expect(getResultScore(job)).toBe('-');
+  });
+
+  it('should fall back to attack_success_rate for garak benchmarks without test object', () => {
+    const job = mockEvaluationJob();
+    job.benchmarks = [{ id: 'quick', provider_id: 'garak' }];
+    job.results = {
+      benchmarks: [
+        {
+          id: 'quick',
+          provider_id: 'garak',
+          metrics: { attack_success_rate: 0, 'dan.Dan_11_0_asr': 0 },
+        },
+      ],
+    };
+    expect(getResultScore(job)).toBe('0%');
+  });
+
+  it('should fall back to attack_success_rate with non-zero value', () => {
+    const job = mockEvaluationJob();
+    job.benchmarks = [{ id: 'quick', provider_id: 'garak' }];
+    job.results = {
+      benchmarks: [
+        {
+          id: 'quick',
+          provider_id: 'garak',
+          metrics: { attack_success_rate: 0.25 },
+        },
+      ],
+    };
+    expect(getResultScore(job)).toBe('25%');
+  });
+
+  it('should use configured primary_score.metric from benchmark config', () => {
+    const job = mockEvaluationJob();
+    job.benchmarks = [
+      {
+        id: 'custom_bench',
+        provider_id: 'custom',
+        primary_score: { metric: 'custom_metric', lower_is_better: false },
+      },
+    ];
+    job.results = {
+      benchmarks: [
+        {
+          id: 'custom_bench',
+          provider_id: 'custom',
+          metrics: { custom_metric: 0.42, other_metric: 0.99 },
+        },
+      ],
+    };
+    expect(getResultScore(job)).toBe('42%');
   });
   /* eslint-enable camelcase */
 
@@ -419,6 +515,44 @@ describe('getBenchmarkResultScore', () => {
     job.results = { benchmarks: [] };
     expect(getBenchmarkResultScore(job, 'missing')).toBe('-');
   });
+
+  /* eslint-disable camelcase */
+  it('should fall back to attack_success_rate for garak benchmarks', () => {
+    const job = mockEvaluationJob();
+    job.benchmarks = [{ id: 'quick', provider_id: 'garak' }];
+    job.results = {
+      benchmarks: [
+        {
+          id: 'quick',
+          provider_id: 'garak',
+          metrics: { attack_success_rate: 0, 'dan.Dan_11_0_asr': 0 },
+        },
+      ],
+    };
+    expect(getBenchmarkResultScore(job, 'quick')).toBe('0%');
+  });
+
+  it('should use configured primary_score.metric from benchmark config', () => {
+    const job = mockEvaluationJob();
+    job.benchmarks = [
+      {
+        id: 'custom_bench',
+        provider_id: 'custom',
+        primary_score: { metric: 'custom_metric', lower_is_better: false },
+      },
+    ];
+    job.results = {
+      benchmarks: [
+        {
+          id: 'custom_bench',
+          provider_id: 'custom',
+          metrics: { custom_metric: 0.65 },
+        },
+      ],
+    };
+    expect(getBenchmarkResultScore(job, 'custom_bench')).toBe('65%');
+  });
+  /* eslint-enable camelcase */
 });
 
 describe('formatDurationCompact', () => {

--- a/packages/eval-hub/frontend/src/app/utilities/__tests__/evaluationUtils.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utilities/__tests__/evaluationUtils.spec.ts
@@ -434,6 +434,72 @@ describe('getResultScore', () => {
     };
     expect(getResultScore(job)).toBe('42%');
   });
+
+  it('should match first result benchmark by resolved index when duplicate IDs have explicit benchmark_index', () => {
+    const job = mockEvaluationJob();
+    job.benchmarks = [
+      {
+        id: 'arc_easy',
+        provider_id: 'lm_evaluation_harness',
+        benchmark_index: 0,
+        primary_score: { metric: 'acc_norm', lower_is_better: false },
+      },
+      {
+        id: 'arc_easy',
+        provider_id: 'lm_evaluation_harness',
+        benchmark_index: 1,
+        primary_score: { metric: 'f1_score', lower_is_better: false },
+      },
+    ];
+    job.results = {
+      benchmarks: [
+        {
+          id: 'arc_easy',
+          provider_id: 'lm_evaluation_harness',
+          benchmark_index: 0,
+          metrics: { acc_norm: 0.85, f1_score: 0.6 },
+        },
+        {
+          id: 'arc_easy',
+          provider_id: 'lm_evaluation_harness',
+          benchmark_index: 1,
+          metrics: { acc_norm: 0.4, f1_score: 0.92 },
+        },
+      ],
+    };
+    expect(getResultScore(job)).toBe('85%');
+  });
+
+  it('should match first result benchmark by position when duplicate IDs omit benchmark_index', () => {
+    const job = mockEvaluationJob();
+    job.benchmarks = [
+      {
+        id: 'arc_easy',
+        provider_id: 'lm_evaluation_harness',
+        primary_score: { metric: 'acc_norm', lower_is_better: false },
+      },
+      {
+        id: 'arc_easy',
+        provider_id: 'lm_evaluation_harness',
+        primary_score: { metric: 'f1_score', lower_is_better: false },
+      },
+    ];
+    job.results = {
+      benchmarks: [
+        {
+          id: 'arc_easy',
+          provider_id: 'lm_evaluation_harness',
+          metrics: { acc_norm: 0.85, f1_score: 0.6 },
+        },
+        {
+          id: 'arc_easy',
+          provider_id: 'lm_evaluation_harness',
+          metrics: { acc_norm: 0.4, f1_score: 0.92 },
+        },
+      ],
+    };
+    expect(getResultScore(job)).toBe('85%');
+  });
   /* eslint-enable camelcase */
 
   it('should return dash when benchmarks have no test and no metrics', () => {
@@ -551,6 +617,74 @@ describe('getBenchmarkResultScore', () => {
       ],
     };
     expect(getBenchmarkResultScore(job, 'custom_bench')).toBe('65%');
+  });
+
+  it('should select correct config when duplicate IDs have explicit benchmark_index', () => {
+    const job = mockEvaluationJob();
+    job.benchmarks = [
+      {
+        id: 'arc_easy',
+        provider_id: 'lm_evaluation_harness',
+        benchmark_index: 0,
+        primary_score: { metric: 'acc_norm', lower_is_better: false },
+      },
+      {
+        id: 'arc_easy',
+        provider_id: 'lm_evaluation_harness',
+        benchmark_index: 1,
+        primary_score: { metric: 'f1_score', lower_is_better: false },
+      },
+    ];
+    job.results = {
+      benchmarks: [
+        {
+          id: 'arc_easy',
+          provider_id: 'lm_evaluation_harness',
+          benchmark_index: 0,
+          metrics: { acc_norm: 0.85, f1_score: 0.6 },
+        },
+        {
+          id: 'arc_easy',
+          provider_id: 'lm_evaluation_harness',
+          benchmark_index: 1,
+          metrics: { acc_norm: 0.4, f1_score: 0.92 },
+        },
+      ],
+    };
+    expect(getBenchmarkResultScore(job, 'arc_easy', 0)).toBe('85%');
+    expect(getBenchmarkResultScore(job, 'arc_easy', 1)).toBe('92%');
+  });
+
+  it('should select correct config when duplicate IDs omit benchmark_index', () => {
+    const job = mockEvaluationJob();
+    job.benchmarks = [
+      {
+        id: 'arc_easy',
+        provider_id: 'lm_evaluation_harness',
+        primary_score: { metric: 'acc_norm', lower_is_better: false },
+      },
+      {
+        id: 'arc_easy',
+        provider_id: 'lm_evaluation_harness',
+        primary_score: { metric: 'f1_score', lower_is_better: false },
+      },
+    ];
+    job.results = {
+      benchmarks: [
+        {
+          id: 'arc_easy',
+          provider_id: 'lm_evaluation_harness',
+          metrics: { acc_norm: 0.85, f1_score: 0.6 },
+        },
+        {
+          id: 'arc_easy',
+          provider_id: 'lm_evaluation_harness',
+          metrics: { acc_norm: 0.4, f1_score: 0.92 },
+        },
+      ],
+    };
+    expect(getBenchmarkResultScore(job, 'arc_easy', 0)).toBe('85%');
+    expect(getBenchmarkResultScore(job, 'arc_easy', 1)).toBe('92%');
   });
   /* eslint-enable camelcase */
 });

--- a/packages/eval-hub/frontend/src/app/utilities/evaluationUtils.ts
+++ b/packages/eval-hub/frontend/src/app/utilities/evaluationUtils.ts
@@ -129,7 +129,10 @@ export const getResultScore = (job: EvaluationJob): string => {
   }
   if (job.results.benchmarks?.length) {
     const resultBenchmark = job.results.benchmarks[0];
-    const configBenchmark = getJobBenchmarks(job).find((b) => b.id === resultBenchmark.id);
+    const resolvedIndex = resultBenchmark.benchmark_index ?? 0;
+    const configBenchmark = getJobBenchmarks(job).find(
+      (b, idx) => b.id === resultBenchmark.id && (b.benchmark_index ?? idx) === resolvedIndex,
+    );
     return formatBenchmarkScore(resultBenchmark, configBenchmark?.primary_score?.metric) ?? '-';
   }
   return '-';
@@ -149,9 +152,9 @@ export const getBenchmarkResultScore = (
     return '-';
   }
   const configBenchmark = getJobBenchmarks(job).find(
-    (b) =>
+    (b, idx) =>
       b.id === benchmarkId &&
-      (benchmarkIndex === undefined || b.benchmark_index === benchmarkIndex),
+      (benchmarkIndex === undefined || (b.benchmark_index ?? idx) === benchmarkIndex),
   );
   return formatBenchmarkScore(benchmark, configBenchmark?.primary_score?.metric) ?? '-';
 };

--- a/packages/eval-hub/frontend/src/app/utilities/evaluationUtils.ts
+++ b/packages/eval-hub/frontend/src/app/utilities/evaluationUtils.ts
@@ -74,15 +74,41 @@ export const getBenchmarkDisplayName = (id: string): string =>
 export const formatAsPercentage = (value: number): string =>
   Number.isFinite(value) ? `${Math.round(value * 100)}%` : '-';
 
+/**
+ * Extract a display score from a benchmark result, returned as a formatted percentage.
+ *
+ * Resolution order:
+ *  1. `benchmark.test.primary_score` — populated by the eval service when the `test` object is present.
+ *  2. `primaryMetric` lookup in `benchmark.metrics` — the metric name from the benchmark's
+ *     config (`primary_score.metric`). This covers providers like garak whose primary metric
+ *     (`attack_success_rate`) is not in the well-known fallback list, and whose list-endpoint
+ *     response may omit the `test` object entirely.
+ *  3. Well-known metric names (`acc_norm`, `acc`, `attack_success_rate`) as a last resort.
+ *
+ * @param primaryMetric - The configured `primary_score.metric` from the benchmark config
+ *   (e.g. `job.benchmarks[].primary_score.metric`). The benchmark result itself does not
+ *   carry this field, so callers cross-reference with the config benchmarks.
+ */
 export const formatBenchmarkScore = (
   benchmark: NonNullable<EvaluationJob['results']['benchmarks']>[number],
+  primaryMetric?: string,
 ): string | null => {
   const primaryScore = benchmark.test?.primary_score;
   if (primaryScore != null && Number.isFinite(primaryScore)) {
     return formatAsPercentage(primaryScore);
   }
   if (benchmark.metrics) {
-    const candidates = [benchmark.metrics.acc_norm, benchmark.metrics.acc];
+    if (primaryMetric) {
+      const configured = benchmark.metrics[primaryMetric];
+      if (typeof configured === 'number' && Number.isFinite(configured)) {
+        return formatAsPercentage(configured);
+      }
+    }
+    const candidates = [
+      benchmark.metrics.acc_norm,
+      benchmark.metrics.acc,
+      benchmark.metrics.attack_success_rate,
+    ];
     const preferred = candidates.find(
       (v): v is number => typeof v === 'number' && Number.isFinite(v),
     );
@@ -102,7 +128,9 @@ export const getResultScore = (job: EvaluationJob): string => {
     return '-';
   }
   if (job.results.benchmarks?.length) {
-    return formatBenchmarkScore(job.results.benchmarks[0]) ?? '-';
+    const resultBenchmark = job.results.benchmarks[0];
+    const configBenchmark = getJobBenchmarks(job).find((b) => b.id === resultBenchmark.id);
+    return formatBenchmarkScore(resultBenchmark, configBenchmark?.primary_score?.metric) ?? '-';
   }
   return '-';
 };
@@ -120,7 +148,12 @@ export const getBenchmarkResultScore = (
   if (!benchmark) {
     return '-';
   }
-  return formatBenchmarkScore(benchmark) ?? '-';
+  const configBenchmark = getJobBenchmarks(job).find(
+    (b) =>
+      b.id === benchmarkId &&
+      (benchmarkIndex === undefined || b.benchmark_index === benchmarkIndex),
+  );
+  return formatBenchmarkScore(benchmark, configBenchmark?.primary_score?.metric) ?? '-';
 };
 
 export const getResultPass = (job: EvaluationJob): boolean | null => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-89019

## Description

`formatBenchmarkScore` now accepts an optional `primaryMetric` parameter sourced from the benchmark config's `primary_score.metric` field. Previously, score display only checked `test.primary_score` and then fell back to the well-known metrics `acc_norm` and `acc`. Benchmarks from providers like garak (whose primary metric is `attack_success_rate`) or custom providers with non-standard metric names would show `-` instead of their actual score.

Changes:
- `formatBenchmarkScore` resolution order is now: `test.primary_score` > configured `primaryMetric` lookup > well-known fallback list (`acc_norm`, `acc`, `attack_success_rate`).
- `getResultScore` and `getBenchmarkResultScore` now cross-reference the result benchmark with the job's configured benchmarks to pass through the `primary_score.metric` value.
- `attack_success_rate` added to the well-known fallback list so garak benchmarks without a `test` object still display a score.

<img width="2182" height="1457" alt="image" src="https://github.com/user-attachments/assets/ed9a0bd5-68b0-45fb-acfb-2e1992288fdb" />


## How Has This Been Tested?

Unit tests added and run via Jest covering the new logic paths in `formatBenchmarkScore`, `getResultScore`, and `getBenchmarkResultScore`.

Manually tested by hardcoding the GET responses to include garak jobs with 0s.
Use this patch to apply the same test
[garak-hardcoded-test-data.patch](https://github.com/user-attachments/files/31519831/garak-hardcoded-test-data.patch)


## Test Impact

Added and modified tests in `evaluationUtils.spec.ts`:
- **`formatBenchmarkScore`** — new describe block with 7 test cases covering: `test.primary_score` priority, `primaryMetric` parameter usage, `acc_norm`/`acc` fallback, `attack_success_rate` fallback, null returns for unrecognized/missing metrics, and non-numeric metric skipping.
- **`getResultScore`** — 3 new test cases for garak `attack_success_rate` fallback (zero and non-zero values) and configured `primary_score.metric` from benchmark config.
- **`getBenchmarkResultScore`** — 2 new test cases for garak `attack_success_rate` fallback and configured `primary_score.metric` from benchmark config.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark score display by prioritizing explicitly configured primary scores.
  * Added support for benchmark-specific primary metrics when calculating result scores.
  * Expanded score fallbacks to include accuracy, normalized accuracy, and attack success rate metrics.
  * Ensured evaluation and benchmark result views use the appropriate configured metric for more consistent scoring.
  * Improved score resolution when benchmarks share duplicate identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->