### PR TITLE
test(RHOAIENG-83640): expand envtest integration tests for dashboard operator

### DIFF
--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -18,12 +18,12 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter.
-	$(GOLANGCI_LINT) run
+lint: golangci-lint ## Run golangci-lint linter (includes integration-tagged files).
+	$(GOLANGCI_LINT) run --build-tags=integration
 
 .PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
-	$(GOLANGCI_LINT) run --fix
+lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes (includes integration-tagged files).
+	$(GOLANGCI_LINT) run --build-tags=integration --fix
 
 .PHONY: test
 test: fmt vet ## Run tests.

--- a/dashboard-operator/charts/dashboard/templates/deployment.yaml
+++ b/dashboard-operator/charts/dashboard/templates/deployment.yaml
@@ -87,6 +87,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_DEPLOYMENT_NAME
               value: {{ include "dashboard.deploymentName" . }}
+            - name: OPERATOR_SERVICE_ACCOUNT_NAME
+              value: {{ include "dashboard.serviceAccountName" . }}
+            - name: OPERATOR_CONFIGMAP_NAME
+              value: {{ include "dashboard.configMapName" . }}
             {{- range $name, $value := .Values.relatedImages }}
             {{- if $value }}
             - name: {{ $name }}

--- a/dashboard-operator/internal/controller/actions_test.go
+++ b/dashboard-operator/internal/controller/actions_test.go
@@ -451,6 +451,28 @@ func TestAutoDetectObservability(t *testing.T) {
 	}
 }
 
+// TestDeployObservabilityManifests_PersesServiceRequired covers the InvalidConfig
+// path. The CRD's CEL rule makes "enabled: true + persesService: nil" unadmittable
+// by the API server, so this case is unreachable from envtest — it must be a unit
+// test that constructs the Dashboard struct directly. (RHOAIENG-83647)
+func TestDeployObservabilityManifests_PersesServiceRequired(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	dashboard := &v1alpha1.Dashboard{
+		Spec: v1alpha1.DashboardSpec{
+			Observability: &v1alpha1.ObservabilitySpec{
+				Enabled:       true,
+				PersesService: nil,
+			},
+		},
+	}
+
+	err := deployObservabilityManifests(context.Background(), cli, dashboard, "/base", cluster.OpenDataHub)
+	assert.ErrorIs(t, err, ErrPersesServiceRequired)
+}
+
 func TestAutoDetectObservability_NonNotFoundError(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))

