### PR TITLE
RHOAIENG-87583: do not prefill routing config Name/Description from sample

### DIFF
--- a/packages/cypress/cypress/pages/modelDeploymentSettings/routingConfigurations.ts
+++ b/packages/cypress/cypress/pages/modelDeploymentSettings/routingConfigurations.ts
@@ -103,6 +103,10 @@ class LlmdRoutingCreatePage {
     return cy.findByTestId('routing-config-name');
   }
 
+  findDescriptionInput() {
+    return cy.findByTestId('routing-config-description');
+  }
+
   findTopologyTypeSelect() {
     return cy.findByTestId('topology-type-select');
   }

--- a/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdRoutingAdmin.cy.ts
+++ b/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdRoutingAdmin.cy.ts
@@ -282,6 +282,39 @@ describe('LLMD Routing Admin Settings', () => {
       routingConfigurations.findTable().should('exist');
     });
 
+    it('should not overwrite Name or Description when starting from a sample', () => {
+      const sampleYaml = [
+        'apiVersion: serving.kserve.io/v1alpha2',
+        'kind: LLMInferenceServiceConfig',
+        'metadata:',
+        '  name: default-scheduling-policy',
+        '  annotations:',
+        '    openshift.io/display-name: default-scheduling-policy',
+        '    description: Sample routing description',
+        'spec: {}',
+        '',
+      ].join('\n');
+
+      cy.intercept('GET', '**/api/service/model-serving/api/v1/samples/llm-d*', {
+        statusCode: 200,
+        headers: { 'content-type': 'text/plain' },
+        body: sampleYaml,
+      }).as('routerSample');
+
+      llmdRoutingCreatePage.findDisplayNameInput().type('My Custom Router');
+      llmdRoutingCreatePage.findDescriptionInput().type('My custom description');
+      llmdRoutingCreatePage.selectTopologyType(TopologyType.SINGLE_NODE);
+      cy.wait('@routerSample');
+      llmdRoutingCreatePage.findConfigSourceSelect().should('be.enabled');
+      llmdRoutingCreatePage.selectConfigSource('template');
+      cy.wait('@routerSample');
+
+      llmdRoutingCreatePage.findYamlEditor().should('exist');
+      llmdRoutingCreatePage.getYamlEditor().containsText('default-scheduling-policy');
+      llmdRoutingCreatePage.findDisplayNameInput().should('have.value', 'My Custom Router');
+      llmdRoutingCreatePage.findDescriptionInput().should('have.value', 'My custom description');
+    });
+
     it('should create a routing config', () => {
       cy.interceptK8s(
         'POST',

--- a/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/RoutingConfigurationCreateEdit.tsx
@@ -59,9 +59,6 @@ import {
   fireRoutingConfigUpdated,
 } from '../../tracking/llmdTrackingConstants';
 
-const SAMPLE_DISPLAY_NAME_ANNOTATION = 'openshift.io/display-name';
-const SAMPLE_DESCRIPTION_ANNOTATION = 'description';
-
 const resolveTopologyFromConfig = (
   config: LLMInferenceServiceConfigKind,
 ): TopologyType | undefined => {
@@ -156,23 +153,6 @@ const RoutingConfigurationCreateEditInner: React.FC<{
         })
         .then((yaml) => {
           setYamlCode(yaml);
-          try {
-            const parsed: unknown = YAML.parse(yaml);
-            if (isConfigObject(parsed)) {
-              const annotations = parsed.metadata.annotations ?? {};
-              const sampleName =
-                annotations[SAMPLE_DISPLAY_NAME_ANNOTATION] ?? parsed.metadata.name;
-              const sampleDesc = annotations[SAMPLE_DESCRIPTION_ANNOTATION] ?? '';
-              if (sampleName) {
-                k8sNameDesc.onDataChange('name', String(sampleName));
-              }
-              if (sampleDesc) {
-                k8sNameDesc.onDataChange('description', String(sampleDesc));
-              }
-            }
-          } catch {
-            // sample parsing for form fields is best-effort
-          }
         })
         .catch(() => {
           setTemplateError(true);

--- a/packages/llmd-serving/src/settings/routingConfigs/__tests__/RoutingConfigurationCreateEdit.spec.tsx
+++ b/packages/llmd-serving/src/settings/routingConfigs/__tests__/RoutingConfigurationCreateEdit.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceConfigK8sResource';
@@ -86,6 +86,50 @@ describe('RoutingConfigurationCreateEdit', () => {
 
       const topologySelect = screen.getByTestId('topology-type-select');
       expect(topologySelect).not.toBeDisabled();
+    });
+
+    it('should populate YAML from a sample without overwriting Name or Description', async () => {
+      const sampleYaml = `apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: default-scheduling-policy
+  annotations:
+    openshift.io/display-name: default-scheduling-policy
+    description: Sample routing description
+spec: {}
+`;
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(sampleYaml),
+        } as Response),
+      ) as jest.Mock;
+
+      renderAtRoute([], '/routing-configs/add', '/routing-configs/add');
+
+      fireEvent.change(screen.getByTestId('routing-config-name'), {
+        target: { value: 'My Custom Router' },
+      });
+      fireEvent.change(screen.getByTestId('routing-config-description'), {
+        target: { value: 'My custom description' },
+      });
+
+      fireEvent.click(screen.getByTestId('topology-type-select'));
+      fireEvent.click(screen.getByTestId(TopologyType.SINGLE_NODE));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('config-source-select')).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByTestId('config-source-select'));
+      fireEvent.click(screen.getByTestId('template'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('yaml-editor-mock')).toHaveValue(sampleYaml);
+      });
+
+      expect(screen.getByTestId('routing-config-name')).toHaveValue('My Custom Router');
+      expect(screen.getByTestId('routing-config-description')).toHaveValue('My custom description');
     });
   });
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-87583
## Description
Selecting a sample configuration on the llm-d routing form no longer overwrites Name or Description. The sample still populates the YAML body only, matching the topology form.
## How Has This Been Tested?
- Unit test: sample YAML loads; Name/Description stay user-entered
- Cypress mocked: same flow on the create page
## Test Impact
- Updated `RoutingConfigurationCreateEdit.spec.tsx`
- Updated `modelServingLlmdRoutingAdmin.cy.ts`
## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our Best Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved custom routing configuration names and descriptions when loading a sample YAML template.
  * Sample templates now populate only the YAML editor without overwriting user-entered details.

* **Tests**
  * Added coverage confirming custom fields remain unchanged during template loading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->