### PR TITLE
feat(data-registry): implement edit asset modal for tables and volumes

### DIFF
--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/pages/editAssetModal.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/pages/editAssetModal.ts
@@ -10,7 +10,7 @@ class EditAssetModal extends Modal {
   }
 
   findCancelButton() {
-    return this.find().findByRole('button', { name: 'Cancel' });
+    return cy.findByTestId('edit-asset-cancel');
   }
 
   // Asset details section (shared with register-data, read-only in edit mode)
@@ -119,7 +119,7 @@ class EditAssetModal extends Modal {
   }
 
   findErrorAlert() {
-    return this.find().find('.pf-v6-c-alert');
+    return this.find().findByTestId('edit-asset-error');
   }
 }
 

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/pages/editAssetModal.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/pages/editAssetModal.ts
@@ -47,7 +47,7 @@ class EditAssetModal extends Modal {
   }
 
   removeLabel(name: string) {
-    return this.findLabel(name).find('button').click();
+    return cy.findByTestId(`data-label-remove-${name}`).click();
   }
 
   // Data location section

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/pages/editAssetModal.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/pages/editAssetModal.ts
@@ -1,0 +1,126 @@
+import { Modal } from './components/Modal';
+
+class EditAssetModal extends Modal {
+  constructor() {
+    super(/Edit ".*"/);
+  }
+
+  findSaveButton() {
+    return cy.findByTestId('edit-asset-save');
+  }
+
+  findCancelButton() {
+    return this.find().findByRole('button', { name: 'Cancel' });
+  }
+
+  // Asset details section (shared with register-data, read-only in edit mode)
+  findNameInput() {
+    return cy.findByTestId('data-name-input');
+  }
+
+  findDescriptionInput() {
+    return cy.findByTestId('data-description-input');
+  }
+
+  findAssetTypeInput() {
+    return cy.findByTestId('asset-type-toggle');
+  }
+
+  findFormatToggle() {
+    return cy.findByTestId('data-format-toggle');
+  }
+
+  findCollectionInput() {
+    return cy.findByTestId('data-collection-toggle');
+  }
+
+  findAddLabelButton() {
+    return cy.findByTestId('data-add-label-button');
+  }
+
+  findLabelsInput() {
+    return cy.findByTestId('data-labels-input');
+  }
+
+  findLabel(name: string) {
+    return cy.findByTestId(`data-label-${name}`);
+  }
+
+  removeLabel(name: string) {
+    return this.findLabel(name).find('button').click();
+  }
+
+  // Data location section
+  findConnectionToggle() {
+    return cy.findByTestId('data-connection-toggle');
+  }
+
+  findLocationInput() {
+    return cy.findByTestId('data-path-input');
+  }
+
+  // Properties section
+  findPurposeInput() {
+    return cy.findByTestId('data-purpose-input');
+  }
+
+  findLicenseToggle() {
+    return cy.findByTestId('data-license-toggle');
+  }
+
+  findMaturityToggle() {
+    return cy.findByTestId('data-maturity-toggle');
+  }
+
+  findPiiToggle() {
+    return cy.findByTestId('data-pii-toggle');
+  }
+
+  // Custom properties section
+  findAddCustomPropertyButton() {
+    return cy.findByTestId('data-add-custom-property');
+  }
+
+  findCustomPropertyKey(index: number) {
+    return cy.findByTestId(`data-custom-property-key-${index}`);
+  }
+
+  findCustomPropertyValue(index: number) {
+    return cy.findByTestId(`data-custom-property-value-${index}`);
+  }
+
+  findCustomPropertyRemove(index: number) {
+    return cy.findByTestId(`data-custom-property-remove-${index}`);
+  }
+
+  // Schema section (tables only)
+  findAddColumnButton() {
+    return cy.findByTestId('add-schema-column');
+  }
+
+  findSchemaColumnName(index: number) {
+    return cy.findByTestId(`schema-column-name-${index}`);
+  }
+
+  findSchemaColumnTypeToggle(index: number) {
+    return cy.findByTestId(`schema-column-type-${index}`);
+  }
+
+  findSchemaColumnDescription(index: number) {
+    return cy.findByTestId(`schema-column-description-${index}`);
+  }
+
+  findSchemaColumnNullable(index: number) {
+    return cy.findByTestId(`schema-column-nullable-${index}`);
+  }
+
+  findSchemaColumnRemove(index: number) {
+    return cy.findByTestId(`schema-column-remove-${index}`);
+  }
+
+  findErrorAlert() {
+    return this.find().find('.pf-v6-c-alert');
+  }
+}
+
+export const editAssetModal = new EditAssetModal();

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/editAsset.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/editAsset.cy.ts
@@ -101,6 +101,9 @@ describe('Edit Table Asset', () => {
       `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables/claims-data`,
       { body: tableResponse },
     ).as('updateTable');
+    cy.intercept('POST', `${REGISTRY_API}/test-project/labels`, {
+      body: { name: 'new-label' },
+    }).as('createLabel');
 
     cy.findByTestId('asset-actions-toggle').click();
     cy.findByTestId('asset-action-edit').click();
@@ -186,6 +189,25 @@ describe('Edit Table Asset', () => {
     });
   });
 
