### PR TITLE
RHOAIENG-68560: Use dynamic timeout for Cypress E2E test jobs based on tag count

### DIFF
--- a/.github/scripts/test-e2e-timeout.sh
+++ b/.github/scripts/test-e2e-timeout.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Tests for the dynamic e2e timeout formula used in cypress-e2e-test.yml.
+# Run: bash .github/scripts/test-e2e-timeout.sh
+set -euo pipefail
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+# The jq expression under test (must match cypress-e2e-test.yml "Build test matrix" step)
+compute_timeout() {
+  echo "$1" | jq -c '[.[] | {tag: ., timeout: (30 + 7 * (split(" ") | length))}]'
+}
+
+# --- Single tag: 30 + 7*1 = 37 ---
+OUT=$(compute_timeout '["@ci-dashboard-regression-tags"]')
+echo "$OUT" | jq -e '.[0].timeout == 37' >/dev/null || fail "single tag should be 37, got $(echo "$OUT" | jq '.[0].timeout')"
+echo "$OUT" | jq -e '.[0].tag == "@ci-dashboard-regression-tags"' >/dev/null || fail "tag value mismatch"
+pass "single tag (@ci-dashboard-regression-tags) -> 37 min"
+
+# --- Single label-based tag: 30 + 7*1 = 37 ---
+OUT=$(compute_timeout '["@Pipelines"]')
+echo "$OUT" | jq -e '.[0].timeout == 37' >/dev/null || fail "single label tag should be 37, got $(echo "$OUT" | jq '.[0].timeout')"
+pass "single label tag (@Pipelines) -> 37 min"
+
+# --- Two tags: 30 + 7*2 = 44 ---
+OUT=$(compute_timeout '["@TagA @TagB"]')
+echo "$OUT" | jq -e '.[0].timeout == 44' >/dev/null || fail "two tags should be 44, got $(echo "$OUT" | jq '.[0].timeout')"
+pass "two tags -> 44 min"
+
+# --- 22 tags (auto-detected consolidation): 30 + 7*22 = 184 ---
+TAGS_22=$(printf '@T%d ' $(seq 1 22) | sed 's/ $//')
+OUT=$(compute_timeout "[\"$TAGS_22\"]")
+echo "$OUT" | jq -e '.[0].timeout == 184' >/dev/null || fail "22 tags should be 184, got $(echo "$OUT" | jq '.[0].timeout')"
+pass "22 tags -> 184 min"
+
+# --- Mixed matrix: single + multi-tag entries ---
+OUT=$(compute_timeout '["@ci-dashboard-regression-tags", "@TagA @TagB @TagC"]')
+echo "$OUT" | jq -e 'length == 2' >/dev/null || fail "mixed matrix should have 2 entries"
+echo "$OUT" | jq -e '.[0].timeout == 37' >/dev/null || fail "first entry should be 37"
+echo "$OUT" | jq -e '.[1].timeout == 51' >/dev/null || fail "second entry should be 51 (30+7*3), got $(echo "$OUT" | jq '.[1].timeout')"
+pass "mixed matrix -> [37, 51]"
+
+# --- Empty array: produces empty array ---
+OUT=$(compute_timeout '[]')
+echo "$OUT" | jq -e 'length == 0' >/dev/null || fail "empty input should produce empty array"
+pass "empty array -> []"
+
+echo ""
+echo "All tests passed."

--- a/.github/scripts/test-e2e-timeout.sh
+++ b/.github/scripts/test-e2e-timeout.sh
@@ -7,8 +7,9 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "PASS: $*"; }
 
 # The jq expression under test (must match cypress-e2e-test.yml "Build test matrix" step)
+MAX_TIMEOUT=360
 compute_timeout() {
-  echo "$1" | jq -c '[.[] | {tag: ., timeout: (30 + 7 * (split(" ") | length))}]'
+  echo "$1" | jq -c --argjson cap "$MAX_TIMEOUT" '[.[] | {tag: ., timeout: [30 + 7 * (split(" ") | length), $cap] | min}]'
 }
 
 # --- Single tag: 30 + 7*1 = 37 ---
@@ -44,6 +45,24 @@ pass "mixed matrix -> [37, 51]"
 OUT=$(compute_timeout '[]')
 echo "$OUT" | jq -e 'length == 0' >/dev/null || fail "empty input should produce empty array"
 pass "empty array -> []"
+
+# --- At the cap boundary: 47 tags → 30 + 7*47 = 359 (just under cap) ---
+TAGS_47=$(printf '@T%d ' $(seq 1 47) | sed 's/ $//')
+OUT=$(compute_timeout "[\"$TAGS_47\"]")
+echo "$OUT" | jq -e '.[0].timeout == 359' >/dev/null || fail "47 tags should be 359 (under cap), got $(echo "$OUT" | jq '.[0].timeout')"
+pass "47 tags -> 359 min (just under cap)"
+
+# --- Exactly at cap: 48 tags → 30 + 7*48 = 366, capped to 360 ---
+TAGS_48=$(printf '@T%d ' $(seq 1 48) | sed 's/ $//')
+OUT=$(compute_timeout "[\"$TAGS_48\"]")
+echo "$OUT" | jq -e ".[0].timeout == $MAX_TIMEOUT" >/dev/null || fail "48 tags should be capped at $MAX_TIMEOUT, got $(echo "$OUT" | jq '.[0].timeout')"
+pass "48 tags -> $MAX_TIMEOUT min (capped)"
+
+# --- Well above cap: 100 tags → 30 + 7*100 = 730, capped to 360 ---
+TAGS_100=$(printf '@T%d ' $(seq 1 100) | sed 's/ $//')
+OUT=$(compute_timeout "[\"$TAGS_100\"]")
+echo "$OUT" | jq -e ".[0].timeout == $MAX_TIMEOUT" >/dev/null || fail "100 tags should be capped at $MAX_TIMEOUT, got $(echo "$OUT" | jq '.[0].timeout')"
+pass "100 tags -> $MAX_TIMEOUT min (capped)"
 
 echo ""
 echo "All tests passed."

