### PR TITLE
fix(RHOAIENG-81919): watch platform config ConfigMap for version changes

### DIFF
--- a/dashboard-operator/internal/controller/config_watch_test.go
+++ b/dashboard-operator/internal/controller/config_watch_test.go
@@ -187,3 +187,44 @@ func TestConfigMapPredicate_Update(t *testing.T) {
 		})
 	}
 }
+
+// TestConfigMapWatch_HonorsCustomDistributionConfigMapName verifies the watch
+// tracks the resolved distribution config name rather than the hardcoded default.
+// The distribution config ConfigMap name is user-settable (chart value
+// config.name, plumbed in via OPERATOR_CONFIGMAP_NAME); readDistributionConfig /
+// readPlatformVersion resolve it through resolveDistributionConfigMapName. If the
+// watch kept the literal default, a non-default install would miss updates to its
+// real ConfigMap and status.releases[platform].version would go stale — the exact
+// failure this PR fixes (RHOAIENG-81919).
+func TestConfigMapWatch_HonorsCustomDistributionConfigMapName(t *testing.T) {
+	const customName = "custom-distribution-config"
+	t.Setenv("OPERATOR_CONFIGMAP_NAME", customName)
+
+	r := &ctrlpkg.DashboardReconciler{Namespace: testNamespace}
+	p := r.ConfigMapPredicate()
+
+	custom := newConfigMap(customName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil)
+
+	t.Run("map func enqueues for the custom-named ConfigMap", func(t *testing.T) {
+		reqs := r.MapConfigMapToDashboard(context.Background(), custom)
+		require.Len(t, reqs, 1)
+		assert.Equal(t, v1alpha1.DashboardInstanceName, reqs[0].Name)
+	})
+
+	t.Run("the hardcoded default name is not watched once a custom name is set", func(t *testing.T) {
+		def := newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil)
+		assert.Empty(t, r.MapConfigMapToDashboard(context.Background(), def))
+		assert.False(t, p.Create(event.CreateEvent{Object: def}))
+	})
+
+	t.Run("predicate fires on data change for the custom ConfigMap", func(t *testing.T) {
+		assert.True(t, p.Create(event.CreateEvent{Object: custom}))
+		updated := newConfigMap(customName, testNamespace, map[string]string{"platformVersion": "2.21.0"}, nil)
+		assert.True(t, p.Update(event.UpdateEvent{ObjectOld: custom, ObjectNew: updated}))
+	})
+
+	t.Run("predicate fires on consumed annotation change for the custom ConfigMap", func(t *testing.T) {
+		annoUpdated := newConfigMap(customName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, map[string]string{annotations.PlatformVersion: "2.21.0"})
+		assert.True(t, p.Update(event.UpdateEvent{ObjectOld: custom, ObjectNew: annoUpdated}))
+	})
+}

--- a/dashboard-operator/internal/controller/config_watch_test.go
+++ b/dashboard-operator/internal/controller/config_watch_test.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/annotations"
+
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
 )
@@ -109,6 +111,16 @@ func TestConfigMapPredicate_Update(t *testing.T) {
 	r := &ctrlpkg.DashboardReconciler{Namespace: testNamespace}
 	p := r.ConfigMapPredicate()
 
+	// metadata churn: identical Data and consumed annotations, but the object
+	// metadata differs (resourceVersion bump + a rewritten label). The predicate
+	// must ignore this — it is the exact regression the predicate guards against.
+	churnOld := newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil)
+	churnOld.ResourceVersion = "100"
+	churnOld.Labels = map[string]string{"example.com/synced-at": "old"}
+	churnNew := newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil)
+	churnNew.ResourceVersion = "101"
+	churnNew.Labels = map[string]string{"example.com/synced-at": "new"}
+
 	tests := []struct {
 		name    string
 		old     *corev1.ConfigMap
@@ -123,15 +135,21 @@ func TestConfigMapPredicate_Update(t *testing.T) {
 		},
 		{
 			name:    "identical data with only metadata churn does not fire",
-			old:     newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil),
-			updated: newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil),
+			old:     churnOld,
+			updated: churnNew,
 			want:    false,
 		},
 		{
-			name:    "annotation change fires a reconcile",
+			name:    "consumed annotation change fires a reconcile",
 			old:     newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil),
