### PR TITLE
Add URL Validation to Import Pipeline and Import Pipeline Modals

### DIFF
--- a/frontend/src/__mocks__/mockGoogleRpcStatusKF.ts
+++ b/frontend/src/__mocks__/mockGoogleRpcStatusKF.ts
@@ -17,3 +17,11 @@ export const mockCancelledGoogleRpcStatus = ({
   message,
   details: [],
 });
+
+export const mockNotFoundGoogleRpcStatus = ({
+  message = '',
+}: MockGoogleRpcStatusKF): GoogleRpcStatusKF => ({
+  code: 5,
+  message,
+  details: [],
+});

--- a/frontend/src/api/pipelines/__tests__/errorUtils.spec.ts
+++ b/frontend/src/api/pipelines/__tests__/errorUtils.spec.ts
@@ -25,6 +25,30 @@ describe('handlePipelineFailures', () => {
     await expect(handlePipelineFailures(Promise.resolve(statusMock))).rejects.toThrow('not-found');
   });
 
+  it('should throw a GrpcError with grpcCode and result for gRPC error responses', async () => {
+    const grpcErrorResponse = { code: 5, message: 'Run not found' };
+
+    const error: unknown = await handlePipelineFailures(Promise.resolve(grpcErrorResponse)).catch(
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toHaveProperty('grpcCode', 5);
+    expect(error).toHaveProperty('result', grpcErrorResponse);
+  });
+
+  it('should preserve the original result on GrpcError for non-NOT_FOUND(5) gRPC codes', async () => {
+    const grpcErrorResponse = { code: 1, message: 'Cancelled by caller', details: [] };
+
+    const error: unknown = await handlePipelineFailures(Promise.resolve(grpcErrorResponse)).catch(
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toHaveProperty('grpcCode', 1);
+    expect(error).toHaveProperty('result', grpcErrorResponse);
+  });
+
   it('should handle common state errors ', async () => {
     await expect(
       handlePipelineFailures(Promise.reject(new NotReadyError('error'))),

--- a/frontend/src/api/pipelines/errorUtils.ts
+++ b/frontend/src/api/pipelines/errorUtils.ts
@@ -33,7 +33,6 @@ const isGrpcErrorKF = (e: unknown): e is GrpcErrorKF => {
     obj.code !== 0 &&
     typeof obj.message === 'string' &&
     !('error' in e) &&
-    !('details' in e) &&
     !('run_id' in e) &&
     !('recurring_run_id' in e)
   );

--- a/frontend/src/api/pipelines/errorUtils.ts
+++ b/frontend/src/api/pipelines/errorUtils.ts
@@ -13,13 +13,31 @@ type ResultErrorKF = {
   /** Displayable message */
   error_message: string;
 };
-
+export enum GrpcStatusCode {
+  OK = 0,
+  CANCELLED = 1,
+  UNKNOWN = 2,
+  INVALID_ARGUMENT = 3,
+  DEADLINE_EXCEEDED = 4,
+  NOT_FOUND = 5,
+  ALREADY_EXISTS = 6,
+  PERMISSION_DENIED = 7,
+  RESOURCE_EXHAUSTED = 8,
+  FAILED_PRECONDITION = 9,
+  ABORTED = 10,
+  OUT_OF_RANGE = 11,
+  UNIMPLEMENTED = 12,
+  INTERNAL = 13,
+  UNAVAILABLE = 14,
+  DATA_LOSS = 15,
+  UNAUTHENTICATED = 16,
+}
 class GrpcError extends Error {
-  grpcCode: number;
+  grpcCode: GrpcStatusCode;
 
   result?: unknown;
 
-  constructor(message: string, grpcCode: number, result?: unknown) {
+  constructor(message: string, grpcCode: GrpcStatusCode, result?: unknown) {
     super(message);
     this.name = 'PipelineApiError';
     this.grpcCode = grpcCode;

--- a/frontend/src/api/pipelines/errorUtils.ts
+++ b/frontend/src/api/pipelines/errorUtils.ts
@@ -14,6 +14,19 @@ type ResultErrorKF = {
   error_message: string;
 };
 
+class GrpcError extends Error {
+  grpcCode: number;
+
+  result?: unknown;
+
+  constructor(message: string, grpcCode: number, result?: unknown) {
+    super(message);
+    this.name = 'PipelineApiError';
+    this.grpcCode = grpcCode;
+    this.result = result;
+  }
+}
+
 const isErrorKF = (e: unknown): e is ErrorKF =>
   typeof e === 'object' && e !== null && ['error', 'code', 'message'].every((key) => key in e);
 
@@ -46,11 +59,8 @@ const isErrorDetailsKF = (result: unknown): result is ResultErrorKF =>
 export const handlePipelineFailures = <T>(promise: Promise<T>): Promise<T> =>
   promise
     .then((result) => {
-      if (isErrorKF(result)) {
+      if (isErrorKF(result) || isGrpcErrorKF(result)) {
         throw result;
-      }
-      if (isGrpcErrorKF(result)) {
-        throw { ...result, error: result.message };
       }
       if (isErrorDetailsKF(result)) {
         const errorKF: ErrorKF = {
@@ -67,6 +77,9 @@ export const handlePipelineFailures = <T>(promise: Promise<T>): Promise<T> =>
     .catch((e) => {
       if (isErrorKF(e)) {
         throw new Error(e.error);
+      }
+      if (isGrpcErrorKF(e)) {
+        throw new GrpcError(e.message, e.code, e);
       }
       if (isCommonStateError(e)) {
         // Common state errors are handled by useFetchState at storage level, let them deal with it

--- a/frontend/src/api/pipelines/errorUtils.ts
+++ b/frontend/src/api/pipelines/errorUtils.ts
@@ -50,7 +50,7 @@ export const handlePipelineFailures = <T>(promise: Promise<T>): Promise<T> =>
         throw result;
       }
       if (isGrpcErrorKF(result)) {
-        throw new Error(result.message);
+        throw { ...result, error: result.message };
       }
       if (isErrorDetailsKF(result)) {
         const errorKF: ErrorKF = {

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsContext.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsContext.tsx
@@ -44,15 +44,20 @@ export const CompareRunsContextProvider = conditionalArea<CompareRunsContextProv
 
   // get runs from run ids
   const { api } = usePipelinesAPI();
-  const fetchSuccessfulRuns = React.useCallback<FetchStateCallbackPromise<PipelineRunKF[]>>(
+  const fetchValidRuns = React.useCallback<FetchStateCallbackPromise<PipelineRunKF[]>>(
     (opts) =>
-      allSettledPromises(runIdsArray.map((id) => api.getPipelineRun(opts, id))).then(
-        ([successful]) => successful.map(({ value }) => value),
-      ),
+      allSettledPromises<PipelineRunKF, { grpcCode: number; result: PipelineRunKF }>(
+        runIdsArray.map((id) => api.getPipelineRun(opts, id)),
+      ).then(([successful, rejected]) => {
+        const nonNotFound = rejected
+          .filter(({ reason }) => reason.grpcCode !== 5)
+          .map(({ reason }) => reason.result);
+        return [...successful.map(({ value }) => value), ...nonNotFound];
+      }),
     [api, runIdsArray],
   );
 
-  const [runs, loaded] = useFetchState(fetchSuccessfulRuns, []);
+  const [runs, loaded] = useFetchState(fetchValidRuns, []);
 
   // cleanup runs search param url
   const notification = useNotification();

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsContext.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsContext.tsx
@@ -10,6 +10,7 @@ import { CompareRunsSearchParam } from '#~/concepts/pipelines/content/types';
 import useNotification from '#~/utilities/useNotification';
 import { allSettledPromises } from '#~/utilities/allSettledPromises';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
+import { GrpcStatusCode } from '#~/api/pipelines/errorUtils';
 
 type CompareRunsContextType = {
   runs: PipelineRunKF[];
@@ -46,12 +47,15 @@ export const CompareRunsContextProvider = conditionalArea<CompareRunsContextProv
   const { api } = usePipelinesAPI();
   const fetchValidRuns = React.useCallback<FetchStateCallbackPromise<PipelineRunKF[]>>(
     (opts) =>
-      allSettledPromises<PipelineRunKF, { grpcCode: number; result: PipelineRunKF }>(
+      allSettledPromises<PipelineRunKF, { grpcCode?: number; result?: PipelineRunKF }>(
         runIdsArray.map((id) => api.getPipelineRun(opts, id)),
       ).then(([successful, rejected]) => {
         const nonNotFound = rejected
-          .filter(({ reason }) => reason.grpcCode !== 5)
-          .map(({ reason }) => reason.result);
+          .filter(
+            ({ reason }) => reason.grpcCode != null && reason.grpcCode !== GrpcStatusCode.NOT_FOUND,
+          )
+          .map(({ reason }) => reason.result)
+          .filter((result): result is PipelineRunKF => result != null);
         return [...successful.map(({ value }) => value), ...nonNotFound];
       }),
     [api, runIdsArray],

--- a/frontend/src/concepts/pipelines/content/import/PipelineImportBase.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineImportBase.tsx
@@ -295,7 +295,7 @@ const PipelineImportBase: React.FC<PipelineImportBaseProps> = ({
         },
         {
           label: 'Cancel',
-          onClick: onBeforeClose,
+          onClick: () => onBeforeClose(),
           dataTestId: 'modal-cancel-button',
           variant: 'link',
         },

--- a/frontend/src/concepts/pipelines/content/import/PipelineImportBase.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineImportBase.tsx
@@ -1,23 +1,12 @@
 import * as React from 'react';
-import {
-  Form,
-  FormGroup,
-  Stack,
-  StackItem,
-  Modal,
-  ModalBody,
-  ModalHeader,
-  ModalFooter,
-  Spinner,
-  Alert,
-} from '@patternfly/react-core';
+import { Form, FormGroup, Stack, StackItem, Spinner, Alert } from '@patternfly/react-core';
+import { ContentModal } from '@odh-dashboard/ui-core';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import type { K8sNameDescriptionFieldUpdateFunction } from '@odh-dashboard/k8s-core';
 import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
 } from '@odh-dashboard/ui-core/components/K8sNameDescriptionField';
 import type { UpdateObjectAtPropAndValue } from '@odh-dashboard/ui-core';
-import DashboardModalFooter from '@odh-dashboard/ui-core/components/DashboardModalFooter';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import { PipelineKF, PipelineVersionKF } from '#~/concepts/pipelines/kfTypes';
 import { DuplicateNameHelperText } from '#~/concepts/pipelines/content/DuplicateNameHelperText';
@@ -33,6 +22,7 @@ import NameDescriptionField from '#~/concepts/k8s/NameDescriptionField';
 import PipelineMigrationNoteLinks from '#~/concepts/pipelines/content/PipelineMigrationNoteLinks';
 import { DSPipelineAPIServerStore } from '#~/k8sTypes.ts';
 import usePipelineNamespaceCR from '#~/concepts/pipelines/context/usePipelineNamespaceCR';
+import { isValidUrl } from '#~/utilities/utils.ts';
 import { PipelineUploadOption, extractKindFromPipelineYAML, isYAMLPipelineV1 } from './utils';
 import PipelineUploadRadio from './PipelineUploadRadio';
 import { PipelineImportData } from './useImportModalData';
@@ -69,6 +59,7 @@ const PipelineImportBase: React.FC<PipelineImportBaseProps> = ({
   const [error, setError] = React.useState<Error | undefined>();
   const { displayName, name, description, fileContents, pipelineUrl, uploadOption } = data;
   const [hasDuplicateName, setHasDuplicateName] = React.useState(false);
+  const [isUrlValid, setIsUrlValid] = React.useState(true);
   const isArgoWorkflow = extractKindFromPipelineYAML(fileContents) === 'Workflow';
   const isV1PipelineFile = isYAMLPipelineV1(fileContents);
   const [pipelineNamespaceCR, crLoaded, crLoadError] = usePipelineNamespaceCR(namespace);
@@ -111,7 +102,9 @@ const PipelineImportBase: React.FC<PipelineImportBaseProps> = ({
     importing ||
     hasDuplicateName ||
     !name ||
-    (uploadOption === PipelineUploadOption.URL_IMPORT ? !pipelineUrl : !fileContents);
+    (uploadOption === PipelineUploadOption.URL_IMPORT
+      ? !pipelineUrl || !isUrlValid
+      : !fileContents);
 
   const onBeforeClose = React.useCallback(
     (result?: PipelineKF | PipelineVersionKF) => {
@@ -120,6 +113,7 @@ const PipelineImportBase: React.FC<PipelineImportBaseProps> = ({
       setError(undefined);
       resetData();
       setHasDuplicateName(false);
+      setIsUrlValid(true);
     },
     [onClose, resetData, data.pipeline],
   );
@@ -146,6 +140,11 @@ const PipelineImportBase: React.FC<PipelineImportBaseProps> = ({
   );
 
   const onSubmit = () => {
+    if (uploadOption === PipelineUploadOption.URL_IMPORT && !isValidUrl(pipelineUrl)) {
+      setIsUrlValid(false);
+      return;
+    }
+
     setImporting(true);
     setError(undefined);
 
@@ -170,49 +169,42 @@ const PipelineImportBase: React.FC<PipelineImportBaseProps> = ({
 
   if (!crLoaded) {
     return (
-      <Modal
-        isOpen
+      <ContentModal
         onClose={() => onBeforeClose()}
         variant="medium"
-        data-testid={PIPELINE_IMPORT_BASE_TEST_ID}
-      >
-        <ModalHeader title={title} />
-        <ModalBody>
-          <Spinner size="lg" />
-        </ModalBody>
-      </Modal>
+        dataTestId={PIPELINE_IMPORT_BASE_TEST_ID}
+        title={title}
+        contents={<Spinner size="lg" />}
+      />
     );
   }
 
   if (crLoadError) {
     return (
-      <Modal
-        isOpen
+      <ContentModal
         onClose={() => onBeforeClose()}
         variant="medium"
-        data-testid={PIPELINE_IMPORT_BASE_TEST_ID}
-      >
-        <ModalHeader title={title} />
-        <ModalBody>
+        dataTestId={PIPELINE_IMPORT_BASE_TEST_ID}
+        title={title}
+        contents={
           <Stack hasGutter>
             <Alert data-testid="error-message-alert" isInline variant="danger" title="Error">
               {crLoadError instanceof Error ? crLoadError.message : crLoadError}
             </Alert>
           </Stack>
-        </ModalBody>
-      </Modal>
+        }
+      />
     );
   }
 
   return (
-    <Modal
-      isOpen
+    <ContentModal
       onClose={() => onBeforeClose()}
       variant="medium"
-      data-testid={PIPELINE_IMPORT_BASE_TEST_ID}
-    >
-      <ModalHeader title={title} />
-      <ModalBody>
+      dataTestId={PIPELINE_IMPORT_BASE_TEST_ID}
+      title={title}
+      error={error}
+      contents={
         <Form>
           <Stack hasGutter>
             <StackItem>
@@ -273,33 +265,42 @@ const PipelineImportBase: React.FC<PipelineImportBaseProps> = ({
                   setError(undefined);
                 }}
                 pipelineUrl={pipelineUrl}
-                setPipelineUrl={(url) => setData('pipelineUrl', url)}
+                setPipelineUrl={(url) => {
+                  setData('pipelineUrl', url);
+                }}
                 uploadOption={uploadOption}
                 setUploadOption={(option) => setData('uploadOption', option)}
+                isUrlValid={isUrlValid}
+                setIsUrlValid={setIsUrlValid}
               />
             </StackItem>
           </Stack>
         </Form>
-      </ModalBody>
-      <ModalFooter>
-        <DashboardModalFooter
-          onCancel={() => onBeforeClose()}
-          onSubmit={onSubmit}
-          submitLabel={submitButtonText}
-          isSubmitLoading={importing}
-          isSubmitDisabled={isImportButtonDisabled}
-          error={error}
-          alertTitle={
-            isArgoWorkflow
-              ? PIPELINE_ARGO_ERROR
-              : isV1PipelineFile
-              ? 'Pipeline update and recompile required'
-              : 'Error creating pipeline'
-          }
-          alertLinks={isV1PipelineFile ? <PipelineMigrationNoteLinks /> : undefined}
-        />
-      </ModalFooter>
-    </Modal>
+      }
+      alertTitle={
+        isArgoWorkflow
+          ? PIPELINE_ARGO_ERROR
+          : isV1PipelineFile
+          ? 'Pipeline update and recompile required'
+          : 'Error creating pipeline'
+      }
+      alertLinks={isV1PipelineFile ? <PipelineMigrationNoteLinks /> : undefined}
+      buttonActions={[
+        {
+          label: submitButtonText,
+          onClick: onSubmit,
+          dataTestId: 'modal-submit-button',
+          isDisabled: isImportButtonDisabled,
+          isLoading: importing,
+        },
+        {
+          label: 'Cancel',
+          onClick: onBeforeClose,
+          dataTestId: 'modal-cancel-button',
+          variant: 'link',
+        },
+      ]}
+    />
   );
 };
 

--- a/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
@@ -12,7 +12,7 @@ import {
   StackItem,
   TextInput,
 } from '@patternfly/react-core';
-import { isValidUrl as checkValidUrl } from '#~/utilities/utils.ts';
+import { isValidHttpUrl } from '#~/utilities/utils.ts';
 import { PipelineUploadOption } from './utils';
 import PipelineFileUpload from './PipelineFileUpload';
 
@@ -91,10 +91,10 @@ const PipelineUploadRadio: React.FC<PipelineFileUploadProps> = ({
               onChange={(_e, value) => {
                 setPipelineUrl(value);
                 if (!isUrlValid) {
-                  setIsUrlValid(checkValidUrl(value));
+                  setIsUrlValid(isValidHttpUrl(value));
                 }
               }}
-              onBlur={(e) => setIsUrlValid(checkValidUrl(e.currentTarget.value))}
+              onBlur={(e) => setIsUrlValid(isValidHttpUrl(e.currentTarget.value))}
               validated={pipelineUrl.length === 0 || isUrlValid ? 'default' : 'error'}
             />
             {!isUrlValid && pipelineUrl.length > 0 && (

--- a/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
@@ -12,6 +12,7 @@ import {
   StackItem,
   TextInput,
 } from '@patternfly/react-core';
+import { isValidUrl as checkValidUrl } from '#~/utilities/utils.ts';
 import { PipelineUploadOption } from './utils';
 import PipelineFileUpload from './PipelineFileUpload';
 
@@ -22,6 +23,8 @@ type PipelineFileUploadProps = {
   setPipelineUrl: (url: string) => void;
   uploadOption: PipelineUploadOption;
   setUploadOption: (option: PipelineUploadOption) => void;
+  isUrlValid: boolean;
+  setIsUrlValid: (isValid: boolean) => void;
 };
 
 const PipelineUploadRadio: React.FC<PipelineFileUploadProps> = ({
@@ -31,67 +34,87 @@ const PipelineUploadRadio: React.FC<PipelineFileUploadProps> = ({
   setPipelineUrl,
   uploadOption,
   setUploadOption,
-}) => (
-  <Stack hasGutter>
-    <StackItem>
-      <Split hasGutter>
-        <SplitItem>
-          <Radio
-            isChecked={uploadOption === PipelineUploadOption.FILE_UPLOAD}
-            name="upload-file"
-            onChange={() => {
-              setUploadOption(PipelineUploadOption.FILE_UPLOAD);
-              setPipelineUrl('');
-            }}
-            label="Upload a file"
-            id="upload-file"
-            data-testid="upload-file-radio"
-          />
-        </SplitItem>
-        <SplitItem>
-          <Radio
-            isChecked={uploadOption === PipelineUploadOption.URL_IMPORT}
-            name="import-url"
-            onChange={() => {
-              setUploadOption(PipelineUploadOption.URL_IMPORT);
-              setFileContents('');
-            }}
-            label="Import by url"
-            id="import-url"
-            data-testid="import-url-radio"
-          />
-        </SplitItem>
-      </Split>
-    </StackItem>
-    <StackItem>
-      <Alert
-        variant="info"
-        title="For expected file format, refer to Compile Pipeline Documentation."
-        isInline
-      />
-    </StackItem>
-    <StackItem>
-      {uploadOption === PipelineUploadOption.FILE_UPLOAD ? (
-        <PipelineFileUpload fileContents={fileContents} onUpload={setFileContents} />
-      ) : (
-        <FormGroup fieldId="pipeline-url">
-          <TextInput
-            type="url"
-            id="pipeline-url"
-            name="pipeline-url"
-            data-testid="pipeline-url-input"
-            value={pipelineUrl}
-            onChange={(_e, value) => setPipelineUrl(value)}
-          />
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem>URL must be publicly accessible</HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        </FormGroup>
-      )}
-    </StackItem>
-  </Stack>
-);
+  isUrlValid,
+  setIsUrlValid,
+}) => {
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Split hasGutter>
+          <SplitItem>
+            <Radio
+              isChecked={uploadOption === PipelineUploadOption.FILE_UPLOAD}
+              name="upload-file"
+              onChange={() => {
+                setUploadOption(PipelineUploadOption.FILE_UPLOAD);
+                setPipelineUrl('');
+              }}
+              label="Upload a file"
+              id="upload-file"
+              data-testid="upload-file-radio"
+            />
+          </SplitItem>
+          <SplitItem>
+            <Radio
+              isChecked={uploadOption === PipelineUploadOption.URL_IMPORT}
+              name="import-url"
+              onChange={() => {
+                setUploadOption(PipelineUploadOption.URL_IMPORT);
+                setFileContents('');
+              }}
+              label="Import by url"
+              id="import-url"
+              data-testid="import-url-radio"
+            />
+          </SplitItem>
+        </Split>
+      </StackItem>
+      <StackItem>
+        <Alert
+          variant="info"
+          title="For expected file format, refer to Compile Pipeline Documentation."
+          isInline
+        />
+      </StackItem>
+      <StackItem>
+        {uploadOption === PipelineUploadOption.FILE_UPLOAD ? (
+          <PipelineFileUpload fileContents={fileContents} onUpload={setFileContents} />
+        ) : (
+          <FormGroup fieldId="pipeline-url">
+            <TextInput
+              type="url"
+              id="pipeline-url"
+              name="pipeline-url"
+              data-testid="pipeline-url-input"
+              value={pipelineUrl}
+              onChange={(_e, value) => {
+                setPipelineUrl(value);
+                if (!isUrlValid) {
+                  setIsUrlValid(checkValidUrl(value));
+                }
+              }}
+              onBlur={() => setIsUrlValid(checkValidUrl(pipelineUrl))}
+              validated={pipelineUrl.length === 0 || isUrlValid ? 'default' : 'error'}
+            />
+            {!isUrlValid && pipelineUrl.length > 0 && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem data-testid="pipeline-url-error" variant="error">
+                    Invalid URL
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>URL must be publicly accessible</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        )}
+      </StackItem>
+    </Stack>
+  );
+};
 
 export default PipelineUploadRadio;

--- a/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
@@ -48,6 +48,7 @@ const PipelineUploadRadio: React.FC<PipelineFileUploadProps> = ({
               onChange={() => {
                 setUploadOption(PipelineUploadOption.FILE_UPLOAD);
                 setPipelineUrl('');
+                setIsUrlValid(true);
               }}
               label="Upload a file"
               id="upload-file"

--- a/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
@@ -94,7 +94,7 @@ const PipelineUploadRadio: React.FC<PipelineFileUploadProps> = ({
                   setIsUrlValid(checkValidUrl(value));
                 }
               }}
-              onBlur={() => setIsUrlValid(checkValidUrl(pipelineUrl))}
+              onBlur={(e) => setIsUrlValid(checkValidUrl(e.currentTarget.value))}
               validated={pipelineUrl.length === 0 || isUrlValid ? 'default' : 'error'}
             />
             {!isUrlValid && pipelineUrl.length > 0 && (

--- a/frontend/src/concepts/pipelines/content/import/__tests__/PipelineUploadRadio.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/import/__tests__/PipelineUploadRadio.spec.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PipelineUploadRadio from '#~/concepts/pipelines/content/import/PipelineUploadRadio';
+import { PipelineUploadOption } from '#~/concepts/pipelines/content/import/utils';
+
+type HarnessProps = {
+  initialUploadOption?: PipelineUploadOption;
+  initialUrl?: string;
+  initialIsUrlValid?: boolean;
+  onValidChange?: (isValid: boolean) => void;
+};
+
+// Wraps the component the same way PipelineImportBase does: pipelineUrl and isUrlValid
+// are controlled state owned by the parent, not local state in the child.
+const Harness: React.FC<HarnessProps> = ({
+  initialUploadOption = PipelineUploadOption.URL_IMPORT,
+  initialUrl = '',
+  initialIsUrlValid = true,
+  onValidChange,
+}) => {
+  const [fileContents, setFileContents] = React.useState('');
+  const [pipelineUrl, setPipelineUrl] = React.useState(initialUrl);
+  const [uploadOption, setUploadOption] = React.useState(initialUploadOption);
+  const [isUrlValid, setIsUrlValidState] = React.useState(initialIsUrlValid);
+
+  const setIsUrlValid = (valid: boolean) => {
+    setIsUrlValidState(valid);
+    onValidChange?.(valid);
+  };
+
+  return (
+    <>
+      <PipelineUploadRadio
+        fileContents={fileContents}
+        setFileContents={setFileContents}
+        pipelineUrl={pipelineUrl}
+        setPipelineUrl={setPipelineUrl}
+        uploadOption={uploadOption}
+        setUploadOption={setUploadOption}
+        isUrlValid={isUrlValid}
+        setIsUrlValid={setIsUrlValid}
+      />
+      {/* Simulates the parent forcing validation at submit time, even if the field was never blurred */}
+      <button type="button" onClick={() => setIsUrlValid(false)}>
+        force-invalid
+      </button>
+    </>
+  );
+};
+
+describe('PipelineUploadRadio', () => {
+  it('should render the file upload UI by default and hide the URL input', () => {
+    render(<Harness initialUploadOption={PipelineUploadOption.FILE_UPLOAD} />);
+    expect(screen.getByTestId('pipeline-file-upload')).toBeInTheDocument();
+    expect(screen.queryByTestId('pipeline-url-input')).not.toBeInTheDocument();
+  });
+
+  it('should show the URL input with no error when empty', () => {
+    render(<Harness />);
+    const input = screen.getByTestId('pipeline-url-input');
+    expect(input).toBeInTheDocument();
+    expect(screen.queryByTestId('pipeline-url-error')).not.toBeInTheDocument();
+  });
+
+  it('should not show an error while typing an invalid URL before blur', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.type(screen.getByTestId('pipeline-url-input'), 'not-a-url');
+
+    expect(screen.queryByTestId('pipeline-url-error')).not.toBeInTheDocument();
+  });
+
+  it('should show an error on blur when the URL is invalid', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.type(screen.getByTestId('pipeline-url-input'), 'not-a-url');
+    await user.tab();
+
+    expect(screen.getByText('Invalid URL')).toBeInTheDocument();
+  });
+
+  it('should not show an error on blur when the URL is valid', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.type(screen.getByTestId('pipeline-url-input'), 'https://example.com/pipeline.yaml');
+    await user.tab();
+
+    expect(screen.queryByTestId('pipeline-url-error')).not.toBeInTheDocument();
+  });
+
+  it('should clear the error as soon as the URL becomes valid again while typing', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const input = screen.getByTestId('pipeline-url-input');
+    await user.type(input, 'not-a-url');
+    await user.tab();
+    expect(screen.getByText('Invalid URL')).toBeInTheDocument();
+
+    await user.click(input);
+    await user.clear(input);
+    await user.type(input, 'https://example.com/pipeline.yaml');
+
+    expect(screen.queryByTestId('pipeline-url-error')).not.toBeInTheDocument();
+  });
+
+  it('should not flag an empty field as invalid even when isUrlValid is false', () => {
+    render(<Harness initialIsUrlValid={false} initialUrl="" />);
+    // Error text is only rendered when there is content in the field
+    expect(screen.queryByTestId('pipeline-url-error')).not.toBeInTheDocument();
+  });
+
+  it('should reflect a validity flag forced by the parent (e.g. on submit) without requiring blur', async () => {
+    const user = userEvent.setup();
+    render(<Harness initialUrl="not-a-url" />);
+
+    expect(screen.queryByTestId('pipeline-url-error')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'force-invalid' }));
+
+    expect(screen.getByText('Invalid URL')).toBeInTheDocument();
+  });
+
+  it('should call setIsUrlValid with the freshly computed value, not a stale one', async () => {
+    const user = userEvent.setup();
+    const onValidChange = jest.fn();
+    render(
+      <Harness initialUrl="not-a-url" initialIsUrlValid={false} onValidChange={onValidChange} />,
+    );
+
+    const input = screen.getByTestId('pipeline-url-input');
+    await user.click(input);
+    await user.clear(input);
+    await user.type(input, 'https://example.com');
+
+    expect(onValidChange).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/frontend/src/utilities/__tests__/utils.spec.ts
+++ b/frontend/src/utilities/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { safeExecute } from '#~/utilities/utils';
+import { safeExecute, isValidUrl, isValidHttpUrl } from '#~/utilities/utils';
 
 describe('safeExecute', () => {
   it('should return function result when successful', () => {
@@ -36,5 +36,65 @@ describe('safeExecute', () => {
     );
 
     consoleSpy.mockRestore();
+  });
+});
+
+describe('isValidUrl', () => {
+  it('should return true for a valid http URL', () => {
+    expect(isValidUrl('http://example.com')).toBe(true);
+  });
+
+  it('should return true for a valid https URL', () => {
+    expect(isValidUrl('https://example.com/path?query=1')).toBe(true);
+  });
+
+  it('should return true for a valid non-http protocol URL', () => {
+    expect(isValidUrl('ftp://example.com/file.txt')).toBe(true);
+  });
+
+  it('should return true for an empty string', () => {
+    expect(isValidUrl('')).toBe(true);
+  });
+
+  it('should return true for undefined', () => {
+    expect(isValidUrl(undefined)).toBe(true);
+  });
+
+  it('should return false for a malformed URL', () => {
+    expect(isValidUrl('not-a-url')).toBe(false);
+  });
+
+  it('should return false for a URL missing a scheme', () => {
+    expect(isValidUrl('example.com/pipeline.yaml')).toBe(false);
+  });
+});
+
+describe('isValidHttpUrl', () => {
+  it('should return true for a valid http URL', () => {
+    expect(isValidHttpUrl('http://example.com')).toBe(true);
+  });
+
+  it('should return true for a valid https URL', () => {
+    expect(isValidHttpUrl('https://example.com/path?query=1')).toBe(true);
+  });
+
+  it('should return false for a non-http(s) protocol', () => {
+    expect(isValidHttpUrl('ftp://example.com/file.txt')).toBe(false);
+  });
+
+  it('should return true for an empty string', () => {
+    expect(isValidHttpUrl('')).toBe(true);
+  });
+
+  it('should return true for undefined', () => {
+    expect(isValidHttpUrl(undefined)).toBe(true);
+  });
+
+  it('should return false for a malformed URL', () => {
+    expect(isValidHttpUrl('not-a-url')).toBe(false);
+  });
+
+  it('should return false for a URL missing a scheme', () => {
+    expect(isValidHttpUrl('example.com/pipeline.yaml')).toBe(false);
   });
 });

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -163,6 +163,31 @@ export const isInternalRouteIntegrationsApp = (internalRoute?: string): internal
 export const isIntegrationApp = (app: OdhApplication): app is OdhIntegrationApplication =>
   isInternalRouteIntegrationsApp(app.spec.internalRoute);
 
+export const isValidUrl = (url?: string): boolean => {
+  if (!url) {
+    return true;
+  }
+
+  try {
+    return !!new URL(url);
+  } catch {
+    return false;
+  }
+};
+
+export const isValidHttpUrl = (url?: string): boolean => {
+  if (!url) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
 /**
  * DO NOT KEEP USING this beyond a release.
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -14131,10 +14131,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14131,8 +14131,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }

--- a/packages/cypress/cypress/pages/pipelines/pipelineImportModal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelineImportModal.ts
@@ -50,6 +50,10 @@ class PipelineImportModal extends Modal {
     return this.find().findByTestId('pipeline-url-input');
   }
 
+  findPipelineUrlError() {
+    return this.find().findByTestId('pipeline-url-error');
+  }
+
   fillPipelineName(value: string) {
     this.findPipelineNameInput().clear().type(value);
   }

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelinesImport.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelinesImport.cy.ts
@@ -299,6 +299,74 @@ describe('Pipeline Import and Upload', () => {
     );
   });
 
+  it('rejects an invalid pipeline URL until it is corrected', () => {
+    initIntercepts({});
+    pipelinesGlobal.visit(projectName);
+
+    // Return empty for subsequent pipeline list requests (e.g. duplicate name check)
+    pipelinesTable.mockGetPipelines([], projectName);
+
+    // Open the "Import pipeline" modal
+    pipelinesGlobal.findImportPipelineButton().click();
+    pipelineImportModal.shouldBeOpen();
+
+    pipelineImportModal.fillPipelineName('New pipeline');
+    pipelineImportModal.findImportPipelineRadio().check();
+
+    // Typing an invalid URL should not show an error or block the submit button --
+    // the user is free to type and attempt to submit.
+    pipelineImportModal.findPipelineUrlInput().type('not-a-url');
+    pipelineImportModal.findPipelineUrlError().should('not.exist');
+    pipelineImportModal.findSubmitButton().should('be.enabled');
+
+    // Submitting with an invalid URL surfaces the field error and keeps the modal open,
+    // instead of proceeding with the import.
+    pipelineImportModal.submit();
+    pipelineImportModal.findPipelineUrlError().should('exist').and('contain.text', 'Invalid URL');
+    pipelineImportModal.shouldBeOpen();
+
+    // Correcting the URL clears the error immediately.
+    pipelineImportModal.findPipelineUrlInput().clear().type('https://example.com/pipeline.yaml');
+    pipelineImportModal.findPipelineUrlError().should('not.exist');
+
+    // Submitting now proceeds with the import as normal.
+    const uploadPipelineAndVersionParams = {
+      pipeline: {
+        display_name: 'New pipeline',
+      },
+      pipeline_version: {
+        display_name: 'New pipeline',
+        package_url: {
+          pipeline_url: 'https://example.com/pipeline.yaml',
+        },
+      },
+    };
+    const createdMockPipeline = buildMockPipeline(uploadPipelineAndVersionParams.pipeline);
+    const createdVersion = buildMockPipelineVersion(
+      uploadPipelineAndVersionParams.pipeline_version,
+    );
+
+    pipelineImportModal
+      .mockCreatePipelineAndVersion(uploadPipelineAndVersionParams, projectName)
+      .as('uploadPipelineAndVersion');
+    pipelinesTable.mockGetPipelines([createdMockPipeline], projectName);
+    pipelinesTable.mockGetPipelineVersions([createdVersion], 'new-pipeline', projectName);
+    pipelineDetails.mockGetPipeline(projectName, createdMockPipeline).as('getPipeline');
+    pipelineDetails
+      .mockGetPipelineVersion(createdMockPipeline.pipeline_id, createdVersion, projectName)
+      .as('getPipelineVersion');
+
+    pipelineImportModal.submit();
+
+    cy.wait('@uploadPipelineAndVersion');
+    cy.wait('@getPipeline');
+    cy.wait('@getPipelineVersion');
+
+    verifyRelativeURL(
+      `/develop-train/pipelines/definitions/${projectName}/${createdMockPipeline.pipeline_id}/${createdVersion.pipeline_version_id}/view`,
+    );
+  });
+
   it('uploads a new pipeline version', () => {
     initIntercepts({});
     pipelinesGlobal.visit(projectName);

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/compareRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/compareRuns.cy.ts
@@ -15,7 +15,10 @@ import {
   buildMockPipelineVersions,
 } from '@odh-dashboard/internal/__mocks__';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
-import { mockCancelledGoogleRpcStatus } from '@odh-dashboard/internal/__mocks__/mockGoogleRpcStatusKF';
+import {
+  mockCancelledGoogleRpcStatus,
+  mockNotFoundGoogleRpcStatus,
+} from '@odh-dashboard/internal/__mocks__/mockGoogleRpcStatusKF';
 import { mockArtifactStorage } from '@odh-dashboard/internal/__mocks__/mockArtifactStorage';
 import { verifyRelativeURL } from '../../../../utils/url';
 import {
@@ -119,7 +122,10 @@ describe('Compare runs', () => {
       {
         path: { namespace: projectName, serviceName: 'dspa', runId: 'invalid_run_id' },
       },
-      { statusCode: 404 },
+      {
+        statusCode: 404,
+        body: mockNotFoundGoogleRpcStatus({ message: 'Run not found' }),
+      },
     ).as('invalidRun');
 
     compareRunsGlobal.visit(projectName, ['invalid_run_id']);
@@ -133,7 +139,10 @@ describe('Compare runs', () => {
       {
         path: { namespace: projectName, serviceName: 'dspa', runId: 'invalid_run_id' },
       },
-      { statusCode: 404 },
+      {
+        statusCode: 404,
+        body: mockNotFoundGoogleRpcStatus({ message: 'Run not found' }),
+      },
     ).as('invalidRun');
     compareRunsGlobal.visit(projectName, ['invalid_run_id', mockRun.run_id]);
     cy.wait('@invalidRun');


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-52413

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Change adds URL validator utils and uses them in the pipeline import modals. Now when a URL is invalid, it will prevent the form from being submitted and show an error until the url is fixed. There is also a small refactor for the modal to use the new `ContentModal` wrapper.

https://github.com/user-attachments/assets/ff5ee01f-9c5b-4dc6-80ef-866470491106


If the url is valid but the endpoint gives an improper spec or is not reachable, an error message will be shown:
<img width="799" height="219" alt="Screenshot 2026-09-02 at 4 45 23 PM" src="https://github.com/user-attachments/assets/59a79558-bd49-4c9e-9537-28fa795b5c7d" />





## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to Pipelines definitions and ensure you have a pipeline server configured
2. Import a pipeline and click on import by url
3. Enter an invalid url and submit, it should give an error
4. Enter a valid url, it should allow you to submit or make the button valid again.
5. If the button was made invalid due to the error, the button should only become valid once the url is valid and the error clears

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Unit tests added for the radio that selects between import by URL and file upload. Cypress test added to test the flow of a user inputting an invalid URL.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added HTTP/HTTPS URL validation to pipeline imports.
- Invalid URLs now show an error after submission, while corrected URLs clear the error.
- Updated the pipeline import dialog with improved content, alerts, and actions.

## Bug Fixes
- Validation state resets when the dialog closes or file upload is selected.
- Improved handling of pipeline errors and run comparison results.
- Valid pipeline URLs can be submitted successfully after correction.
- Pipeline run comparisons now retain valid runs when non-“not found” errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->