--- a/.github/scripts/test-e2e-timeout.sh
+++ b/.github/scripts/test-e2e-timeout.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "PASS: $*"; }
 
-# The jq expression under test (must match cypress-e2e-test.yml "Build test matrix" step)
+# The jq expression under test — keep in sync with cypress-e2e-test.yml "Build test matrix" step
 MAX_TIMEOUT=360
 compute_timeout() {
   echo "$1" | jq -c --argjson cap "$MAX_TIMEOUT" '[.[] | {tag: ., timeout: [30 + 7 * (split(" ") | length), $cap] | min}]'

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -695,9 +695,9 @@ jobs:
             MATRIX=$(echo "$MATRIX" | jq -c --arg entry "$AUTO_DETECTED_ENTRY" '. + [$entry] | unique')
           fi
           
-          # Ensure compact JSON for GitHub Actions output
-          MATRIX=$(echo "$MATRIX" | jq -c '.')
-          
+          # Convert to objects with dynamic timeout: 30 min base + 7 min per tag
+          MATRIX=$(echo "$MATRIX" | jq -c '[.[] | {tag: ., timeout: (30 + 7 * (split(" ") | length))}]')
+
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
           echo "source=$SOURCE" >> $GITHUB_OUTPUT
           echo "🧪 Final matrix: $MATRIX (source: $SOURCE)"
@@ -774,11 +774,11 @@ jobs:
       !cancelled() && !failure() &&
       needs.select-cluster.result == 'success'
     runs-on: self-hosted
-    timeout-minutes: 90
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
-        tag: ${{ fromJson(needs.get-test-tags.outputs.matrix) }}
+        include: ${{ fromJson(needs.get-test-tags.outputs.matrix) }}
     env:
       CLUSTER_NAME: ${{ needs.select-cluster.outputs.cluster_name }}
       MATRIX_TAG: ${{ matrix.tag }}

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -696,6 +696,7 @@ jobs:
           fi
           
           # Convert to objects with dynamic timeout: 30 min base + 7 min per tag, capped at 360 min
+          # Keep in sync with .github/scripts/test-e2e-timeout.sh
           MATRIX=$(echo "$MATRIX" | jq -c '[.[] | {tag: ., timeout: [30 + 7 * (split(" ") | length), 360] | min}]')
 
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -695,8 +695,8 @@ jobs:
             MATRIX=$(echo "$MATRIX" | jq -c --arg entry "$AUTO_DETECTED_ENTRY" '. + [$entry] | unique')
           fi
           
-          # Convert to objects with dynamic timeout: 30 min base + 7 min per tag
-          MATRIX=$(echo "$MATRIX" | jq -c '[.[] | {tag: ., timeout: (30 + 7 * (split(" ") | length))}]')
+          # Convert to objects with dynamic timeout: 30 min base + 7 min per tag, capped at 360 min
+          MATRIX=$(echo "$MATRIX" | jq -c '[.[] | {tag: ., timeout: [30 + 7 * (split(" ") | length), 360] | min}]')
 
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
           echo "source=$SOURCE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
Replaces the fixed `timeout-minutes: 90` in the `e2e-tests` job with a dynamic expression that scales proportionally to the number of tags in each matrix entry: **30 minutes base + 7 minutes per tag**.

  The base covers setup overhead (checkout, build cache restore, server start, cleanup) and the per-tag increment accounts for the specs matched by each tag. Previously, the fixed timeout either wasted time on small jobs or risked cutting off large ones.

  **Timeout examples:**

  | Scenario | Tags | Timeout |
  |---|---|---|
  | `@ci-dashboard-regression-tags` (1 tag) | 1 | 37 min |
  | Single label-based tag (e.g. `@Pipelines`) | 1 | 37 min |
  | 3 auto-detected tags | 3 | 51 min |
  | 22 auto-detected tags | 22 | 184 min |

  **Changes:**

  - Matrix output transformed from a string array to an array of objects (`{tag, timeout}`) using jq in the `get-test-tags` job
  - Matrix strategy switched from `tag:` to `include:` so both `matrix.tag` and `matrix.timeout` resolve as top-level variables
  - `timeout-minutes` now uses `${{ matrix.timeout }}`
  - Added a test script (`.github/scripts/test-e2e-timeout.sh`) that verifies the jq timeout formula against all acceptance criteria scenarios

  ## How Has This Been Tested?

  - `bash .github/scripts/test-e2e-timeout.sh` — all 6 test cases pass (single tag, label tag, two tags, 22 tags, mixed matrix, empty array)
  - Verified the jq expression produces correct output manually
  - Confirmed only two `matrix.tag`/`matrix.timeout` references exist in the workflow and both resolve correctly with the `include` strategy

  ## Test Impact

  Added `.github/scripts/test-e2e-timeout.sh` — a standalone bash test script that validates the jq timeout formula. Follows the same pattern as `scripts/security-audit/test-security-audit.sh`.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end test runs now use dynamically calculated timeouts based on tag complexity, with a maximum of 360 minutes.
  * Test matrix entries retain their tags while applying individual timeout values.

* **Tests**
  * Added validation for timeout calculations, timeout limits, tag preservation, multiple tags, mixed matrices, and empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->