--- a/dashboard-operator/internal/controller/config.go
+++ b/dashboard-operator/internal/controller/config.go
@@ -73,7 +73,7 @@ func readDistributionConfig(ctx context.Context, cli client.Client, namespace st
 	logger := log.FromContext(ctx)
 
 	cm := &corev1.ConfigMap{}
-	key := types.NamespacedName{Name: distributionConfigMapName, Namespace: namespace}
+	key := types.NamespacedName{Name: resolveDistributionConfigMapName(), Namespace: namespace}
 
 	if err := cli.Get(ctx, key, cm); err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -121,7 +121,7 @@ func readPlatformVersion(ctx context.Context, cli client.Client, namespace strin
 	logger := log.FromContext(ctx)
 
 	cm := &corev1.ConfigMap{}
-	key := types.NamespacedName{Name: distributionConfigMapName, Namespace: namespace}
+	key := types.NamespacedName{Name: resolveDistributionConfigMapName(), Namespace: namespace}
 
 	if err := cli.Get(ctx, key, cm); err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -40,22 +40,61 @@ const conditionMaasConsumerPortalAvailable = "MaasConsumerPortalAvailable"
 var operatorDeploymentName = getOperatorDeploymentName()
 
 func getOperatorDeploymentName() string {
-	if name := os.Getenv("OPERATOR_DEPLOYMENT_NAME"); name != "" {
-		return name
-	}
-	return "dashboard-operator"
+	return envOrDefault("OPERATOR_DEPLOYMENT_NAME", "dashboard-operator")
 }
 
-func operatorOwnedResourceNames() map[string]bool {
+// operatorServiceAccountName and resolveDistributionConfigMapName resolve the names the operator's
+// Helm chart rendered for its own ServiceAccount and config ConfigMap. Both derive from user-settable
+// chart values (serviceAccount.name, config.name), so the chart plumbs the rendered names in via
+// env — the Go side must not re-derive them by convention, or a non-default install would delete
+// the operator's own resources during managementState: Removed teardown. Defaults match the chart.
+func operatorServiceAccountName() string {
+	// Defaults to the deployment name: the chart's default serviceAccount.name renders to exactly
+	// that, and unit tests that override the deployment name expect the SA to track it.
+	return envOrDefault("OPERATOR_SERVICE_ACCOUNT_NAME", operatorDeploymentName)
+}
+
+// resolveDistributionConfigMapName returns the name of the chart-rendered config ConfigMap
+// (dashboard.configMapName / .Values.config.name, default odh-dashboard-config). This is the
+// ConfigMap the operator reads for distribution identity and which teardown must preserve. Its
+// name is user-settable, so the chart plumbs it in via OPERATOR_CONFIGMAP_NAME.
+func resolveDistributionConfigMapName() string {
+	return envOrDefault("OPERATOR_CONFIGMAP_NAME", distributionConfigMapName)
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// operatorOwnedResources returns the set of the operator's own resources that teardown must never
+// delete, keyed by "<Kind>/<name>". Teardown selects resources by the part-of=dashboard label the
+// chart's commonLabels stamp on everything it renders — including operator-owned resources — so
+// these must be skipped by name. Keying on kind+name (not name alone) keeps a genuinely
+// module-owned resource that happens to share a name (e.g. a module ConfigMap named
+// odh-dashboard-config) from silently surviving teardown.
+//
+// The webhook serving-cert Secret is intentionally absent: cert-manager issues it from the chart's
+// Certificate (which has no secretTemplate), so it never carries the part-of label and is never
+// selected by teardown's label query — no skip entry is needed.
+func operatorOwnedResources() map[string]bool {
 	base := operatorDeploymentName
 	return map[string]bool{
-		base:                      true,
-		base + "-role":            true,
-		base + "-rolebinding":     true,
-		base + "-webhook":         true, // webhook Service (dashboard.webhookServiceName)
-		base + "-webhook-tls":     true, // webhook serving-cert Secret (dashboard.webhookCertSecretName)
-		distributionConfigMapName: true, // operator config ConfigMap (odh-dashboard-config)
+		"Deployment/" + base:                              true,
+		"ServiceAccount/" + operatorServiceAccountName():  true,
+		"Service/" + base + "-webhook":                    true, // dashboard.webhookServiceName
+		"ConfigMap/" + resolveDistributionConfigMapName(): true, // dashboard.configMapName
+		"ClusterRole/" + base + "-role":                   true,
+		"ClusterRoleBinding/" + base + "-rolebinding":     true,
 	}
+}
+
+// isOperatorOwned reports whether a resource of the given kind and name is one of the operator's
+// own resources that teardown must preserve.
+func isOperatorOwned(resources map[string]bool, kind, name string) bool {
+	return resources[kind+"/"+name]
 }
 
 var persesdashboardGVK = schema.GroupVersionKind{
@@ -754,9 +793,9 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	// The operator's own Helm chart stamps platform.opendatahub.io/part-of=dashboard
 	// (commonLabels) onto every resource it renders — including the webhook Service and
 	// the operator ConfigMap, both of which land in the applications namespace. Teardown
-	// must skip these by name so it never deletes operator-owned resources (e.g. deleting
+	// must skip these by kind+name so it never deletes operator-owned resources (e.g. deleting
 	// the webhook Service breaks the failurePolicy: Fail ValidatingWebhookConfiguration).
-	operatorResources := operatorOwnedResourceNames()
+	operatorResources := operatorOwnedResources()
 
 	deleteTyped := func(list client.ObjectList, kind string, opts ...client.ListOption) error {
 		if err := r.List(ctx, list, opts...); err != nil {
@@ -765,7 +804,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 
 		items := extractItems(list)
 		for i := range items {
-			if operatorResources[items[i].GetName()] {
+			if isOperatorOwned(operatorResources, kind, items[i].GetName()) {
 				continue
 			}
 			logger.Info("Deleting managed resource", "kind", kind, "name", items[i].GetName())
@@ -783,7 +822,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	for i := range deployments.Items {
 		dep := &deployments.Items[i]
-		if dep.Name == operatorDeploymentName {
+		if isOperatorOwned(operatorResources, "Deployment", dep.Name) {
 			continue
 		}
 		logger.Info("Deleting managed resource", "kind", "Deployment", "name", dep.Name)
@@ -808,7 +847,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	for i := range serviceAccounts.Items {
 		sa := &serviceAccounts.Items[i]
-		if operatorResources[sa.Name] {
+		if isOperatorOwned(operatorResources, "ServiceAccount", sa.Name) {
 			continue
 		}
 		logger.Info("Deleting managed resource", "kind", "ServiceAccount", "name", sa.Name)
@@ -843,7 +882,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	for i := range clusterRoles.Items {
 		cr := &clusterRoles.Items[i]
-		if operatorResources[cr.Name] {
+		if isOperatorOwned(operatorResources, "ClusterRole", cr.Name) {
 			continue
 		}
 		logger.Info("Deleting managed resource", "kind", "ClusterRole", "name", cr.Name)
@@ -858,7 +897,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	for i := range clusterRoleBindings.Items {
 		crb := &clusterRoleBindings.Items[i]
-		if operatorResources[crb.Name] {
+		if isOperatorOwned(operatorResources, "ClusterRoleBinding", crb.Name) {
 			continue
 		}
 		logger.Info("Deleting managed resource", "kind", "ClusterRoleBinding", "name", crb.Name)

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -49,9 +49,12 @@ func getOperatorDeploymentName() string {
 func operatorOwnedResourceNames() map[string]bool {
 	base := operatorDeploymentName
 	return map[string]bool{
-		base:                  true,
-		base + "-role":        true,
-		base + "-rolebinding": true,
+		base:                      true,
+		base + "-role":            true,
+		base + "-rolebinding":     true,
+		base + "-webhook":         true, // webhook Service (dashboard.webhookServiceName)
+		base + "-webhook-tls":     true, // webhook serving-cert Secret (dashboard.webhookCertSecretName)
+		distributionConfigMapName: true, // operator config ConfigMap (odh-dashboard-config)
 	}
 }
 
@@ -748,6 +751,13 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	inNamespace := client.InNamespace(r.ApplicationsNamespace)
 
+	// The operator's own Helm chart stamps platform.opendatahub.io/part-of=dashboard
+	// (commonLabels) onto every resource it renders — including the webhook Service and
+	// the operator ConfigMap, both of which land in the applications namespace. Teardown
+	// must skip these by name so it never deletes operator-owned resources (e.g. deleting
+	// the webhook Service breaks the failurePolicy: Fail ValidatingWebhookConfiguration).
+	operatorResources := operatorOwnedResourceNames()
+
 	deleteTyped := func(list client.ObjectList, kind string, opts ...client.ListOption) error {
 		if err := r.List(ctx, list, opts...); err != nil {
 			return fmt.Errorf("listing %s: %w", kind, err)
@@ -755,6 +765,9 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 
 		items := extractItems(list)
 		for i := range items {
+			if operatorResources[items[i].GetName()] {
+				continue
+			}
 			logger.Info("Deleting managed resource", "kind", kind, "name", items[i].GetName())
 			if err := r.Delete(ctx, items[i]); client.IgnoreNotFound(err) != nil {
 				return fmt.Errorf("deleting %s %s: %w", kind, items[i].GetName(), err)
@@ -788,8 +801,6 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	if err := deleteTyped(&configmaps, "ConfigMap", matchLabels, inNamespace); err != nil {
 		return err
 	}
-
-	operatorResources := operatorOwnedResourceNames()
 
 	var serviceAccounts corev1.ServiceAccountList
 	if err := r.List(ctx, &serviceAccounts, matchLabels, inNamespace); err != nil {

--- a/dashboard-operator/internal/controller/deployment_integration_test.go
+++ b/dashboard-operator/internal/controller/deployment_integration_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+)
+
+// TestIntegration_DeploysResources verifies that a Managed Dashboard renders and
+// applies the core manifests plus the standalone module Deployments/Services for
+// every enabled module, and that the federation ConfigMap lists them. (RHOAIENG-83645)
+func TestIntegration_DeploysResources(t *testing.T) {
+	manifests := createIntegrationManifests(t, []string{"gen-ai", "maas"})
+	r := newManifestReconciler(manifests)
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept("genAi", "maas"),
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	// Core manifests: the dashboard-core-config ConfigMap should exist, labeled
+	// as part-of the dashboard (applied via SSA by the deployer).
+	coreCM := &corev1.ConfigMap{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+		Name:      "dashboard-core-config",
+		Namespace: integrationNamespace,
+	}, coreCM))
+	assert.Equal(t, "dashboard", coreCM.Labels[labels.PlatformPartOf],
+		"core ConfigMap should carry the part-of=dashboard label")
+
+	// Each enabled module has exactly one Deployment and one Service.
+	for _, slug := range []string{"gen-ai", "maas"} {
+		assert.Len(t, listDeployments(t, slug), 1, "expected one Deployment for %s", slug)
+		assert.Len(t, listServices(t, slug), 1, "expected one Service for %s", slug)
+	}
+
+	// Federation ConfigMap lists both modules plus the always-present coreBff entry.
+	entries := parseFederationEntries(t, getFederationConfigMap(t))
+	assert.NotNil(t, findFederationEntry(entries, "genAi"), "genAi should be in federation config")
+	assert.NotNil(t, findFederationEntry(entries, "maas"), "maas should be in federation config")
+	assert.NotNil(t, findFederationEntry(entries, "coreBff"), "coreBff should always be in federation config")
+}
+
+// TestIntegration_ModuleStatusesPopulated verifies the reconciler records a status
+// entry for every registered module — enabled ones as deployed/degraded, and
+// explicitly disabled ones as Disabled with the ExplicitOverride reason. (RHOAIENG-83645)
+func TestIntegration_ModuleStatusesPopulated(t *testing.T) {
+	manifests := createIntegrationManifests(t, []string{"gen-ai"})
+	r := newManifestReconciler(manifests)
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept("genAi"),
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	dashboard = getDashboard(t)
+	require.Len(t, dashboard.Status.ModuleStatuses, len(ctrlpkg.ModuleNames()),
+		"every registered module should have a status entry")
+
+	genAi := dashboard.Status.ModuleStatuses["genAi"]
+	assert.NotEqual(t, v1alpha1.ModulePhaseDisabled, genAi.Phase, "genAi should be enabled")
+	assert.NotEqual(t, v1alpha1.ModulePhaseNotDeployed, genAi.Phase, "genAi should be deployed or degraded")
+
+	// modelRegistry is disabled via spec override; Components is nil so the DSC
+	// gate is skipped and the reason is the explicit override, not a missing component.
+	modelRegistry := dashboard.Status.ModuleStatuses["modelRegistry"]
+	assert.Equal(t, v1alpha1.ModulePhaseDisabled, modelRegistry.Phase)
+	assert.Equal(t, "ExplicitOverride", modelRegistry.Reason)
+}

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -18,6 +18,8 @@ var ComputeFederationConfigHash = computeFederationConfigHash
 
 var MainDashboardDeploymentName = mainDashboardDeploymentName
 
+const FederationHashAnnotation = federationHashAnnotation
+
 func BuildFederationConfigMap(r *DashboardReconciler, statuses map[string]v1alpha1.ModuleStatus, dashboard *v1alpha1.Dashboard) (*corev1.ConfigMap, error) {
 	return r.buildFederationConfigMap(statuses, dashboard)
 }

--- a/dashboard-operator/internal/controller/federation_integration_test.go
+++ b/dashboard-operator/internal/controller/federation_integration_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+)
+
+// allModuleSlugs lists every module's ManifestSlug — used to build a full manifest
+// tree for the all-modules-enabled federation test.
+var allModuleSlugs = []string{
+	"model-registry", "gen-ai", "mlflow", "maas", "eval-hub",
+	"automl", "autorag", "agent-ops", "notebooks",
+}
+
+// TestIntegration_AddInterBFFParams verifies the reconciler injects service-discovery
+// env vars into a module's params.env for its inter-BFF dependencies: gen-ai depends
+// on maas, so gen-ai's params.env must gain BFF_MAAS_SERVICE_NAME/PORT while maas —
+// which has no such dependency — must not. (RHOAIENG-83649)
+func TestIntegration_AddInterBFFParams(t *testing.T) {
+	manifests := createIntegrationManifests(t, []string{"gen-ai", "maas"})
+	r := newManifestReconciler(manifests)
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept("genAi", "maas"),
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	// gen-ai depends on maas — its params.env gets the maas service coordinates.
+	genAiParams := readParamsEnv(t, filepath.Join(manifests, "modules", "gen-ai", "params.env"))
+	assert.Equal(t, "odh-dashboard-maas-ui", genAiParams["BFF_MAAS_SERVICE_NAME"])
+	assert.Equal(t, "8243", genAiParams["BFF_MAAS_SERVICE_PORT"])
+
+	// maas has no inter-BFF dependency — no BFF_MAAS_* keys should be written.
+	maasParams := readParamsEnv(t, filepath.Join(manifests, "modules", "maas", "params.env"))
+	assert.NotContains(t, maasParams, "BFF_MAAS_SERVICE_NAME")
+	assert.NotContains(t, maasParams, "BFF_MAAS_SERVICE_PORT")
+}
+
+// TestIntegration_FederationConfigMap_AllModulesEnabled verifies that with all
+// modules enabled (DSC gates satisfied), the federation ConfigMap lists every
+// module plus the synthetic coreBff and mlflowEmbedded entries, and omits perses
+// when observability is off. (RHOAIENG-83649)
+func TestIntegration_FederationConfigMap_AllModulesEnabled(t *testing.T) {
+	manifests := createIntegrationManifests(t, allModuleSlugs)
+	r := newManifestReconciler(manifests)
+
+	// Satisfy every module's RequiredDSCComponents so none are gated off.
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Components: map[string]v1alpha1.ComponentAvailability{
+			"modelregistry":  {ManagementState: "Managed"},
+			"mlflowoperator": {ManagementState: "Managed"},
+			"trustyai":       {ManagementState: "Managed"},
+			"aipipelines":    {ManagementState: "Managed"},
+		},
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	entries := parseFederationEntries(t, getFederationConfigMap(t))
+
+	// Every registered module has a federation entry.
+	for _, name := range ctrlpkg.ModuleNames() {
+		assert.NotNil(t, findFederationEntry(entries, name), "module %s should be in federation config", name)
+	}
+
+	// Synthetic entries that always/conditionally accompany the modules.
+	assert.NotNil(t, findFederationEntry(entries, "coreBff"), "coreBff entry should always be present")
+	assert.NotNil(t, findFederationEntry(entries, "mlflowEmbedded"), "mlflowEmbedded should be present when mlflow is deployed")
+
+	// Observability is off, so there must be no perses entry.
+	assert.Nil(t, findFederationEntry(entries, "perses"), "perses should be absent when observability is disabled")
+}
+
+// TestIntegration_FederationConfigMap_HashAnnotation verifies the reconciler stamps
+// the main dashboard Deployment's pod template with a federation-config hash and that
+// the hash changes when the set of enabled modules changes — the mechanism that
+// triggers a rolling restart when federation config drifts. (RHOAIENG-83649)
+func TestIntegration_FederationConfigMap_HashAnnotation(t *testing.T) {
+	manifests := createIntegrationManifests(t, []string{"model-registry"})
+	r := newManifestReconciler(manifests)
+
+	ctx := context.Background()
+
+	// The main dashboard Deployment is not part of the minimal core manifests, so
+	// pre-create it (labeled part-of=dashboard so cleanupModuleResources removes it).
+	deployName := ctrlpkg.MainDashboardDeploymentName(cluster.OpenDataHub)
+	mainDeploy := newMainDashboardDeployment(deployName)
+	require.NoError(t, k8sClient.Create(ctx, mainDeploy))
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept("modelRegistry"),
+	})
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	hash1 := federationHashOf(t, deployName)
+	require.NotEmpty(t, hash1, "federation hash annotation should be set after reconcile")
+
+	// Disable all modules — the federation config (and thus its hash) must change.
+	dashboard = getDashboard(t)
+	dashboard.Spec.Modules = disableAllModulesExcept()
+	require.NoError(t, k8sClient.Update(ctx, dashboard))
+
+	reconcile(t, r)
+
+	hash2 := federationHashOf(t, deployName)
+	require.NotEmpty(t, hash2)
+	assert.NotEqual(t, hash1, hash2, "federation hash should change when the enabled module set changes")
+}
+
+// newMainDashboardDeployment returns a minimal Deployment carrying the
+// part-of=dashboard label so the reconciler can patch its federation-config hash.
+func newMainDashboardDeployment(name string) *appsv1.Deployment {
+	replicas := int32(1)
+	labelSet := map[string]string{"app": name}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: integrationNamespace,
+			Labels:    map[string]string{labels.PlatformPartOf: "dashboard"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labelSet},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labelSet},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  name,
+						Image: "registry.example.com/dashboard:latest",
+					}},
+				},
+			},
+		},
+	}
+}
+
+// federationHashOf reads the federation-config hash annotation from a Deployment's
+// pod template.
+func federationHashOf(t *testing.T, name string) string {
+	t.Helper()
+	dep := &appsv1.Deployment{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      name,
+		Namespace: integrationNamespace,
+	}, dep))
+
+	return dep.Spec.Template.Annotations[ctrlpkg.FederationHashAnnotation]
+}

--- a/dashboard-operator/internal/controller/federation_integration_test.go
+++ b/dashboard-operator/internal/controller/federation_integration_test.go
@@ -61,6 +61,21 @@ func TestIntegration_AddInterBFFParams(t *testing.T) {
 	maasParams := readParamsEnv(t, filepath.Join(manifests, "modules", "maas", "params.env"))
 	assert.NotContains(t, maasParams, "BFF_MAAS_SERVICE_NAME")
 	assert.NotContains(t, maasParams, "BFF_MAAS_SERVICE_PORT")
+
+	// Disable maas and reconcile again. gen-ai stays deployed (it has no hard
+	// dependency on maas), so its params.env is rewritten — the now-stale maas
+	// service coordinates must be removed rather than lingering.
+	dashboard = getDashboard(t)
+	dashboard.Spec.Modules = disableAllModulesExcept("genAi")
+	require.NoError(t, k8sClient.Update(ctx, dashboard))
+
+	reconcile(t, r)
+
+	genAiParams = readParamsEnv(t, filepath.Join(manifests, "modules", "gen-ai", "params.env"))
+	assert.NotContains(t, genAiParams, "BFF_MAAS_SERVICE_NAME",
+		"stale maas coordinates should be removed once maas is disabled")
+	assert.NotContains(t, genAiParams, "BFF_MAAS_SERVICE_PORT",
+		"stale maas coordinates should be removed once maas is disabled")
 }
 
 // TestIntegration_FederationConfigMap_AllModulesEnabled verifies that with all

--- a/dashboard-operator/internal/controller/federation_integration_test.go
+++ b/dashboard-operator/internal/controller/federation_integration_test.go
@@ -31,7 +31,12 @@ var allModuleSlugs = []string{
 // TestIntegration_AddInterBFFParams verifies the reconciler injects service-discovery
 // env vars into a module's params.env for its inter-BFF dependencies: gen-ai depends
 // on maas, so gen-ai's params.env must gain BFF_MAAS_SERVICE_NAME/PORT while maas —
-// which has no such dependency — must not. (RHOAIENG-83649)
+// which has no such dependency — must not.
+//
+// This asserts on the operator's rendered params.env (the source the module's
+// ConfigMap is generated from), not on a running pod's environment — envtest schedules
+// no kubelet. It exercises the addInterBFFParams write/clear path only; whether a
+// module actually consumes those keys is up to that module's kustomization. (RHOAIENG-83649)
 func TestIntegration_AddInterBFFParams(t *testing.T) {
 	manifests := createIntegrationManifests(t, []string{"gen-ai", "maas"})
 	r := newManifestReconciler(manifests)

--- a/dashboard-operator/internal/controller/integration_test.go
+++ b/dashboard-operator/internal/controller/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,11 +17,13 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -37,6 +40,7 @@ const integrationNamespace = "integration-test"
 var (
 	testEnv   *envtest.Environment
 	k8sClient client.Client
+	restCfg   *rest.Config
 )
 
 func TestMain(m *testing.M) {
@@ -51,6 +55,10 @@ func TestMain(m *testing.M) {
 	}
 	if err := routev1.AddToScheme(s); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to add routev1 scheme: %v\n", err)
+		os.Exit(1)
+	}
+	if err := apiextensionsv1.AddToScheme(s); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to add apiextensionsv1 scheme: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -68,6 +76,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "failed to start envtest: %v\n", err)
 		os.Exit(1)
 	}
+	restCfg = cfg
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: s})
 	if err != nil {
@@ -611,6 +620,69 @@ func TestIntegration_MaasConsumerPortalConsoleLinkRemovedWhenDisabled(t *testing
 
 	assert.Nil(t, getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName),
 		"ConsoleLink should be removed when managementState is Removed and portal is disabled")
+}
+
+// newReconciler builds a DashboardReconciler wired to the shared k8sClient.
+func newManifestReconciler(manifests string) *ctrlpkg.DashboardReconciler {
+	return newReconcilerWithClient(k8sClient, manifests)
+}
+
+// newReconcilerWithClient builds a DashboardReconciler with an explicit client.
+// The observability _Deployed test uses this to inject an isolated client whose
+// RESTMapper has been warmed with the Perses CRD.
+func newReconcilerWithClient(cli client.Client, manifests string) *ctrlpkg.DashboardReconciler {
+	return &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                cli.Scheme(),
+		ManifestsBasePath:     manifests,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             integrationNamespace,
+		ApplicationsNamespace: integrationNamespace,
+	}
+}
+
+// deleteIgnoreNotFound deletes each object via the shared client, ignoring NotFound.
+func deleteIgnoreNotFound(t *testing.T, objs ...client.Object) {
+	t.Helper()
+	ctx := context.Background()
+	for _, o := range objs {
+		if err := k8sClient.Delete(ctx, o); client.IgnoreNotFound(err) != nil {
+			t.Logf("warning: failed to delete %T %s: %v", o, o.GetName(), err)
+		}
+	}
+}
+
+// newIsolatedClient builds a fresh client with its own RESTMapper. The
+// observability _Deployed test uses it so that listing PersesDashboards (which
+// caches a positive REST mapping once the CRD exists) never poisons the shared
+// client's mapper that _PersesCRDNotFound relies on staying empty.
+func newIsolatedClient(t *testing.T) client.Client {
+	t.Helper()
+	c, err := client.New(restCfg, client.Options{Scheme: k8sClient.Scheme()})
+	require.NoError(t, err)
+
+	return c
+}
+
+// readParamsEnv parses a KEY=VALUE params.env file into a map, mirroring the
+// controller's own readExistingParams (blank and comment lines skipped). Used to
+// assert the inter-BFF service-discovery env vars the reconciler writes.
+func readParamsEnv(t *testing.T, path string) map[string]string {
+	t.Helper()
+	params := map[string]string{}
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if k, v, ok := strings.Cut(line, "="); ok {
+			params[k] = v
+		}
+	}
+
+	return params
 }
 
 func TestIntegration_StandaloneEnableModule(t *testing.T) {

--- a/dashboard-operator/internal/controller/integration_test.go
+++ b/dashboard-operator/internal/controller/integration_test.go
@@ -81,7 +81,7 @@ func TestMain(m *testing.M) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: s})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create client: %v\n", err)
-		testEnv.Stop()
+		_ = testEnv.Stop()
 		os.Exit(1)
 	}
 
@@ -89,13 +89,15 @@ func TestMain(m *testing.M) {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: integrationNamespace}}
 	if err := k8sClient.Create(ctx, ns); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create test namespace: %v\n", err)
-		testEnv.Stop()
+		_ = testEnv.Stop()
 		os.Exit(1)
 	}
 
 	code := m.Run()
 