+  it('should clear the final custom property', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+    cy.intercept(
+      'PATCH',
+      `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables/claims-data`,
+      { body: tableResponse },
+    ).as('updateTable');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-edit').click();
+    editAssetModal.findCustomPropertyRemove(0).click();
+    editAssetModal.findSaveButton().click();
+
+    cy.wait('@updateTable').then((interception) => {
+      expect(interception.request.body).to.have.property('properties').that.deep.equals({});
+    });
+  });
+
   it('should close modal on cancel', () => {
     cy.visit('/main-view/tables/test-project/analytics/claims-data');
     cy.wait('@getTable');
@@ -234,7 +256,7 @@ describe('Edit Volume Asset', () => {
     cy.visit('/main-view/volumes/test-project/default/training-docs');
     cy.wait('@getVolume');
 
-    cy.intercept('PATCH', `${REGISTRY_API}/test-project/namespaces/default/volumes/training-docs`, {
+    cy.intercept('PUT', `${REGISTRY_API}/test-project/namespaces/default/volumes/training-docs`, {
       body: volumeResponse,
     }).as('updateVolume');
 

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/editAsset.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/editAsset.cy.ts
@@ -1,0 +1,253 @@
+/* eslint-disable camelcase */
+import { mockNamespace } from '~/__mocks__/mockNamespace';
+import { mockUserSettings } from '~/__mocks__/mockUserSettings';
+import { mockAssetResponse } from '~/__mocks__/mockAssetResponse';
+import { mockVolumeInfo } from '~/__mocks__/mockVolumeInfo';
+import { CLIENT_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import { editAssetModal } from '~/__tests__/cypress/cypress/pages/editAssetModal';
+
+const REGISTRY_API = '/data-registry/api/v1';
+
+const initIntercepts = () => {
+  cy.interceptApi(
+    'GET /api/:apiVersion/user',
+    { path: { apiVersion: CLIENT_API_VERSION } },
+    mockUserSettings({ userId: 'test-user' }),
+  );
+  cy.interceptApi('GET /api/:apiVersion/namespaces', { path: { apiVersion: CLIENT_API_VERSION } }, [
+    mockNamespace({ name: 'test-project' }),
+  ]);
+};
+
+describe('Edit Table Asset', () => {
+  const tableResponse = mockAssetResponse({
+    name: 'claims-data',
+    description: 'Claims processing data',
+    format: 'parquet',
+    location: 's3://bucket/claims',
+    collection: 'analytics',
+    connection_ref: { type: 'rhai', secret_name: 'my-s3-connection' },
+    labels: ['production', 'claims'],
+    properties: {
+      purpose: 'fraud detection',
+      license: 'internal-use',
+      maturity: 'production',
+      pii_status: 'contains-pii',
+      'custom-key': 'custom-value',
+    },
+    columns: [
+      { name: 'id', type: 'integer', nullable: false, description: 'Primary key' },
+      { name: 'amount', type: 'float', nullable: true, description: 'Claim amount' },
+    ],
+  });
+
+  beforeEach(() => {
+    initIntercepts();
+    cy.intercept(
+      'GET',
+      `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables/claims-data`,
+      { body: tableResponse },
+    ).as('getTable');
+  });
+
+  it('should open edit modal and display pre-populated fields', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-edit').click();
+
+    editAssetModal.shouldBeOpen();
+    editAssetModal.findNameInput().should('have.value', 'claims-data');
+    editAssetModal.findDescriptionInput().should('have.value', 'Claims processing data');
+    editAssetModal.findAssetTypeInput().should('have.value', 'Structured');
+    editAssetModal.findFormatToggle().should('contain.text', 'Parquet');
+    editAssetModal.findCollectionInput().should('have.value', 'analytics');
+    editAssetModal.findConnectionToggle().should('contain.text', 'my-s3-connection');
+    editAssetModal.findLocationInput().should('have.value', 's3://bucket/claims');
+    editAssetModal.findPurposeInput().should('have.value', 'fraud detection');
+  });
+
+  it('should edit description and save table', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.intercept(
+      'PATCH',
+      `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables/claims-data`,
+      { body: tableResponse },
+    ).as('updateTable');
+    cy.intercept('POST', `${REGISTRY_API}/test-project/labels`, { body: { name: 'new-label' } });
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-edit').click();
+    editAssetModal.shouldBeOpen();
+
+    editAssetModal.findDescriptionInput().clear();
+    editAssetModal.findDescriptionInput().type('Updated description');
+    editAssetModal.findSaveButton().click();
+
+    cy.wait('@updateTable').then((interception) => {
+      expect(interception.request.body).to.have.property('description', 'Updated description');
+    });
+  });
+
+  it('should add and remove labels', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.intercept(
+      'PATCH',
+      `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables/claims-data`,
+      { body: tableResponse },
+    ).as('updateTable');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-edit').click();
+    editAssetModal.shouldBeOpen();
+
+    editAssetModal.findLabel('production').should('exist');
+    editAssetModal.findLabel('claims').should('exist');
+
+    editAssetModal.findAddLabelButton().click();
+    editAssetModal.findLabelsInput().type('new-label{enter}');
+
+    editAssetModal.removeLabel('production');
+
+    editAssetModal.findSaveButton().click();
+
+    cy.wait('@updateTable').then((interception) => {
+      expect(interception.request.body).to.have.property('add_labels');
+      expect(interception.request.body.add_labels).to.include('new-label');
+      expect(interception.request.body).to.have.property('remove_labels');
+      expect(interception.request.body.remove_labels).to.include('production');
+    });
+  });
+
+  it('should add and remove custom properties', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.intercept(
+      'PATCH',
+      `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables/claims-data`,
+      { body: tableResponse },
+    ).as('updateTable');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-edit').click();
+    editAssetModal.shouldBeOpen();
+
+    editAssetModal.findCustomPropertyKey(0).should('have.value', 'custom-key');
+    editAssetModal.findCustomPropertyValue(0).should('have.value', 'custom-value');
+
+    editAssetModal.findAddCustomPropertyButton().click();
+    editAssetModal.findCustomPropertyKey(1).type('new-key');
+    editAssetModal.findCustomPropertyValue(1).type('new-value');
+
+    editAssetModal.findCustomPropertyRemove(0).click();
+
+    editAssetModal.findSaveButton().click();
+
+    cy.wait('@updateTable').then((interception) => {
+      expect(interception.request.body).to.have.property('properties');
+      expect(interception.request.body.properties).to.have.property('new-key', 'new-value');
+      expect(interception.request.body.properties).to.not.have.property('custom-key');
+    });
+  });
+
+  it('should display schema section and add a column', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.intercept(
+      'PATCH',
+      `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables/claims-data`,
+      { body: tableResponse },
+    ).as('updateTable');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-edit').click();
+    editAssetModal.shouldBeOpen();
+
+    editAssetModal.findSchemaColumnName(0).should('have.value', 'id');
+    editAssetModal.findSchemaColumnTypeToggle(0).should('contain.text', 'integer');
+    editAssetModal.findSchemaColumnName(1).should('have.value', 'amount');
+
+    editAssetModal.findAddColumnButton().click();
+    editAssetModal.findSchemaColumnName(2).type('status');
+
+    editAssetModal.findSaveButton().click();
+
+    cy.wait('@updateTable').then((interception) => {
+      expect(interception.request.body).to.have.property('schema_fields');
+      expect(interception.request.body.schema_fields).to.have.length(3);
+      expect(interception.request.body.schema_fields[2]).to.have.property('name', 'status');
+    });
+  });
+
+  it('should close modal on cancel', () => {
+    cy.visit('/main-view/tables/test-project/analytics/claims-data');
+    cy.wait('@getTable');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-edit').click();
+    editAssetModal.shouldBeOpen();
+
+    editAssetModal.findCancelButton().click();
+    editAssetModal.shouldBeOpen(false);
+  });
+});
+
+describe('Edit Volume Asset', () => {
+  const volumeResponse = mockVolumeInfo({
+    name: 'training-docs',
+    comment: 'Training document storage',
+    'storage-location': 's3://bucket/docs/training',
+    labels: ['source-docs'],
+    properties: { purpose: 'training' },
+  });
+
+  beforeEach(() => {
+    initIntercepts();
+    cy.intercept('GET', `${REGISTRY_API}/test-project/namespaces/default/volumes/training-docs`, {
+      body: volumeResponse,
+    }).as('getVolume');
+  });
+
+  it('should open edit modal for volume with pre-populated fields', () => {
+    cy.visit('/main-view/volumes/test-project/default/training-docs');
+    cy.wait('@getVolume');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-edit').click();
+
+    editAssetModal.shouldBeOpen();
+    editAssetModal.findNameInput().should('have.value', 'training-docs');
+    editAssetModal.findDescriptionInput().should('have.value', 'Training document storage');
+    editAssetModal.findAssetTypeInput().should('have.value', 'Unstructured');
+    editAssetModal.findPurposeInput().should('have.value', 'training');
+    editAssetModal.findAddColumnButton().should('not.exist');
+  });
+
+  it('should edit volume and save', () => {
+    cy.visit('/main-view/volumes/test-project/default/training-docs');
+    cy.wait('@getVolume');
+
+    cy.intercept('PATCH', `${REGISTRY_API}/test-project/namespaces/default/volumes/training-docs`, {
+      body: volumeResponse,
+    }).as('updateVolume');
+
+    cy.findByTestId('asset-actions-toggle').click();
+    cy.findByTestId('asset-action-edit').click();
+    editAssetModal.shouldBeOpen();
+
+    editAssetModal.findDescriptionInput().clear();
+    editAssetModal.findDescriptionInput().type('Updated volume description');
+    editAssetModal.findSaveButton().click();
+
+    cy.wait('@updateVolume').then((interception) => {
+      expect(interception.request.body).to.have.property('comment', 'Updated volume description');
+    });
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/components/SchemaColumnsTable.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/SchemaColumnsTable.spec.tsx
@@ -23,12 +23,14 @@ describe('SchemaColumnsTable', () => {
     expect(screen.getAllByText('string')).toHaveLength(2);
   });
 
-  it('should only show Name and Type columns', () => {
+  it('should show all schema columns', () => {
     render(<SchemaColumnsTable columns={mockColumns} />);
     const headers = screen.getByTestId('schema-columns-table').querySelectorAll('thead th');
-    expect(headers).toHaveLength(2);
+    expect(headers).toHaveLength(4);
     expect(headers[0]).toHaveTextContent('Name');
     expect(headers[1]).toHaveTextContent('Type');
+    expect(headers[2]).toHaveTextContent('Description');
+    expect(headers[3]).toHaveTextContent('Nullable');
   });
 
   it('should render empty state when no columns', () => {

--- a/packages/data-registry/frontend/src/app/api/dataRegistry.ts
+++ b/packages/data-registry/frontend/src/app/api/dataRegistry.ts
@@ -39,6 +39,7 @@ const assetResponseSchema = z
     // eslint-disable-next-line camelcase
     asset_type: z.string(),
     columns: z.array(schemaFieldSchema).optional(),
+    labels: z.array(z.string()).nullable().optional(),
   })
   .passthrough();
 
@@ -49,6 +50,7 @@ const volumeInfoSchema = z
     'schema-name': z.string(),
     'volume-type': z.string(),
     'storage-location': z.string(),
+    labels: z.array(z.string()).nullable().optional(),
   })
   .passthrough();
 

--- a/packages/data-registry/frontend/src/app/api/dataRegistry.ts
+++ b/packages/data-registry/frontend/src/app/api/dataRegistry.ts
@@ -1,3 +1,4 @@
+import * as z from 'zod';
 import {
   AssetResponse,
   AssetListResponse,
@@ -25,13 +26,42 @@ class ApiError extends Error {
   }
 }
 
-const fetchJSON = async <T>(url: string): Promise<T> => {
+const schemaFieldSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+  description: z.string().optional(),
+  nullable: z.boolean().optional(),
+});
+
+const assetResponseSchema = z
+  .object({
+    name: z.string(),
+    // eslint-disable-next-line camelcase
+    asset_type: z.string(),
+    columns: z.array(schemaFieldSchema).optional(),
+  })
+  .passthrough();
+
+const volumeInfoSchema = z
+  .object({
+    name: z.string(),
+    'catalog-name': z.string(),
+    'schema-name': z.string(),
+    'volume-type': z.string(),
+    'storage-location': z.string(),
+  })
+  .passthrough();
+
+const fetchJSON = async <T>(url: string, schema?: z.ZodType<T>): Promise<T> => {
   const response = await fetch(url);
   if (!response.ok) {
     const text = await response.text();
     throw new ApiError(response.status, `API error ${response.status}: ${text}`);
   }
-  return response.json();
+  if (!schema) {
+    return response.json();
+  }
+  return schema.parse(await response.json());
 };
 
 const fetchRequest = async (url: string, method: string, body?: unknown): Promise<Response> => {
@@ -87,6 +117,7 @@ export const fetchGenericTable = (
         collection,
       )}/generic-tables/${encodeURIComponent(name)}`,
     ),
+    assetResponseSchema,
   );
 
 export const deleteGenericTable = (
@@ -132,6 +163,7 @@ export const fetchVolume = (
         collection,
       )}/volumes/${encodeURIComponent(name)}`,
     ),
+    volumeInfoSchema,
   );
 
 export const deleteVolume = (project: string, collection: string, name: string): Promise<void> =>
@@ -196,7 +228,7 @@ export const updateGenericTable = async (
 
 export type UpdateVolumeRequest = {
   comment?: string;
-  'storage-location'?: string;
+  storage_location?: string;
   owner?: string;
   add_labels?: string[];
   remove_labels?: string[];
@@ -215,7 +247,7 @@ export const updateVolume = async (
         collection,
       )}/volumes/${encodeURIComponent(name)}`,
     ),
-    'PATCH',
+    'PUT',
     data,
   );
 };

--- a/packages/data-registry/frontend/src/app/api/dataRegistry.ts
+++ b/packages/data-registry/frontend/src/app/api/dataRegistry.ts
@@ -83,7 +83,9 @@ export const fetchGenericTable = (
 ): Promise<AssetResponse> =>
   fetchJSON(
     registryUrl(
-      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(collection)}/generic-tables/${encodeURIComponent(name)}`,
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(
+        collection,
+      )}/generic-tables/${encodeURIComponent(name)}`,
     ),
   );
 
@@ -94,7 +96,9 @@ export const deleteGenericTable = (
 ): Promise<void> =>
   fetchRequest(
     registryUrl(
-      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(collection)}/generic-tables/${encodeURIComponent(name)}`,
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(
+        collection,
+      )}/generic-tables/${encodeURIComponent(name)}`,
     ),
     'DELETE',
   ).then(() => undefined);
@@ -124,14 +128,18 @@ export const fetchVolume = (
 ): Promise<VolumeInfo> =>
   fetchJSON(
     registryUrl(
-      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(collection)}/volumes/${encodeURIComponent(name)}`,
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(
+        collection,
+      )}/volumes/${encodeURIComponent(name)}`,
     ),
   );
 
 export const deleteVolume = (project: string, collection: string, name: string): Promise<void> =>
   fetchRequest(
     registryUrl(
-      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(collection)}/volumes/${encodeURIComponent(name)}`,
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(
+        collection,
+      )}/volumes/${encodeURIComponent(name)}`,
     ),
     'DELETE',
   ).then(() => undefined);
@@ -149,6 +157,67 @@ export const createGenericTable = async (
     data,
   );
   return response.json();
+};
+
+// Update assets
+
+export type UpdateGenericTableRequest = {
+  description?: string;
+  format?: string;
+  location?: string;
+  connection_ref?: { type: string; secret_name?: string; id?: string };
+  purpose?: string;
+  license?: string;
+  maturity?: string;
+  pii?: string;
+  owner?: string;
+  add_labels?: string[];
+  remove_labels?: string[];
+  schema_fields?: { name: string; type: string; description?: string; nullable?: boolean }[];
+  properties?: Record<string, string>;
+};
+
+export const updateGenericTable = async (
+  project: string,
+  collection: string,
+  name: string,
+  data: UpdateGenericTableRequest,
+): Promise<void> => {
+  await fetchRequest(
+    registryUrl(
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(
+        collection,
+      )}/generic-tables/${encodeURIComponent(name)}`,
+    ),
+    'PATCH',
+    data,
+  );
+};
+
+export type UpdateVolumeRequest = {
+  comment?: string;
+  'storage-location'?: string;
+  owner?: string;
+  add_labels?: string[];
+  remove_labels?: string[];
+  properties?: Record<string, string>;
+};
+
+export const updateVolume = async (
+  project: string,
+  collection: string,
+  name: string,
+  data: UpdateVolumeRequest,
+): Promise<void> => {
+  await fetchRequest(
+    registryUrl(
+      `/${encodeURIComponent(project)}/namespaces/${encodeURIComponent(
+        collection,
+      )}/volumes/${encodeURIComponent(name)}`,
+    ),
+    'PATCH',
+    data,
+  );
 };
 
 // Labels

