### PR TITLE
fix(EvalHub): benchmark gallery UX improvements and search by ID

### DIFF
--- a/packages/eval-hub/frontend/src/app/components/BenchmarkCard.scss
+++ b/packages/eval-hub/frontend/src/app/components/BenchmarkCard.scss
@@ -1,4 +1,5 @@
 .evalhub-benchmark-card__subtitle {
   color: var(--pf-t--global--text--color--subtle);
   margin-top: var(--pf-t--global--spacer--xs);
+  overflow-wrap: anywhere;
 }

--- a/packages/eval-hub/frontend/src/app/components/BenchmarkCard.scss
+++ b/packages/eval-hub/frontend/src/app/components/BenchmarkCard.scss
@@ -1,7 +1,4 @@
 .evalhub-benchmark-card__subtitle {
-  color: var(--pf-t--global--text--color--regular);
+  color: var(--pf-t--global--text--color--subtle);
   margin-top: var(--pf-t--global--spacer--xs);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }

--- a/packages/eval-hub/frontend/src/app/components/BenchmarkCard.tsx
+++ b/packages/eval-hub/frontend/src/app/components/BenchmarkCard.tsx
@@ -9,7 +9,6 @@ import {
   Content,
   Label,
   LabelGroup,
-  Tooltip,
 } from '@patternfly/react-core';
 import { FlatBenchmark } from '~/app/types';
 import {
@@ -59,11 +58,9 @@ const BenchmarkCard: React.FC<BenchmarkCardProps> = ({
         >
           {benchmark.name}
         </Button>
-        <Tooltip content={`${benchmark.id} · ${benchmark.providerName}`} position="bottom">
-          <Content component="p" className="evalhub-benchmark-card__subtitle">
-            {benchmark.id} · {benchmark.providerName}
-          </Content>
-        </Tooltip>
+        <Content component="p" className="evalhub-benchmark-card__subtitle">
+          {benchmark.id} · {benchmark.providerName}
+        </Content>
       </CardTitle>
 
       <CardBody>

--- a/packages/eval-hub/frontend/src/app/components/BenchmarkCard.tsx
+++ b/packages/eval-hub/frontend/src/app/components/BenchmarkCard.tsx
@@ -9,6 +9,7 @@ import {
   Content,
   Label,
   LabelGroup,
+  Tooltip,
 } from '@patternfly/react-core';
 import { FlatBenchmark } from '~/app/types';
 import {
@@ -58,13 +59,11 @@ const BenchmarkCard: React.FC<BenchmarkCardProps> = ({
         >
           {benchmark.name}
         </Button>
-        <Content
-          component="p"
-          title={`${benchmark.id} · ${benchmark.providerName}`}
-          className="evalhub-benchmark-card__subtitle"
-        >
-          {benchmark.id} · {benchmark.providerName}
-        </Content>
+        <Tooltip content={`${benchmark.id} · ${benchmark.providerName}`} position="bottom">
+          <Content component="p" className="evalhub-benchmark-card__subtitle">
+            {benchmark.id} · {benchmark.providerName}
+          </Content>
+        </Tooltip>
       </CardTitle>
 
       <CardBody>

--- a/packages/eval-hub/frontend/src/app/pages/ChooseStandardisedBenchmarksPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/ChooseStandardisedBenchmarksPage.tsx
@@ -127,7 +127,11 @@ const ChooseStandardisedBenchmarksPage: React.FC = () => {
     const metricsFilters = filterData[BenchmarkFilterOptions.metrics];
 
     return allBenchmarks.filter((b) => {
-      if (nameFilter && !b.name.toLowerCase().includes(nameFilter)) {
+      if (
+        nameFilter &&
+        !b.name.toLowerCase().includes(nameFilter) &&
+        !b.id.toLowerCase().includes(nameFilter)
+      ) {
         return false;
       }
       if (categoryFilters.length > 0 && !categoryFilters.includes(b.category ?? '')) {
@@ -175,6 +179,8 @@ const ChooseStandardisedBenchmarksPage: React.FC = () => {
     filterData[BenchmarkFilterOptions.name].trim() !== '' ||
     filterData[BenchmarkFilterOptions.category].length > 0 ||
     filterData[BenchmarkFilterOptions.metrics].length > 0;
+
+  const nameChipLabel = 'Name or ID';
 
   return (
     <Drawer isExpanded={!!selectedBenchmark}>
@@ -273,11 +279,11 @@ const ChooseStandardisedBenchmarksPage: React.FC = () => {
                                   [BenchmarkFilterOptions.name]: '',
                                 }))
                               }
-                              categoryName="Name"
+                              categoryName={nameChipLabel}
                             >
                               <SearchInput
-                                aria-label="Filter by name"
-                                placeholder="Filter by name"
+                                aria-label="Filter by name or ID"
+                                placeholder="Filter by name or ID"
                                 value={filterData[BenchmarkFilterOptions.name]}
                                 onChange={(_event, value) =>
                                   setFilterData((prev) => ({

--- a/packages/eval-hub/frontend/src/app/pages/ChooseStandardisedBenchmarksPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/ChooseStandardisedBenchmarksPage.tsx
@@ -180,8 +180,6 @@ const ChooseStandardisedBenchmarksPage: React.FC = () => {
     filterData[BenchmarkFilterOptions.category].length > 0 ||
     filterData[BenchmarkFilterOptions.metrics].length > 0;
 
-  const nameChipLabel = 'Name or ID';
-
   return (
     <Drawer isExpanded={!!selectedBenchmark}>
       <DrawerContent
@@ -279,7 +277,7 @@ const ChooseStandardisedBenchmarksPage: React.FC = () => {
                                   [BenchmarkFilterOptions.name]: '',
                                 }))
                               }
-                              categoryName={nameChipLabel}
+                              categoryName="Name or ID"
                             >
                               <SearchInput
                                 aria-label="Filter by name or ID"

--- a/packages/eval-hub/frontend/src/app/pages/__tests__/ChooseStandardisedBenchmarksPage.spec.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/__tests__/ChooseStandardisedBenchmarksPage.spec.tsx
@@ -177,4 +177,49 @@ describe('ChooseStandardisedBenchmarksPage', () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it('should filter benchmarks by ID case-insensitively', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Filter by name or ID'), {
+      target: { value: 'ARC_EASY' },
+    });
+    expect(screen.getByTestId('benchmark-card-lm_evaluation_harness-arc_easy')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-inspect/arc'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-truthfulqa_mc1'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should restore all benchmarks after removing the name/ID filter chip', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Filter by name or ID'), {
+      target: { value: 'arc_easy' },
+    });
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-truthfulqa_mc1'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close arc_easy' }));
+
+    expect(screen.getByTestId('benchmark-card-lm_evaluation_harness-arc_easy')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('benchmark-card-lm_evaluation_harness-inspect/arc'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('benchmark-card-lm_evaluation_harness-truthfulqa_mc1'),
+    ).toBeInTheDocument();
+  });
+
+  it('should show a loading spinner while providers are loading', () => {
+    mockUseProviders.mockReturnValue({
+      providers: [],
+      loaded: false,
+      loadError: undefined,
+    });
+    renderPage();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Filter by name or ID')).not.toBeInTheDocument();
+  });
 });

--- a/packages/eval-hub/frontend/src/app/pages/__tests__/ChooseStandardisedBenchmarksPage.spec.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/__tests__/ChooseStandardisedBenchmarksPage.spec.tsx
@@ -1,0 +1,180 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ChooseStandardisedBenchmarksPage from '~/app/pages/ChooseStandardisedBenchmarksPage';
+import { Provider } from '~/app/types';
+
+const mockUseProviders = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock('~/app/hooks/useProviders', () => ({
+  useProviders: () => mockUseProviders(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@odh-dashboard/ui-core', () => ({
+  ...jest.requireActual('@odh-dashboard/ui-core'),
+  ...require('~/__tests__/unit/testUtils/mocks').mockApplicationsPageModule(),
+}));
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const makeProvider = (overrides: Partial<Provider> = {}): Provider => ({
+  resource: { id: 'lm_evaluation_harness' },
+  name: 'lm_evaluation_harness',
+  title: 'LM Evaluation Harness',
+  benchmarks: [],
+  ...overrides,
+});
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/test-project/evaluation/benchmarks']}>
+      <Routes>
+        <Route
+          path="/:namespace/evaluation/benchmarks"
+          element={<ChooseStandardisedBenchmarksPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe('ChooseStandardisedBenchmarksPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseProviders.mockReturnValue({
+      providers: [
+        makeProvider({
+          benchmarks: [
+            {
+              id: 'arc_easy',
+              name: 'Basic science Q&A',
+              category: 'Reasoning',
+              metrics: ['accuracy'],
+            },
+            {
+              id: 'inspect/arc',
+              name: 'ARC',
+              category: 'Reasoning',
+              metrics: ['accuracy'],
+            },
+            {
+              id: 'truthfulqa_mc1',
+              name: 'TruthfulQA',
+              category: 'Knowledge',
+              metrics: ['accuracy'],
+            },
+          ],
+        }),
+      ],
+      loaded: true,
+      loadError: undefined,
+    });
+  });
+
+  it('should render the filter input with correct placeholder', () => {
+    renderPage();
+    expect(screen.getByPlaceholderText('Filter by name or ID')).toBeInTheDocument();
+  });
+
+  it('should show all benchmarks when no filter is applied', () => {
+    renderPage();
+    expect(screen.getByTestId('benchmark-card-lm_evaluation_harness-arc_easy')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('benchmark-card-lm_evaluation_harness-inspect/arc'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('benchmark-card-lm_evaluation_harness-truthfulqa_mc1'),
+    ).toBeInTheDocument();
+  });
+
+  it('should filter benchmarks by name', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Filter by name or ID'), {
+      target: { value: 'TruthfulQA' },
+    });
+    expect(
+      screen.getByTestId('benchmark-card-lm_evaluation_harness-truthfulqa_mc1'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-arc_easy'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-inspect/arc'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should filter benchmarks by ID', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Filter by name or ID'), {
+      target: { value: 'arc_easy' },
+    });
+    expect(screen.getByTestId('benchmark-card-lm_evaluation_harness-arc_easy')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-inspect/arc'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-truthfulqa_mc1'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should match benchmarks by partial ID', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Filter by name or ID'), {
+      target: { value: 'inspect/' },
+    });
+    expect(
+      screen.getByTestId('benchmark-card-lm_evaluation_harness-inspect/arc'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-arc_easy'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-truthfulqa_mc1'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should match benchmarks by name or ID when input matches both', () => {
+    renderPage();
+    // 'arc' matches the name "ARC" and the IDs "arc_easy" and "inspect/arc"
+    fireEvent.change(screen.getByPlaceholderText('Filter by name or ID'), {
+      target: { value: 'arc' },
+    });
+    expect(screen.getByTestId('benchmark-card-lm_evaluation_harness-arc_easy')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('benchmark-card-lm_evaluation_harness-inspect/arc'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('benchmark-card-lm_evaluation_harness-truthfulqa_mc1'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show chip label as "Name or ID" when filter is active', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Filter by name or ID'), {
+      target: { value: 'arc' },
+    });
+    expect(screen.getByText('Name or ID')).toBeInTheDocument();
+  });
+
+  it('should show no results message when filter matches nothing', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Filter by name or ID'), {
+      target: { value: 'zzznomatch' },
+    });
+    expect(screen.queryByText('Basic science Q&A')).not.toBeInTheDocument();
+    expect(screen.queryByText('ARC')).not.toBeInTheDocument();
+    expect(screen.queryByText('TruthfulQA')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'No benchmarks match the filter criteria. Try adjusting or clearing your filters.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/eval-hub/frontend/src/app/pages/__tests__/ChooseStandardisedBenchmarksPage.spec.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/__tests__/ChooseStandardisedBenchmarksPage.spec.tsx
@@ -201,7 +201,7 @@ describe('ChooseStandardisedBenchmarksPage', () => {
       screen.queryByTestId('benchmark-card-lm_evaluation_harness-truthfulqa_mc1'),
     ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close arc_easy' }));
+    fireEvent.click(screen.getByRole('button', { name: /arc_easy/i }));
 
     expect(screen.getByTestId('benchmark-card-lm_evaluation_harness-arc_easy')).toBeInTheDocument();
     expect(


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-85771

## Description

Three small UX improvements to the benchmark gallery page in EvalHub:

1. **Search by ID** — the name filter now searches both benchmark name and ID, with updated placeholder/label text ("Filter by name or ID"). Useful for benchmarks with technical IDs like `inspect/arc` that don't match their display name.
2. **Subtitle wraps instead of truncates** — removed `overflow: hidden / text-overflow: ellipsis / white-space: nowrap` from `.evalhub-benchmark-card__subtitle` so long IDs wrap rather than getting cut off silently. Also switched the text color token from `--pf-t--global--text--color--regular` to `--pf-t--global--text--color--subtle` for better visual hierarchy.

Benchmark ID and framework on new line
<img width="2550" height="1279" alt="Screenshot 2026-08-27 at 3 32 36 PM" src="https://github.com/user-attachments/assets/ca6f4ea9-7fe1-43fb-8f84-2f9c5b2a4994" />

Search Via Benchmark ID

https://github.com/user-attachments/assets/7586557d-6e8f-45e3-9a42-4eec16abe50e


## How Has This Been Tested?

- Manually tested filter behaviour against benchmark cards with matching/non-matching names and IDs.
- Unit tests cover all filter scenarios including case-insensitive ID search, partial match, chip removal, and empty-results state.

## Test Impact

Added comprehensive unit tests for `ChooseStandardisedBenchmarksPage` (`ChooseStandardisedBenchmarksPage.spec.tsx`) covering:
- Filter by name
- Filter by ID (exact and partial match)
- Case-insensitive filtering
- Filter chip removal restores all results
- No-match empty state
- Loading state

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark search now matches both benchmark names and IDs.
  * Updated filter labels and placeholders to clarify name-or-ID searching.
  * Long benchmark subtitles are displayed in full without truncation.

* **Bug Fixes**
  * Removed the redundant hover tooltip from benchmark subtitles.

* **Tests**
  * Added coverage for filtering, loading states, empty results, case-insensitive matching, and filter removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->