-	testEnv.Stop()
+	if err := testEnv.Stop(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop envtest: %v\n", err)
+	}
 	os.Exit(code)
 }
 
@@ -622,7 +624,7 @@ func TestIntegration_MaasConsumerPortalConsoleLinkRemovedWhenDisabled(t *testing
 		"ConsoleLink should be removed when managementState is Removed and portal is disabled")
 }
 
-// newReconciler builds a DashboardReconciler wired to the shared k8sClient.
+// newManifestReconciler builds a DashboardReconciler wired to the shared k8sClient.
 func newManifestReconciler(manifests string) *ctrlpkg.DashboardReconciler {
 	return newReconcilerWithClient(k8sClient, manifests)
 }

--- a/dashboard-operator/internal/controller/legacy_cleanup_integration_test.go
+++ b/dashboard-operator/internal/controller/legacy_cleanup_integration_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+// TestIntegration_LegacySidecarCleanup verifies that a normal reconcile removes the
+// resources left behind by the now-removed sidecar deployment mode (upgrade safety),
+// while leaving unrelated resources in the namespace untouched. (RHOAIENG-83648)
+func TestIntegration_LegacySidecarCleanup(t *testing.T) {
+	seedLegacySidecarResources(t)
+
+	// An unrelated ConfigMap that must survive the legacy sweep.
+	survivor := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated-config", Namespace: integrationNamespace},
+		Data:       map[string]string{"keep": "me"},
+	}
+	require.NoError(t, k8sClient.Create(context.Background(), survivor))
+	t.Cleanup(func() { deleteIgnoreNotFound(t, survivor) })
+
+	manifests := createIntegrationManifests(t, nil)
+	r := newManifestReconciler(manifests)
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept(), // all modules disabled
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	// cleanupLegacySidecarResources runs first in the deployment pipeline.
+	reconcile(t, r)
+	reconcile(t, r)
+
+	// All six legacy resources must be gone.
+	assertNotFound(t, &corev1.ServiceAccount{}, types.NamespacedName{Name: "odh-dashboard-modules", Namespace: integrationNamespace})
+	assertNotFound(t, &corev1.Secret{}, types.NamespacedName{Name: "odh-dashboard-modules-token", Namespace: integrationNamespace})
+	assertNotFound(t, &networkingv1.NetworkPolicy{}, types.NamespacedName{Name: "odh-dashboard-allow-ports", Namespace: integrationNamespace})
+	assertNotFound(t, &corev1.ConfigMap{}, types.NamespacedName{Name: "sidecar-params", Namespace: integrationNamespace})
+	assertNotFound(t, &rbacv1.ClusterRole{}, types.NamespacedName{Name: "odh-dashboard-modules"})
+	assertNotFound(t, &rbacv1.ClusterRoleBinding{}, types.NamespacedName{Name: "odh-dashboard-modules"})
+
+	// The unrelated ConfigMap must still exist.
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+		Name:      "unrelated-config",
+		Namespace: integrationNamespace,
+	}, &corev1.ConfigMap{}), "unrelated ConfigMap should survive the legacy cleanup")
+}
+
+// seedLegacySidecarResources creates the six resources the removed sidecar mode used
+// to provision, registering cleanup so they never leak (cluster-scoped ones in
+// particular). The reconcile under test is expected to delete them.
+func seedLegacySidecarResources(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	objs := []client.Object{
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-modules", Namespace: integrationNamespace}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-modules-token", Namespace: integrationNamespace}},
+		&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-allow-ports", Namespace: integrationNamespace},
+			Spec:       networkingv1.NetworkPolicySpec{PodSelector: metav1.LabelSelector{}},
+		},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "sidecar-params", Namespace: integrationNamespace}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-modules"}},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-modules"},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "odh-dashboard-modules",
+			},
+		},
+	}
+
+	for _, o := range objs {
+		require.NoError(t, k8sClient.Create(ctx, o))
+	}
+	t.Cleanup(func() { deleteIgnoreNotFound(t, objs...) })
+}
+
+// assertNotFound asserts that getting the object at key returns a NotFound error.
+func assertNotFound(t *testing.T, obj client.Object, key types.NamespacedName) {
+	t.Helper()
+	err := k8sClient.Get(context.Background(), key, obj)
+	assert.True(t, k8serrors.IsNotFound(err), "expected %T %q to be NotFound, got: %v", obj, key.Name, err)
+}