-			updated: newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, map[string]string{"platform.opendatahub.io/version": "2.21.0"}),
+			updated: newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, map[string]string{annotations.PlatformVersion: "2.21.0"}),
 			want:    true,
+		},
+		{
+			name:    "unrelated annotation churn does not fire",
+			old:     newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{}"}),
+			updated: newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{\"data\":{}}"}),
+			want:    false,
 		},
 		{
 			name:    "unrelated ConfigMap does not fire even on data change",

--- a/dashboard-operator/internal/controller/config_watch_test.go
+++ b/dashboard-operator/internal/controller/config_watch_test.go
@@ -146,6 +146,21 @@ func TestConfigMapPredicate_Update(t *testing.T) {
 			want:    true,
 		},
 		{
+			// The PlatformType/PlatformVersion annotations are consumed only from
+			// odh-dashboard-config; dashboard-operator-config contributes reconcile
+			// inputs via Data alone, so an annotation change on it is a no-op.
+			name:    "consumed annotation change on operator config does not fire",
+			old:     newConfigMap(operatorConfigMapName, testNamespace, map[string]string{"reconcileInterval": "30s"}, nil),
+			updated: newConfigMap(operatorConfigMapName, testNamespace, map[string]string{"reconcileInterval": "30s"}, map[string]string{annotations.PlatformVersion: "2.21.0"}),
+			want:    false,
+		},
+		{
+			name:    "operator config data change fires a reconcile",
+			old:     newConfigMap(operatorConfigMapName, testNamespace, map[string]string{"reconcileInterval": "30s"}, nil),
+			updated: newConfigMap(operatorConfigMapName, testNamespace, map[string]string{"reconcileInterval": "60s"}, nil),
+			want:    true,
+		},
+		{
 			name:    "unrelated annotation churn does not fire",
 			old:     newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{}"}),
 			updated: newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{\"data\":{}}"}),

--- a/dashboard-operator/internal/controller/config_watch_test.go
+++ b/dashboard-operator/internal/controller/config_watch_test.go
@@ -1,0 +1,156 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+)
+
+// distributionConfigMapName and operatorConfigMapName mirror the unexported
+// constants in the controller package. Kept in sync with config.go.
+const (
+	distributionConfigMapName = "odh-dashboard-config"
+	operatorConfigMapName     = "dashboard-operator-config"
+)
+
+func newConfigMap(name, namespace string, data, annotations map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Data: data,
+	}
+}
+
+func TestMapConfigMapToDashboard(t *testing.T) {
+	r := &ctrlpkg.DashboardReconciler{Namespace: testNamespace}
+
+	tests := []struct {
+		name        string
+		obj         *corev1.ConfigMap
+		wantRequest bool
+	}{
+		{
+			name:        "distribution config in operator namespace enqueues singleton",
+			obj:         newConfigMap(distributionConfigMapName, testNamespace, nil, nil),
+			wantRequest: true,
+		},
+		{
+			name:        "operator config in operator namespace enqueues singleton",
+			obj:         newConfigMap(operatorConfigMapName, testNamespace, nil, nil),
+			wantRequest: true,
+		},
+		{
+			name:        "watched name in a different namespace is ignored",
+			obj:         newConfigMap(distributionConfigMapName, "other-ns", nil, nil),
+			wantRequest: false,
+		},
+		{
+			name:        "unrelated ConfigMap in operator namespace is ignored",
+			obj:         newConfigMap("some-other-config", testNamespace, nil, nil),
+			wantRequest: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqs := r.MapConfigMapToDashboard(context.Background(), tt.obj)
+
+			if !tt.wantRequest {
+				assert.Empty(t, reqs)
+				return
+			}
+
+			require.Len(t, reqs, 1)
+			assert.Equal(t, v1alpha1.DashboardInstanceName, reqs[0].Name)
+			assert.Empty(t, reqs[0].Namespace, "Dashboard is cluster-scoped, request should carry no namespace")
+		})
+	}
+}
+
+func TestConfigMapPredicate_CreateDeleteGeneric(t *testing.T) {
+	r := &ctrlpkg.DashboardReconciler{Namespace: testNamespace}
+	p := r.ConfigMapPredicate()
+
+	watched := newConfigMap(distributionConfigMapName, testNamespace, nil, nil)
+	wrongNS := newConfigMap(distributionConfigMapName, "other-ns", nil, nil)
+	unrelated := newConfigMap("some-other-config", testNamespace, nil, nil)
+
+	t.Run("create fires only for watched ConfigMaps in operator namespace", func(t *testing.T) {
+		assert.True(t, p.Create(event.CreateEvent{Object: watched}))
+		assert.False(t, p.Create(event.CreateEvent{Object: wrongNS}))
+		assert.False(t, p.Create(event.CreateEvent{Object: unrelated}))
+	})
+
+	t.Run("delete fires only for watched ConfigMaps in operator namespace", func(t *testing.T) {
+		assert.True(t, p.Delete(event.DeleteEvent{Object: watched}))
+		assert.False(t, p.Delete(event.DeleteEvent{Object: wrongNS}))
+		assert.False(t, p.Delete(event.DeleteEvent{Object: unrelated}))
+	})
+
+	t.Run("generic fires only for watched ConfigMaps in operator namespace", func(t *testing.T) {
+		assert.True(t, p.Generic(event.GenericEvent{Object: watched}))
+		assert.False(t, p.Generic(event.GenericEvent{Object: wrongNS}))
+		assert.False(t, p.Generic(event.GenericEvent{Object: unrelated}))
+	})
+}
+
+func TestConfigMapPredicate_Update(t *testing.T) {
+	r := &ctrlpkg.DashboardReconciler{Namespace: testNamespace}
+	p := r.ConfigMapPredicate()
+
+	tests := []struct {
+		name    string
+		old     *corev1.ConfigMap
+		updated *corev1.ConfigMap
+		want    bool
+	}{
+		{
+			name:    "data change fires a reconcile",
+			old:     newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil),
+			updated: newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.21.0"}, nil),
+			want:    true,
+		},
+		{
+			name:    "identical data with only metadata churn does not fire",
+			old:     newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil),
+			updated: newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil),
+			want:    false,
+		},
+		{
+			name:    "annotation change fires a reconcile",
+			old:     newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, nil),
+			updated: newConfigMap(distributionConfigMapName, testNamespace, map[string]string{"platformVersion": "2.20.0"}, map[string]string{"platform.opendatahub.io/version": "2.21.0"}),
+			want:    true,
+		},
+		{
+			name:    "unrelated ConfigMap does not fire even on data change",
+			old:     newConfigMap("some-other-config", testNamespace, map[string]string{"a": "1"}, nil),
+			updated: newConfigMap("some-other-config", testNamespace, map[string]string{"a": "2"}, nil),
+			want:    false,
+		},
+		{
+			name:    "watched name in a different namespace does not fire",
+			old:     newConfigMap(distributionConfigMapName, "other-ns", map[string]string{"platformVersion": "2.20.0"}, nil),
+			updated: newConfigMap(distributionConfigMapName, "other-ns", map[string]string{"platformVersion": "2.21.0"}, nil),
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.Update(event.UpdateEvent{ObjectOld: tt.old, ObjectNew: tt.updated})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -1088,7 +1088,9 @@ func (r *DashboardReconciler) mapConfigMapToDashboard(_ context.Context, obj cli
 // compared, not the whole map, so unrelated metadata churn — resourceVersion
 // bumps, managed-field rewrites, GitOps/Helm bookkeeping annotations such as
 // last-applied-configuration or meta.helm.sh/* — does not enqueue a no-op
-// reconcile.
+// reconcile. The annotation comparison is scoped to odh-dashboard-config, the
+// only ConfigMap those annotations are consumed from; dashboard-operator-config
+// contributes reconcile inputs through Data alone.
 func (r *DashboardReconciler) configMapPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc:  func(e event.CreateEvent) bool { return r.isWatchedConfigMap(e.Object) },
@@ -1105,8 +1107,14 @@ func (r *DashboardReconciler) configMapPredicate() predicate.Predicate {
 				return true
 			}
 
-			annotationChanged := oldCM.Annotations[annotations.PlatformType] != newCM.Annotations[annotations.PlatformType] ||
-				oldCM.Annotations[annotations.PlatformVersion] != newCM.Annotations[annotations.PlatformVersion]
+			// PlatformType / PlatformVersion annotations are read only from
+			// odh-dashboard-config (readDistributionConfig). Restrict the
+			// annotation comparison to that ConfigMap so annotation churn on
+			// dashboard-operator-config — which contributes only via Data — does
+			// not enqueue a no-op reconcile.
+			annotationChanged := newCM.Name == distributionConfigMapName &&
+				(oldCM.Annotations[annotations.PlatformType] != newCM.Annotations[annotations.PlatformType] ||
+					oldCM.Annotations[annotations.PlatformVersion] != newCM.Annotations[annotations.PlatformVersion])
 
 			return !maps.Equal(oldCM.Data, newCM.Data) || annotationChanged
 		},

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/annotations"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/render/kustomize"
 
@@ -1048,23 +1049,30 @@ func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 		Complete(r)
 }
 
