### PR TITLE
Add mock BFF endpoints for external models and providers

### DIFF
--- a/packages/maas/bff/internal/api/api_keys_handlers_test.go
+++ b/packages/maas/bff/internal/api/api_keys_handlers_test.go
@@ -355,7 +355,7 @@ var _ = Describe("APIKeysHandlers", Ordered, func() {
 			subsRepo := repositories.NewSubscriptionsRepository(testLogger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 			policiesRepo := repositories.NewPoliciesRepository(testLogger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 			modelRefsRepo := repositories.NewMaaSModelRefsRepository(testLogger, k8Factory)
-			repos, err := repositories.NewRepositories(testLogger, k8Factory, envConfig, subsRepo, policiesRepo, modelRefsRepo, nil, nil)
+			repos, err := repositories.NewRepositories(testLogger, k8Factory, envConfig, subsRepo, policiesRepo, modelRefsRepo, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			app := &App{

--- a/packages/maas/bff/internal/api/app.go
+++ b/packages/maas/bff/internal/api/app.go
@@ -172,6 +172,8 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 	var policiesRepo repositories.PoliciesRepositoryInterface
 	var modelRefsRepo repositories.MaaSModelRefsRepositoryInterface
 	var externalModelsRepo repositories.ExternalModelsRepositoryInterface
+	var externalProvidersRepo repositories.ExternalProvidersRepositoryInterface
+	var secretsRepo repositories.SecretsRepositoryInterface
 	var yamlRepo repositories.YamlRepositoryInterface
 
 	if cfg.MockK8Client {
@@ -179,16 +181,20 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		policiesRepo = repositories.NewMockPoliciesRepository(logger)
 		modelRefsRepo = repositories.NewMockMaaSModelRefsRepository(logger)
 		externalModelsRepo = repositories.NewMockExternalModelsRepository(logger, modelRefsRepo)
+		externalProvidersRepo = repositories.NewMockExternalProvidersRepository(logger)
+		secretsRepo = repositories.NewMockSecretsRepository(logger)
 		yamlRepo = repositories.NewMockYamlRepository(logger)
 	} else {
 		subscriptionsRepo = repositories.NewSubscriptionsRepository(logger, k8sFactory, cfg.MaaSSubscriptionNamespace)
 		policiesRepo = repositories.NewPoliciesRepository(logger, k8sFactory, cfg.MaaSSubscriptionNamespace)
 		modelRefsRepo = repositories.NewMaaSModelRefsRepository(logger, k8sFactory)
 		externalModelsRepo = repositories.NewExternalModelsRepository(logger, k8sFactory, modelRefsRepo)
+		externalProvidersRepo = repositories.NewExternalProvidersRepository(logger, k8sFactory)
+		secretsRepo = repositories.NewSecretsRepository(logger, k8sFactory)
 		yamlRepo = repositories.NewYamlRepository(logger, k8sFactory, cfg.MaaSSubscriptionNamespace)
 	}
 
-	repos, err := repositories.NewRepositories(logger, k8sFactory, cfg, subscriptionsRepo, policiesRepo, modelRefsRepo, externalModelsRepo, yamlRepo)
+	repos, err := repositories.NewRepositories(logger, k8sFactory, cfg, subscriptionsRepo, policiesRepo, modelRefsRepo, externalModelsRepo, externalProvidersRepo, secretsRepo, yamlRepo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repositories: %w", err)
 	}
@@ -288,6 +294,8 @@ func (app *App) Routes() http.Handler {
 	attachPolicyHandlers(apiRouter, app)
 	attachMaaSModelRefHandlers(apiRouter, app)
 	attachExternalModelHandlers(apiRouter, app)
+	attachExternalProviderHandlers(apiRouter, app)
+	attachSecretHandlers(apiRouter, app)
 	attachYamlHandlers(apiRouter, app)
 	apiRouter.GET(constants.ApiPathPrefix+"/models", handlerWithMaasApi(app, ListModelsHandler))
 	apiRouter.GET(constants.IsMaasAdminPath, handlerWithApp(app, IsMaasAdminHandler))

--- a/packages/maas/bff/internal/api/app_test.go
+++ b/packages/maas/bff/internal/api/app_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Static File serving Test", func() {
 			envConfig := config.EnvConfig{
 				StaticAssetsDir: "../../static",
 			}
-			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			app := &App{
 				kubernetesClientFactory: k8Factory,

--- a/packages/maas/bff/internal/api/externalmodel_handlers.go
+++ b/packages/maas/bff/internal/api/externalmodel_handlers.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
+	"github.com/opendatahub-io/maas-library/bff/internal/repositories"
 )
 
 func attachExternalModelHandlers(apiRouter *httprouter.Router, app *App) {
@@ -45,7 +45,7 @@ func CreateExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 
 	var request Envelope[models.CreateExternalModelRequest, None]
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := app.ReadJSON(w, r, &request); err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
@@ -57,7 +57,7 @@ func CreateExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request
 
 	result, err := app.repositories.ExternalModels.CreateExternalModel(ctx, request.Data)
 	if err != nil {
-		if strings.Contains(err.Error(), "already exists") {
+		if errors.Is(err, repositories.ErrAlreadyExists) {
 			app.errorResponse(w, r, &HTTPError{
 				StatusCode: http.StatusConflict,
 				Error:      ErrorPayload{Code: "409", Message: err.Error()},
@@ -85,7 +85,7 @@ func UpdateExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request
 	}
 
 	var request Envelope[models.UpdateExternalModelRequest, None]
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := app.ReadJSON(w, r, &request); err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
@@ -99,7 +99,7 @@ func UpdateExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request
 
 	result, err := app.repositories.ExternalModels.UpdateExternalModel(ctx, namespace, name, request.Data)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, repositories.ErrNotFound) {
 			app.errorResponse(w, r, &HTTPError{
 				StatusCode: http.StatusNotFound,
 				Error:      ErrorPayload{Code: "404", Message: err.Error()},
@@ -127,7 +127,7 @@ func DeleteExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request
 	}
 
 	if err := app.repositories.ExternalModels.DeleteExternalModel(ctx, namespace, name); err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, repositories.ErrNotFound) {
 			app.errorResponse(w, r, &HTTPError{
 				StatusCode: http.StatusNotFound,
 				Error:      ErrorPayload{Code: "404", Message: err.Error()},

--- a/packages/maas/bff/internal/api/externalmodel_handlers.go
+++ b/packages/maas/bff/internal/api/externalmodel_handlers.go
@@ -1,12 +1,12 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/julienschmidt/httprouter"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
@@ -14,6 +14,8 @@ import (
 
 func attachExternalModelHandlers(apiRouter *httprouter.Router, app *App) {
 	apiRouter.GET(constants.ExternalModelListPath, handlerWithApp(app, ListExternalModelsHandler))
+	apiRouter.POST(constants.ExternalModelCreatePath, handlerWithApp(app, CreateExternalModelHandler))
+	apiRouter.PUT(constants.ExternalModelUpdatePath, handlerWithApp(app, UpdateExternalModelHandler))
 	apiRouter.DELETE(constants.ExternalModelDeletePath, handlerWithApp(app, DeleteExternalModelHandler))
 }
 
@@ -38,6 +40,82 @@ func ListExternalModelsHandler(app *App, w http.ResponseWriter, r *http.Request,
 	}
 }
 
+// CreateExternalModelHandler handles POST /api/v1/externalmodel
+func CreateExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	var request Envelope[models.CreateExternalModelRequest, None]
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if err := validateCreateExternalModelRequest(request.Data); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	result, err := app.repositories.ExternalModels.CreateExternalModel(ctx, request.Data)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			app.errorResponse(w, r, &HTTPError{
+				StatusCode: http.StatusConflict,
+				Error:      ErrorPayload{Code: "409", Message: err.Error()},
+			})
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	response := Envelope[*models.ExternalModelSummary, None]{Data: result}
+	if err := app.WriteJSON(w, http.StatusCreated, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// UpdateExternalModelHandler handles PUT /api/v1/externalmodel/:namespace/:name
+func UpdateExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	ctx := r.Context()
+	namespace := params.ByName("namespace")
+	name := params.ByName("name")
+	if namespace == "" || name == "" {
+		app.badRequestResponse(w, r, errors.New("ExternalModel namespace and name are required"))
+		return
+	}
+
+	var request Envelope[models.UpdateExternalModelRequest, None]
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if len(request.Data.ProviderRefs) > 0 {
+		if err := validateProviderRefs(request.Data.ProviderRefs); err != nil {
+			app.badRequestResponse(w, r, err)
+			return
+		}
+	}
+
+	result, err := app.repositories.ExternalModels.UpdateExternalModel(ctx, namespace, name, request.Data)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			app.errorResponse(w, r, &HTTPError{
+				StatusCode: http.StatusNotFound,
+				Error:      ErrorPayload{Code: "404", Message: err.Error()},
+			})
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	response := Envelope[*models.ExternalModelSummary, None]{Data: result}
+	if err := app.WriteJSON(w, http.StatusOK, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
 // DeleteExternalModelHandler handles DELETE /api/v1/externalmodel/:namespace/:name
 func DeleteExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 	ctx := r.Context()
@@ -49,7 +127,7 @@ func DeleteExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request
 	}
 
 	if err := app.repositories.ExternalModels.DeleteExternalModel(ctx, namespace, name); err != nil {
-		if k8sErrors.IsNotFound(err) {
+		if strings.Contains(err.Error(), "not found") {
 			app.errorResponse(w, r, &HTTPError{
 				StatusCode: http.StatusNotFound,
 				Error:      ErrorPayload{Code: "404", Message: err.Error()},
@@ -75,4 +153,38 @@ func namespaceFromContext(r *http.Request) (string, error) {
 		return "", errors.New("namespace is required")
 	}
 	return namespace, nil
+}
+
+func validateCreateExternalModelRequest(request models.CreateExternalModelRequest) error {
+	if strings.TrimSpace(request.Name) == "" {
+		return errors.New("name is required")
+	}
+	if strings.TrimSpace(request.Namespace) == "" {
+		return errors.New("namespace is required")
+	}
+	return validateProviderRefs(request.ProviderRefs)
+}
+
+func validateProviderRefs(refs []models.ProviderRef) error {
+	if len(refs) == 0 {
+		return errors.New("at least one providerRef is required")
+	}
+	for _, ref := range refs {
+		if strings.TrimSpace(ref.ProviderName) == "" {
+			return errors.New("providerRef.providerName is required")
+		}
+		if ref.Weight < 1 || ref.Weight > 100 {
+			return errors.New("providerRef.weight must be between 1 and 100")
+		}
+		if strings.TrimSpace(ref.APIFormat) == "" {
+			return errors.New("providerRef.apiFormat is required")
+		}
+		if strings.TrimSpace(ref.Path) == "" {
+			return errors.New("providerRef.path is required")
+		}
+		if strings.TrimSpace(ref.TargetModel) == "" {
+			return errors.New("providerRef.targetModel is required")
+		}
+	}
+	return nil
 }

--- a/packages/maas/bff/internal/api/externalmodel_handlers.go
+++ b/packages/maas/bff/internal/api/externalmodel_handlers.go
@@ -173,8 +173,8 @@ func validateProviderRefs(refs []models.ProviderRef) error {
 		if strings.TrimSpace(ref.ProviderName) == "" {
 			return errors.New("providerRef.providerName is required")
 		}
-		if ref.Weight < 1 || ref.Weight > 100 {
-			return errors.New("providerRef.weight must be between 1 and 100")
+		if ref.Weight < 0 || ref.Weight > 100 {
+			return errors.New("providerRef.weight must be between 0 and 100")
 		}
 		if strings.TrimSpace(ref.APIFormat) == "" {
 			return errors.New("providerRef.apiFormat is required")

--- a/packages/maas/bff/internal/api/externalprovider_handlers.go
+++ b/packages/maas/bff/internal/api/externalprovider_handlers.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+func attachExternalProviderHandlers(apiRouter *httprouter.Router, app *App) {
+	apiRouter.GET(constants.ExternalProviderListPath, handlerWithApp(app, ListExternalProvidersHandler))
+	apiRouter.POST(constants.ExternalProviderCreatePath, handlerWithApp(app, CreateExternalProviderHandler))
+	apiRouter.PUT(constants.ExternalProviderUpdatePath, handlerWithApp(app, UpdateExternalProviderHandler))
+	apiRouter.DELETE(constants.ExternalProviderDeletePath, handlerWithApp(app, DeleteExternalProviderHandler))
+}
+
+// ListExternalProvidersHandler handles GET /api/v1/externalprovider?namespace=X
+func ListExternalProvidersHandler(app *App, w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+	namespace, err := namespaceFromContext(r)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	providers, err := app.repositories.ExternalProviders.ListExternalProviders(ctx, namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	response := Envelope[[]models.ExternalProviderSummary, None]{Data: providers}
+	if err := app.WriteJSON(w, http.StatusOK, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// CreateExternalProviderHandler handles POST /api/v1/externalprovider
+func CreateExternalProviderHandler(app *App, w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	var request Envelope[models.CreateExternalProviderRequest, None]
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if err := validateCreateExternalProviderRequest(request.Data); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	result, err := app.repositories.ExternalProviders.CreateExternalProvider(ctx, request.Data)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			app.errorResponse(w, r, &HTTPError{
+				StatusCode: http.StatusConflict,
+				Error:      ErrorPayload{Code: "409", Message: err.Error()},
+			})
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	response := Envelope[*models.ExternalProviderSummary, None]{Data: result}
+	if err := app.WriteJSON(w, http.StatusCreated, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// UpdateExternalProviderHandler handles PUT /api/v1/externalprovider/:namespace/:name
+func UpdateExternalProviderHandler(app *App, w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	ctx := r.Context()
+	namespace := params.ByName("namespace")
+	name := params.ByName("name")
+	if namespace == "" || name == "" {
+		app.badRequestResponse(w, r, errors.New("ExternalProvider namespace and name are required"))
+		return
+	}
+
+	var request Envelope[models.UpdateExternalProviderRequest, None]
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if request.Data.AuthMechanism != nil && !request.Data.AuthMechanism.IsValid() {
+		app.badRequestResponse(w, r, errors.New("authMechanism must be 'apikey', 'sigv4', or 'oauth2'"))
+		return
+	}
+
+	result, err := app.repositories.ExternalProviders.UpdateExternalProvider(ctx, namespace, name, request.Data)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			app.errorResponse(w, r, &HTTPError{
+				StatusCode: http.StatusNotFound,
+				Error:      ErrorPayload{Code: "404", Message: err.Error()},
+			})
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	response := Envelope[*models.ExternalProviderSummary, None]{Data: result}
+	if err := app.WriteJSON(w, http.StatusOK, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// DeleteExternalProviderHandler handles DELETE /api/v1/externalprovider/:namespace/:name
+func DeleteExternalProviderHandler(app *App, w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	ctx := r.Context()
+	namespace := params.ByName("namespace")
+	name := params.ByName("name")
+	if namespace == "" || name == "" {
+		app.badRequestResponse(w, r, errors.New("ExternalProvider namespace and name are required"))
+		return
+	}
+
+	if err := app.repositories.ExternalProviders.DeleteExternalProvider(ctx, namespace, name); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			app.errorResponse(w, r, &HTTPError{
+				StatusCode: http.StatusNotFound,
+				Error:      ErrorPayload{Code: "404", Message: err.Error()},
+			})
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	response := Envelope[None, None]{Data: nil}
+	if err := app.WriteJSON(w, http.StatusOK, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func validateCreateExternalProviderRequest(request models.CreateExternalProviderRequest) error {
+	if strings.TrimSpace(request.Name) == "" {
+		return errors.New("name is required")
+	}
+	if strings.TrimSpace(request.Namespace) == "" {
+		return errors.New("namespace is required")
+	}
+	if strings.TrimSpace(request.EndpointUrl) == "" {
+		return errors.New("endpointUrl is required")
+	}
+	if !request.AuthMechanism.IsValid() {
+		return errors.New("authMechanism must be 'apikey', 'sigv4', or 'oauth2'")
+	}
+	if strings.TrimSpace(request.CredentialSecretRef) == "" {
+		return errors.New("credentialSecretRef is required")
+	}
+	if strings.TrimSpace(request.Provider) == "" {
+		return errors.New("provider is required")
+	}
+	return nil
+}

--- a/packages/maas/bff/internal/api/externalprovider_handlers.go
+++ b/packages/maas/bff/internal/api/externalprovider_handlers.go
@@ -171,21 +171,5 @@ func validateCreateExternalProviderRequest(request models.CreateExternalProvider
 }
 
 func validateEndpointURL(raw string) error {
-	s := strings.TrimSpace(raw)
-	if s == "" {
-		return errors.New("endpointUrl is required")
-	}
-	schemeSep := strings.Index(s, "://")
-	if schemeSep == -1 {
-		return nil
-	}
-	scheme := strings.ToLower(s[:schemeSep])
-	if scheme != "http" && scheme != "https" {
-		return errors.New("endpointUrl must be an http or https URL")
-	}
-	host := strings.Trim(s[schemeSep+3:], "/")
-	if strings.TrimSpace(host) == "" {
-		return errors.New("endpointUrl must include a host")
-	}
-	return nil
+	return repositories.ValidateEndpointURL(raw)
 }

--- a/packages/maas/bff/internal/api/externalprovider_handlers.go
+++ b/packages/maas/bff/internal/api/externalprovider_handlers.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
+	"github.com/opendatahub-io/maas-library/bff/internal/repositories"
 )
 
 func attachExternalProviderHandlers(apiRouter *httprouter.Router, app *App) {
@@ -45,7 +45,7 @@ func CreateExternalProviderHandler(app *App, w http.ResponseWriter, r *http.Requ
 	ctx := r.Context()
 
 	var request Envelope[models.CreateExternalProviderRequest, None]
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := app.ReadJSON(w, r, &request); err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
@@ -57,7 +57,7 @@ func CreateExternalProviderHandler(app *App, w http.ResponseWriter, r *http.Requ
 
 	result, err := app.repositories.ExternalProviders.CreateExternalProvider(ctx, request.Data)
 	if err != nil {
-		if strings.Contains(err.Error(), "already exists") {
+		if errors.Is(err, repositories.ErrAlreadyExists) {
 			app.errorResponse(w, r, &HTTPError{
 				StatusCode: http.StatusConflict,
 				Error:      ErrorPayload{Code: "409", Message: err.Error()},
@@ -85,7 +85,7 @@ func UpdateExternalProviderHandler(app *App, w http.ResponseWriter, r *http.Requ
 	}
 
 	var request Envelope[models.UpdateExternalProviderRequest, None]
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := app.ReadJSON(w, r, &request); err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
@@ -94,10 +94,16 @@ func UpdateExternalProviderHandler(app *App, w http.ResponseWriter, r *http.Requ
 		app.badRequestResponse(w, r, errors.New("authMechanism must be 'apikey', 'sigv4', or 'oauth2'"))
 		return
 	}
+	if strings.TrimSpace(request.Data.EndpointUrl) != "" {
+		if err := validateEndpointURL(request.Data.EndpointUrl); err != nil {
+			app.badRequestResponse(w, r, err)
+			return
+		}
+	}
 
 	result, err := app.repositories.ExternalProviders.UpdateExternalProvider(ctx, namespace, name, request.Data)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, repositories.ErrNotFound) {
 			app.errorResponse(w, r, &HTTPError{
 				StatusCode: http.StatusNotFound,
 				Error:      ErrorPayload{Code: "404", Message: err.Error()},
@@ -125,7 +131,7 @@ func DeleteExternalProviderHandler(app *App, w http.ResponseWriter, r *http.Requ
 	}
 
 	if err := app.repositories.ExternalProviders.DeleteExternalProvider(ctx, namespace, name); err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, repositories.ErrNotFound) {
 			app.errorResponse(w, r, &HTTPError{
 				StatusCode: http.StatusNotFound,
 				Error:      ErrorPayload{Code: "404", Message: err.Error()},
@@ -149,8 +155,8 @@ func validateCreateExternalProviderRequest(request models.CreateExternalProvider
 	if strings.TrimSpace(request.Namespace) == "" {
 		return errors.New("namespace is required")
 	}
-	if strings.TrimSpace(request.EndpointUrl) == "" {
-		return errors.New("endpointUrl is required")
+	if err := validateEndpointURL(request.EndpointUrl); err != nil {
+		return err
 	}
 	if !request.AuthMechanism.IsValid() {
 		return errors.New("authMechanism must be 'apikey', 'sigv4', or 'oauth2'")
@@ -160,6 +166,26 @@ func validateCreateExternalProviderRequest(request models.CreateExternalProvider
 	}
 	if strings.TrimSpace(request.Provider) == "" {
 		return errors.New("provider is required")
+	}
+	return nil
+}
+
+func validateEndpointURL(raw string) error {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return errors.New("endpointUrl is required")
+	}
+	schemeSep := strings.Index(s, "://")
+	if schemeSep == -1 {
+		return nil
+	}
+	scheme := strings.ToLower(s[:schemeSep])
+	if scheme != "http" && scheme != "https" {
+		return errors.New("endpointUrl must be an http or https URL")
+	}
+	host := strings.Trim(s[schemeSep+3:], "/")
+	if strings.TrimSpace(host) == "" {
+		return errors.New("endpointUrl must include a host")
 	}
 	return nil
 }

--- a/packages/maas/bff/internal/api/externalprovider_handlers_test.go
+++ b/packages/maas/bff/internal/api/externalprovider_handlers_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,5 +27,69 @@ var _ = Describe("ExternalProviderHandlers", Ordered, func() {
 		Expect(rs.StatusCode).To(Equal(http.StatusOK))
 		Expect(len(actual.Data)).To(BeNumerically(">=", 1))
 		Expect(actual.Data[0].DisplayName).NotTo(BeEmpty())
+	})
+
+	It("creates an ExternalProvider", func() {
+		name := fmt.Sprintf("test-provider-%d", GinkgoRandomSeed())
+		actual, rs, err := setupMockApiTest[Envelope[*models.ExternalProviderSummary, None]](
+			http.MethodPost,
+			"/api/v1/externalprovider",
+			Envelope[models.CreateExternalProviderRequest, None]{
+				Data: models.CreateExternalProviderRequest{
+					Name:                name,
+					Namespace:           "maas-models",
+					DisplayName:         "Test Provider",
+					EndpointUrl:         "https://api.example.com",
+					AuthMechanism:       models.AuthMechanismAPIKey,
+					CredentialSecretRef: "test-api-key",
+					Provider:            "openai",
+				},
+			},
+			k8Factory,
+			identity,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+		Expect(actual.Data).NotTo(BeNil())
+		Expect(actual.Data.Name).To(Equal(name))
+		Expect(actual.Data.Namespace).To(Equal("maas-models"))
+		Expect(actual.Data.DisplayName).To(Equal("Test Provider"))
+		Expect(actual.Data.Provider).To(Equal("openai"))
+		Expect(actual.Data.CredentialSecretRef).To(Equal("test-api-key"))
+	})
+
+	It("updates an ExternalProvider", func() {
+		displayName := "Updated OpenAI"
+		actual, rs, err := setupMockApiTest[Envelope[*models.ExternalProviderSummary, None]](
+			http.MethodPut,
+			"/api/v1/externalprovider/maas-models/openai-prod",
+			Envelope[models.UpdateExternalProviderRequest, None]{
+				Data: models.UpdateExternalProviderRequest{
+					DisplayName: &displayName,
+				},
+			},
+			k8Factory,
+			identity,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		Expect(actual.Data).NotTo(BeNil())
+		Expect(actual.Data.Name).To(Equal("openai-prod"))
+		Expect(actual.Data.DisplayName).To(Equal(displayName))
+	})
+
+	It("deletes an ExternalProvider", func() {
+		_, rs, err := setupMockApiTest[Envelope[None, None]](
+			http.MethodDelete,
+			"/api/v1/externalprovider/maas-models/openai-prod",
+			nil,
+			k8Factory,
+			identity,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
 	})
 })

--- a/packages/maas/bff/internal/api/externalprovider_handlers_test.go
+++ b/packages/maas/bff/internal/api/externalprovider_handlers_test.go
@@ -39,7 +39,7 @@ var _ = Describe("ExternalProviderHandlers", Ordered, func() {
 					Name:                name,
 					Namespace:           "maas-models",
 					DisplayName:         "Test Provider",
-					EndpointUrl:         "https://api.example.com",
+					EndpointUrl:         "api.example.com",
 					AuthMechanism:       models.AuthMechanismAPIKey,
 					CredentialSecretRef: "test-api-key",
 					Provider:            "openai",

--- a/packages/maas/bff/internal/api/externalprovider_handlers_test.go
+++ b/packages/maas/bff/internal/api/externalprovider_handlers_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+var _ = Describe("ExternalProviderHandlers", Ordered, func() {
+	identity := &kubernetes.RequestIdentity{UserID: "user@example.com"}
+
+	It("lists ExternalProviders in a namespace", func() {
+		actual, rs, err := setupApiTest[Envelope[[]models.ExternalProviderSummary, None]](
+			http.MethodGet,
+			"/api/v1/externalprovider?namespace=maas-models",
+			nil,
+			k8Factory,
+			identity,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		Expect(len(actual.Data)).To(BeNumerically(">=", 1))
+		Expect(actual.Data[0].DisplayName).NotTo(BeEmpty())
+	})
+})

--- a/packages/maas/bff/internal/api/healthcheck_handler_test.go
+++ b/packages/maas/bff/internal/api/healthcheck_handler_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHealthCheckHandler(t *testing.T) {
-	repos, err := repositories.NewRepositories(nil, nil, config.EnvConfig{}, nil, nil, nil, nil, nil)
+	repos, err := repositories.NewRepositories(nil, nil, config.EnvConfig{}, nil, nil, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 	app := App{config: config.EnvConfig{
 		Port: 4000,

--- a/packages/maas/bff/internal/api/maas_api_unavailable_test.go
+++ b/packages/maas/bff/internal/api/maas_api_unavailable_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestRequireMaasApiReady_Returns503WhenUnavailable(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	repos, err := repositories.NewRepositories(logger, nil, config.EnvConfig{}, nil, nil, nil, nil, nil)
+	repos, err := repositories.NewRepositories(logger, nil, config.EnvConfig{}, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewRepositories: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestRequireMaasApiReady_Returns503WhenUnavailable(t *testing.T) {
 
 func TestHandlerWithMaasApi_Returns503WhenUnavailable(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	repos, err := repositories.NewRepositories(logger, nil, config.EnvConfig{}, nil, nil, nil, nil, nil)
+	repos, err := repositories.NewRepositories(logger, nil, config.EnvConfig{}, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewRepositories: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestHandlerWithMaasApi_AllowsRequestWhenReady(t *testing.T) {
 	defer maasFakeServer.Close()
 
 	envConfig := config.EnvConfig{MaasApiUrl: maasFakeServer.URL}
-	repos, err := repositories.NewRepositories(logger, nil, envConfig, nil, nil, nil, nil, nil)
+	repos, err := repositories.NewRepositories(logger, nil, envConfig, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewRepositories: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestWireMaasApiURL_EnablesReadyHandlers(t *testing.T) {
 	defer maasFakeServer.Close()
 
 	envConfig := config.EnvConfig{MaasApiUrl: ""}
-	repos, err := repositories.NewRepositories(logger, nil, envConfig, nil, nil, nil, nil, nil)
+	repos, err := repositories.NewRepositories(logger, nil, envConfig, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewRepositories: %v", err)
 	}

--- a/packages/maas/bff/internal/api/namespaces_handler_test.go
+++ b/packages/maas/bff/internal/api/namespaces_handler_test.go
@@ -24,7 +24,7 @@ var _ = Describe("TestNamespacesHandler", func() {
 
 		BeforeAll(func() {
 			By("setting up the test app in dev mode")
-			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			testApp = App{
@@ -141,7 +141,7 @@ var _ = Describe("TestNamespacesHandler", func() {
 			By("setting up the test app in dev mode")
 			kubernetesMockedTokenClientFactory, err := k8mocks.NewTokenClientFactory(clientset, restConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
-			repos, err := repositories.NewRepositories(logger, kubernetesMockedTokenClientFactory, envConfig, nil, nil, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, kubernetesMockedTokenClientFactory, envConfig, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			testApp = App{
 				config:                  config.EnvConfig{DevMode: true},

--- a/packages/maas/bff/internal/api/secret_handlers.go
+++ b/packages/maas/bff/internal/api/secret_handlers.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+func attachSecretHandlers(apiRouter *httprouter.Router, app *App) {
+	apiRouter.GET(constants.SecretListPath, handlerWithApp(app, ListSecretsHandler))
+	apiRouter.POST(constants.SecretCreatePath, handlerWithApp(app, CreateSecretHandler))
+}
+
+// ListSecretsHandler handles GET /api/v1/secrets?namespace=X
+func ListSecretsHandler(app *App, w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+	namespace, err := namespaceFromContext(r)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	secrets, err := app.repositories.Secrets.ListSecrets(ctx, namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	response := Envelope[[]models.SecretSummary, None]{Data: secrets}
+	if err := app.WriteJSON(w, http.StatusOK, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// CreateSecretHandler handles POST /api/v1/secrets
+func CreateSecretHandler(app *App, w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	var request Envelope[models.CreateSecretRequest, None]
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if strings.TrimSpace(request.Data.Namespace) == "" {
+		app.badRequestResponse(w, r, errors.New("namespace is required"))
+		return
+	}
+	if strings.TrimSpace(request.Data.Name) == "" {
+		app.badRequestResponse(w, r, errors.New("name is required"))
+		return
+	}
+	if strings.TrimSpace(request.Data.Value) == "" {
+		app.badRequestResponse(w, r, errors.New("value is required"))
+		return
+	}
+
+	result, err := app.repositories.Secrets.CreateSecret(ctx, request.Data)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			app.errorResponse(w, r, &HTTPError{
+				StatusCode: http.StatusConflict,
+				Error:      ErrorPayload{Code: "409", Message: err.Error()},
+			})
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	response := Envelope[*models.CreateSecretResponse, None]{Data: result}
+	if err := app.WriteJSON(w, http.StatusCreated, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/packages/maas/bff/internal/api/secret_handlers.go
+++ b/packages/maas/bff/internal/api/secret_handlers.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
+	"github.com/opendatahub-io/maas-library/bff/internal/repositories"
 )
 
 func attachSecretHandlers(apiRouter *httprouter.Router, app *App) {
@@ -43,7 +43,7 @@ func CreateSecretHandler(app *App, w http.ResponseWriter, r *http.Request, _ htt
 	ctx := r.Context()
 
 	var request Envelope[models.CreateSecretRequest, None]
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := app.ReadJSON(w, r, &request); err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
@@ -63,7 +63,7 @@ func CreateSecretHandler(app *App, w http.ResponseWriter, r *http.Request, _ htt
 
 	result, err := app.repositories.Secrets.CreateSecret(ctx, request.Data)
 	if err != nil {
-		if strings.Contains(err.Error(), "already exists") {
+		if errors.Is(err, repositories.ErrAlreadyExists) {
 			app.errorResponse(w, r, &HTTPError{
 				StatusCode: http.StatusConflict,
 				Error:      ErrorPayload{Code: "409", Message: err.Error()},

--- a/packages/maas/bff/internal/api/secret_handlers_test.go
+++ b/packages/maas/bff/internal/api/secret_handlers_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+var _ = Describe("SecretHandlers", Ordered, func() {
+	identity := &kubernetes.RequestIdentity{UserID: "user@example.com"}
+
+	It("lists Secrets in a namespace", func() {
+		actual, rs, err := setupMockApiTest[Envelope[[]models.SecretSummary, None]](
+			http.MethodGet,
+			"/api/v1/secrets?namespace=maas-models",
+			nil,
+			k8Factory,
+			identity,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		Expect(len(actual.Data)).To(BeNumerically(">=", 1))
+		Expect(actual.Data[0].Name).NotTo(BeEmpty())
+	})
+
+	It("creates a Secret", func() {
+		name := fmt.Sprintf("test-secret-%d", GinkgoRandomSeed())
+		actual, rs, err := setupMockApiTest[Envelope[*models.CreateSecretResponse, None]](
+			http.MethodPost,
+			"/api/v1/secrets",
+			Envelope[models.CreateSecretRequest, None]{
+				Data: models.CreateSecretRequest{
+					Namespace: "maas-models",
+					Name:      name,
+					Value:     "sk-test",
+				},
+			},
+			k8Factory,
+			identity,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+		Expect(actual.Data).NotTo(BeNil())
+		Expect(actual.Data.Name).To(Equal(name))
+	})
+})

--- a/packages/maas/bff/internal/api/test_utils.go
+++ b/packages/maas/bff/internal/api/test_utils.go
@@ -61,9 +61,11 @@ func setupApiTest[T any](method, url string, body interface{}, k8Factory kuberne
 	policiesRepo := repositories.NewPoliciesRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 	modelRefsRepo := repositories.NewMaaSModelRefsRepository(logger, k8Factory)
 	externalModelsRepo := repositories.NewExternalModelsRepository(logger, k8Factory, modelRefsRepo)
+	externalProvidersRepo := repositories.NewExternalProvidersRepository(logger, k8Factory)
+	secretsRepo := repositories.NewSecretsRepository(logger, k8Factory)
 	yamlRepo := repositories.NewYamlRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 
-	repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, subscriptionsRepo, policiesRepo, modelRefsRepo, externalModelsRepo, yamlRepo)
+	repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, subscriptionsRepo, policiesRepo, modelRefsRepo, externalModelsRepo, externalProvidersRepo, secretsRepo, yamlRepo)
 	if err != nil {
 		return empty, nil, err
 	}

--- a/packages/maas/bff/internal/api/test_utils.go
+++ b/packages/maas/bff/internal/api/test_utils.go
@@ -17,8 +17,17 @@ import (
 	"github.com/opendatahub-io/maas-library/bff/internal/repositories"
 )
 
-// setupApiTest is a minimal helper to exercise remaining handlers (user, namespaces, healthcheck)
+// setupApiTest exercises handlers against envtest-backed Kubernetes repositories.
 func setupApiTest[T any](method, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, identity *kubernetes.RequestIdentity) (T, *http.Response, error) {
+	return doApiTest[T](method, url, body, k8Factory, identity, false)
+}
+
+// setupMockApiTest exercises handlers against in-memory mock repositories (dev BFF path).
+func setupMockApiTest[T any](method, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, identity *kubernetes.RequestIdentity) (T, *http.Response, error) {
+	return doApiTest[T](method, url, body, k8Factory, identity, true)
+}
+
+func doApiTest[T any](method, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, identity *kubernetes.RequestIdentity, useMocks bool) (T, *http.Response, error) {
 	var empty T
 	var reqBody io.Reader
 	if body != nil {
@@ -56,16 +65,7 @@ func setupApiTest[T any](method, url string, body interface{}, k8Factory kuberne
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	// Tests use real K8s repos backed by envtest (not mocks)
-	subscriptionsRepo := repositories.NewSubscriptionsRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
-	policiesRepo := repositories.NewPoliciesRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
-	modelRefsRepo := repositories.NewMaaSModelRefsRepository(logger, k8Factory)
-	externalModelsRepo := repositories.NewExternalModelsRepository(logger, k8Factory, modelRefsRepo)
-	externalProvidersRepo := repositories.NewExternalProvidersRepository(logger, k8Factory)
-	secretsRepo := repositories.NewSecretsRepository(logger, k8Factory)
-	yamlRepo := repositories.NewYamlRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
-
-	repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, subscriptionsRepo, policiesRepo, modelRefsRepo, externalModelsRepo, externalProvidersRepo, secretsRepo, yamlRepo)
+	repos, err := newTestRepositories(logger, k8Factory, envConfig, useMocks)
 	if err != nil {
 		return empty, nil, err
 	}
@@ -96,4 +96,41 @@ func setupApiTest[T any](method, url string, body interface{}, k8Factory kuberne
 		return empty, res, err
 	}
 	return out, res, nil
+}
+
+func newTestRepositories(
+	logger *slog.Logger,
+	k8Factory kubernetes.KubernetesClientFactory,
+	envConfig config.EnvConfig,
+	useMocks bool,
+) (*repositories.Repositories, error) {
+	if useMocks {
+		modelRefsRepo := repositories.NewMockMaaSModelRefsRepository(logger)
+		return repositories.NewRepositories(
+			logger,
+			k8Factory,
+			envConfig,
+			repositories.NewMockSubscriptionsRepository(logger),
+			repositories.NewMockPoliciesRepository(logger),
+			modelRefsRepo,
+			repositories.NewMockExternalModelsRepository(logger, modelRefsRepo),
+			repositories.NewMockExternalProvidersRepository(logger),
+			repositories.NewMockSecretsRepository(logger),
+			repositories.NewMockYamlRepository(logger),
+		)
+	}
+
+	modelRefsRepo := repositories.NewMaaSModelRefsRepository(logger, k8Factory)
+	return repositories.NewRepositories(
+		logger,
+		k8Factory,
+		envConfig,
+		repositories.NewSubscriptionsRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace),
+		repositories.NewPoliciesRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace),
+		modelRefsRepo,
+		repositories.NewExternalModelsRepository(logger, k8Factory, modelRefsRepo),
+		repositories.NewExternalProvidersRepository(logger, k8Factory),
+		repositories.NewSecretsRepository(logger, k8Factory),
+		repositories.NewYamlRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace),
+	)
 }

--- a/packages/maas/bff/internal/api/user_handler_test.go
+++ b/packages/maas/bff/internal/api/user_handler_test.go
@@ -35,7 +35,7 @@ var _ = Describe("TestUserHandler", func() {
 
 		BeforeAll(func() {
 			By("creating the test app")
-			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			testApp = App{
 				kubernetesClientFactory: k8Factory,

--- a/packages/maas/bff/internal/constants/api_routes.go
+++ b/packages/maas/bff/internal/constants/api_routes.go
@@ -44,5 +44,17 @@ const (
 
 	// ExternalModel routes
 	ExternalModelListPath   = ApiPathPrefix + "/externalmodel"
+	ExternalModelCreatePath = ApiPathPrefix + "/externalmodel"
+	ExternalModelUpdatePath = ApiPathPrefix + "/externalmodel/:namespace/:name"
 	ExternalModelDeletePath = ApiPathPrefix + "/externalmodel/:namespace/:name"
+
+	// ExternalProvider routes
+	ExternalProviderListPath   = ApiPathPrefix + "/externalprovider"
+	ExternalProviderCreatePath = ApiPathPrefix + "/externalprovider"
+	ExternalProviderUpdatePath = ApiPathPrefix + "/externalprovider/:namespace/:name"
+	ExternalProviderDeletePath = ApiPathPrefix + "/externalprovider/:namespace/:name"
+
+	// Secret routes
+	SecretListPath   = ApiPathPrefix + "/secrets"
+	SecretCreatePath = ApiPathPrefix + "/secrets"
 )

--- a/packages/maas/bff/internal/mocks/external_mock.go
+++ b/packages/maas/bff/internal/mocks/external_mock.go
@@ -286,3 +286,10 @@ func GetMockExternalModelSummaries() []models.ExternalModelSummary {
 		},
 	}
 }
+
+func GetMockSecretSummaries() []models.SecretSummary {
+	return []models.SecretSummary{
+		{Name: "openai-api-key"},
+		{Name: "anthropic-api-key"},
+	}
+}

--- a/packages/maas/bff/internal/models/externalmodel.go
+++ b/packages/maas/bff/internal/models/externalmodel.go
@@ -35,3 +35,21 @@ type ExternalModelSummary struct {
 	Reason        string                           `json:"reason,omitempty"`
 	MaaSModelRef  *ExternalModelMaaSModelRefStatus `json:"maaSModelRef,omitempty"`
 }
+
+// CreateExternalModelRequest is the request body for creating an ExternalModel.
+type CreateExternalModelRequest struct {
+	Name         string        `json:"name"`
+	Namespace    string        `json:"namespace"`
+	DisplayName  string        `json:"displayName,omitempty"`
+	Description  string        `json:"description,omitempty"`
+	ModelName    string        `json:"modelName,omitempty"`
+	ProviderRefs []ProviderRef `json:"providerRefs"`
+}
+
+// UpdateExternalModelRequest is the request body for updating an ExternalModel.
+type UpdateExternalModelRequest struct {
+	DisplayName  *string       `json:"displayName,omitempty"`
+	Description  *string       `json:"description,omitempty"`
+	ModelName    string        `json:"modelName,omitempty"`
+	ProviderRefs []ProviderRef `json:"providerRefs,omitempty"`
+}

--- a/packages/maas/bff/internal/models/externalprovider.go
+++ b/packages/maas/bff/internal/models/externalprovider.go
@@ -48,3 +48,26 @@ type ExternalProviderSummary struct {
 	StatusMessage       string            `json:"statusMessage,omitempty"`
 	Reason              string            `json:"reason,omitempty"`
 }
+
+// CreateExternalProviderRequest is the request body for creating an ExternalProvider.
+type CreateExternalProviderRequest struct {
+	Name                string            `json:"name"`
+	Namespace           string            `json:"namespace"`
+	DisplayName         string            `json:"displayName,omitempty"`
+	Description         string            `json:"description,omitempty"`
+	EndpointUrl         string            `json:"endpointUrl"`
+	AuthMechanism       AuthMechanism     `json:"authMechanism"`
+	CredentialSecretRef string            `json:"credentialSecretRef"`
+	Provider            string            `json:"provider"`
+	Config              map[string]string `json:"config,omitempty"`
+}
+
+// UpdateExternalProviderRequest is the request body for updating an ExternalProvider.
+type UpdateExternalProviderRequest struct {
+	DisplayName         *string           `json:"displayName,omitempty"`
+	Description         *string           `json:"description,omitempty"`
+	EndpointUrl         string            `json:"endpointUrl,omitempty"`
+	AuthMechanism       *AuthMechanism    `json:"authMechanism,omitempty"`
+	CredentialSecretRef string            `json:"credentialSecretRef,omitempty"`
+	Config              map[string]string `json:"config,omitempty"`
+}

--- a/packages/maas/bff/internal/models/secret.go
+++ b/packages/maas/bff/internal/models/secret.go
@@ -1,0 +1,18 @@
+package models
+
+// SecretSummary is a Kubernetes Secret name (values are never returned).
+type SecretSummary struct {
+	Name string `json:"name"`
+}
+
+// CreateSecretRequest is the request body for creating a Secret.
+type CreateSecretRequest struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Value     string `json:"value"`
+}
+
+// CreateSecretResponse is returned after creating a Secret.
+type CreateSecretResponse struct {
+	Name string `json:"name"`
+}

--- a/packages/maas/bff/internal/repositories/external_helpers.go
+++ b/packages/maas/bff/internal/repositories/external_helpers.go
@@ -229,3 +229,10 @@ func convertUnstructuredToExternalModelSummary(obj *unstructured.Unstructured) *
 
 	return summary
 }
+
+func normalizeEndpointURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	return strings.TrimRight(s, "/")
+}

--- a/packages/maas/bff/internal/repositories/external_helpers.go
+++ b/packages/maas/bff/internal/repositories/external_helpers.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -230,14 +231,26 @@ func convertUnstructuredToExternalModelSummary(obj *unstructured.Unstructured) *
 	return summary
 }
 
+var endpointFQDNPattern = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)+$`)
+
+const maxEndpointFQDNLength = 253
+
 func normalizeEndpointURL(raw string) string {
-	s := strings.TrimSpace(raw)
-	lower := strings.ToLower(s)
-	switch {
-	case strings.HasPrefix(lower, "https://"):
-		s = s[len("https://"):]
-	case strings.HasPrefix(lower, "http://"):
-		s = s[len("http://"):]
+	return strings.TrimSpace(raw)
+}
+
+// ValidateEndpointURL checks ExternalProvider spec.endpoint against the CRD:
+// FQDN, no scheme or path, 1–253 characters.
+func ValidateEndpointURL(raw string) error {
+	host := normalizeEndpointURL(raw)
+	if host == "" {
+		return fmt.Errorf("endpointUrl is required")
 	}
-	return strings.TrimRight(s, "/")
+	if len(host) > maxEndpointFQDNLength {
+		return fmt.Errorf("endpointUrl must be at most %d characters", maxEndpointFQDNLength)
+	}
+	if !endpointFQDNPattern.MatchString(host) {
+		return fmt.Errorf("endpointUrl must be an FQDN with no scheme or path (e.g. api.openai.com)")
+	}
+	return nil
 }

--- a/packages/maas/bff/internal/repositories/external_helpers.go
+++ b/packages/maas/bff/internal/repositories/external_helpers.go
@@ -232,7 +232,12 @@ func convertUnstructuredToExternalModelSummary(obj *unstructured.Unstructured) *
 
 func normalizeEndpointURL(raw string) string {
 	s := strings.TrimSpace(raw)
-	s = strings.TrimPrefix(s, "https://")
-	s = strings.TrimPrefix(s, "http://")
+	lower := strings.ToLower(s)
+	switch {
+	case strings.HasPrefix(lower, "https://"):
+		s = s[len("https://"):]
+	case strings.HasPrefix(lower, "http://"):
+		s = s[len("http://"):]
+	}
 	return strings.TrimRight(s, "/")
 }

--- a/packages/maas/bff/internal/repositories/external_helpers_test.go
+++ b/packages/maas/bff/internal/repositories/external_helpers_test.go
@@ -229,3 +229,30 @@ func TestEnrichExternalModelSummaries_AuthOverride(t *testing.T) {
 		t.Fatalf("expected provider credentialSecretRef, got %q", enriched[1].ProviderRefs[0].Provider.CredentialSecretRef)
 	}
 }
+
+func TestValidateEndpointURL(t *testing.T) {
+	valid := []string{
+		"api.openai.com",
+		"bedrock.amazonaws.com",
+	}
+	for _, raw := range valid {
+		if err := ValidateEndpointURL(raw); err != nil {
+			t.Errorf("%q: unexpected error: %v", raw, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"   ",
+		"localhost",
+		"api.openai.com/v1",
+		"https://api.openai.com",
+		"http://api.openai.com/",
+		"ftp://api.openai.com",
+	}
+	for _, raw := range invalid {
+		if err := ValidateEndpointURL(raw); err == nil {
+			t.Errorf("%q: expected error", raw)
+		}
+	}
+}

--- a/packages/maas/bff/internal/repositories/externalmodels.go
+++ b/packages/maas/bff/internal/repositories/externalmodels.go
@@ -82,7 +82,7 @@ func (r *ExternalModelsRepository) DeleteExternalModel(ctx context.Context, name
 	err = client.GetDynamicClient().Resource(constants.ExternalModelGvr).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
-			return fmt.Errorf("ExternalModel '%s' not found: %w", name, err)
+			return fmt.Errorf("%w: ExternalModel '%s' not found", ErrNotFound, name)
 		}
 		return fmt.Errorf("failed to delete ExternalModel: %w", err)
 	}

--- a/packages/maas/bff/internal/repositories/externalmodels.go
+++ b/packages/maas/bff/internal/repositories/externalmodels.go
@@ -100,3 +100,18 @@ func (r *ExternalModelsRepository) deleteMaaSModelRefForExternalModel(ctx contex
 	}
 	return err
 }
+
+func (r *ExternalModelsRepository) CreateExternalModel(
+	_ context.Context,
+	_ models.CreateExternalModelRequest,
+) (*models.ExternalModelSummary, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (r *ExternalModelsRepository) UpdateExternalModel(
+	_ context.Context,
+	_, _ string,
+	_ models.UpdateExternalModelRequest,
+) (*models.ExternalModelSummary, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/packages/maas/bff/internal/repositories/externalmodels_mock.go
+++ b/packages/maas/bff/internal/repositories/externalmodels_mock.go
@@ -14,6 +14,7 @@ import (
 type MockExternalModelsRepository struct {
 	logger        *slog.Logger
 	modelRefsRepo MaaSModelRefsRepositoryInterface
+	created       []models.ExternalModelSummary
 }
 
 // NewMockExternalModelsRepository creates a new mock ExternalModel repository.
@@ -32,6 +33,11 @@ func (r *MockExternalModelsRepository) ListExternalModels(ctx context.Context, n
 
 	result := make([]models.ExternalModelSummary, 0)
 	for _, item := range mocks.GetMockExternalModelSummaries() {
+		if item.Namespace == namespace {
+			result = append(result, item)
+		}
+	}
+	for _, item := range r.created {
 		if item.Namespace == namespace {
 			result = append(result, item)
 		}
@@ -62,15 +68,143 @@ func (r *MockExternalModelsRepository) ListExternalModels(ctx context.Context, n
 	), nil
 }
 
+func (r *MockExternalModelsRepository) CreateExternalModel(ctx context.Context, request models.CreateExternalModelRequest) (*models.ExternalModelSummary, error) {
+	r.logger.Debug("Creating ExternalModel (mock)", slog.String("name", request.Name))
+
+	for _, item := range mocks.GetMockExternalModelSummaries() {
+		if item.Name == request.Name && item.Namespace == request.Namespace {
+			return nil, fmt.Errorf("ExternalModel '%s' already exists", request.Name)
+		}
+	}
+	for _, item := range r.created {
+		if item.Name == request.Name && item.Namespace == request.Namespace {
+			return nil, fmt.Errorf("ExternalModel '%s' already exists", request.Name)
+		}
+	}
+
+	if err := r.createMaaSModelRefForExternalModel(ctx, request); err != nil {
+		return nil, err
+	}
+
+	modelName := request.ModelName
+	if modelName == "" {
+		modelName = request.Name
+	}
+
+	summary := models.ExternalModelSummary{
+		Name:         request.Name,
+		Namespace:    request.Namespace,
+		DisplayName:  request.DisplayName,
+		Description:  request.Description,
+		ModelName:    modelName,
+		ProviderRefs: request.ProviderRefs,
+		Phase:        "Pending",
+	}
+	r.created = append(r.created, summary)
+	return &summary, nil
+}
+
+func (r *MockExternalModelsRepository) UpdateExternalModel(ctx context.Context, namespace, name string, request models.UpdateExternalModelRequest) (*models.ExternalModelSummary, error) {
+	r.logger.Debug("Updating ExternalModel (mock)", slog.String("namespace", namespace), slog.String("name", name))
+
+	for i, item := range r.created {
+		if item.Name == name && item.Namespace == namespace {
+			updated := r.created[i]
+			if request.DisplayName != nil {
+				updated.DisplayName = *request.DisplayName
+			}
+			if request.Description != nil {
+				updated.Description = *request.Description
+			}
+			if request.ModelName != "" {
+				updated.ModelName = request.ModelName
+			}
+			if len(request.ProviderRefs) > 0 {
+				updated.ProviderRefs = request.ProviderRefs
+			}
+			r.created[i] = updated
+			if err := r.syncMaaSModelRefOnUpdate(ctx, namespace, name, request); err != nil {
+				return nil, err
+			}
+			return &updated, nil
+		}
+	}
+
+	for _, item := range mocks.GetMockExternalModelSummaries() {
+		if item.Name == name && item.Namespace == namespace {
+			updated := item
+			if request.DisplayName != nil {
+				updated.DisplayName = *request.DisplayName
+			}
+			if request.Description != nil {
+				updated.Description = *request.Description
+			}
+			if request.ModelName != "" {
+				updated.ModelName = request.ModelName
+			}
+			if len(request.ProviderRefs) > 0 {
+				updated.ProviderRefs = request.ProviderRefs
+			}
+			if err := r.syncMaaSModelRefOnUpdate(ctx, namespace, name, request); err != nil {
+				return nil, err
+			}
+			return &updated, nil
+		}
+	}
+
+	return nil, fmt.Errorf("ExternalModel '%s' not found", name)
+}
+
 func (r *MockExternalModelsRepository) DeleteExternalModel(ctx context.Context, namespace, name string) error {
 	r.logger.Debug("Deleting ExternalModel (mock)", slog.String("namespace", namespace), slog.String("name", name))
 
+	for i, item := range r.created {
+		if item.Name == name && item.Namespace == namespace {
+			r.created = append(r.created[:i], r.created[i+1:]...)
+			return r.deleteMaaSModelRefForExternalModel(ctx, namespace, name)
+		}
+	}
 	for _, item := range mocks.GetMockExternalModelSummaries() {
 		if item.Name == name && item.Namespace == namespace {
 			return r.deleteMaaSModelRefForExternalModel(ctx, namespace, name)
 		}
 	}
 	return fmt.Errorf("ExternalModel '%s' not found", name)
+}
+func (r *MockExternalModelsRepository) createMaaSModelRefForExternalModel(
+	ctx context.Context,
+	request models.CreateExternalModelRequest,
+) error {
+	_, err := r.modelRefsRepo.CreateMaaSModelRef(ctx, models.CreateMaaSModelRefRequest{
+		Name:        request.Name,
+		Namespace:   request.Namespace,
+		DisplayName: request.DisplayName,
+		Description: request.Description,
+		ModelRef: models.ModelReference{
+			Kind: "ExternalModel",
+			Name: request.Name,
+		},
+	}, false)
+	return err
+}
+
+func (r *MockExternalModelsRepository) syncMaaSModelRefOnUpdate(
+	ctx context.Context,
+	namespace, name string,
+	request models.UpdateExternalModelRequest,
+) error {
+	_, err := r.modelRefsRepo.UpdateMaaSModelRef(ctx, namespace, name, models.UpdateMaaSModelRefRequest{
+		ModelRef: models.ModelReference{
+			Kind: "ExternalModel",
+			Name: name,
+		},
+		DisplayName: request.DisplayName,
+		Description: request.Description,
+	}, false)
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		return nil
+	}
+	return err
 }
 
 func (r *MockExternalModelsRepository) deleteMaaSModelRefForExternalModel(ctx context.Context, namespace, name string) error {

--- a/packages/maas/bff/internal/repositories/externalmodels_mock.go
+++ b/packages/maas/bff/internal/repositories/externalmodels_mock.go
@@ -80,12 +80,12 @@ func (r *MockExternalModelsRepository) CreateExternalModel(ctx context.Context, 
 
 	for _, item := range mocks.GetMockExternalModelSummaries() {
 		if item.Name == request.Name && item.Namespace == request.Namespace {
-			return nil, fmt.Errorf("ExternalModel '%s' already exists", request.Name)
+			return nil, fmt.Errorf("%w: ExternalModel '%s' already exists", ErrAlreadyExists, request.Name)
 		}
 	}
 	for _, item := range r.created {
 		if item.Name == request.Name && item.Namespace == request.Namespace {
-			return nil, fmt.Errorf("ExternalModel '%s' already exists", request.Name)
+			return nil, fmt.Errorf("%w: ExternalModel '%s' already exists", ErrAlreadyExists, request.Name)
 		}
 	}
 
@@ -162,7 +162,7 @@ func (r *MockExternalModelsRepository) UpdateExternalModel(ctx context.Context, 
 		}
 	}
 
-	return nil, fmt.Errorf("ExternalModel '%s' not found", name)
+	return nil, fmt.Errorf("%w: ExternalModel '%s' not found", ErrNotFound, name)
 }
 
 func (r *MockExternalModelsRepository) DeleteExternalModel(ctx context.Context, namespace, name string) error {
@@ -182,7 +182,7 @@ func (r *MockExternalModelsRepository) DeleteExternalModel(ctx context.Context, 
 			return r.deleteMaaSModelRefForExternalModel(ctx, namespace, name)
 		}
 	}
-	return fmt.Errorf("ExternalModel '%s' not found", name)
+	return fmt.Errorf("%w: ExternalModel '%s' not found", ErrNotFound, name)
 }
 func (r *MockExternalModelsRepository) createMaaSModelRefForExternalModel(
 	ctx context.Context,

--- a/packages/maas/bff/internal/repositories/externalmodels_mock.go
+++ b/packages/maas/bff/internal/repositories/externalmodels_mock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"github.com/opendatahub-io/maas-library/bff/internal/mocks"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
@@ -14,6 +15,7 @@ import (
 type MockExternalModelsRepository struct {
 	logger        *slog.Logger
 	modelRefsRepo MaaSModelRefsRepositoryInterface
+	mu            sync.RWMutex
 	created       []models.ExternalModelSummary
 }
 
@@ -37,11 +39,13 @@ func (r *MockExternalModelsRepository) ListExternalModels(ctx context.Context, n
 			result = append(result, item)
 		}
 	}
+	r.mu.RLock()
 	for _, item := range r.created {
 		if item.Namespace == namespace {
 			result = append(result, item)
 		}
 	}
+	r.mu.RUnlock()
 
 	providers := make([]models.ExternalProviderSummary, 0)
 	for _, item := range mocks.GetMockExternalProviderSummaries() {
@@ -70,6 +74,9 @@ func (r *MockExternalModelsRepository) ListExternalModels(ctx context.Context, n
 
 func (r *MockExternalModelsRepository) CreateExternalModel(ctx context.Context, request models.CreateExternalModelRequest) (*models.ExternalModelSummary, error) {
 	r.logger.Debug("Creating ExternalModel (mock)", slog.String("name", request.Name))
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	for _, item := range mocks.GetMockExternalModelSummaries() {
 		if item.Name == request.Name && item.Namespace == request.Namespace {
@@ -106,6 +113,9 @@ func (r *MockExternalModelsRepository) CreateExternalModel(ctx context.Context, 
 
 func (r *MockExternalModelsRepository) UpdateExternalModel(ctx context.Context, namespace, name string, request models.UpdateExternalModelRequest) (*models.ExternalModelSummary, error) {
 	r.logger.Debug("Updating ExternalModel (mock)", slog.String("namespace", namespace), slog.String("name", name))
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	for i, item := range r.created {
 		if item.Name == name && item.Namespace == namespace {
@@ -157,6 +167,9 @@ func (r *MockExternalModelsRepository) UpdateExternalModel(ctx context.Context, 
 
 func (r *MockExternalModelsRepository) DeleteExternalModel(ctx context.Context, namespace, name string) error {
 	r.logger.Debug("Deleting ExternalModel (mock)", slog.String("namespace", namespace), slog.String("name", name))
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	for i, item := range r.created {
 		if item.Name == name && item.Namespace == namespace {

--- a/packages/maas/bff/internal/repositories/externalprovider.go
+++ b/packages/maas/bff/internal/repositories/externalprovider.go
@@ -1,0 +1,52 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+type ExternalProvidersRepository struct {
+	logger     *slog.Logger
+	k8sFactory kubernetes.KubernetesClientFactory
+}
+
+func NewExternalProvidersRepository(
+	logger *slog.Logger,
+	k8sFactory kubernetes.KubernetesClientFactory,
+) *ExternalProvidersRepository {
+	return &ExternalProvidersRepository{logger: logger, k8sFactory: k8sFactory}
+}
+
+func (r *ExternalProvidersRepository) ListExternalProviders(
+	ctx context.Context,
+	namespace string,
+) ([]models.ExternalProviderSummary, error) {
+	client, err := r.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return listExternalProviderSummariesInNamespace(ctx, client.GetDynamicClient(), namespace)
+}
+
+func (r *ExternalProvidersRepository) CreateExternalProvider(
+	_ context.Context,
+	_ models.CreateExternalProviderRequest,
+) (*models.ExternalProviderSummary, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (r *ExternalProvidersRepository) UpdateExternalProvider(
+	_ context.Context,
+	_, _ string,
+	_ models.UpdateExternalProviderRequest,
+) (*models.ExternalProviderSummary, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (r *ExternalProvidersRepository) DeleteExternalProvider(_ context.Context, _, _ string) error {
+	return fmt.Errorf("not implemented")
+}

--- a/packages/maas/bff/internal/repositories/externalproviders_mock.go
+++ b/packages/maas/bff/internal/repositories/externalproviders_mock.go
@@ -1,0 +1,142 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/mocks"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+// MockExternalProvidersRepository returns mock data for development.
+type MockExternalProvidersRepository struct {
+	logger  *slog.Logger
+	created []models.ExternalProviderSummary
+}
+
+// NewMockExternalProvidersRepository creates a new mock ExternalProvider repository.
+func NewMockExternalProvidersRepository(logger *slog.Logger) *MockExternalProvidersRepository {
+	return &MockExternalProvidersRepository{logger: logger}
+}
+
+func (r *MockExternalProvidersRepository) ListExternalProviders(_ context.Context, namespace string) ([]models.ExternalProviderSummary, error) {
+	r.logger.Debug("Listing ExternalProviders (mock)", slog.String("namespace", namespace))
+
+	result := make([]models.ExternalProviderSummary, 0)
+	for _, item := range mocks.GetMockExternalProviderSummaries() {
+		if item.Namespace == namespace {
+			result = append(result, item)
+		}
+	}
+	for _, item := range r.created {
+		if item.Namespace == namespace {
+			result = append(result, item)
+		}
+	}
+	return result, nil
+}
+
+func (r *MockExternalProvidersRepository) CreateExternalProvider(_ context.Context, request models.CreateExternalProviderRequest) (*models.ExternalProviderSummary, error) {
+	r.logger.Debug("Creating ExternalProvider (mock)", slog.String("name", request.Name))
+
+	for _, item := range mocks.GetMockExternalProviderSummaries() {
+		if item.Name == request.Name && item.Namespace == request.Namespace {
+			return nil, fmt.Errorf("ExternalProvider '%s' already exists", request.Name)
+		}
+	}
+	for _, item := range r.created {
+		if item.Name == request.Name && item.Namespace == request.Namespace {
+			return nil, fmt.Errorf("ExternalProvider '%s' already exists", request.Name)
+		}
+	}
+
+	summary := models.ExternalProviderSummary{
+		Name:                request.Name,
+		Namespace:           request.Namespace,
+		DisplayName:         request.DisplayName,
+		Description:         request.Description,
+		EndpointUrl:         normalizeEndpointURL(request.EndpointUrl),
+		AuthMechanism:       request.AuthMechanism,
+		CredentialSecretRef: request.CredentialSecretRef,
+		Provider:            request.Provider,
+		Config:              request.Config,
+		Phase:               "Pending",
+	}
+	r.created = append(r.created, summary)
+	return &summary, nil
+}
+
+func (r *MockExternalProvidersRepository) UpdateExternalProvider(_ context.Context, namespace, name string, request models.UpdateExternalProviderRequest) (*models.ExternalProviderSummary, error) {
+	r.logger.Debug("Updating ExternalProvider (mock)", slog.String("namespace", namespace), slog.String("name", name))
+
+	for i, item := range r.created {
+		if item.Name == name && item.Namespace == namespace {
+			updated := r.created[i]
+			if request.DisplayName != nil {
+				updated.DisplayName = *request.DisplayName
+			}
+			if request.Description != nil {
+				updated.Description = *request.Description
+			}
+			if request.EndpointUrl != "" {
+				updated.EndpointUrl = normalizeEndpointURL(request.EndpointUrl)
+			}
+			if request.AuthMechanism != nil {
+				updated.AuthMechanism = *request.AuthMechanism
+			}
+			if request.CredentialSecretRef != "" {
+				updated.CredentialSecretRef = request.CredentialSecretRef
+			}
+			if request.Config != nil {
+				updated.Config = request.Config
+			}
+			r.created[i] = updated
+			return &updated, nil
+		}
+	}
+
+	for _, item := range mocks.GetMockExternalProviderSummaries() {
+		if item.Name == name && item.Namespace == namespace {
+			updated := item
+			if request.DisplayName != nil {
+				updated.DisplayName = *request.DisplayName
+			}
+			if request.Description != nil {
+				updated.Description = *request.Description
+			}
+			if request.EndpointUrl != "" {
+				updated.EndpointUrl = normalizeEndpointURL(request.EndpointUrl)
+			}
+			if request.AuthMechanism != nil {
+				updated.AuthMechanism = *request.AuthMechanism
+			}
+			if request.CredentialSecretRef != "" {
+				updated.CredentialSecretRef = request.CredentialSecretRef
+			}
+			if request.Config != nil {
+				updated.Config = request.Config
+			}
+			return &updated, nil
+		}
+	}
+
+	return nil, fmt.Errorf("ExternalProvider '%s' not found", name)
+}
+
+func (r *MockExternalProvidersRepository) DeleteExternalProvider(_ context.Context, namespace, name string) error {
+	r.logger.Debug("Deleting ExternalProvider (mock)", slog.String("namespace", namespace), slog.String("name", name))
+
+	for i, item := range r.created {
+		if item.Name == name && item.Namespace == namespace {
+			r.created = append(r.created[:i], r.created[i+1:]...)
+			return nil
+		}
+	}
+	for _, item := range mocks.GetMockExternalProviderSummaries() {
+		if item.Name == name && item.Namespace == namespace {
+			return nil
+		}
+	}
+	return fmt.Errorf("ExternalProvider '%s' not found", name)
+}

--- a/packages/maas/bff/internal/repositories/externalproviders_mock.go
+++ b/packages/maas/bff/internal/repositories/externalproviders_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/opendatahub-io/maas-library/bff/internal/mocks"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
@@ -12,6 +13,7 @@ import (
 // MockExternalProvidersRepository returns mock data for development.
 type MockExternalProvidersRepository struct {
 	logger  *slog.Logger
+	mu      sync.RWMutex
 	created []models.ExternalProviderSummary
 }
 
@@ -29,6 +31,8 @@ func (r *MockExternalProvidersRepository) ListExternalProviders(_ context.Contex
 			result = append(result, item)
 		}
 	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	for _, item := range r.created {
 		if item.Namespace == namespace {
 			result = append(result, item)
@@ -39,6 +43,9 @@ func (r *MockExternalProvidersRepository) ListExternalProviders(_ context.Contex
 
 func (r *MockExternalProvidersRepository) CreateExternalProvider(_ context.Context, request models.CreateExternalProviderRequest) (*models.ExternalProviderSummary, error) {
 	r.logger.Debug("Creating ExternalProvider (mock)", slog.String("name", request.Name))
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	for _, item := range mocks.GetMockExternalProviderSummaries() {
 		if item.Name == request.Name && item.Namespace == request.Namespace {
@@ -69,6 +76,9 @@ func (r *MockExternalProvidersRepository) CreateExternalProvider(_ context.Conte
 
 func (r *MockExternalProvidersRepository) UpdateExternalProvider(_ context.Context, namespace, name string, request models.UpdateExternalProviderRequest) (*models.ExternalProviderSummary, error) {
 	r.logger.Debug("Updating ExternalProvider (mock)", slog.String("namespace", namespace), slog.String("name", name))
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	for i, item := range r.created {
 		if item.Name == name && item.Namespace == namespace {
@@ -126,6 +136,9 @@ func (r *MockExternalProvidersRepository) UpdateExternalProvider(_ context.Conte
 
 func (r *MockExternalProvidersRepository) DeleteExternalProvider(_ context.Context, namespace, name string) error {
 	r.logger.Debug("Deleting ExternalProvider (mock)", slog.String("namespace", namespace), slog.String("name", name))
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	for i, item := range r.created {
 		if item.Name == name && item.Namespace == namespace {

--- a/packages/maas/bff/internal/repositories/externalproviders_mock.go
+++ b/packages/maas/bff/internal/repositories/externalproviders_mock.go
@@ -49,12 +49,12 @@ func (r *MockExternalProvidersRepository) CreateExternalProvider(_ context.Conte
 
 	for _, item := range mocks.GetMockExternalProviderSummaries() {
 		if item.Name == request.Name && item.Namespace == request.Namespace {
-			return nil, fmt.Errorf("ExternalProvider '%s' already exists", request.Name)
+			return nil, fmt.Errorf("%w: ExternalProvider '%s' already exists", ErrAlreadyExists, request.Name)
 		}
 	}
 	for _, item := range r.created {
 		if item.Name == request.Name && item.Namespace == request.Namespace {
-			return nil, fmt.Errorf("ExternalProvider '%s' already exists", request.Name)
+			return nil, fmt.Errorf("%w: ExternalProvider '%s' already exists", ErrAlreadyExists, request.Name)
 		}
 	}
 
@@ -131,7 +131,7 @@ func (r *MockExternalProvidersRepository) UpdateExternalProvider(_ context.Conte
 		}
 	}
 
-	return nil, fmt.Errorf("ExternalProvider '%s' not found", name)
+	return nil, fmt.Errorf("%w: ExternalProvider '%s' not found", ErrNotFound, name)
 }
 
 func (r *MockExternalProvidersRepository) DeleteExternalProvider(_ context.Context, namespace, name string) error {
@@ -151,5 +151,5 @@ func (r *MockExternalProvidersRepository) DeleteExternalProvider(_ context.Conte
 			return nil
 		}
 	}
-	return fmt.Errorf("ExternalProvider '%s' not found", name)
+	return fmt.Errorf("%w: ExternalProvider '%s' not found", ErrNotFound, name)
 }

--- a/packages/maas/bff/internal/repositories/repositories.go
+++ b/packages/maas/bff/internal/repositories/repositories.go
@@ -38,24 +38,42 @@ type MaaSModelRefsRepositoryInterface interface {
 	DeleteMaaSModelRef(ctx context.Context, namespace, name string, dryRun bool) error
 }
 
-// ExternalModelsRepositoryInterface defines the contract for ExternalModel list and delete operations.
+// ExternalModelsRepositoryInterface defines the contract for ExternalModel operations.
 type ExternalModelsRepositoryInterface interface {
 	ListExternalModels(ctx context.Context, namespace string) ([]models.ExternalModelSummary, error)
+	CreateExternalModel(ctx context.Context, request models.CreateExternalModelRequest) (*models.ExternalModelSummary, error)
+	UpdateExternalModel(ctx context.Context, namespace, name string, request models.UpdateExternalModelRequest) (*models.ExternalModelSummary, error)
 	DeleteExternalModel(ctx context.Context, namespace, name string) error
+}
+
+// ExternalProvidersRepositoryInterface defines the contract for ExternalProvider operations.
+type ExternalProvidersRepositoryInterface interface {
+	ListExternalProviders(ctx context.Context, namespace string) ([]models.ExternalProviderSummary, error)
+	CreateExternalProvider(ctx context.Context, request models.CreateExternalProviderRequest) (*models.ExternalProviderSummary, error)
+	UpdateExternalProvider(ctx context.Context, namespace, name string, request models.UpdateExternalProviderRequest) (*models.ExternalProviderSummary, error)
+	DeleteExternalProvider(ctx context.Context, namespace, name string) error
+}
+
+// SecretsRepositoryInterface defines the contract for Secret operations.
+type SecretsRepositoryInterface interface {
+	ListSecrets(ctx context.Context, namespace string) ([]models.SecretSummary, error)
+	CreateSecret(ctx context.Context, request models.CreateSecretRequest) (*models.CreateSecretResponse, error)
 }
 
 // Repositories struct is a single convenient container to hold and represent all our repositories.
 type Repositories struct {
-	HealthCheck    *HealthCheckRepository
-	User           *UserRepository
-	Namespace      *NamespaceRepository
-	APIKeys        *APIKeysRepository
-	Models         *ModelsRepository
-	Subscriptions  SubscriptionsRepositoryInterface
-	Policies       PoliciesRepositoryInterface
-	MaaSModelRefs  MaaSModelRefsRepositoryInterface
-	ExternalModels ExternalModelsRepositoryInterface
-	Yaml           YamlRepositoryInterface
+	HealthCheck       *HealthCheckRepository
+	User              *UserRepository
+	Namespace         *NamespaceRepository
+	APIKeys           *APIKeysRepository
+	Models            *ModelsRepository
+	Subscriptions     SubscriptionsRepositoryInterface
+	Policies          PoliciesRepositoryInterface
+	MaaSModelRefs     MaaSModelRefsRepositoryInterface
+	ExternalModels    ExternalModelsRepositoryInterface
+	ExternalProviders ExternalProvidersRepositoryInterface
+	Secrets           SecretsRepositoryInterface
+	Yaml              YamlRepositoryInterface
 }
 
 func NewRepositories(
@@ -66,6 +84,8 @@ func NewRepositories(
 	policies PoliciesRepositoryInterface,
 	maasModelRefs MaaSModelRefsRepositoryInterface,
 	externalModels ExternalModelsRepositoryInterface,
+	externalProviders ExternalProvidersRepositoryInterface,
+	secrets SecretsRepositoryInterface,
 	yamlRepo YamlRepositoryInterface,
 ) (*Repositories, error) {
 	apiKeysRepo, err := NewAPIKeysRepository(logger, config.MaasApiUrl)
@@ -79,15 +99,17 @@ func NewRepositories(
 	}
 
 	return &Repositories{
-		HealthCheck:    NewHealthCheckRepository(),
-		User:           NewUserRepository(),
-		Namespace:      NewNamespaceRepository(),
-		APIKeys:        apiKeysRepo,
-		Models:         modelsRepo,
-		Subscriptions:  subscriptions,
-		Policies:       policies,
-		MaaSModelRefs:  maasModelRefs,
-		ExternalModels: externalModels,
-		Yaml:           yamlRepo,
+		HealthCheck:       NewHealthCheckRepository(),
+		User:              NewUserRepository(),
+		Namespace:         NewNamespaceRepository(),
+		APIKeys:           apiKeysRepo,
+		Models:            modelsRepo,
+		Subscriptions:     subscriptions,
+		Policies:          policies,
+		MaaSModelRefs:     maasModelRefs,
+		ExternalModels:    externalModels,
+		ExternalProviders: externalProviders,
+		Secrets:           secrets,
+		Yaml:              yamlRepo,
 	}, nil
 }

--- a/packages/maas/bff/internal/repositories/secrets.go
+++ b/packages/maas/bff/internal/repositories/secrets.go
@@ -1,0 +1,33 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+type SecretsRepository struct {
+	logger     *slog.Logger
+	k8sFactory kubernetes.KubernetesClientFactory
+}
+
+func NewSecretsRepository(
+	logger *slog.Logger,
+	k8sFactory kubernetes.KubernetesClientFactory,
+) *SecretsRepository {
+	return &SecretsRepository{logger: logger, k8sFactory: k8sFactory}
+}
+
+func (r *SecretsRepository) ListSecrets(_ context.Context, _ string) ([]models.SecretSummary, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (r *SecretsRepository) CreateSecret(
+	_ context.Context,
+	_ models.CreateSecretRequest,
+) (*models.CreateSecretResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/packages/maas/bff/internal/repositories/secrets_mock.go
+++ b/packages/maas/bff/internal/repositories/secrets_mock.go
@@ -1,0 +1,65 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/mocks"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+type mockSecretRecord struct {
+	namespace string
+	name      string
+}
+
+// MockSecretsRepository returns mock data for development.
+type MockSecretsRepository struct {
+	logger  *slog.Logger
+	created []mockSecretRecord
+}
+
+// NewMockSecretsRepository creates a new mock Secrets repository.
+func NewMockSecretsRepository(logger *slog.Logger) *MockSecretsRepository {
+	return &MockSecretsRepository{logger: logger}
+}
+
+func (r *MockSecretsRepository) ListSecrets(_ context.Context, namespace string) ([]models.SecretSummary, error) {
+	r.logger.Debug("Listing Secrets (mock)", slog.String("namespace", namespace))
+
+	// Mock data represents secrets created/managed via this BFF (BBR-managed).
+	result := make([]models.SecretSummary, 0)
+	for _, item := range mocks.GetMockSecretSummaries() {
+		if namespace == "maas-models" {
+			result = append(result, item)
+		}
+	}
+	for _, item := range r.created {
+		if item.namespace == namespace {
+			result = append(result, models.SecretSummary{Name: item.name})
+		}
+	}
+	return result, nil
+}
+
+func (r *MockSecretsRepository) CreateSecret(_ context.Context, request models.CreateSecretRequest) (*models.CreateSecretResponse, error) {
+	r.logger.Debug("Creating Secret (mock)", slog.String("name", request.Name), slog.String("namespace", request.Namespace))
+
+	for _, item := range mocks.GetMockSecretSummaries() {
+		if item.Name == request.Name && request.Namespace == "maas-models" {
+			return nil, fmt.Errorf("Secret '%s' already exists", request.Name)
+		}
+	}
+	for _, item := range r.created {
+		if item.name == request.Name && item.namespace == request.Namespace {
+			return nil, fmt.Errorf("Secret '%s' already exists", request.Name)
+		}
+	}
+
+	r.created = append(r.created, mockSecretRecord{
+		namespace: request.Namespace,
+		name:      request.Name,
+	})
+	return &models.CreateSecretResponse{Name: request.Name}, nil
+}

--- a/packages/maas/bff/internal/repositories/secrets_mock.go
+++ b/packages/maas/bff/internal/repositories/secrets_mock.go
@@ -48,12 +48,12 @@ func (r *MockSecretsRepository) CreateSecret(_ context.Context, request models.C
 
 	for _, item := range mocks.GetMockSecretSummaries() {
 		if item.Name == request.Name && request.Namespace == "maas-models" {
-			return nil, fmt.Errorf("Secret '%s' already exists", request.Name)
+			return nil, fmt.Errorf("secret '%s' already exists", request.Name)
 		}
 	}
 	for _, item := range r.created {
 		if item.name == request.Name && item.namespace == request.Namespace {
-			return nil, fmt.Errorf("Secret '%s' already exists", request.Name)
+			return nil, fmt.Errorf("secret '%s' already exists", request.Name)
 		}
 	}
 

--- a/packages/maas/bff/internal/repositories/secrets_mock.go
+++ b/packages/maas/bff/internal/repositories/secrets_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/opendatahub-io/maas-library/bff/internal/mocks"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
@@ -17,6 +18,7 @@ type mockSecretRecord struct {
 // MockSecretsRepository returns mock data for development.
 type MockSecretsRepository struct {
 	logger  *slog.Logger
+	mu      sync.RWMutex
 	created []mockSecretRecord
 }
 
@@ -35,6 +37,8 @@ func (r *MockSecretsRepository) ListSecrets(_ context.Context, namespace string)
 			result = append(result, item)
 		}
 	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	for _, item := range r.created {
 		if item.namespace == namespace {
 			result = append(result, models.SecretSummary{Name: item.name})
@@ -46,14 +50,17 @@ func (r *MockSecretsRepository) ListSecrets(_ context.Context, namespace string)
 func (r *MockSecretsRepository) CreateSecret(_ context.Context, request models.CreateSecretRequest) (*models.CreateSecretResponse, error) {
 	r.logger.Debug("Creating Secret (mock)", slog.String("name", request.Name), slog.String("namespace", request.Namespace))
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	for _, item := range mocks.GetMockSecretSummaries() {
 		if item.Name == request.Name && request.Namespace == "maas-models" {
-			return nil, fmt.Errorf("secret '%s' already exists", request.Name)
+			return nil, fmt.Errorf("%w: secret '%s' already exists", ErrAlreadyExists, request.Name)
 		}
 	}
 	for _, item := range r.created {
 		if item.name == request.Name && item.namespace == request.Namespace {
-			return nil, fmt.Errorf("secret '%s' already exists", request.Name)
+			return nil, fmt.Errorf("%w: secret '%s' already exists", ErrAlreadyExists, request.Name)
 		}
 	}
 

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -1735,7 +1735,47 @@ paths:
                     items:
                       $ref: '#/components/schemas/ExternalModelSummary'
 
+    post:
+      tags: [externalmodels]
+      summary: Create an ExternalModel
+      operationId: createExternalModel
+      description: Creates a new ExternalModel and its companion MaaSModelRef.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExternalModelRequest'
+      responses:
+        '201':
+          description: ExternalModel created
+
   /api/v1/externalmodel/{namespace}/{name}:
+    put:
+      tags: [externalmodels]
+      summary: Update an ExternalModel
+      operationId: updateExternalModel
+      parameters:
+        - in: path
+          name: namespace
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateExternalModelRequest'
+      responses:
+        '200':
+          description: ExternalModel updated
+
     delete:
       tags: [externalmodels]
       summary: Delete an ExternalModel
@@ -1757,6 +1797,121 @@ paths:
           description: ExternalModel deleted
         '404':
           description: ExternalModel not found
+
+# ── ExternalProvider Endpoints ────────────────────────────────────────
+
+  /api/v1/externalprovider:
+    get:
+      tags: [externalproviders]
+      summary: List ExternalProviders
+      operationId: listExternalProviders
+      parameters:
+        - in: query
+          name: namespace
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ExternalProvider list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ExternalProviderSummary'
+    post:
+      tags: [externalproviders]
+      summary: Create an ExternalProvider
+      operationId: createExternalProvider
+      description: Creates a new ExternalProvider.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExternalProviderRequest'
+      responses:
+        '201':
+          description: ExternalProvider created
+
+  /api/v1/externalprovider/{namespace}/{name}:
+    put:
+      tags: [externalproviders]
+      summary: Update an ExternalProvider
+      operationId: updateExternalProvider
+      parameters:
+        - in: path
+          name: namespace
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateExternalProviderRequest'
+      responses:
+        '200':
+          description: ExternalProvider updated
+    delete:
+      tags: [externalproviders]
+      summary: Delete an ExternalProvider
+      operationId: deleteExternalProvider
+      parameters:
+        - in: path
+          name: namespace
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ExternalProvider deleted
+
+  # ── Secret Endpoints ──────────────────────────────────────────────────
+
+  /api/v1/secrets:
+    get:
+      tags: [secrets]
+      summary: List BBR-managed Secret names
+      operationId: listSecrets
+      description: Returns Secret names labeled inference.networking.k8s.io/bbr-managed=true. Values are never returned.
+      parameters:
+        - in: query
+          name: namespace
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Secret name list (values never returned)
+    post:
+      tags: [secrets]
+      summary: Create a Secret
+      operationId: createSecret
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSecretRequest'
+      responses:
+        '201':
+          description: Secret created
 
 components:
   securitySchemes:
@@ -2835,6 +2990,86 @@ components:
           description: >
             True when the companion MaaSModelRef has status.conditions type=GovernanceAttached
             with status=True (active subscription + auth policy pairing).
+    
+    ExternalProviderSummary:
+      type: object
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        displayName:
+          type: string
+          description: Human-readable display name (from openshift.io/display-name annotation)
+        description:
+          type: string
+          description: Description (from openshift.io/description annotation)
+        endpointUrl:
+          type: string
+        authMechanism:
+          type: string
+          enum: [apikey, sigv4, oauth2]
+          description: ExternalProvider spec.auth.type (inference CRD)
+        credentialSecretRef:
+          type: string
+        provider:
+          type: string
+        config:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional provider-specific configuration key-value pairs (spec.config)
+        phase:
+          type: string
+
+    CreateExternalProviderRequest:
+      type: object
+      required: [name, namespace, endpointUrl, authMechanism, credentialSecretRef, provider]
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        displayName:
+          type: string
+          description: Optional human-readable display name (openshift.io/display-name annotation)
+        description:
+          type: string
+          description: Optional description (openshift.io/description annotation)
+        endpointUrl:
+          type: string
+        authMechanism:
+          type: string
+          enum: [apikey, sigv4, oauth2]
+        credentialSecretRef:
+          type: string
+        provider:
+          type: string
+        config:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional provider-specific configuration key-value pairs (spec.config)
+
+    UpdateExternalProviderRequest:
+      type: object
+      properties:
+        displayName:
+          type: string
+        description:
+          type: string
+        endpointUrl:
+          type: string
+        authMechanism:
+          type: string
+          enum: [apikey, sigv4, oauth2]
+        credentialSecretRef:
+          type: string
+        config:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional provider-specific configuration key-value pairs (spec.config)
 
     ExternalModelSummary:
       type: object
@@ -2866,3 +3101,68 @@ components:
           example: Reconciled
         maaSModelRef:
           $ref: '#/components/schemas/ExternalModelMaaSModelRefStatus'
+    
+    CreateExternalModelRequest:
+      type: object
+      required: [name, namespace, providerRefs]
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        displayName:
+          type: string
+          description: Optional human-readable display name (openshift.io/display-name annotation)
+        description:
+          type: string
+          description: Optional description (openshift.io/description annotation)
+        modelName:
+          type: string
+        providerRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderRef'
+
+    UpdateExternalModelRequest:
+      type: object
+      properties:
+        displayName:
+          type: string
+        description:
+          type: string
+        modelName:
+          type: string
+        providerRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderRef'
+
+    
+
+    SecretSummary:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
+
+    CreateSecretRequest:
+      type: object
+      required: [namespace, name, value]
+      properties:
+        namespace:
+          type: string
+        name:
+          type: string
+        value:
+          type: string
+          writeOnly: true
+
+    CreateSecretResponse:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -1898,7 +1898,16 @@ paths:
             type: string
       responses:
         '200':
-          description: Secret name list (values never returned)
+          description: Secret name list.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SecretSummary'
     post:
       tags: [secrets]
       summary: Create a Secret
@@ -2912,8 +2921,9 @@ components:
           type: string
         weight:
           type: integer
-          minimum: 1
+          minimum: 0
           maximum: 100
+          description: Relative traffic proportion. 0 disables the ref. Defaults to 1 if omitted on the CR.
         apiFormat:
           type: string
         path:
@@ -2946,6 +2956,10 @@ components:
           type: string
         endpointUrl:
           type: string
+          minLength: 1
+          maxLength: 253
+          pattern: '^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)+$'
+          description: FQDN of the external provider with no scheme or path (e.g. api.openai.com)
         authMechanism:
           type: string
           enum: [apikey, sigv4, oauth2]
@@ -3006,6 +3020,10 @@ components:
           description: Description (from openshift.io/description annotation)
         endpointUrl:
           type: string
+          minLength: 1
+          maxLength: 253
+          pattern: '^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)+$'
+          description: FQDN of the external provider with no scheme or path (e.g. api.openai.com)
         authMechanism:
           type: string
           enum: [apikey, sigv4, oauth2]
@@ -3038,6 +3056,10 @@ components:
           description: Optional description (openshift.io/description annotation)
         endpointUrl:
           type: string
+          minLength: 1
+          maxLength: 253
+          pattern: '^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)+$'
+          description: FQDN of the external provider with no scheme or path (e.g. api.openai.com)
         authMechanism:
           type: string
           enum: [apikey, sigv4, oauth2]
@@ -3060,6 +3082,10 @@ components:
           type: string
         endpointUrl:
           type: string
+          minLength: 1
+          maxLength: 253
+          pattern: '^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)+$'
+          description: FQDN of the external provider with no scheme or path (e.g. api.openai.com)
         authMechanism:
           type: string
           enum: [apikey, sigv4, oauth2]


### PR DESCRIPTION
PR1 of  https://redhat.atlassian.net/browse/RHOAIENG-88480

## Description

Mock BFF support for External Provider CRUD, External Model create/update, and Secrets list/create so the UI can be developed against `make dev-bff-federated-mock`.

External Model list/delete already shipped in #8478. This is **PR 1** of [RHOAIENG-88480](https://redhat.atlassian.net/browse/RHOAIENG-88480) (epic [RHOAIENG-88468](https://redhat.atlassian.net/browse/RHOAIENG-88468)): handlers, OpenAPI, DTOs, and in-memory mocks. Live Kubernetes create/update (and live secret list/create) stay stubs and land in a follow-up.

These routes are UI-only. They are **not** part of the inter-BFF contract in `packages/maas/bff/CONSUMERS.md` (`POST /api/v1/api-keys`, `GET /api/v1/models`).


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Terminal 1:

- make dev-bff-federated-mock from packages/maas

Terminal 2:

```

export BFF=http://localhost:8081/api/v1
export NS=maas-models

```

# External models
Create:
```
curl -sS -H "kubeflow-userid: user@example.com" \
  -H "Content-Type: application/json" \
  -X POST "$BFF/externalmodel" \
  -d '{"data":{"name":"external-model","namespace":"maas-models","modelName":"gpt-4o","providerRefs":[{"providerName":"my-provider-new","weight":100,"apiFormat":"openai-chat","path":"/v1/chat/completions","targetModel":"gpt-4o"}]}}' | jq .
```
List:
```
curl -sS -H 'kubeflow-userid: user@example.com' \
  "$BFF/externalmodel?namespace=${NS}" | jq .
```
```
{
      "name": "external-model",
      "namespace": "maas-models",
      "modelName": "gpt-4o",
      "providerRefs": [
        {
          "providerName": "my-provider-new",
          "weight": 100,
          "apiFormat": "openai-chat",
          "path": "/v1/chat/completions",
          "targetModel": "gpt-4o"
        }
      ],
      "phase": "Pending"
    }
```

Update:

```
curl -sS -H "kubeflow-userid: user@example.com" \
  -H "Content-Type: application/json" \
  -X PUT "$BFF/externalmodel/${NS}/external-model" \
  -d '{"data":{"displayName":"Updated external model","description":"Updated via PUT","modelName":"gpt-4o","providerRefs":[{"providerName":"my-provider-new","weight":100,"apiFormat":"openai-chat-new","path":"/v1/chat/completions-new","targetModel":"gpt-4o-new","config":{"region":"us-west-2"}}]}}' | jq .
```
List:
```
curl -sS -H "kubeflow-userid: user@example.com" \
  "$BFF/externalmodel?namespace=${NS}" | jq '.data[] | select(.name=="external-model")'
```
```
{
  "name": "external-model",
  "namespace": "maas-models",
  "displayName": "Updated external model",
  "description": "Updated via PUT",
  "modelName": "gpt-4o",
  "providerRefs": [
    {
      "providerName": "my-provider-new",
      "weight": 100,
      "apiFormat": "openai-chat-new",
      "path": "/v1/chat/completions-new",
      "targetModel": "gpt-4o-new",
      "config": {
        "region": "us-west-2"
      }
    }
  ],
  "phase": "Pending"
}
```
Delete:
```
curl -sS -H "kubeflow-userid: user@example.com" \
  -X DELETE "$BFF/externalmodel/${NS}/external-model" | jq .
```
{
  "data": null
}


# ExternalProvider:
Create provider
```
curl -sS -H "kubeflow-userid: user@example.com" \
  -H "Content-Type: application/json" \
  -X POST "$BFF/externalprovider" \
  -d '{"data":{"name":"my-provider-new","namespace":"maas-models","displayName":"displayname","description":"description","endpointUrl":"api.example.com","authMechanism":"apikey","credentialSecretRef":"openai-api-key","provider":"openai","config":{"region":"us-east-1"}}}' | jq .
```

List:
```
curl -sS -H "kubeflow-userid: user@example.com" \
  "$BFF/externalprovider?namespace=${NS}" | jq . 
```    
```
{
      "name": "my-provider-new",
      "namespace": "maas-models",
      "displayName": "displayname",
      "description": "description",
      "endpointUrl": "api.example.com",
      "authMechanism": "apikey",
      "credentialSecretRef": "openai-api-key",
      "provider": "openai",
      "config": {
        "region": "us-east-1"
      },
      "phase": "Pending"
    }
```


 Update: after my-provider-new exists
```
curl -sS -H 'kubeflow-userid: user@example.com' -H 'Content-Type: application/json' -X PUT "$BFF/externalprovider/${NS}/my-provider-new" -d '{"data":{"displayName":"display name update","description":"description update","endpointUrl":"api.example.com","authMechanism":"sigv4","credentialSecretRef":"openai-api-key","config":{"region":"us-east-2"}}}' | jq .
```

List:
```
curl -sS -H "kubeflow-userid: user@example.com" \
  "$BFF/externalprovider?namespace=${NS}" | jq . 
```
```
    {
      "name": "my-provider-new",
      "namespace": "maas-models",
      "displayName": "display name update",
      "description": "description update",
      "endpointUrl": "api.exampleupdate.com",
      "authMechanism": "sigv4",
      "credentialSecretRef": "openai-api-key",
      "provider": "openai",
      "config": {
        "region": "us-east-2"
      },
      "phase": "Pending"
    }
```


Delete:
```
curl -sS -H 'kubeflow-userid: user@example.com' \
  -X DELETE "$BFF/externalprovider/${NS}/my-provider-new" | jq .
```

# secrets

Create:
```
curl -sS -H "kubeflow-userid: user@example.com" \
  -H "Content-Type: application/json" \
  -X POST "$BFF/secrets" \
  -d '{"data":{"namespace":"maas-models","name":"my-new-secret","value":"sk-test-not-returned"}}' | jq .
```

```
{
  "data": {
    "name": "my-new-secret"
  }
}

```

List:
```
curl -sS -H "kubeflow-userid: user@example.com" \
  "$BFF/secrets?namespace=${NS}" | jq '.data[].name'
```
```
"openai-api-key"
"anthropic-api-key"
"my-new-secret"
```

## Test Impact

- Envtest: External Provider list; External Model list and delete (companion MaaSModelRef).
- Mock-backed handler tests: External Provider create/update/delete; Secret list/create.
- Live Kubernetes create/update for providers/models and live secret list/create are stubs (`not implemented`) and are not envtested; that coverage belongs in the follow-up PR.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-88480]: https://redhat.atlassian.net/browse/RHOAIENG-88480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-88468]: https://redhat.atlassian.net/browse/RHOAIENG-88468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints to list, create, update, and delete external providers.
  * Added API endpoints to create and update external models.
  * Added secret listing and creation endpoints that never expose secret values.
  * Added request validation for provider URLs, required fields, and provider weights.
* **Documentation**
  * Updated the API specification with new endpoints, request models, responses, and validation rules.
* **Bug Fixes**
  * Improved not-found and conflict error responses for external resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->