--- a/dashboard-operator/internal/controller/managementstate_integration_test.go
+++ b/dashboard-operator/internal/controller/managementstate_integration_test.go
@@ -1,0 +1,181 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+// TestIntegration_ManagementStateRemoved_TeardownResources verifies that switching a
+// deployed Dashboard to managementState: Removed tears down the module operands while
+// preserving the CR and the operator's own resources, and reports the removed state on
+// the status. (RHOAIENG-83646)
+func TestIntegration_ManagementStateRemoved_TeardownResources(t *testing.T) {
+	seedOperatorOwnedResources(t)
+
+	manifests := createIntegrationManifests(t, []string{"model-registry"})
+	r := newManifestReconciler(manifests)
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept("modelRegistry"),
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	// Deploy first, then confirm the module operand exists.
+	reconcile(t, r)
+	reconcile(t, r)
+	require.Len(t, listDeployments(t, "model-registry"), 1, "module Deployment should exist before removal")
+
+	// Flip to Removed and reconcile once to run the teardown path.
+	dashboard = getDashboard(t)
+	dashboard.Spec.ManagementState = "Removed"
+	require.NoError(t, k8sClient.Update(ctx, dashboard))
+
+	reconcile(t, r)
+
+	// Module operands are gone.
+	assert.Empty(t, listDeployments(t, "model-registry"), "module Deployment should be removed")
+	assert.Empty(t, listServices(t, "model-registry"), "module Service should be removed")
+
+	// Operator-owned resources are preserved (skipped by name during teardown).
+	assertExists(t, &appsv1.Deployment{}, types.NamespacedName{Name: "dashboard-operator", Namespace: integrationNamespace})
+	assertExists(t, &corev1.ServiceAccount{}, types.NamespacedName{Name: "dashboard-operator", Namespace: integrationNamespace})
+	assertExists(t, &rbacv1.ClusterRole{}, types.NamespacedName{Name: "dashboard-operator-role"})
+	assertExists(t, &rbacv1.ClusterRoleBinding{}, types.NamespacedName{Name: "dashboard-operator-rolebinding"})
+
+	// CR is preserved and its status reflects the removal.
+	dashboard = getDashboard(t)
+	assert.Equal(t, common.PhaseNotReady, dashboard.Status.Phase)
+	assert.Empty(t, dashboard.Status.URL)
+	assert.Nil(t, dashboard.Status.ModuleStatuses)
+
+	cond := conditions.FindStatusCondition(dashboard, string(common.ConditionTypeProvisioningSucceeded))
+	require.NotNil(t, cond, "ProvisioningSucceeded condition should be present")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "Removed", cond.Reason)
+}
+
+// TestIntegration_ManagementStateRemoved_IdempotentRereconcile verifies that repeated
+// reconciles of a Removed Dashboard are stable — no errors, no resource recreation, and
+// unchanged status. (RHOAIENG-83646)
+func TestIntegration_ManagementStateRemoved_IdempotentRereconcile(t *testing.T) {
+	seedOperatorOwnedResources(t)
+
+	manifests := createIntegrationManifests(t, []string{"model-registry"})
+	r := newManifestReconciler(manifests)
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept("modelRegistry"),
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	dashboard = getDashboard(t)
+	dashboard.Spec.ManagementState = "Removed"
+	require.NoError(t, k8sClient.Update(ctx, dashboard))
+
+	// First teardown reconcile plus two more — all must be stable.
+	reconcile(t, r)
+	reconcile(t, r)
+	reconcile(t, r)
+
+	assert.Empty(t, listDeployments(t, "model-registry"), "module Deployment should stay removed")
+	assert.Empty(t, listServices(t, "model-registry"), "module Service should stay removed")
+
+	dashboard = getDashboard(t)
+	assert.Equal(t, common.PhaseNotReady, dashboard.Status.Phase)
+	assert.Nil(t, dashboard.Status.ModuleStatuses)
+
+	// Operator-owned resources remain intact across repeated teardowns.
+	assertExists(t, &appsv1.Deployment{}, types.NamespacedName{Name: "dashboard-operator", Namespace: integrationNamespace})
+	assertExists(t, &rbacv1.ClusterRole{}, types.NamespacedName{Name: "dashboard-operator-role"})
+	assertExists(t, &rbacv1.ClusterRoleBinding{}, types.NamespacedName{Name: "dashboard-operator-rolebinding"})
+}
+
+// seedOperatorOwnedResources creates the operator's own Deployment, ServiceAccount,
+// ClusterRole and ClusterRoleBinding — all carrying the part-of=dashboard label so the
+// teardown lists them, then skips them by name. Cleanup is registered so cluster-scoped
+// resources never leak.
+func seedOperatorOwnedResources(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	partOf := map[string]string{labels.PlatformPartOf: "dashboard"}
+	replicas := int32(1)
+	podLabels := map[string]string{"app": "dashboard-operator"}
+
+	objs := []client.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator", Namespace: integrationNamespace, Labels: partOf},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "manager",
+							Image: "registry.example.com/dashboard-operator:latest",
+						}},
+					},
+				},
+			},
+		},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator", Namespace: integrationNamespace, Labels: partOf}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator-role", Labels: partOf}},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator-rolebinding", Labels: partOf},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "dashboard-operator-role",
+			},
+		},
+	}
+
+	for _, o := range objs {
+		require.NoError(t, k8sClient.Create(ctx, o))
+	}
+	t.Cleanup(func() { deleteIgnoreNotFound(t, objs...) })
+}
+
+// assertExists asserts that getting the object at key succeeds.
+func assertExists(t *testing.T, obj client.Object, key types.NamespacedName) {
+	t.Helper()
+	require.NoError(t, k8sClient.Get(context.Background(), key, obj),
+		"expected %T %q to exist", obj, key.Name)
+}