--- a/packages/data-registry/frontend/src/app/components/EditAssetModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/EditAssetModal.tsx
@@ -54,16 +54,14 @@ const getConnectionDisplayValue = (connectionRef?: ConnectionRef | null): string
   return connectionRef.id;
 };
 
-let nextId = 0;
-
-const buildFormDefaults = (props: EditAssetModalProps): EditAssetFormData => {
+const buildFormDefaults = (props: EditAssetModalProps, idStart: number): EditAssetFormData => {
   const { asset, assetKind, collection } = props;
   const isTable = assetKind === 'table';
   const properties = asset.properties ?? {};
 
   const customProperties = Object.entries(properties)
     .filter(([key]) => !WELL_KNOWN_PROPERTIES.has(key))
-    .map(([key, value]) => ({ id: ++nextId, key, value }));
+    .map(([key, value], index) => ({ id: idStart + index + 1, key, value }));
 
   return {
     assetType: isTable ? 'structured' : 'unstructured',
@@ -82,8 +80,8 @@ const buildFormDefaults = (props: EditAssetModalProps): EditAssetFormData => {
     piiStatus: properties.pii_status || '',
     customProperties,
     schemaFields: isTable
-      ? (asset.columns ?? []).map((col) => ({
-          id: ++nextId,
+      ? (asset.columns ?? []).map((col, index) => ({
+          id: idStart + customProperties.length + index + 1,
           name: col.name,
           type: col.type,
           description: col.description ?? '',
@@ -99,15 +97,26 @@ const EditAssetModal: React.FC<EditAssetModalProps> = (props) => {
 
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState('');
+  const idRef = React.useRef(0);
 
-  const defaults = React.useMemo(() => buildFormDefaults(props), [props]);
-  const originalLabels = React.useMemo(() => asset.labels ?? [], [asset.labels]);
+  const defaults = React.useMemo(() => {
+    const result = buildFormDefaults(props, idRef.current);
+    idRef.current += result.customProperties.length + result.schemaFields.length;
+    return result;
+    // buildFormDefaults only reads these stable asset inputs from props.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [asset, assetKind, collection]);
+  const originalLabels = React.useMemo(() => asset.labels ?? [], [asset]);
 
   const form = useForm<EditAssetFormData>({
     resolver: zodResolver(editAssetSchema),
     defaultValues: defaults,
     mode: 'onBlur',
   });
+
+  React.useEffect(() => {
+    form.reset(defaults);
+  }, [defaults, form]);
 
   const handleSubmit = React.useCallback(
     async (data: EditAssetFormData) => {
@@ -148,7 +157,7 @@ const EditAssetModal: React.FC<EditAssetModalProps> = (props) => {
             pii: data.piiStatus || undefined,
             ...(addLabels.length > 0 ? { add_labels: addLabels } : {}),
             ...(removeLabels.length > 0 ? { remove_labels: removeLabels } : {}),
-            ...(Object.keys(customProps).length > 0 ? { properties: customProps } : {}),
+            properties: customProps,
             schema_fields: data.schemaFields.map((col) => ({
               name: col.name,
               type: col.type,
@@ -173,10 +182,10 @@ const EditAssetModal: React.FC<EditAssetModalProps> = (props) => {
 
           await updateVolume(project, collection, name, {
             comment: data.description,
-            'storage-location': data.path || undefined,
+            storage_location: data.path || undefined,
             ...(addLabels.length > 0 ? { add_labels: addLabels } : {}),
             ...(removeLabels.length > 0 ? { remove_labels: removeLabels } : {}),
-            ...(Object.keys(allProperties).length > 0 ? { properties: allProperties } : {}),
+            properties: allProperties,
           });
         }
         onSaved();
@@ -199,7 +208,12 @@ const EditAssetModal: React.FC<EditAssetModalProps> = (props) => {
       <ModalHeader title={`Edit "${asset.name}"`} />
       <ModalBody>
         {error ? (
-          <Alert variant="danger" isInline title="Error saving changes">
+          <Alert
+            variant="danger"
+            isInline
+            title="Error saving changes"
+            data-testid="edit-asset-error"
+          >
             {error}
           </Alert>
         ) : null}
@@ -223,7 +237,12 @@ const EditAssetModal: React.FC<EditAssetModalProps> = (props) => {
         >
           Save
         </Button>
-        <Button variant="link" onClick={onClose} isDisabled={isSubmitting}>
+        <Button
+          variant="link"
+          onClick={onClose}
+          isDisabled={isSubmitting}
+          data-testid="edit-asset-cancel"
+        >
           Cancel
         </Button>
       </ModalFooter>

--- a/packages/data-registry/frontend/src/app/components/EditAssetModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/EditAssetModal.tsx
@@ -1,0 +1,234 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import {
+  Alert,
+  Button,
+  Form,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@patternfly/react-core';
+import { useForm, FormProvider } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { AssetResponse, ConnectionRef, VolumeInfo } from '~/app/types';
+import { ApiError, createLabel, updateGenericTable, updateVolume } from '~/app/api/dataRegistry';
+import { editAssetSchema, EditAssetFormData } from '~/app/schemas/editAsset.schema';
+import AssetDetailsSection from './register-data/AssetDetailsSection';
+import DataLocationSection from './register-data/DataLocationSection';
+import PropertiesSection from './register-data/PropertiesSection';
+import CustomPropertiesSection from './register-data/CustomPropertiesSection';
+import SchemaSection from './register-data/SchemaSection';
+
+type EditTableModalProps = {
+  asset: AssetResponse;
+  assetKind: 'table';
+  project: string;
+  collection: string;
+  name: string;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+type EditVolumeModalProps = {
+  asset: VolumeInfo;
+  assetKind: 'volume';
+  project: string;
+  collection: string;
+  name: string;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+type EditAssetModalProps = EditTableModalProps | EditVolumeModalProps;
+
+const WELL_KNOWN_PROPERTIES = new Set(['purpose', 'license', 'maturity', 'pii_status']);
+
+const getConnectionDisplayValue = (connectionRef?: ConnectionRef | null): string => {
+  if (!connectionRef) {
+    return 'None';
+  }
+  if (connectionRef.type === 'rhai') {
+    return connectionRef.secret_name;
+  }
+  return connectionRef.id;
+};
+
+let nextId = 0;
+
+const buildFormDefaults = (props: EditAssetModalProps): EditAssetFormData => {
+  const { asset, assetKind, collection } = props;
+  const isTable = assetKind === 'table';
+  const properties = asset.properties ?? {};
+
+  const customProperties = Object.entries(properties)
+    .filter(([key]) => !WELL_KNOWN_PROPERTIES.has(key))
+    .map(([key, value]) => ({ id: ++nextId, key, value }));
+
+  return {
+    assetType: isTable ? 'structured' : 'unstructured',
+    name: asset.name,
+    description: isTable ? (asset.description ?? '') : (asset.comment ?? ''),
+    format: isTable ? asset.format || 'other' : asset.config?.content_type || 'other',
+    collection,
+    labels: asset.labels ?? [],
+    connection: isTable
+      ? getConnectionDisplayValue(asset.connection_ref)
+      : asset['storage-location'] || '',
+    path: isTable ? (asset.location ?? '') : asset['storage-location'],
+    purpose: properties.purpose || '',
+    license: properties.license || '',
+    maturity: properties.maturity || '',
+    piiStatus: properties.pii_status || '',
+    customProperties,
+    schemaFields: isTable
+      ? (asset.columns ?? []).map((col) => ({
+          id: ++nextId,
+          name: col.name,
+          type: col.type,
+          description: col.description ?? '',
+          nullable: col.nullable ?? false,
+        }))
+      : [],
+  };
+};
+
+const EditAssetModal: React.FC<EditAssetModalProps> = (props) => {
+  const { asset, assetKind, project, collection, name, onClose, onSaved } = props;
+  const isTable = assetKind === 'table';
+
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [error, setError] = React.useState('');
+
+  const defaults = React.useMemo(() => buildFormDefaults(props), [props]);
+  const originalLabels = React.useMemo(() => asset.labels ?? [], [asset.labels]);
+
+  const form = useForm<EditAssetFormData>({
+    resolver: zodResolver(editAssetSchema),
+    defaultValues: defaults,
+    mode: 'onBlur',
+  });
+
+  const handleSubmit = React.useCallback(
+    async (data: EditAssetFormData) => {
+      setIsSubmitting(true);
+      setError('');
+
+      const addLabels = data.labels.filter((l) => !originalLabels.includes(l));
+      const removeLabels = originalLabels.filter((l) => !data.labels.includes(l));
+
+      const customProps: Record<string, string> = {};
+      data.customProperties.forEach((prop) => {
+        if (prop.key && prop.value) {
+          customProps[prop.key] = prop.value;
+        }
+      });
+
+      try {
+        if (addLabels.length > 0) {
+          await Promise.all(
+            addLabels.map((label) =>
+              createLabel(project, { name: label }).catch((err) => {
+                if (err instanceof ApiError && err.status === 409) {
+                  return;
+                }
+                throw err;
+              }),
+            ),
+          );
+        }
+        if (isTable) {
+          await updateGenericTable(project, collection, name, {
+            description: data.description,
+            format: data.format || undefined,
+            location: data.path || undefined,
+            purpose: data.purpose || undefined,
+            license: data.license || undefined,
+            maturity: data.maturity || undefined,
+            pii: data.piiStatus || undefined,
+            ...(addLabels.length > 0 ? { add_labels: addLabels } : {}),
+            ...(removeLabels.length > 0 ? { remove_labels: removeLabels } : {}),
+            ...(Object.keys(customProps).length > 0 ? { properties: customProps } : {}),
+            schema_fields: data.schemaFields.map((col) => ({
+              name: col.name,
+              type: col.type,
+              description: col.description || undefined,
+              nullable: col.nullable,
+            })),
+          });
+        } else {
+          const allProperties: Record<string, string> = { ...customProps };
+          if (data.purpose) {
+            allProperties.purpose = data.purpose;
+          }
+          if (data.license) {
+            allProperties.license = data.license;
+          }
+          if (data.maturity) {
+            allProperties.maturity = data.maturity;
+          }
+          if (data.piiStatus) {
+            allProperties.pii_status = data.piiStatus;
+          }
+
+          await updateVolume(project, collection, name, {
+            comment: data.description,
+            'storage-location': data.path || undefined,
+            ...(addLabels.length > 0 ? { add_labels: addLabels } : {}),
+            ...(removeLabels.length > 0 ? { remove_labels: removeLabels } : {}),
+            ...(Object.keys(allProperties).length > 0 ? { properties: allProperties } : {}),
+          });
+        }
+        onSaved();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to save changes');
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [isTable, project, collection, name, originalLabels, onSaved],
+  );
+
+  return (
+    <Modal
+      isOpen
+      onClose={isSubmitting ? undefined : onClose}
+      variant="medium"
+      data-testid="edit-asset-modal"
+    >
+      <ModalHeader title={`Edit "${asset.name}"`} />
+      <ModalBody>
+        {error ? (
+          <Alert variant="danger" isInline title="Error saving changes">
+            {error}
+          </Alert>
+        ) : null}
+        <FormProvider {...form}>
+          <Form>
+            <AssetDetailsSection isEditMode />
+            <DataLocationSection pathLabel={isTable ? 'Path' : 'Storage location'} />
+            <PropertiesSection />
+            <CustomPropertiesSection />
+            {isTable ? <SchemaSection /> : null}
+          </Form>
+        </FormProvider>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          onClick={form.handleSubmit(handleSubmit)}
+          isDisabled={isSubmitting}
+          isLoading={isSubmitting}
+          data-testid="edit-asset-save"
+        >
+          Save
+        </Button>
+        <Button variant="link" onClick={onClose} isDisabled={isSubmitting}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default EditAssetModal;

--- a/packages/data-registry/frontend/src/app/components/EditAssetModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/EditAssetModal.tsx
@@ -44,14 +44,17 @@ type EditAssetModalProps = EditTableModalProps | EditVolumeModalProps;
 
 const WELL_KNOWN_PROPERTIES = new Set(['purpose', 'license', 'maturity', 'pii_status']);
 
-const getConnectionDisplayValue = (connectionRef?: ConnectionRef | null): string => {
+const getConnectionDisplayValue = (connectionRef?: ConnectionRef | string | null): string => {
   if (!connectionRef) {
     return 'None';
   }
-  if (connectionRef.type === 'rhai') {
-    return connectionRef.secret_name;
+  if (typeof connectionRef === 'string') {
+    return connectionRef;
   }
-  return connectionRef.id;
+  if (connectionRef.type === 'rhai') {
+    return connectionRef.secret_name || 'None';
+  }
+  return connectionRef.id || 'None';
 };
 
 const buildFormDefaults = (props: EditAssetModalProps, idStart: number): EditAssetFormData => {
@@ -149,12 +152,12 @@ const EditAssetModal: React.FC<EditAssetModalProps> = (props) => {
         if (isTable) {
           await updateGenericTable(project, collection, name, {
             description: data.description,
-            format: data.format || undefined,
-            location: data.path || undefined,
-            purpose: data.purpose || undefined,
-            license: data.license || undefined,
-            maturity: data.maturity || undefined,
-            pii: data.piiStatus || undefined,
+            format: data.format,
+            location: data.path,
+            purpose: data.purpose,
+            license: data.license,
+            maturity: data.maturity,
+            pii: data.piiStatus,
             ...(addLabels.length > 0 ? { add_labels: addLabels } : {}),
             ...(removeLabels.length > 0 ? { remove_labels: removeLabels } : {}),
             properties: customProps,
@@ -182,7 +185,7 @@ const EditAssetModal: React.FC<EditAssetModalProps> = (props) => {
 
           await updateVolume(project, collection, name, {
             comment: data.description,
-            storage_location: data.path || undefined,
+            storage_location: data.path,
             ...(addLabels.length > 0 ? { add_labels: addLabels } : {}),
             ...(removeLabels.length > 0 ? { remove_labels: removeLabels } : {}),
             properties: allProperties,

--- a/packages/data-registry/frontend/src/app/components/EditAssetModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/EditAssetModal.tsx
@@ -72,7 +72,7 @@ const buildFormDefaults = (props: EditAssetModalProps, idStart: number): EditAss
     labels: asset.labels ?? [],
     connection: isTable
       ? getConnectionDisplayValue(asset.connection_ref)
-      : asset['storage-location'] || '',
+      : asset.properties?.['connection-ref'] || '',
     path: isTable ? (asset.location ?? '') : asset['storage-location'],
     purpose: properties.purpose || '',
     license: properties.license || '',
@@ -220,7 +220,11 @@ const EditAssetModal: React.FC<EditAssetModalProps> = (props) => {
         <FormProvider {...form}>
           <Form>
             <AssetDetailsSection isEditMode />
-            <DataLocationSection pathLabel={isTable ? 'Path' : 'Storage location'} />
+            <DataLocationSection
+              pathLabel={isTable ? 'Path' : 'Storage location'}
+              showConnection
+              isConnectionReadOnly
+            />
             <PropertiesSection />
             <CustomPropertiesSection />
             {isTable ? <SchemaSection /> : null}

--- a/packages/data-registry/frontend/src/app/components/register-data/AssetDetailsSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-data/AssetDetailsSection.tsx
@@ -385,6 +385,7 @@ const AssetDetailsSection: React.FC<AssetDetailsSectionProps> = (props) => {
                 key={label}
                 variant={isEditMode ? 'outline' : undefined}
                 onClose={() => handleRemoveLabel(label)}
+                closeBtnProps={{ 'data-testid': `data-label-remove-${label}` }}
                 data-testid={`data-label-${label}`}
               >
                 {label}

--- a/packages/data-registry/frontend/src/app/components/register-data/AssetDetailsSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-data/AssetDetailsSection.tsx
@@ -22,6 +22,7 @@ import {
 import { PlusCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Controller, useFormContext } from 'react-hook-form';
 import { RegisterDataFormData } from '~/app/schemas/registerData.schema';
+import { EditAssetFormData } from '~/app/schemas/editAsset.schema';
 
 const UNSTRUCTURED_FORMATS = [
   { key: 'documents', label: 'Documents', description: 'Text, PDFs, and office files' },
@@ -46,22 +47,27 @@ const DEFAULT_FORMATS: Record<string, string> = {
   structured: 'iceberg',
 };
 
-type AssetDetailsSectionProps = {
-  collections: string[];
-  onManageCollections: () => void;
-};
+type AssetDetailsSectionProps =
+  | {
+      isEditMode?: false;
+      collections: string[];
+      onManageCollections: () => void;
+    }
+  | {
+      isEditMode: true;
+      collections?: never;
+      onManageCollections?: never;
+    };
 
-const AssetDetailsSection: React.FC<AssetDetailsSectionProps> = ({
-  collections,
-  onManageCollections,
-}) => {
+const AssetDetailsSection: React.FC<AssetDetailsSectionProps> = (props) => {
+  const { isEditMode } = props;
   const {
     control,
     formState: { errors },
     setValue,
     getValues,
     watch,
-  } = useFormContext<RegisterDataFormData>();
+  } = useFormContext<RegisterDataFormData | EditAssetFormData>();
 
   const assetType = watch('assetType');
   const labels = watch('labels');
@@ -95,33 +101,46 @@ const AssetDetailsSection: React.FC<AssetDetailsSectionProps> = ({
   );
 
   return (
-    <FormSection title="Data asset details" titleElement="h2">
-      <Content component="p">
-        Provide general identification and classification details for this data asset.
-      </Content>
+    <FormSection title={isEditMode ? 'Asset details' : 'Data asset details'} titleElement="h2">
+      {isEditMode ? null : (
+        <Content component="p">
+          Provide general identification and classification details for this data asset.
+        </Content>
+      )}
 
-      <Controller
-        name="name"
-        control={control}
-        render={({ field }) => (
-          <FormGroup label="Asset name" isRequired fieldId="data-name">
-            <TextInput
-              id="data-name"
-              {...field}
-              isRequired
-              validated={errors.name ? 'error' : 'default'}
-              data-testid="data-name-input"
-            />
-            {errors.name ? (
-              <FormHelperText>
-                <HelperText>
-                  <HelperTextItem variant="error">{errors.name.message}</HelperTextItem>
-                </HelperText>
-              </FormHelperText>
-            ) : null}
-          </FormGroup>
-        )}
-      />
+      {isEditMode ? (
+        <FormGroup label="Name" fieldId="data-name">
+          <TextInput
+            id="data-name"
+            value={getValues('name')}
+            readOnlyVariant="default"
+            data-testid="data-name-input"
+          />
+        </FormGroup>
+      ) : (
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <FormGroup label="Asset name" isRequired fieldId="data-name">
+              <TextInput
+                id="data-name"
+                {...field}
+                isRequired
+                validated={errors.name ? 'error' : 'default'}
+                data-testid="data-name-input"
+              />
+              {errors.name ? (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem variant="error">{errors.name.message}</HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              ) : null}
+            </FormGroup>
+          )}
+        />
+      )}
 
       <Controller
         name="description"
@@ -145,65 +164,76 @@ const AssetDetailsSection: React.FC<AssetDetailsSectionProps> = ({
         )}
       />
 
-      <Controller
-        name="assetType"
-        control={control}
-        render={({ field }) => (
-          <FormGroup
-            label="Asset type"
-            isRequired
-            fieldId="asset-type"
-            labelHelp={
-              <Popover bodyContent="Unstructured assets are file-based volumes. Structured assets represent tabular data with defined columns and types.">
-                <Icon aria-label="Asset type info" role="button">
-                  <OutlinedQuestionCircleIcon />
-                </Icon>
-              </Popover>
-            }
-          >
-            <Select
-              isOpen={isAssetTypeOpen}
-              selected={field.value}
-              onSelect={(_event, value) => {
-                const newType = String(value);
-                field.onChange(newType);
-                setValue('format', DEFAULT_FORMATS[newType]);
-                setValue('schemaFields', []);
-                setIsAssetTypeOpen(false);
-              }}
-              onOpenChange={setIsAssetTypeOpen}
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  onClick={() => setIsAssetTypeOpen((prev) => !prev)}
-                  isExpanded={isAssetTypeOpen}
-                  isFullWidth
-                  data-testid="asset-type-toggle"
-                >
-                  {field.value === 'structured' ? 'Structured' : 'Unstructured'}
-                </MenuToggle>
-              )}
+      {isEditMode ? (
+        <FormGroup label="Asset type" fieldId="asset-type">
+          <TextInput
+            id="asset-type"
+            value={assetType === 'structured' ? 'Structured' : 'Unstructured'}
+            readOnlyVariant="default"
+            data-testid="asset-type-toggle"
+          />
+        </FormGroup>
+      ) : (
+        <Controller
+          name="assetType"
+          control={control}
+          render={({ field }) => (
+            <FormGroup
+              label="Asset type"
+              isRequired
+              fieldId="asset-type"
+              labelHelp={
+                <Popover bodyContent="Unstructured assets are file-based volumes. Structured assets represent tabular data with defined columns and types.">
+                  <Icon aria-label="Asset type info" role="button">
+                    <OutlinedQuestionCircleIcon />
+                  </Icon>
+                </Popover>
+              }
             >
-              <SelectList>
-                <SelectOption
-                  value="unstructured"
-                  description="File-based volumes (documents, images, audio, video)"
-                  data-testid="asset-type-unstructured"
-                >
-                  Unstructured
-                </SelectOption>
-                <SelectOption
-                  value="structured"
-                  description="Tabular data with defined columns and types"
-                  data-testid="asset-type-structured"
-                >
-                  Structured
-                </SelectOption>
-              </SelectList>
-            </Select>
-          </FormGroup>
-        )}
-      />
+              <Select
+                isOpen={isAssetTypeOpen}
+                selected={field.value}
+                onSelect={(_event, value) => {
+                  const newType = String(value);
+                  field.onChange(newType);
+                  setValue('format', DEFAULT_FORMATS[newType]);
+                  setValue('schemaFields', []);
+                  setIsAssetTypeOpen(false);
+                }}
+                onOpenChange={setIsAssetTypeOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsAssetTypeOpen((prev) => !prev)}
+                    isExpanded={isAssetTypeOpen}
+                    isFullWidth
+                    data-testid="asset-type-toggle"
+                  >
+                    {field.value === 'structured' ? 'Structured' : 'Unstructured'}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  <SelectOption
+                    value="unstructured"
+                    description="File-based volumes (documents, images, audio, video)"
+                    data-testid="asset-type-unstructured"
+                  >
+                    Unstructured
+                  </SelectOption>
+                  <SelectOption
+                    value="structured"
+                    description="Tabular data with defined columns and types"
+                    data-testid="asset-type-structured"
+                  >
+                    Structured
+                  </SelectOption>
+                </SelectList>
+              </Select>
+            </FormGroup>
+          )}
+        />
+      )}
 
       <Controller
         name="format"
@@ -258,67 +288,86 @@ const AssetDetailsSection: React.FC<AssetDetailsSectionProps> = ({
         )}
       />
 
-      <Controller
-        name="collection"
-        control={control}
-        render={({ field }) => (
-          <FormGroup label="Collection" isRequired fieldId="data-collection">
-            <Content component="p">
-              Assign this asset to collections to help group your data. To manage collections for
-              the entire project, go to{' '}
-              <Button variant="link" isInline onClick={onManageCollections}>
-                Manage collections
-              </Button>
-              .
-            </Content>
-            <Select
-              isOpen={isCollectionOpen}
-              selected={field.value}
-              onSelect={(_event, value) => {
-                if (value === '__create_new__') {
+      {isEditMode ? (
+        <FormGroup label="Collection" fieldId="data-collection">
+          <Content component="p">
+            Assign this asset to collections to help group your data. To manage collections for the
+            entire project, go to{' '}
+            <Button variant="link" isInline isDisabled>
+              Manage collections
+            </Button>
+            .
+          </Content>
+          <TextInput
+            id="data-collection"
+            value={getValues('collection')}
+            readOnlyVariant="default"
+            data-testid="data-collection-toggle"
+          />
+        </FormGroup>
+      ) : (
+        <Controller
+          name="collection"
+          control={control}
+          render={({ field }) => (
+            <FormGroup label="Collection" fieldId="data-collection">
+              <Content component="p">
+                Assign this asset to collections to help group your data. To manage collections for
+                the entire project, go to{' '}
+                <Button variant="link" isInline onClick={props.onManageCollections}>
+                  Manage collections
+                </Button>
+                .
+              </Content>
+              <Select
+                isOpen={isCollectionOpen}
+                selected={field.value}
+                onSelect={(_event, value) => {
+                  if (value === '__create_new__') {
+                    setIsCollectionOpen(false);
+                    props.onManageCollections();
+                    return;
+                  }
+                  field.onChange(String(value));
                   setIsCollectionOpen(false);
-                  onManageCollections();
-                  return;
-                }
-                field.onChange(String(value));
-                setIsCollectionOpen(false);
-              }}
-              onOpenChange={setIsCollectionOpen}
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  onClick={() => setIsCollectionOpen((prev) => !prev)}
-                  isExpanded={isCollectionOpen}
-                  isFullWidth
-                  data-testid="data-collection-toggle"
-                >
-                  {field.value || 'Select collection'}
-                </MenuToggle>
-              )}
-            >
-              <SelectList>
-                {collections.map((coll) => (
-                  <SelectOption key={coll} value={coll}>
-                    {coll}
+                }}
+                onOpenChange={setIsCollectionOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsCollectionOpen((prev) => !prev)}
+                    isExpanded={isCollectionOpen}
+                    isFullWidth
+                    data-testid="data-collection-toggle"
+                  >
+                    {field.value || 'Select collection'}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  {props.collections.map((coll) => (
+                    <SelectOption key={coll} value={coll}>
+                      {coll}
+                    </SelectOption>
+                  ))}
+                  <SelectOption key="__create_new__" value="__create_new__">
+                    <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                      Create new collection
+                    </Button>
                   </SelectOption>
-                ))}
-                <SelectOption key="__create_new__" value="__create_new__">
-                  <Button variant="link" isInline icon={<PlusCircleIcon />}>
-                    Create new collection
-                  </Button>
-                </SelectOption>
-              </SelectList>
-            </Select>
-            {errors.collection ? (
-              <FormHelperText>
-                <HelperText>
-                  <HelperTextItem variant="error">{errors.collection.message}</HelperTextItem>
-                </HelperText>
-              </FormHelperText>
-            ) : null}
-          </FormGroup>
-        )}
-      />
+                </SelectList>
+              </Select>
+              {errors.collection ? (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem variant="error">{errors.collection.message}</HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              ) : null}
+            </FormGroup>
+          )}
+        />
+      )}
 
       <FormGroup label="Labels" fieldId="data-labels">
         <Content component="p">
@@ -332,7 +381,12 @@ const AssetDetailsSection: React.FC<AssetDetailsSectionProps> = ({
         {labels.length > 0 ? (
           <LabelGroup numLabels={5}>
             {labels.map((label) => (
-              <Label key={label} onClose={() => handleRemoveLabel(label)}>
+              <Label
+                key={label}
+                variant={isEditMode ? 'outline' : undefined}
+                onClose={() => handleRemoveLabel(label)}
+                data-testid={`data-label-${label}`}
+              >
                 {label}
               </Label>
             ))}

--- a/packages/data-registry/frontend/src/app/components/register-data/CustomPropertiesSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-data/CustomPropertiesSection.tsx
@@ -11,9 +11,10 @@ import {
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { RegisterDataFormData } from '~/app/schemas/registerData.schema';
+import { EditAssetFormData } from '~/app/schemas/editAsset.schema';
 
 const CustomPropertiesSection: React.FC = () => {
-  const { control, register } = useFormContext<RegisterDataFormData>();
+  const { control, register } = useFormContext<RegisterDataFormData | EditAssetFormData>();
   const { fields, append, remove } = useFieldArray({ control, name: 'customProperties' });
 
   return (

--- a/packages/data-registry/frontend/src/app/components/register-data/DataLocationSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-data/DataLocationSection.tsx
@@ -23,9 +23,13 @@ type DataLocationSectionProps =
       connectionsLoaded: boolean;
       connectionsError?: Error;
       pathLabel?: never;
+      showConnection?: never;
+      isConnectionReadOnly?: never;
     }
   | {
       pathLabel?: string;
+      showConnection?: boolean;
+      isConnectionReadOnly?: boolean;
       connections?: never;
       connectionsLoaded?: never;
       connectionsError?: never;
@@ -37,6 +41,8 @@ const DataLocationSection: React.FC<DataLocationSectionProps> = (props) => {
     connectionsLoaded = true,
     connectionsError,
     pathLabel = 'Path',
+    showConnection = false,
+    isConnectionReadOnly = false,
   } = props;
   const isEditMode = !('connections' in props);
   const { control } = useFormContext<RegisterDataFormData | EditAssetFormData>();
@@ -67,7 +73,7 @@ const DataLocationSection: React.FC<DataLocationSectionProps> = (props) => {
         </Alert>
       ) : null}
 
-      {isEditMode ? null : (
+      {!isEditMode || showConnection ? (
         <Controller
           name="connection"
           control={control}
@@ -87,7 +93,7 @@ const DataLocationSection: React.FC<DataLocationSectionProps> = (props) => {
                     onClick={() => setIsConnectionOpen((prev) => !prev)}
                     isExpanded={isConnectionOpen}
                     isFullWidth
-                    isDisabled={!!connectionsError}
+                    isDisabled={!!connectionsError || isConnectionReadOnly}
                     data-testid="data-connection-toggle"
                   >
                     {!connectionsLoaded ? <Spinner size="sm" /> : getToggleLabel(field.value)}
@@ -116,7 +122,7 @@ const DataLocationSection: React.FC<DataLocationSectionProps> = (props) => {
             </FormGroup>
           )}
         />
-      )}
+      ) : null}
 
       <Controller
         name="path"

--- a/packages/data-registry/frontend/src/app/components/register-data/DataLocationSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-data/DataLocationSection.tsx
@@ -15,19 +15,31 @@ import {
 import { Controller, useFormContext } from 'react-hook-form';
 import { RegisterDataFormData } from '~/app/schemas/registerData.schema';
 import { ConnectionModel } from '~/app/types';
+import { EditAssetFormData } from '~/app/schemas/editAsset.schema';
 
-type DataLocationSectionProps = {
-  connections: ConnectionModel[];
-  connectionsLoaded: boolean;
-  connectionsError?: Error;
-};
+type DataLocationSectionProps =
+  | {
+      connections: ConnectionModel[];
+      connectionsLoaded: boolean;
+      connectionsError?: Error;
+      pathLabel?: never;
+    }
+  | {
+      pathLabel?: string;
+      connections?: never;
+      connectionsLoaded?: never;
+      connectionsError?: never;
+    };
 
-const DataLocationSection: React.FC<DataLocationSectionProps> = ({
-  connections,
-  connectionsLoaded,
-  connectionsError,
-}) => {
-  const { control } = useFormContext<RegisterDataFormData>();
+const DataLocationSection: React.FC<DataLocationSectionProps> = (props) => {
+  const {
+    connections = [],
+    connectionsLoaded = true,
+    connectionsError,
+    pathLabel = 'Path',
+  } = props;
+  const isEditMode = !('connections' in props);
+  const { control } = useFormContext<RegisterDataFormData | EditAssetFormData>();
   const [isConnectionOpen, setIsConnectionOpen] = React.useState(false);
 
   const getToggleLabel = (value: string): string => {
@@ -55,60 +67,62 @@ const DataLocationSection: React.FC<DataLocationSectionProps> = ({
         </Alert>
       ) : null}
 
-      <Controller
-        name="connection"
-        control={control}
-        render={({ field }) => (
-          <FormGroup label="Connection" fieldId="data-connection">
-            <Select
-              isOpen={isConnectionOpen}
-              selected={field.value}
-              onSelect={(_event, value) => {
-                field.onChange(String(value));
-                setIsConnectionOpen(false);
-              }}
-              onOpenChange={setIsConnectionOpen}
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  onClick={() => setIsConnectionOpen((prev) => !prev)}
-                  isExpanded={isConnectionOpen}
-                  isFullWidth
-                  isDisabled={!!connectionsError}
-                  data-testid="data-connection-toggle"
-                >
-                  {!connectionsLoaded ? <Spinner size="sm" /> : getToggleLabel(field.value)}
-                </MenuToggle>
-              )}
-            >
-              <SelectList>
-                {connections.length === 0 ? (
-                  <SelectOption value="" isDisabled>
-                    No connections available
-                  </SelectOption>
-                ) : (
-                  connections.map((conn) => (
-                    <SelectOption
-                      key={conn.name}
-                      value={conn.name}
-                      description={conn.connectionType}
-                      data-testid={`connection-option-${conn.name}`}
-                    >
-                      {conn.displayName || conn.name}
-                    </SelectOption>
-                  ))
+      {isEditMode ? null : (
+        <Controller
+          name="connection"
+          control={control}
+          render={({ field }) => (
+            <FormGroup label="Connection" fieldId="data-connection">
+              <Select
+                isOpen={isConnectionOpen}
+                selected={field.value}
+                onSelect={(_event, value) => {
+                  field.onChange(String(value));
+                  setIsConnectionOpen(false);
+                }}
+                onOpenChange={setIsConnectionOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsConnectionOpen((prev) => !prev)}
+                    isExpanded={isConnectionOpen}
+                    isFullWidth
+                    isDisabled={!!connectionsError}
+                    data-testid="data-connection-toggle"
+                  >
+                    {!connectionsLoaded ? <Spinner size="sm" /> : getToggleLabel(field.value)}
+                  </MenuToggle>
                 )}
-              </SelectList>
-            </Select>
-          </FormGroup>
-        )}
-      />
+              >
+                <SelectList>
+                  {connections.length === 0 ? (
+                    <SelectOption value="" isDisabled>
+                      No connections available
+                    </SelectOption>
+                  ) : (
+                    connections.map((conn) => (
+                      <SelectOption
+                        key={conn.name}
+                        value={conn.name}
+                        description={conn.connectionType}
+                        data-testid={`connection-option-${conn.name}`}
+                      >
+                        {conn.displayName || conn.name}
+                      </SelectOption>
+                    ))
+                  )}
+                </SelectList>
+              </Select>
+            </FormGroup>
+          )}
+        />
+      )}
 
       <Controller
         name="path"
         control={control}
         render={({ field }) => (
-          <FormGroup label="Path" fieldId="data-path">
+          <FormGroup label={pathLabel} fieldId="data-path">
             <TextInput id="data-path" {...field} data-testid="data-path-input" />
           </FormGroup>
         )}

--- a/packages/data-registry/frontend/src/app/components/register-data/PropertiesSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-data/PropertiesSection.tsx
@@ -15,6 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { Controller, useFormContext } from 'react-hook-form';
 import { RegisterDataFormData } from '~/app/schemas/registerData.schema';
+import { EditAssetFormData } from '~/app/schemas/editAsset.schema';
 
 const LICENSE_OPTIONS = [
   { key: 'internal-use', label: 'Internal use' },
@@ -55,7 +56,7 @@ const SelectField: React.FC<SelectFieldProps> = ({
   options,
   placeholder,
 }) => {
-  const { control } = useFormContext<RegisterDataFormData>();
+  const { control } = useFormContext<RegisterDataFormData | EditAssetFormData>();
   const [isOpen, setIsOpen] = React.useState(false);
 
   return (
@@ -102,7 +103,7 @@ const PropertiesSection: React.FC = () => {
   const {
     control,
     formState: { errors },
-  } = useFormContext<RegisterDataFormData>();
+  } = useFormContext<RegisterDataFormData | EditAssetFormData>();
 
   return (
     <FormSection title="Properties" titleElement="h2">

--- a/packages/data-registry/frontend/src/app/components/register-data/SchemaSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-data/SchemaSection.tsx
@@ -20,6 +20,7 @@ import {
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useFieldArray, useFormContext, Controller } from 'react-hook-form';
 import { RegisterDataFormData } from '~/app/schemas/registerData.schema';
+import { EditAssetFormData } from '~/app/schemas/editAsset.schema';
 
 const COLUMN_TYPE_OPTIONS = [
   { key: 'string', label: 'string' },
@@ -39,7 +40,7 @@ const SchemaSection: React.FC = () => {
     control,
     register,
     formState: { errors },
-  } = useFormContext<RegisterDataFormData>();
+  } = useFormContext<RegisterDataFormData | EditAssetFormData>();
   const { fields, append, remove } = useFieldArray({ control, name: 'schemaFields' });
   const [openTypeIndex, setOpenTypeIndex] = React.useState<number | null>(null);
   const nextIdRef = React.useRef(0);

--- a/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
@@ -84,6 +84,7 @@ const TableDetailPage: React.FC = () => {
           <MenuToggle
             ref={toggleRef}
             variant="plain"
+            isDisabled={!loaded}
             onClick={() => setIsActionsOpen((prev) => !prev)}
             isExpanded={isActionsOpen}
             aria-label="Actions"

--- a/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
@@ -19,7 +19,6 @@ import {
   Tabs,
   TabContent,
   TabTitleText,
-  Tooltip,
 } from '@patternfly/react-core';
 import { EllipsisVIcon, SearchIcon } from '@patternfly/react-icons';
 import ApplicationsPage from '~/app/components/ApplicationsPage';
@@ -27,6 +26,7 @@ import { useGenericTable } from '~/app/hooks/useGenericTable';
 import { deleteGenericTable } from '~/app/api/dataRegistry';
 import { browseUrl } from '~/app/utilities/routes';
 import DeleteAssetModal from '~/app/components/DeleteAssetModal';
+import EditAssetModal from '~/app/components/EditAssetModal';
 import TableDetailView from './TableDetailView';
 
 const TableDetailPage: React.FC = () => {
@@ -37,9 +37,10 @@ const TableDetailPage: React.FC = () => {
   }>();
   const navigate = useNavigate();
 
-  const [asset, loaded, loadError] = useGenericTable(project, collection, name);
+  const [asset, loaded, loadError, refresh] = useGenericTable(project, collection, name);
   const [isActionsOpen, setIsActionsOpen] = React.useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
 
   const handleDelete = React.useCallback(async () => {
     if (!project || !collection || !name) {
@@ -94,11 +95,13 @@ const TableDetailPage: React.FC = () => {
         popperProps={{ position: 'right' }}
       >
         <DropdownList>
-          <Tooltip content="Edit functionality coming soon">
-            <DropdownItem key="edit" isDisabled data-testid="asset-action-edit">
-              Edit
-            </DropdownItem>
-          </Tooltip>
+          <DropdownItem
+            key="edit"
+            onClick={() => setIsEditModalOpen(true)}
+            data-testid="asset-action-edit"
+          >
+            Edit
+          </DropdownItem>
           <DropdownItem
             key="delete"
             onClick={() => setIsDeleteModalOpen(true)}
@@ -114,6 +117,20 @@ const TableDetailPage: React.FC = () => {
           assetType="table"
           onDelete={handleDelete}
           onClose={() => setIsDeleteModalOpen(false)}
+        />
+      ) : null}
+      {isEditModalOpen && asset && project && collection && name ? (
+        <EditAssetModal
+          asset={asset}
+          assetKind="table"
+          project={project}
+          collection={collection}
+          name={name}
+          onClose={() => setIsEditModalOpen(false)}
+          onSaved={() => {
+            setIsEditModalOpen(false);
+            refresh();
+          }}
         />
       ) : null}
     </>

--- a/packages/data-registry/frontend/src/app/pages/VolumeDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/VolumeDetailPage.tsx
@@ -19,7 +19,6 @@ import {
   Tabs,
   TabContent,
   TabTitleText,
-  Tooltip,
 } from '@patternfly/react-core';
 import { EllipsisVIcon, SearchIcon } from '@patternfly/react-icons';
 import ApplicationsPage from '~/app/components/ApplicationsPage';
@@ -27,6 +26,7 @@ import { useVolume } from '~/app/hooks/useVolume';
 import { deleteVolume } from '~/app/api/dataRegistry';
 import { browseUrl } from '~/app/utilities/routes';
 import DeleteAssetModal from '~/app/components/DeleteAssetModal';
+import EditAssetModal from '~/app/components/EditAssetModal';
 import VolumeDetailView from './VolumeDetailView';
 
 const VolumeDetailPage: React.FC = () => {
@@ -37,9 +37,10 @@ const VolumeDetailPage: React.FC = () => {
   }>();
   const navigate = useNavigate();
 
-  const [volume, loaded, loadError] = useVolume(project, collection, name);
+  const [volume, loaded, loadError, refresh] = useVolume(project, collection, name);
   const [isActionsOpen, setIsActionsOpen] = React.useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
 
   const handleDelete = React.useCallback(async () => {
     if (!project || !collection || !name) {
@@ -94,11 +95,13 @@ const VolumeDetailPage: React.FC = () => {
         popperProps={{ position: 'right' }}
       >
         <DropdownList>
-          <Tooltip content="Edit functionality coming soon">
-            <DropdownItem key="edit" isDisabled data-testid="asset-action-edit">
-              Edit
-            </DropdownItem>
-          </Tooltip>
+          <DropdownItem
+            key="edit"
+            onClick={() => setIsEditModalOpen(true)}
+            data-testid="asset-action-edit"
+          >
+            Edit
+          </DropdownItem>
           <DropdownItem
             key="delete"
             onClick={() => setIsDeleteModalOpen(true)}
@@ -114,6 +117,20 @@ const VolumeDetailPage: React.FC = () => {
           assetType="volume"
           onDelete={handleDelete}
           onClose={() => setIsDeleteModalOpen(false)}
+        />
+      ) : null}
+      {isEditModalOpen && volume && project && collection && name ? (
+        <EditAssetModal
+          asset={volume}
+          assetKind="volume"
+          project={project}
+          collection={collection}
+          name={name}
+          onClose={() => setIsEditModalOpen(false)}
+          onSaved={() => {
+            setIsEditModalOpen(false);
+            refresh();
+          }}
         />
       ) : null}
     </>

--- a/packages/data-registry/frontend/src/app/pages/VolumeDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/VolumeDetailPage.tsx
@@ -84,6 +84,7 @@ const VolumeDetailPage: React.FC = () => {
           <MenuToggle
             ref={toggleRef}
             variant="plain"
+            isDisabled={!loaded}
             onClick={() => setIsActionsOpen((prev) => !prev)}
             isExpanded={isActionsOpen}
             aria-label="Actions"

--- a/packages/data-registry/frontend/src/app/schemas/editAsset.schema.ts
+++ b/packages/data-registry/frontend/src/app/schemas/editAsset.schema.ts
@@ -13,12 +13,28 @@ export const editAssetSchema = z.object({
   license: z.string(),
   maturity: z.string(),
   piiStatus: z.string(),
-  customProperties: z.array(z.object({ id: z.number(), key: z.string(), value: z.string() })),
+  customProperties: z
+    .array(z.object({ id: z.number(), key: z.string(), value: z.string() }))
+    .superRefine((properties, ctx) => {
+      const keys = new Set<string>();
+      properties.forEach((property, index) => {
+        if (property.key && keys.has(property.key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Duplicate property key: ${property.key}`,
+            path: [index, 'key'],
+          });
+        }
+        if (property.key) {
+          keys.add(property.key);
+        }
+      });
+    }),
   schemaFields: z.array(
     z.object({
       id: z.number(),
-      name: z.string(),
-      type: z.string(),
+      name: z.string().trim().min(1, 'Column name is required'),
+      type: z.string().trim().min(1, 'Column type is required'),
       description: z.string(),
       nullable: z.boolean(),
     }),

--- a/packages/data-registry/frontend/src/app/schemas/editAsset.schema.ts
+++ b/packages/data-registry/frontend/src/app/schemas/editAsset.schema.ts
@@ -1,0 +1,28 @@
+import * as z from 'zod';
+
+export const editAssetSchema = z.object({
+  assetType: z.enum(['unstructured', 'structured']),
+  name: z.string(),
+  description: z.string().max(500, 'Description must be 500 characters or fewer'),
+  format: z.string(),
+  collection: z.string(),
+  labels: z.array(z.string()),
+  connection: z.string(),
+  path: z.string(),
+  purpose: z.string().max(200, 'Purpose must be 200 characters or fewer'),
+  license: z.string(),
+  maturity: z.string(),
+  piiStatus: z.string(),
+  customProperties: z.array(z.object({ id: z.number(), key: z.string(), value: z.string() })),
+  schemaFields: z.array(
+    z.object({
+      id: z.number(),
+      name: z.string(),
+      type: z.string(),
+      description: z.string(),
+      nullable: z.boolean(),
+    }),
+  ),
+});
+
+export type EditAssetFormData = z.infer<typeof editAssetSchema>;

--- a/packages/data-registry/frontend/src/app/types.ts
+++ b/packages/data-registry/frontend/src/app/types.ts
@@ -64,7 +64,7 @@ export type AssetResponse = {
   connection_ref?: ConnectionRef | string | null;
   owner?: string;
   description?: string;
-  labels?: string[];
+  labels?: string[] | null;
   properties?: Record<string, string>;
   registered_by?: string;
   updated_by?: string;
@@ -86,7 +86,7 @@ export type VolumeInfo = {
   owner?: string;
   'created-at'?: string;
   'updated-at'?: string;
-  labels?: string[];
+  labels?: string[] | null;
   properties?: Record<string, string>;
   config?: Record<string, string>;
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAI-637

## Description

Implements the edit asset modal for both tables and volumes in the Data Registry UI. The modal reuses the existing `register-data/` form sections by adding an `isEditMode` prop, rather than duplicating components. In edit mode, name, asset type, and collection fields are read-only while description, format, labels, data location, properties, custom properties, and schema columns remain editable.

This branch has been rebased onto `main`; the related table-registration and asset-detail work is now already included upstream.

Key changes:
- **`EditAssetModal.tsx`** — Modal component using `react-hook-form` with `zod` validation, discriminated union props for table vs volume, PATCH API calls with label diff logic (`add_labels`/`remove_labels`)
- **`editAsset.schema.ts`** — Zod schema aligned with the registration schema field names for component reuse
- **`register-data/` sections** — Added edit-mode support to shared form sections, including read-only name/type/collection fields and the volume storage-location label
- **`dataRegistry.ts`** — Added `updateGenericTable` (PATCH) and `updateVolume` (PATCH) API functions
- **`TableDetailPage.tsx` / `VolumeDetailPage.tsx`** — Wired the edit modal with a kebab-menu action
- **Cypress coverage** — Added mocked table and volume edit flows with a reusable page object

## Screenshots

Edit structured data asset:
<img width="818" height="1057" alt="Screenshot 2026-09-03 at 14 45 10" src="https://github.com/user-attachments/assets/3f50e649-311c-466c-9194-33a9487901d4" />

<img width="812" height="790" alt="Screenshot 2026-09-03 at 14 45 22" src="https://github.com/user-attachments/assets/ea5d13b4-ae50-45f9-a78a-1467433c3266" />

<img width="799" height="459" alt="Screenshot 2026-09-03 at 14 45 24" src="https://github.com/user-attachments/assets/501f9a43-e212-4379-881a-090b75a6906c" />

Edit unstructured data asset: 
<img width="820" height="1064" alt="Screenshot 2026-09-03 at 14 47 14" src="https://github.com/user-attachments/assets/a19f8832-b154-49a5-9c99-2796dc9e52ee" />
<img width="809" height="777" alt="Screenshot 2026-09-03 at 14 47 22" src="https://github.com/user-attachments/assets/1d749cfb-7661-42e8-804e-a68a29edb783" />


## How Has This Been Tested?

- TypeScript type-check passes
- All 13 data-registry frontend unit suites pass (94 tests)
- ESLint passes for the changed TypeScript files
- Cypress mock tests cover pre-populated fields, description editing, labels, custom properties, schema columns, cancel, and volume save flows

## Test Impact

- **New Cypress mock tests** (`editAsset.cy.ts`): 8 tests covering table and volume edit flows
- **New page object** (`editAssetModal.ts`): Reusable page object for edit modal interactions
- Updated the schema-table unit assertion to match the four-column detail view now in `main`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added editing for table and volume data assets from their detail pages.
  - Users can update descriptions, purposes, labels, custom properties, schema columns, and data locations.
  - Added form validation and error handling for asset updates.
  - Asset details refresh automatically after successful edits.
  - Existing registration form sections now support asset editing workflows.

- **Bug Fixes**
  - Improved response validation for data registry requests.
  - Edit actions remain unavailable until asset details finish loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->