### PR TITLE
test(e2e): remove @SmokeSet4 tag from AutoML binary classification test

### DIFF
--- a/packages/cypress/cypress/tests/e2e/automl/testAutomlBinaryClassification.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/automl/testAutomlBinaryClassification.cy.ts
@@ -51,7 +51,7 @@ describe('AutoML Binary Classification E2E', { testIsolation: false }, () => {
 
   it(
     'Can create and submit an AutoML binary classification run',
-    { tags: ['@SmokeSet4', '@AutoML', '@AutoMLCI', '@Featureflagged'] },
+    { tags: ['@AutoML', '@AutoMLCI', '@Featureflagged'] },
     () => {
       configureAutomlRun(testData, projectName, uuid);
 


### PR DESCRIPTION
## Description
Removes the `@SmokeSet4` tag from the AutoML binary classification E2E test. This test also carries `@Featureflagged`, meaning it requires the AutoML feature flag to be enabled — an assumption that doesn't hold in all Smoke environments. The test continues to run under `@AutoML`, `@AutoMLCI`, and `@Featureflagged` suites where the feature flag is expected to be present.

## How Has This Been Tested?
Tag-only change — no logic modified. Verified no other AutoML E2E tests carry smoke tags.

## Test Impact
The affected test will no longer execute as part of the SmokeSet4 suite. It remains covered by `@AutoMLCI` and `@Featureflagged` CI runs.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AutoML binary classification end-to-end test tagging.
  * Removed the smoke-test designation while retaining AutoML, CI, and feature-flag coverage labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->