--- a/dashboard-operator/internal/controller/managementstate_integration_test.go
+++ b/dashboard-operator/internal/controller/managementstate_integration_test.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,10 +46,15 @@ func TestIntegration_ManagementStateRemoved_TeardownResources(t *testing.T) {
 		cleanupModuleResources(t)
 	})
 
-	// Deploy first, then confirm the module operand exists.
+	// Deploy first, then confirm the module operand and a managed core resource exist.
 	reconcile(t, r)
 	reconcile(t, r)
 	require.Len(t, listDeployments(t, "model-registry"), 1, "module Deployment should exist before removal")
+	// dashboard-core-config is a managed (non-operator-owned) ConfigMap the operator deploys; it
+	// carries the same part-of=dashboard label as operator-owned resources. Confirm it exists now
+	// so the post-teardown assertion below proves teardown actually deletes managed ConfigMaps
+	// rather than skipping every ConfigMap that shares the label.
+	assertExists(t, &corev1.ConfigMap{}, types.NamespacedName{Name: "dashboard-core-config", Namespace: integrationNamespace})
 
 	// Flip to Removed and reconcile once to run the teardown path.
 	dashboard = getDashboard(t)
@@ -61,11 +67,15 @@ func TestIntegration_ManagementStateRemoved_TeardownResources(t *testing.T) {
 	assert.Empty(t, listDeployments(t, "model-registry"), "module Deployment should be removed")
 	assert.Empty(t, listServices(t, "model-registry"), "module Service should be removed")
 
-	// Operator-owned resources are preserved (skipped by name during teardown).
+	// The managed core ConfigMap is deleted — teardown discriminates by name, not just by label.
+	assertGone(t, &corev1.ConfigMap{}, types.NamespacedName{Name: "dashboard-core-config", Namespace: integrationNamespace})
+
+	// Operator-owned resources are preserved (skipped by name during teardown). The webhook
+	// serving-cert Secret is intentionally not asserted: cert-manager issues it without the
+	// part-of label, so teardown never selects it and a survival check would be false confidence.
 	assertExists(t, &appsv1.Deployment{}, types.NamespacedName{Name: "dashboard-operator", Namespace: integrationNamespace})
 	assertExists(t, &corev1.ServiceAccount{}, types.NamespacedName{Name: "dashboard-operator", Namespace: integrationNamespace})
 	assertExists(t, &corev1.Service{}, types.NamespacedName{Name: "dashboard-operator-webhook", Namespace: integrationNamespace})
-	assertExists(t, &corev1.Secret{}, types.NamespacedName{Name: "dashboard-operator-webhook-tls", Namespace: integrationNamespace})
 	assertExists(t, &corev1.ConfigMap{}, types.NamespacedName{Name: "odh-dashboard-config", Namespace: integrationNamespace})
 	assertExists(t, &rbacv1.ClusterRole{}, types.NamespacedName{Name: "dashboard-operator-role"})
 	assertExists(t, &rbacv1.ClusterRoleBinding{}, types.NamespacedName{Name: "dashboard-operator-rolebinding"})
@@ -132,10 +142,14 @@ func TestIntegration_ManagementStateRemoved_IdempotentRereconcile(t *testing.T) 
 }
 
 // seedOperatorOwnedResources creates the operator's own resources — Deployment,