-// watchedConfigMaps returns the set of ConfigMap names, in the operator
-// namespace, whose contents feed reconcile inputs: platform version and
-// distribution identity (odh-dashboard-config), and the reconcile interval
+// watchedConfigMaps is the set of ConfigMap names, in the operator namespace,
+// whose contents feed reconcile inputs: platform version and distribution
+// identity (odh-dashboard-config), and the reconcile interval
 // (dashboard-operator-config). Changes to these must trigger a reconcile so the
 // Dashboard status stays fresh even when nothing else touches the CR
-// (RHOAIENG-81919).
-func watchedConfigMaps() map[string]bool {
-	return map[string]bool{
-		distributionConfigMapName: true,
-		operatorConfigMapName:     true,
-	}
+// (RHOAIENG-81919). It never changes at runtime, so it is a package-level value
+// rather than rebuilt per event.
+var watchedConfigMaps = map[string]bool{
+	distributionConfigMapName: true,
+	operatorConfigMapName:     true,
+}
+
+// isWatchedConfigMap reports whether obj is one of the config ConfigMaps in the
+// operator namespace that feed reconcile inputs. Both the predicate and the map
+// func route through this single helper so their nil handling and scoping
+// cannot drift.
+func (r *DashboardReconciler) isWatchedConfigMap(obj client.Object) bool {
+	return obj != nil && obj.GetNamespace() == r.Namespace && watchedConfigMaps[obj.GetName()]
 }
 
 // mapConfigMapToDashboard enqueues a reconcile for the singleton Dashboard when
 // one of the watched config ConfigMaps in the operator namespace changes.
 func (r *DashboardReconciler) mapConfigMapToDashboard(_ context.Context, obj client.Object) []reconcile.Request {
-	if obj.GetNamespace() != r.Namespace || !watchedConfigMaps()[obj.GetName()] {
+	if !r.isWatchedConfigMap(obj) {
 		return nil
 	}
 
@@ -1074,22 +1082,20 @@ func (r *DashboardReconciler) mapConfigMapToDashboard(_ context.Context, obj cli
 }
 
 // configMapPredicate limits ConfigMap events to the watched config ConfigMaps in
-// the operator namespace. For updates it fires only when Data or Annotations
-// changed, avoiding no-op reconciles from metadata churn (e.g. resourceVersion
-// bumps or managed-field rewrites). Annotations are compared because the
-// distribution identity may arrive as orchestrator annotations, not just data
-// keys (see readDistributionConfig).
+// the operator namespace. For updates it fires only when Data or a consumed
+// annotation (PlatformType / PlatformVersion — the distribution identity read by
+// readDistributionConfig) actually changed. Only those two annotation keys are
+// compared, not the whole map, so unrelated metadata churn — resourceVersion
+// bumps, managed-field rewrites, GitOps/Helm bookkeeping annotations such as
+// last-applied-configuration or meta.helm.sh/* — does not enqueue a no-op
+// reconcile.
 func (r *DashboardReconciler) configMapPredicate() predicate.Predicate {
-	isWatched := func(obj client.Object) bool {
-		return obj != nil && obj.GetNamespace() == r.Namespace && watchedConfigMaps()[obj.GetName()]
-	}
-
 	return predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return isWatched(e.Object) },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return isWatched(e.Object) },
-		GenericFunc: func(e event.GenericEvent) bool { return isWatched(e.Object) },
+		CreateFunc:  func(e event.CreateEvent) bool { return r.isWatchedConfigMap(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return r.isWatchedConfigMap(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return r.isWatchedConfigMap(e.Object) },
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if !isWatched(e.ObjectNew) {
+			if !r.isWatchedConfigMap(e.ObjectNew) {
 				return false
 			}
 
@@ -1099,8 +1105,10 @@ func (r *DashboardReconciler) configMapPredicate() predicate.Predicate {
 				return true
 			}
 
-			return !maps.Equal(oldCM.Data, newCM.Data) ||
-				!maps.Equal(oldCM.Annotations, newCM.Annotations)
+			annotationChanged := oldCM.Annotations[annotations.PlatformType] != newCM.Annotations[annotations.PlatformType] ||
+				oldCM.Annotations[annotations.PlatformVersion] != newCM.Annotations[annotations.PlatformVersion]
+
+			return !maps.Equal(oldCM.Data, newCM.Data) || annotationChanged
 		},
 	}
 }

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -1049,24 +1049,28 @@ func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 		Complete(r)
 }
 
-// watchedConfigMaps is the set of ConfigMap names, in the operator namespace,
-// whose contents feed reconcile inputs: platform version and distribution
-// identity (odh-dashboard-config), and the reconcile interval
-// (dashboard-operator-config). Changes to these must trigger a reconcile so the
-// Dashboard status stays fresh even when nothing else touches the CR
-// (RHOAIENG-81919). It never changes at runtime, so it is a package-level value
-// rather than rebuilt per event.
-var watchedConfigMaps = map[string]bool{
-	distributionConfigMapName: true,
-	operatorConfigMapName:     true,
-}
-
 // isWatchedConfigMap reports whether obj is one of the config ConfigMaps in the
-// operator namespace that feed reconcile inputs. Both the predicate and the map
-// func route through this single helper so their nil handling and scoping
-// cannot drift.
+// operator namespace whose contents feed reconcile inputs: platform version and
+// distribution identity (the distribution config, odh-dashboard-config by
+// default) and the reconcile interval (dashboard-operator-config). Changes to
+// these must trigger a reconcile so the Dashboard status stays fresh even when
+// nothing else touches the CR (RHOAIENG-81919).
+//
+// The distribution config name is user-settable (chart value config.name, plumbed
+// in via OPERATOR_CONFIGMAP_NAME), so it is resolved through the same helper the
+// readers use rather than compared against the hardcoded default — otherwise a
+// non-default install would watch the wrong ConfigMap and status would go stale.
+//
+// Both the predicate and the map func route through this single helper so their
+// nil handling and scoping cannot drift.
 func (r *DashboardReconciler) isWatchedConfigMap(obj client.Object) bool {
-	return obj != nil && obj.GetNamespace() == r.Namespace && watchedConfigMaps[obj.GetName()]
+	if obj == nil || obj.GetNamespace() != r.Namespace {
+		return false
+	}
+
+	name := obj.GetName()
+
+	return name == resolveDistributionConfigMapName() || name == operatorConfigMapName
 }
 
 // mapConfigMapToDashboard enqueues a reconcile for the singleton Dashboard when
@@ -1088,8 +1092,9 @@ func (r *DashboardReconciler) mapConfigMapToDashboard(_ context.Context, obj cli
 // compared, not the whole map, so unrelated metadata churn — resourceVersion
 // bumps, managed-field rewrites, GitOps/Helm bookkeeping annotations such as
 // last-applied-configuration or meta.helm.sh/* — does not enqueue a no-op
-// reconcile. The annotation comparison is scoped to odh-dashboard-config, the
-// only ConfigMap those annotations are consumed from; dashboard-operator-config
+// reconcile. The annotation comparison is scoped to the distribution config, the
+// only ConfigMap those annotations are consumed from (resolved via the same helper
+// the readers use, so a chart-customized name is honored); dashboard-operator-config
 // contributes reconcile inputs through Data alone.
 func (r *DashboardReconciler) configMapPredicate() predicate.Predicate {
 	return predicate.Funcs{
@@ -1107,12 +1112,13 @@ func (r *DashboardReconciler) configMapPredicate() predicate.Predicate {
 				return true
 			}
 
-			// PlatformType / PlatformVersion annotations are read only from
-			// odh-dashboard-config (readDistributionConfig). Restrict the
-			// annotation comparison to that ConfigMap so annotation churn on
-			// dashboard-operator-config — which contributes only via Data — does
-			// not enqueue a no-op reconcile.
-			annotationChanged := newCM.Name == distributionConfigMapName &&
+			// PlatformType / PlatformVersion annotations are read only from the
+			// distribution config (readDistributionConfig). Restrict the annotation
+			// comparison to that ConfigMap — resolved via the same helper the readers
+			// use, so a chart-customized name is honored — so annotation churn on
+			// dashboard-operator-config, which contributes only via Data, does not
+			// enqueue a no-op reconcile.
+			annotationChanged := newCM.Name == resolveDistributionConfigMapName() &&
 				(oldCM.Annotations[annotations.PlatformType] != newCM.Annotations[annotations.PlatformType] ||
 					oldCM.Annotations[annotations.PlatformVersion] != newCM.Annotations[annotations.PlatformVersion])
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -18,10 +19,16 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/opendatahub-io/odh-platform-utilities/api/common"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
@@ -1020,11 +1027,80 @@ func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 	// resources trigger re-reconciliation. During Removed state the extra
 	// reconcile is harmless — teardown is idempotent and bounded by the
 	// number of owned resources.
+	//
+	// Watches() on ConfigMap tracks the platform config ConfigMaps that feed
+	// reconcile inputs but are not owned by the Dashboard CR (they are managed
+	// by the platform operator). Without this, a platform-driven change such as
+	// a platformVersion bump in odh-dashboard-config would not trigger a
+	// reconcile, leaving status.releases[platform].version stale until an
+	// unrelated event fired (RHOAIENG-81919).
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Dashboard{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.mapConfigMapToDashboard),
+			builder.WithPredicates(r.configMapPredicate()),
+		).
 		Complete(r)
+}
+
+// watchedConfigMaps returns the set of ConfigMap names, in the operator
+// namespace, whose contents feed reconcile inputs: platform version and
+// distribution identity (odh-dashboard-config), and the reconcile interval
+// (dashboard-operator-config). Changes to these must trigger a reconcile so the
+// Dashboard status stays fresh even when nothing else touches the CR
+// (RHOAIENG-81919).
+func watchedConfigMaps() map[string]bool {
+	return map[string]bool{
+		distributionConfigMapName: true,
+		operatorConfigMapName:     true,
+	}
+}
+
+// mapConfigMapToDashboard enqueues a reconcile for the singleton Dashboard when
+// one of the watched config ConfigMaps in the operator namespace changes.
+func (r *DashboardReconciler) mapConfigMapToDashboard(_ context.Context, obj client.Object) []reconcile.Request {
+	if obj.GetNamespace() != r.Namespace || !watchedConfigMaps()[obj.GetName()] {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+	}}
+}
+
+// configMapPredicate limits ConfigMap events to the watched config ConfigMaps in
+// the operator namespace. For updates it fires only when Data or Annotations
+// changed, avoiding no-op reconciles from metadata churn (e.g. resourceVersion
+// bumps or managed-field rewrites). Annotations are compared because the
+// distribution identity may arrive as orchestrator annotations, not just data
+// keys (see readDistributionConfig).
+func (r *DashboardReconciler) configMapPredicate() predicate.Predicate {
+	isWatched := func(obj client.Object) bool {
+		return obj != nil && obj.GetNamespace() == r.Namespace && watchedConfigMaps()[obj.GetName()]
+	}
+
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return isWatched(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return isWatched(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return isWatched(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if !isWatched(e.ObjectNew) {
+				return false
+			}
+
+			oldCM, oldOK := e.ObjectOld.(*corev1.ConfigMap)
+			newCM, newOK := e.ObjectNew.(*corev1.ConfigMap)
+			if !oldOK || !newOK {
+				return true
+			}
+
+			return !maps.Equal(oldCM.Data, newCM.Data) ||
+				!maps.Equal(oldCM.Annotations, newCM.Annotations)
+		},
+	}
 }

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 )
@@ -63,3 +66,11 @@ const ConditionMaasConsumerPortalAvailable = conditionMaasConsumerPortalAvailabl
 var ConsoleLinkGVK = consoleLinkGVK
 
 var ConsoleLinkListGVK = consoleLinkListGVK
+
+func (r *DashboardReconciler) MapConfigMapToDashboard(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.mapConfigMapToDashboard(ctx, obj)
+}
+
+func (r *DashboardReconciler) ConfigMapPredicate() predicate.Predicate {
+	return r.configMapPredicate()
+}


### PR DESCRIPTION
<!--- https://issues.redhat.com/browse/RHOAIENG-81919 -->

Fixes [RHOAIENG-81919](https://issues.redhat.com/browse/RHOAIENG-81919)

## Description

The `dashboard-operator` writes `status.releases[platform].version` from the `odh-dashboard-config` ConfigMap on every reconcile, but the controller did not **watch** that ConfigMap. When the platform operator updates `platformVersion` (or any other platform-managed key/annotation) in `odh-dashboard-config`, no reconcile was triggered, so `status.releases[platform].version` stayed stale until an unrelated event (e.g. touching the CR, an owned-resource change, or the periodic requeue) happened to fire.

This change wires the config ConfigMaps that feed reconcile inputs into the controller's watch set:

- Adds a `Watches(&corev1.ConfigMap{}, ...)` to `SetupWithManager` that enqueues the singleton `default-dashboard` Dashboard when a watched config ConfigMap changes.
- A map function (`mapConfigMapToDashboard`) scopes the enqueue to `odh-dashboard-config` (`platformVersion` + distribution identity) and `dashboard-operator-config` (`reconcileInterval`) **in the operator namespace** only.
- A predicate (`configMapPredicate`) filters events to those ConfigMaps and, on updates, fires only when `Data` or `Annotations` actually change — avoiding no-op reconciles from metadata churn (e.g. `resourceVersion` bumps or managed-field rewrites). Annotations are compared because the distribution identity can arrive as orchestrator annotations, not just data keys (see `readDistributionConfig`).

Notes:
- No RBAC change is required — the operator already has `get;list;watch;...` on `configmaps` (it `Owns(&corev1.ConfigMap{})`).
- The existing `Owns(&corev1.ConfigMap{})` and the new `Watches(&corev1.ConfigMap{}, ...)` coexist: owned ConfigMaps (e.g. `federation-config`) are filtered out of the new watch by the name/namespace predicate, so they are not double-enqueued.

## How Has This Been Tested?

Automated checks run locally from `dashboard-operator/`:

- `go build ./...` — passes
- `go vet ./...` — passes
- `make lint` (golangci-lint v2, standard preset) — `0 issues`
- `go test -race -count=1 ./internal/controller/...` — passes (full package, including the new tests)

Manual reproduction from the ticket (ConfigMap patch → reconcile → status refresh) is best exercised in a live cluster / DAG E2E; that end-to-end coverage is tracked separately in the linked RHOAIENG-82790.

## Test Impact

Added `dashboard-operator/internal/controller/config_watch_test.go` with table-driven unit tests (internal funcs exposed via `export_test.go`):

- `mapConfigMapToDashboard` — enqueues the singleton for each watched ConfigMap in the operator namespace; ignores watched names in other namespaces and unrelated ConfigMap names.
- `configMapPredicate` — Create/Delete/Generic fire only for watched ConfigMaps in the operator namespace; Update fires on `Data` change and on `Annotations` change, but not on metadata-only churn, and never for unrelated names or other namespaces.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-81919]: https://redhat.atlassian.net/browse/RHOAIENG-81919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The dashboard now automatically reconciles when relevant platform or operator configuration changes.

* **Bug Fixes**
  * Configuration event handling now ignores unrelated resources, namespaces, and metadata-only updates, reducing unnecessary reconciliations.
  * Changes to configuration data and supported platform metadata are detected reliably.

* **Tests**
  * Added coverage for configuration change detection, event filtering, and dashboard reconciliation triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->