### PR TITLE
fix(nim-serving): use project NIMAccount secrets in place of legacy NIM secret placeholders

### DIFF
--- a/packages/nim-serving/src/api/accounts/constants.ts
+++ b/packages/nim-serving/src/api/accounts/constants.ts
@@ -1,4 +1,5 @@
 export const NIM_SECRET_NAME = 'nvidia-nim-secrets';
+export const NIM_PULL_SECRET_NAME = 'ngc-secret';
 export const NIM_ACCOUNT_NAME = 'odh-nim-account';
 // The Account operator validates the key using this field
 export const NIM_API_KEY_DATA_KEY = 'api_key';

--- a/packages/nim-serving/src/api/servingruntime/__tests__/utils.spec.ts
+++ b/packages/nim-serving/src/api/servingruntime/__tests__/utils.spec.ts
@@ -1,5 +1,10 @@
+import { mockNimAccount } from '@odh-dashboard/internal/__mocks__/mockNimAccount';
 import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
-import { applyNIMServingRuntimeShmMounts, removeNIMServingRuntimeResources } from '../utils';
+import {
+  applyNIMServingRuntimeCredentials,
+  applyNIMServingRuntimeShmMounts,
+  removeNIMServingRuntimeResources,
+} from '../utils';
 
 const makeServingRuntime = (
   containers: ServingRuntimeKind['spec']['containers'],
@@ -106,6 +111,102 @@ const CONTAINER_RESOURCES = {
   limits: { cpu: '0', memory: '0Gi' },
   requests: { cpu: '0', memory: '0Gi' },
 };
+
+describe('applyNIMServingRuntimeCredentials', () => {
+  const makeNIMAccount = () => {
+    const account = mockNimAccount({
+      namespace: 'test-project',
+      apiKeySecretName: 'project-nim-api-key',
+    });
+    account.status = {
+      ...account.status,
+      nimPullSecret: { name: 'project-nim-pull-secret' },
+    };
+    return account;
+  };
+
+  it('should replace NIM credential placeholders while preserving unrelated references', () => {
+    const runtime = makeServingRuntime([
+      {
+        name: 'kserve-container',
+        env: [
+          {
+            name: 'NGC_API_KEY',
+            valueFrom: { secretKeyRef: { name: 'nvidia-nim-secrets', key: 'NGC_API_KEY' } },
+          },
+          {
+            name: 'UNRELATED_SECRET',
+            valueFrom: { secretKeyRef: { name: 'unrelated-secret', key: 'token' } },
+          },
+        ],
+      },
+      {
+        name: 'sidecar',
+        env: [
+          {
+            name: 'NGC_API_KEY',
+            valueFrom: { secretKeyRef: { name: 'nvidia-nim-secrets', key: 'NGC_API_KEY' } },
+          },
+        ],
+      },
+    ]);
+    runtime.spec.imagePullSecrets = [{ name: 'ngc-secret' }, { name: 'unrelated-pull-secret' }];
+
+    const result = applyNIMServingRuntimeCredentials(runtime, makeNIMAccount());
+
+    expect(result.spec.containers[0].env).toEqual([
+      {
+        name: 'NGC_API_KEY',
+        valueFrom: { secretKeyRef: { name: 'project-nim-api-key', key: 'NGC_API_KEY' } },
+      },
+      {
+        name: 'UNRELATED_SECRET',
+        valueFrom: { secretKeyRef: { name: 'unrelated-secret', key: 'token' } },
+      },
+    ]);
+    expect(result.spec.containers[1].env?.[0].valueFrom?.secretKeyRef?.name).toBe(
+      'project-nim-api-key',
+    );
+    expect(result.spec.imagePullSecrets).toEqual([
+      { name: 'project-nim-pull-secret' },
+      { name: 'unrelated-pull-secret' },
+    ]);
+  });
+
+  it('should not mutate the input ServingRuntime', () => {
+    const runtime = makeServingRuntime([
+      {
+        name: 'kserve-container',
+        env: [
+          {
+            name: 'NGC_API_KEY',
+            valueFrom: { secretKeyRef: { name: 'nvidia-nim-secrets', key: 'NGC_API_KEY' } },
+          },
+        ],
+      },
+    ]);
+    runtime.spec.imagePullSecrets = [{ name: 'ngc-secret' }];
+
+    applyNIMServingRuntimeCredentials(runtime, makeNIMAccount());
+
+    expect(runtime.spec.containers[0].env?.[0].valueFrom?.secretKeyRef?.name).toBe(
+      'nvidia-nim-secrets',
+    );
+    expect(runtime.spec.imagePullSecrets).toEqual([{ name: 'ngc-secret' }]);
+  });
+
+  it('should leave runtimes without NIM credential placeholders unchanged', () => {
+    const runtime = makeServingRuntime([
+      {
+        name: 'kserve-container',
+        env: [{ name: 'UNRELATED', valueFrom: { secretKeyRef: { name: 'other', key: 'key' } } }],
+      },
+    ]);
+    runtime.spec.imagePullSecrets = [{ name: 'other-pull-secret' }];
+
+    expect(applyNIMServingRuntimeCredentials(runtime, makeNIMAccount())).toEqual(runtime);
+  });
+});
 
 describe('removeNIMServingRuntimeResources', () => {
   it('should drop the resources from every container', () => {

--- a/packages/nim-serving/src/api/servingruntime/utils.ts
+++ b/packages/nim-serving/src/api/servingruntime/utils.ts
@@ -1,5 +1,50 @@
-import { Volume, VolumeMount } from '@odh-dashboard/k8s-core';
+import { type NIMAccountKind, Volume, VolumeMount } from '@odh-dashboard/k8s-core';
 import { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
+import { NGC_API_KEY_DATA_KEY, NIM_PULL_SECRET_NAME, NIM_SECRET_NAME } from '../accounts/constants';
+
+export const applyNIMServingRuntimeCredentials = (
+  servingRuntime: ServingRuntimeKind,
+  nimAccount: NIMAccountKind,
+): ServingRuntimeKind => {
+  const pullSecretName = nimAccount.status?.nimPullSecret?.name;
+  if (!pullSecretName) {
+    throw new Error('NIM image pull secret is not available for this project.');
+  }
+
+  const updatedServingRuntime = structuredClone(servingRuntime);
+  updatedServingRuntime.spec.containers = updatedServingRuntime.spec.containers.map(
+    (container) => ({
+      ...container,
+      env: container.env?.map((env) => {
+        const secretKeyRef = env.valueFrom?.secretKeyRef;
+        if (env.name !== NGC_API_KEY_DATA_KEY || !secretKeyRef) {
+          return env;
+        }
+
+        return {
+          ...env,
+          valueFrom: {
+            ...env.valueFrom,
+            secretKeyRef: {
+              ...secretKeyRef,
+              name:
+                secretKeyRef.name === NIM_SECRET_NAME
+                  ? nimAccount.spec.apiKeySecret.name
+                  : secretKeyRef.name,
+            },
+          },
+        };
+      }),
+    }),
+  );
+
+  updatedServingRuntime.spec.imagePullSecrets = updatedServingRuntime.spec.imagePullSecrets?.map(
+    (secret) =>
+      secret.name === NIM_PULL_SECRET_NAME ? { ...secret, name: pullSecretName } : secret,
+  );
+
+  return updatedServingRuntime;
+};
 
 const shmVolumeMount = (): VolumeMount => ({
   name: 'shm',

--- a/packages/nim-serving/src/nimKServe/__tests__/deploy.spec.ts
+++ b/packages/nim-serving/src/nimKServe/__tests__/deploy.spec.ts
@@ -2,17 +2,24 @@ import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/f
 import type { KServeDeployment } from '@odh-dashboard/kserve/types';
 import { deployKServeDeployment } from '@odh-dashboard/kserve/deploy';
 import { mockNimServingRuntimeTemplate } from '@odh-dashboard/model-serving/__mocks__/mockLegacyNimResource';
+import { mockNimAccount } from '@odh-dashboard/internal/__mocks__/mockNimAccount';
 import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
 import type { TemplateKind } from '@odh-dashboard/k8s-core';
 import { deployNIMKServeDeployment, isNIMKServeDeployActive } from '../deploy';
 import { NIMImageFieldWizardField } from '../../pages/deploymentWizard/fields/NIMImageField';
 import { NIMAccountStatus } from '../../api/accounts/utils';
+import { getNIMAccount } from '../../api/accounts/k8s';
 
 jest.mock('@odh-dashboard/kserve/deploy', () => ({
   deployKServeDeployment: jest.fn(),
 }));
 
+jest.mock('../../api/accounts/k8s', () => ({
+  getNIMAccount: jest.fn(),
+}));
+
 const mockDeployKServeDeployment = jest.mocked(deployKServeDeployment);
+const mockGetNIMAccount = jest.mocked(getNIMAccount);
 
 const WIZARD_DATA = {
   modelLocationData: { data: { type: 'nvidia-nim' } },
@@ -28,6 +35,36 @@ const makeExternalData = (nimTemplate?: TemplateKind) => ({
     },
   },
 });
+
+const makeNIMAccount = () => {
+  const account = mockNimAccount({
+    namespace: 'test-project',
+    apiKeySecretName: 'project-nim-api-key',
+  });
+  account.status = {
+    ...account.status,
+    nimPullSecret: { name: 'project-nim-pull-secret' },
+  };
+  return account;
+};
+
+const makeTemplateWithCredentialPlaceholders = (): TemplateKind => {
+  const template = mockNimServingRuntimeTemplate({ namespace: 'test-project' });
+  const runtime = template.objects[0] as ServingRuntimeKind;
+  runtime.spec.containers[0].env = [
+    {
+      name: 'NGC_API_KEY',
+      valueFrom: {
+        secretKeyRef: {
+          name: 'nvidia-nim-secrets',
+          key: 'NGC_API_KEY',
+        },
+      },
+    },
+  ];
+  runtime.spec.imagePullSecrets = [{ name: 'ngc-secret' }];
+  return template;
+};
 
 /** The runtime `deployNIMKServeDeployment` handed down to KServe. */
 const getDeployedRuntime = (): ServingRuntimeKind | undefined =>
@@ -59,6 +96,7 @@ describe('deployNIMKServeDeployment', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDeployKServeDeployment.mockResolvedValue({} as KServeDeployment);
+    mockGetNIMAccount.mockResolvedValue(makeNIMAccount());
   });
 
   it('should resolve the serving runtime from the NIM template', async () => {
@@ -70,6 +108,54 @@ describe('deployNIMKServeDeployment', () => {
 
     expect(mockDeployKServeDeployment).toHaveBeenCalledTimes(1);
     expect(getDeployedRuntime()?.metadata.name).toBe('nvidia-nim-runtime');
+  });
+
+  it('should replace template credential references with the project NIM Account secrets', async () => {
+    mockGetNIMAccount.mockResolvedValue(makeNIMAccount());
+
+    await deployNIMKServeDeployment(
+      WIZARD_DATA,
+      makeExternalData(makeTemplateWithCredentialPlaceholders()),
+      'test-project',
+    );
+
+    const runtime = getDeployedRuntime();
+    expect(mockGetNIMAccount).toHaveBeenCalledWith('test-project');
+    expect(
+      runtime?.spec.containers[0].env?.find((env) => env.name === 'NGC_API_KEY')?.valueFrom
+        ?.secretKeyRef,
+    ).toEqual({ name: 'project-nim-api-key', key: 'NGC_API_KEY' });
+    expect(runtime?.spec.imagePullSecrets).toEqual([{ name: 'project-nim-pull-secret' }]);
+  });
+
+  it('should reject a new deployment when the project has no NIM Account', async () => {
+    mockGetNIMAccount.mockResolvedValue(undefined);
+
+    await expect(
+      deployNIMKServeDeployment(
+        WIZARD_DATA,
+        makeExternalData(mockNimServingRuntimeTemplate({ namespace: 'test-project' })),
+        'test-project',
+      ),
+    ).rejects.toThrow('NIM Account not found');
+
+    expect(mockDeployKServeDeployment).not.toHaveBeenCalled();
+  });
+
+  it('should reject a new deployment when the NIM Account has no image pull secret', async () => {
+    const account = makeNIMAccount();
+    account.status = { ...account.status, nimPullSecret: undefined };
+    mockGetNIMAccount.mockResolvedValue(account);
+
+    await expect(
+      deployNIMKServeDeployment(
+        WIZARD_DATA,
+        makeExternalData(mockNimServingRuntimeTemplate({ namespace: 'test-project' })),
+        'test-project',
+      ),
+    ).rejects.toThrow('NIM image pull secret is not available');
+
+    expect(mockDeployKServeDeployment).not.toHaveBeenCalled();
   });
 
   it('should apply the shm mounts to the resolved runtime', async () => {
@@ -127,6 +213,7 @@ describe('deployNIMKServeDeployment', () => {
     );
 
     expect(getDeployedRuntime()).toBe(existingServer);
+    expect(mockGetNIMAccount).not.toHaveBeenCalled();
   });
 
   it('should forward the dry run flag to KServe', async () => {

--- a/packages/nim-serving/src/nimKServe/deploy.ts
+++ b/packages/nim-serving/src/nimKServe/deploy.ts
@@ -12,7 +12,9 @@ import {
   isNIMImageFieldExternalData,
   NIMImageFieldWizardField,
 } from '../pages/deploymentWizard/fields/NIMImageField';
+import { getNIMAccount } from '../api/accounts/k8s';
 import {
+  applyNIMServingRuntimeCredentials,
   applyNIMServingRuntimeShmMounts,
   removeNIMServingRuntimeResources,
 } from '../api/servingruntime/utils';
@@ -56,6 +58,14 @@ export const deployNIMKServeDeployment = async (
       if (!runtime) {
         throw new Error(`Unable to find NIM ServingRuntime Template in namespace ${projectName}`);
       }
+      const nimAccount = await getNIMAccount(projectName);
+      if (!nimAccount) {
+        throw new Error(
+          'NIM Account not found in this project. Configure NVIDIA NIM in the project settings first.',
+        );
+      }
+
+      runtime = applyNIMServingRuntimeCredentials(runtime, nimAccount);
       // The NIM Template has a `volumeMounts` defined but not the `volumes` for shm. Add it to prevent errors
       runtime = applyNIMServingRuntimeShmMounts(runtime);
       // The container resources come from the InferenceService's hardware profile, not the Template


### PR DESCRIPTION
## Description

Fixes [RHOAIENG-87989](https://redhat.atlassian.net/browse/RHOAIENG-87989).

- Resolve the current project's `NIMAccount` before creating a NIM KServe `ServingRuntime`.
- Replace the legacy `nvidia-nim-secrets` API-key reference and `ngc-secret` image-pull-secret placeholder with the Account-managed secret names.
- Fail before generic KServe deployment when the NIM Account or its image pull secret is unavailable.
- Preserve unrelated environment variables and pull secrets, and do not alter an existing runtime during edits.

## How Has This Been Tested?

```bash
npm run test-unit --workspace=@odh-dashboard/nim-serving
npm run type-check --workspace=@odh-dashboard/nim-serving
npm run lint --workspace=@odh-dashboard/nim-serving
```

All 21 NIM serving unit-test suites passed (222 tests), type-check passed, and lint passed with one existing restricted-import warning in `packages/nim-serving/src/pages/projectSettings/NIMSettingsLink.tsx`.

Also tested on the Zaffre cluster: a NIM model deployed with these chnages has the correct NGC_API_KEY and image pull secret names from the project’s NIMAccount.

## Test Impact

- Added NIM KServe deployment regression coverage for Account-derived API-key and image-pull-secret references.
- Added failure coverage for a missing NIM Account and a missing Account image pull secret.
- Added coverage that edit deployments do not resolve Account credentials or modify the existing ServingRuntime.
- Added ServingRuntime credential transformation tests for multiple containers, unrelated field preservation, and input immutability.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-87989]: https://redhat.atlassian.net/browse/RHOAIENG-87989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