-// ServiceAccount, ClusterRole, ClusterRoleBinding, the webhook Service and its serving-cert
-// Secret, and the operator config ConfigMap — all carrying the part-of=dashboard label the
-// operator's Helm chart stamps on them (commonLabels). Teardown lists them by label, then
-// must skip them by name. Cleanup is registered so cluster-scoped resources never leak.
+// ServiceAccount, ClusterRole, ClusterRoleBinding, the webhook Service, and the operator config
+// ConfigMap — all carrying the part-of=dashboard label the operator's Helm chart stamps on them
+// (commonLabels). Teardown lists them by label, then must skip them by name. Cleanup is registered
+// so cluster-scoped resources never leak.
+//
+// The webhook serving-cert Secret is deliberately not seeded: cert-manager issues it from the
+// chart's Certificate (no secretTemplate), so it never carries the part-of label and is never
+// selected by teardown — seeding + asserting its survival would only give false confidence.
 func seedOperatorOwnedResources(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
@@ -169,8 +183,6 @@ func seedOperatorOwnedResources(t *testing.T) {
 				Ports: []corev1.ServicePort{{Port: 443}},
 			},
 		},
-		// Webhook serving-cert Secret.
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator-webhook-tls", Namespace: integrationNamespace, Labels: partOf}},
 		// Operator config ConfigMap the operator itself reads.
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-config", Namespace: integrationNamespace, Labels: partOf}},
 		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator-role", Labels: partOf}},
@@ -195,4 +207,12 @@ func assertExists(t *testing.T, obj client.Object, key types.NamespacedName) {
 	t.Helper()
 	require.NoError(t, k8sClient.Get(context.Background(), key, obj),
 		"expected %T %q to exist", obj, key.Name)
+}
+
+// assertGone asserts that getting the object at key returns NotFound.
+func assertGone(t *testing.T, obj client.Object, key types.NamespacedName) {
+	t.Helper()
+	err := k8sClient.Get(context.Background(), key, obj)
+	assert.True(t, apierrors.IsNotFound(err),
+		"expected %T %q to be gone, got err=%v", obj, key.Name, err)
 }

--- a/dashboard-operator/internal/controller/managementstate_integration_test.go
+++ b/dashboard-operator/internal/controller/managementstate_integration_test.go
@@ -64,6 +64,9 @@ func TestIntegration_ManagementStateRemoved_TeardownResources(t *testing.T) {
 	// Operator-owned resources are preserved (skipped by name during teardown).
 	assertExists(t, &appsv1.Deployment{}, types.NamespacedName{Name: "dashboard-operator", Namespace: integrationNamespace})
 	assertExists(t, &corev1.ServiceAccount{}, types.NamespacedName{Name: "dashboard-operator", Namespace: integrationNamespace})
+	assertExists(t, &corev1.Service{}, types.NamespacedName{Name: "dashboard-operator-webhook", Namespace: integrationNamespace})
+	assertExists(t, &corev1.Secret{}, types.NamespacedName{Name: "dashboard-operator-webhook-tls", Namespace: integrationNamespace})
+	assertExists(t, &corev1.ConfigMap{}, types.NamespacedName{Name: "odh-dashboard-config", Namespace: integrationNamespace})
 	assertExists(t, &rbacv1.ClusterRole{}, types.NamespacedName{Name: "dashboard-operator-role"})
 	assertExists(t, &rbacv1.ClusterRoleBinding{}, types.NamespacedName{Name: "dashboard-operator-rolebinding"})
 
@@ -122,14 +125,17 @@ func TestIntegration_ManagementStateRemoved_IdempotentRereconcile(t *testing.T) 
 
 	// Operator-owned resources remain intact across repeated teardowns.
 	assertExists(t, &appsv1.Deployment{}, types.NamespacedName{Name: "dashboard-operator", Namespace: integrationNamespace})
+	assertExists(t, &corev1.Service{}, types.NamespacedName{Name: "dashboard-operator-webhook", Namespace: integrationNamespace})
+	assertExists(t, &corev1.ConfigMap{}, types.NamespacedName{Name: "odh-dashboard-config", Namespace: integrationNamespace})
 	assertExists(t, &rbacv1.ClusterRole{}, types.NamespacedName{Name: "dashboard-operator-role"})
 	assertExists(t, &rbacv1.ClusterRoleBinding{}, types.NamespacedName{Name: "dashboard-operator-rolebinding"})
 }
 
-// seedOperatorOwnedResources creates the operator's own Deployment, ServiceAccount,
-// ClusterRole and ClusterRoleBinding — all carrying the part-of=dashboard label so the
-// teardown lists them, then skips them by name. Cleanup is registered so cluster-scoped
-// resources never leak.
+// seedOperatorOwnedResources creates the operator's own resources — Deployment,
+// ServiceAccount, ClusterRole, ClusterRoleBinding, the webhook Service and its serving-cert
+// Secret, and the operator config ConfigMap — all carrying the part-of=dashboard label the
+// operator's Helm chart stamps on them (commonLabels). Teardown lists them by label, then
+// must skip them by name. Cleanup is registered so cluster-scoped resources never leak.
 func seedOperatorOwnedResources(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
@@ -156,6 +162,17 @@ func seedOperatorOwnedResources(t *testing.T) {
 			},
 		},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator", Namespace: integrationNamespace, Labels: partOf}},
+		// Webhook Service: deleting it would break the failurePolicy: Fail ValidatingWebhookConfiguration.
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator-webhook", Namespace: integrationNamespace, Labels: partOf},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: 443}},
+			},
+		},
+		// Webhook serving-cert Secret.
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator-webhook-tls", Namespace: integrationNamespace, Labels: partOf}},
+		// Operator config ConfigMap the operator itself reads.
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-config", Namespace: integrationNamespace, Labels: partOf}},
 		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator-role", Labels: partOf}},
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{Name: "dashboard-operator-rolebinding", Labels: partOf},

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -341,11 +341,19 @@ func (r *DashboardReconciler) deleteModuleResources(
 
 // addInterBFFParams writes each inter-BFF dependency's service coordinates into the
 // module's params.env (rendered into that module's generated <slug>-params ConfigMap).
-// It only maintains those keys — a module wires them into its container env via envFrom
-// or a kustomize replacement if it needs them. gen-ai, the only current consumer, still
-// hardcodes the maas coordinates in its Deployment, so these keys are inert for it today;
-// keeping the write/clear logic correct means the ConfigMap is right whenever a module
-// starts consuming it.
+//
+// These BFF_*_SERVICE_NAME/PORT keys are operator-owned: the operator adds them only when
+// the target module is deployed and clears them when it is not, so their presence in the
+// ConfigMap is not stable across reconciles. A consuming module MUST therefore:
+//   - NOT ship static defaults for these keys in its own params.env (the operator overwrites
+//     or deletes them), and
+//   - consume them at runtime via envFrom on the generated <slug>-params ConfigMap, NOT via a
+//     build-time kustomize `replacement` sourcing one of these keys — a replacement referencing
+//     a key that has been cleared (dependency disabled) fails manifest rendering.
+//
+// gen-ai, the only current consumer, still hardcodes the maas coordinates in its Deployment, so
+// these keys are inert for it today; keeping the write/clear logic correct means the ConfigMap is
+// right whenever a module starts consuming it via envFrom.
 func addInterBFFParams(params map[string]string, moduleName string, statuses map[string]v1alpha1.ModuleStatus, platform cluster.Platform) {
 	mod := moduleRegistry[moduleName]
 	if mod.InterBFFDeps == nil {

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -345,6 +345,12 @@ func addInterBFFParams(params map[string]string, moduleName string, statuses map
 		return
 	}
 	for _, dep := range mod.InterBFFDeps {
+		// Clear any previously written coordinates first. params.env persists across
+		// reconciles, so a dependency that is no longer deployed must not leave stale
+		// service coordinates behind.
+		delete(params, dep.EnvServiceName)
+		delete(params, dep.EnvServicePort)
+
 		targetMod, ok := moduleRegistry[dep.TargetModule]
 		if !ok {
 			continue

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -339,6 +339,13 @@ func (r *DashboardReconciler) deleteModuleResources(
 
 // --- Inter-BFF env var params ---
 
+// addInterBFFParams writes each inter-BFF dependency's service coordinates into the
+// module's params.env (rendered into that module's generated <slug>-params ConfigMap).
+// It only maintains those keys — a module wires them into its container env via envFrom
+// or a kustomize replacement if it needs them. gen-ai, the only current consumer, still
+// hardcodes the maas coordinates in its Deployment, so these keys are inert for it today;
+// keeping the write/clear logic correct means the ConfigMap is right whenever a module
+// starts consuming it.
 func addInterBFFParams(params map[string]string, moduleName string, statuses map[string]v1alpha1.ModuleStatus, platform cluster.Platform) {
 	mod := moduleRegistry[moduleName]
 	if mod.InterBFFDeps == nil {

--- a/dashboard-operator/internal/controller/observability_integration_test.go
+++ b/dashboard-operator/internal/controller/observability_integration_test.go
@@ -160,12 +160,9 @@ func TestIntegration_Observability_Deployed(t *testing.T) {
 	assert.Equal(t, metav1.ConditionTrue, cond.Status)
 	assert.Equal(t, "Deployed", cond.Reason)
 
-	// The federation config should carry a perses proxy entry.
-	entries := parseFederationEntries(t, getFederationConfigMap(t))
-	assert.NotNil(t, findFederationEntry(entries, "perses"),
-		"perses federation entry should be present when observability is deployed")
-
-	// The rendered observability ConfigMap should have been applied.
+	// The rendered observability ConfigMap should have been applied. This is the signal that
+	// distinguishes the Deployed path: the perses federation entry is driven by the spec and is
+	// present in the _PersesCRDNotFound case too, so asserting on it here would prove nothing.
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
 		Name:      "perses-dashboard-config",
 		Namespace: integrationNamespace,

--- a/dashboard-operator/internal/controller/observability_integration_test.go
+++ b/dashboard-operator/internal/controller/observability_integration_test.go
@@ -1,0 +1,247 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+// conditionObservabilityAvailable mirrors the controller's condition type name.
+const conditionObservabilityAvailable = "ObservabilityAvailable"
+
+// persesDashboardListGVK matches the GVK the reconciler uses to probe for the
+// PersesDashboard CRD. Listing this on a client caches its REST mapping, so it
+// is only ever listed on the discardable isolated client (see _Deployed).
+var persesDashboardListGVK = schema.GroupVersionKind{
+	Group:   "perses.dev",
+	Version: "v1alpha1",
+	Kind:    "PersesDashboardList",
+}
+
+// TestIntegration_Observability_Disabled verifies that a Dashboard without an
+// observability spec reports ObservabilityAvailable=False with reason Disabled.
+// (RHOAIENG-83647)
+func TestIntegration_Observability_Disabled(t *testing.T) {
+	manifests := createIntegrationManifests(t, nil)
+	r := newManifestReconciler(manifests)
+
+	// No observability spec and no data-science-perses Service in the namespace,
+	// so autoDetectObservability leaves the spec nil.
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept(),
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	cond := conditions.FindStatusCondition(getDashboard(t), conditionObservabilityAvailable)
+	require.NotNil(t, cond, "ObservabilityAvailable condition should be present")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "Disabled", cond.Reason)
+}
+
+// TestIntegration_Observability_PersesCRDNotFound verifies that when observability
+// is enabled but the PersesDashboard CRD is absent, the reconciler reports
+// ObservabilityAvailable=False with reason PersesCRDNotFound (rather than failing
+// the whole reconcile). Uses the shared client so its RESTMapper stays free of a
+// perses mapping. (RHOAIENG-83647)
+func TestIntegration_Observability_PersesCRDNotFound(t *testing.T) {
+	manifests := createIntegrationManifests(t, nil)
+	r := newManifestReconciler(manifests)
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept(),
+		Observability: &v1alpha1.ObservabilitySpec{
+			Enabled: true,
+			PersesService: &v1alpha1.ServiceTarget{
+				Name:      "perses",
+				Namespace: integrationNamespace,
+				Port:      8080,
+			},
+		},
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	cond := conditions.FindStatusCondition(getDashboard(t), conditionObservabilityAvailable)
+	require.NotNil(t, cond, "ObservabilityAvailable condition should be present")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "PersesCRDNotFound", cond.Reason)
+}
+
+// TestIntegration_Observability_Deployed verifies the happy path: with the
+// PersesDashboard CRD installed and observability manifests present, the reconciler
+// renders and deploys them, adds the perses federation entry, and reports
+// ObservabilityAvailable=True with reason Deployed.
+//
+// It runs last (source + file order) and uses an isolated client so that listing
+// PersesDashboards — which caches a positive REST mapping once the CRD exists —
+// never poisons the shared client's mapper that _PersesCRDNotFound relies on.
+// (RHOAIENG-83647)
+func TestIntegration_Observability_Deployed(t *testing.T) {
+	manifests := createIntegrationManifests(t, nil)
+	writeObservabilityOverlay(t, manifests)
+	installPersesCRD(t)
+
+	// Isolated client whose RESTMapper we deliberately warm with the perses
+	// mapping; the shared k8sClient must never learn it.
+	persesClient := newIsolatedClient(t)
+	require.Eventually(t, func() bool {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(persesDashboardListGVK)
+
+		return persesClient.List(context.Background(), list) == nil
+	}, 30*time.Second, 200*time.Millisecond, "isolated client should discover the PersesDashboard CRD")
+
+	r := newReconcilerWithClient(persesClient, manifests)
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept(),
+		Observability: &v1alpha1.ObservabilitySpec{
+			Enabled: true,
+			PersesService: &v1alpha1.ServiceTarget{
+				Name:      "perses",
+				Namespace: integrationNamespace,
+				Port:      8080,
+			},
+		},
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	cond := conditions.FindStatusCondition(getDashboard(t), conditionObservabilityAvailable)
+	require.NotNil(t, cond, "ObservabilityAvailable condition should be present")
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, "Deployed", cond.Reason)
+
+	// The federation config should carry a perses proxy entry.
+	entries := parseFederationEntries(t, getFederationConfigMap(t))
+	assert.NotNil(t, findFederationEntry(entries, "perses"),
+		"perses federation entry should be present when observability is deployed")
+
+	// The rendered observability ConfigMap should have been applied.
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+		Name:      "perses-dashboard-config",
+		Namespace: integrationNamespace,
+	}, &corev1.ConfigMap{}), "observability ConfigMap should be deployed")
+}
+
+// writeObservabilityOverlay writes a minimal observability kustomize overlay at
+// <base>/observability/odh producing a perses-dashboard-config ConfigMap — the
+// path observabilityManifestInfo resolves for the OpenDataHub platform.
+func writeObservabilityOverlay(t *testing.T, base string) {
+	t.Helper()
+
+	overlay := filepath.Join(base, "observability", "odh")
+	require.NoError(t, os.MkdirAll(overlay, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "configmap.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: perses-dashboard-config
+data:
+  key: value
+`), 0644))
+}
+
+// installPersesCRD creates the PersesDashboard CRD via the shared client (creating
+// the CRD object exercises only the apiextensions mapping, which is safe on the
+// shared client) and waits for it to become Established. Cleanup removes it so the
+// shared client's mapper never sees a perses mapping after this test.
+func installPersesCRD(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	preserveUnknown := true
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "persesdashboards.perses.dev"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "perses.dev",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "persesdashboards",
+				Singular: "persesdashboard",
+				Kind:     "PersesDashboard",
+				ListKind: "PersesDashboardList",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    "v1alpha1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type:                   "object",
+						XPreserveUnknownFields: &preserveUnknown,
+					},
+				},
+			}},
+		},
+	}
+
+	require.NoError(t, k8sClient.Create(ctx, crd))
+	t.Cleanup(func() { deleteIgnoreNotFound(t, crd) })
+
+	require.Eventually(t, func() bool {
+		got := &apiextensionsv1.CustomResourceDefinition{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: crd.Name}, got); err != nil {
+			return false
+		}
+		for _, c := range got.Status.Conditions {
+			if c.Type == apiextensionsv1.Established && c.Status == apiextensionsv1.ConditionTrue {
+				return true
+			}
+		}
+
+		return false
+	}, 30*time.Second, 200*time.Millisecond, "PersesDashboard CRD should become Established")
+}


### PR DESCRIPTION
<!--- Epic: https://issues.redhat.com/browse/RHOAIENG-83640 -->

Related issues:
- https://issues.redhat.com/browse/RHOAIENG-83645
- https://issues.redhat.com/browse/RHOAIENG-83646
- https://issues.redhat.com/browse/RHOAIENG-83647
- https://issues.redhat.com/browse/RHOAIENG-83648
- https://issues.redhat.com/browse/RHOAIENG-83649
- Epic (context): https://issues.redhat.com/browse/RHOAIENG-83640

## Description

Expands the envtest integration-test coverage for the **Dashboard Module Controller** (`dashboard-operator/`), implementing the remaining child tasks of the *Envtest Integration Test Foundation* epic ([RHOAIENG-83640](https://redhat.atlassian.net/browse/RHOAIENG-83640)) in a single PR. The foundation itself (`TestMain`, the helper harness, and the first four `TestIntegration_*` tests) landed earlier in #8742; this PR builds on that harness.

envtest runs the real reconcile loop against a real kube-apiserver (no kubelet/pod scheduling), so these tests catch CRD/CEL validation, status-subresource behaviour, SSA ownership, teardown/label semantics, and REST-mapper edge cases that the fake-client unit tests cannot.

What's added (by ticket):

- **[RHOAIENG-83645](https://redhat.atlassian.net/browse/RHOAIENG-83645) — standalone deployment reconciliation** (`deployment_integration_test.go`): asserts the core ConfigMap and per-module Deployments/Services are applied with the `part-of=dashboard` label, that the federation ConfigMap lists the enabled modules plus `coreBff`, and that every registered module gets a status entry (enabled → deployed/degraded, explicitly-disabled → `Disabled`/`ExplicitOverride`).
- **[RHOAIENG-83646](https://redhat.atlassian.net/browse/RHOAIENG-83646) — `managementState: Removed` teardown** (`managementstate_integration_test.go`): flipping a deployed Dashboard to `Removed` tears down module operands while preserving the CR and the operator's own resources (skipped by name), and reports `Phase=NotReady`, empty URL, nil module statuses, and `ProvisioningSucceeded=False (Removed)`. A second test asserts repeated reconciles are idempotent. Writing this test surfaced a teardown bug (see *Production fixes* below), which this PR also fixes.
- **[RHOAIENG-83647](https://redhat.atlassian.net/browse/RHOAIENG-83647) — observability reconciliation** (`observability_integration_test.go` + one unit test): covers `ObservabilityAvailable` = `Disabled`, `PersesCRDNotFound`, and `Deployed`. The CEL-unadmittable `InvalidConfig` case (enabled + no `persesService`) is unreachable from envtest, so it is covered by a unit test in `actions_test.go` that calls `deployObservabilityManifests` directly.
- **[RHOAIENG-83648](https://redhat.atlassian.net/browse/RHOAIENG-83648) — legacy sidecar cleanup** (`legacy_cleanup_integration_test.go`): a normal reconcile removes the resources left behind by the now-removed sidecar deployment mode (upgrade safety) while leaving unrelated resources untouched.
- **[RHOAIENG-83649](https://redhat.atlassian.net/browse/RHOAIENG-83649) — inter-BFF params + federation ConfigMap** (`federation_integration_test.go`): asserts gen-ai's `params.env` gains `BFF_MAAS_SERVICE_NAME`/`PORT` from its inter-BFF dependency (and maas gets none), that an all-modules-enabled config yields a federation entry per module plus `coreBff`/`mlflowEmbedded` (and no `perses` when observability is off), and that the main-dashboard pod-template federation-config hash changes when the enabled-module set changes.

### Reinterpretation note

Two tickets were written before the sidecar deployment mode was removed (#9392). The controller now has a single (standalone) deployment mode; there is no `DeploymentMode` field and no sidecar/standalone switching. The affected tickets were reinterpreted to match the current codebase and their Jira descriptions updated accordingly:
- [RHOAIENG-83645](https://redhat.atlassian.net/browse/RHOAIENG-83645) ("sidecar mode reconciliation") → standalone deployment reconciliation.
- [RHOAIENG-83648](https://redhat.atlassian.net/browse/RHOAIENG-83648) ("mode switching sidecar↔standalone") → legacy sidecar cleanup (upgrade safety).

### Implementation note (REST-mapper isolation)

The observability `_Deployed` test installs the `PersesDashboard` CRD and drives the reconcile with an **isolated** client whose RESTMapper is warmed with the perses mapping. This keeps the shared test client's mapper free of a cached perses mapping, which the `_PersesCRDNotFound` case depends on staying absent. `_Deployed` is also ordered last so its CRD create/delete never bleeds into the other cases.

## How Has This Been Tested?

All checks were run locally from `dashboard-operator/` (hermetic envtest — no live cluster):

- `make test-integration` — all 15 `TestIntegration_*` tests pass (11 new + 4 pre-existing). The observability group was run repeatedly (`-run TestIntegration_Observability`, several iterations) to confirm the RESTMapper isolation is not flaky.
- `make test` — unit suite green, including the new `TestDeployObservabilityManifests_PersesServiceRequired`; confirms the `//go:build integration` tag keeps the two suites isolated.
- `make lint` — 0 issues.
- `make build` — builds clean.
- `git status --porcelain` — no generated-file drift (no changes under `api/` or `config/`).

## Production fixes

Although the goal of this PR is test coverage, writing the tests surfaced two real defects in the operator, which are fixed here (both in `internal/controller/`):

- **Teardown deleted operator-owned resources** (`dashboard_reconciler.go`). `teardownManagedResources` deletes everything labeled `platform.opendatahub.io/part-of=dashboard` in the applications namespace, but the operator's own Helm chart stamps that same `commonLabel` on the resources it renders — including the webhook `Service` and the operator config `ConfigMap`, both of which live in that namespace. On `managementState: Removed` the teardown would delete the webhook Service, breaking the `failurePolicy: Fail` `ValidatingWebhookConfiguration`. Fix: expand `operatorOwnedResourceNames()` (webhook Service, its serving-cert Secret, config ConfigMap) and apply the by-name skip inside `deleteTyped` so Service/ConfigMap/Secret (and NetworkPolicy/Role/RoleBinding) all preserve operator-owned resources.
- **Stale inter-BFF params were never cleared** (`module_deploy.go`). `params.env` persists across reconciles, so once a dependency was disabled its `BFF_*_SERVICE_NAME`/`PORT` keys lingered in the module's rendered `<slug>-params` ConfigMap. `addInterBFFParams` now clears each dependency's keys before (re)writing them. Note this corrects the rendered ConfigMap only — gen-ai, the sole current consumer, hardcodes the maas coordinates in its Deployment, so the keys are inert for its running pods today; the fix keeps the ConfigMap correct for whenever a module starts consuming it.

## Test Impact

Primarily a test PR — it adds integration and unit tests for the dashboard-operator, plus the two small production fixes described above that the new tests surfaced. No manual/cluster testing was performed; verification was via the local `make` targets above. CI picks the new tagged tests up automatically through the existing "Integration tests (envtest)" step in `.github/workflows/dashboard-operator-tests.yml` — no workflow changes required.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work — *not applicable: hermetic envtest run locally, no cluster testing; see How Has This Been Tested.*
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) — *N/A: Go operator code; follows the `dashboard-operator` conventions in `.claude/rules/envtest-integration-tests.md` and `operator-controller.md`; `make lint` is clean.*

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-83640]: https://redhat.atlassian.net/browse/RHOAIENG-83640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-83645]: https://redhat.atlassian.net/browse/RHOAIENG-83645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed outdated inter-module service parameters when dependent modules are disabled, preventing stale configuration after updates.

- **Tests**
  - Added integration coverage for module deployments, services, federation configuration, status reporting, and configuration-hash updates.
  - Verified observability behavior when disabled, unavailable, or successfully deployed.
  - Added checks for management-state removal, idempotent teardown, and cleanup of legacy resources.
  - Added validation for required observability configuration and inter-module service parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
