### PR TITLE
feat(data-registry): add labels management

### DIFF
--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
@@ -30,7 +30,7 @@ const mockAssetsResponse = {
       format: 'milvus',
       location: 'milvus://embeddings',
       description: 'Vector embeddings',
-      labels: ['embeddings'],
+      labels: ['embeddings', 'production'],
       collection: 'analytics',
       connection_ref: null,
       owner: 'user1',
@@ -328,7 +328,7 @@ describe('Register Volume', () => {
     cy.findByTestId('register-volume-submit').click();
 
     cy.wait('@createVolumeConflict');
-    cy.contains('Error registering volume').should('exist');
+    cy.contains('Error registering data').should('exist');
     cy.findByTestId('register-volume-modal').should('exist');
   });
 
@@ -356,5 +356,152 @@ describe('Register Volume', () => {
     cy.findByTestId('register-data-button').click();
     cy.findByTestId('volume-collection-toggle').click();
     cy.contains('Create new collection').should('exist');
+  });
+});
+
+describe('Manage Labels', () => {
+  beforeEach(() => {
+    initIntercepts();
+  });
+
+  it('should open manage labels modal from kebab menu', () => {
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+    cy.findByTestId('manage-labels-modal').should('exist');
+    cy.contains('Manage labels').should('exist');
+    cy.contains(
+      'Create and delete labels to manage how assets are organized across this project.',
+    ).should('exist');
+    cy.contains('Changes affect all project assets').should('exist');
+  });
+
+  it('should display labels with associated assets', () => {
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+
+    cy.findByTestId('label-row-production').should('exist');
+    cy.findByTestId('label-row-claims').should('exist');
+    cy.findByTestId('label-row-embeddings').should('exist');
+    cy.findByTestId('label-row-source-docs').should('exist');
+  });
+
+  it('should show label belonging to multiple assets', () => {
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+
+    cy.findByTestId('label-row-production').should('contain.text', 'claims-data');
+    cy.findByTestId('label-row-production').should('contain.text', 'embeddings');
+  });
+
+  it('should show dash for labels with no assets', () => {
+    cy.intercept('GET', `${REGISTRY_API}/test-project/labels`, {
+      body: { labels: ['orphan-label'] },
+    }).as('getLabelsOrphan');
+
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+
+    cy.findByTestId('label-row-orphan-label').should('contain.text', '–');
+  });
+
+  it('should filter labels by name', () => {
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+
+    cy.findByTestId('label-filter').find('input').type('prod');
+    cy.findByTestId('label-row-production').should('exist');
+    cy.findByTestId('label-row-claims').should('not.exist');
+    cy.findByTestId('label-row-source-docs').should('not.exist');
+    cy.findByTestId('label-row-embeddings').should('not.exist');
+  });
+
+  it('should show create label inline row and confirm button disabled until input', () => {
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+
+    cy.findByTestId('create-label-button').click();
+    cy.findByTestId('create-label-row').should('exist');
+    cy.findByTestId('new-label-input').should('exist');
+    cy.findByTestId('confirm-create-label').should('be.disabled');
+
+    cy.findByTestId('new-label-input').type('new-label');
+    cy.findByTestId('confirm-create-label').should('not.be.disabled');
+  });
+
+  it('should create a new label', () => {
+    cy.intercept('POST', `${REGISTRY_API}/test-project/labels`, {
+      statusCode: 201,
+      body: { name: 'new-label' },
+    }).as('createLabel');
+
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+
+    cy.findByTestId('create-label-button').click();
+    cy.findByTestId('new-label-input').type('new-label');
+    cy.findByTestId('confirm-create-label').click();
+
+    cy.wait('@createLabel').then((interception) => {
+      expect(interception.request.body).to.deep.equal({ name: 'new-label' });
+    });
+  });
+
+  it('should cancel create label', () => {
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+
+    cy.findByTestId('create-label-button').click();
+    cy.findByTestId('create-label-row').should('exist');
+    cy.findByTestId('cancel-create-label').click();
+    cy.findByTestId('create-label-row').should('not.exist');
+  });
+
+  it('should delete a label', () => {
+    cy.intercept('DELETE', `${REGISTRY_API}/test-project/labels/claims`, {
+      statusCode: 204,
+    }).as('deleteLabel');
+
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+
+    cy.findByTestId('delete-label-claims').click();
+    cy.wait('@deleteLabel');
+  });
+
+  it('should show error on create label conflict', () => {
+    cy.intercept('POST', `${REGISTRY_API}/test-project/labels`, {
+      statusCode: 409,
+      body: { status_code: 409, detail: 'Label already exists: production' },
+    }).as('createLabelConflict');
+
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+
+    cy.findByTestId('create-label-button').click();
+    cy.findByTestId('new-label-input').type('production');
+    cy.findByTestId('confirm-create-label').click();
+
+    cy.wait('@createLabelConflict');
+    cy.findByTestId('manage-labels-error').should('exist');
+  });
+
+  it('should close modal', () => {
+    visitWithData();
+    cy.findByTestId('registry-kebab').click();
+    cy.findByTestId('manage-labels-action').click();
+    cy.findByTestId('manage-labels-modal').should('exist');
+
+    cy.contains('button', 'Close').click();
+    cy.findByTestId('manage-labels-modal').should('not.exist');
   });
 });

--- a/packages/data-registry/frontend/src/__tests__/unit/components/ManageLabelsModal.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/ManageLabelsModal.spec.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ManageLabelsModal from '~/app/components/ManageLabelsModal';
+import { createLabel, deleteLabel } from '~/app/api/dataRegistry';
+import { RegistryAsset } from '~/app/hooks/useAssets';
+
+jest.mock('~/app/api/dataRegistry', () => ({
+  createLabel: jest.fn(),
+  deleteLabel: jest.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+const mockCreateLabel = jest.mocked(createLabel);
+const mockDeleteLabel = jest.mocked(deleteLabel);
+
+const mockAssets: RegistryAsset[] = [
+  {
+    name: 'claims-data',
+    description: 'Claims processing data',
+    format: 'parquet',
+    assetType: 'table',
+    location: 's3://bucket/claims',
+    connectionRef: 'minio-connection',
+    labels: ['production', 'shared-label'],
+    collection: 'analytics',
+  },
+  {
+    name: 'raw-documents',
+    description: 'PDF documents',
+    format: 'application/pdf',
+    assetType: 'volume',
+    location: 's3://bucket/docs',
+    connectionRef: '',
+    labels: ['source-docs', 'shared-label'],
+    collection: 'guidelines',
+  },
+  {
+    name: 'embeddings',
+    description: 'Vector embeddings',
+    format: 'milvus',
+    assetType: 'table',
+    location: 'milvus://embeddings',
+    connectionRef: '',
+    labels: ['production'],
+    collection: 'analytics',
+  },
+];
+
+const mockLabels = ['production', 'source-docs', 'shared-label', 'unused-label'];
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  project: 'test-project',
+  labels: mockLabels,
+  assets: mockAssets,
+  onRefresh: jest.fn(),
+};
+
+const renderModal = (props?: Partial<React.ComponentProps<typeof ManageLabelsModal>>) =>
+  render(<ManageLabelsModal {...defaultProps} {...props} />);
+
+describe('ManageLabelsModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render modal with title and description', () => {
+    renderModal();
+    expect(screen.getByText('Manage labels')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Create and delete labels to manage how assets are organized across this project.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('should render info alert', () => {
+    renderModal();
+    expect(screen.getByText('Changes affect all project assets')).toBeTruthy();
+  });
+
+  it('should render all labels with outline variant', () => {
+    renderModal();
+    mockLabels.forEach((label) => {
+      expect(screen.getByTestId(`label-row-${label}`)).toBeTruthy();
+    });
+  });
+
+  it('should show associated assets for each label', () => {
+    renderModal();
+    const productionRow = screen.getByTestId('label-row-production');
+    expect(productionRow.textContent).toContain('claims-data');
+    expect(productionRow.textContent).toContain('embeddings');
+
+    const sharedRow = screen.getByTestId('label-row-shared-label');
+    expect(sharedRow.textContent).toContain('claims-data');
+    expect(sharedRow.textContent).toContain('raw-documents');
+
+    const unusedRow = screen.getByTestId('label-row-unused-label');
+    expect(unusedRow.textContent).toContain('–');
+  });
+
+  it('should show label belonging to multiple assets', () => {
+    renderModal();
+    const sharedRow = screen.getByTestId('label-row-shared-label');
+    expect(sharedRow.textContent).toContain('claims-data');
+    expect(sharedRow.textContent).toContain('raw-documents');
+  });
+
+  it('should filter labels by name', () => {
+    renderModal();
+    const filter = screen.getByTestId('label-filter');
+    fireEvent.change(filter.querySelector('input')!, { target: { value: 'prod' } });
+
+    expect(screen.getByTestId('label-row-production')).toBeTruthy();
+    expect(screen.queryByTestId('label-row-source-docs')).toBeNull();
+    expect(screen.queryByTestId('label-row-shared-label')).toBeNull();
+  });
+
+  it('should show create label row when create button is clicked', () => {
+    renderModal();
+    fireEvent.click(screen.getByTestId('create-label-button'));
+    expect(screen.getByTestId('create-label-row')).toBeTruthy();
+    expect(screen.getByTestId('new-label-input')).toBeTruthy();
+    expect(screen.getByTestId('confirm-create-label').getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('should enable confirm button when label name is entered', () => {
+    renderModal();
+    fireEvent.click(screen.getByTestId('create-label-button'));
+    fireEvent.change(screen.getByTestId('new-label-input'), { target: { value: 'new-label' } });
+    expect(screen.getByTestId('confirm-create-label').getAttribute('disabled')).toBeNull();
+  });
+
+  it('should call createLabel and refresh on confirm', async () => {
+    mockCreateLabel.mockResolvedValue({ name: 'new-label' });
+    renderModal();
+    fireEvent.click(screen.getByTestId('create-label-button'));
+    fireEvent.change(screen.getByTestId('new-label-input'), { target: { value: 'new-label' } });
+    fireEvent.click(screen.getByTestId('confirm-create-label'));
+
+    await waitFor(() => {
+      expect(mockCreateLabel).toHaveBeenCalledWith('test-project', { name: 'new-label' });
+      expect(defaultProps.onRefresh).toHaveBeenCalled();
+    });
+  });
+
+  it('should cancel create label row', () => {
+    renderModal();
+    fireEvent.click(screen.getByTestId('create-label-button'));
+    expect(screen.getByTestId('create-label-row')).toBeTruthy();
+    fireEvent.click(screen.getByTestId('cancel-create-label'));
+    expect(screen.queryByTestId('create-label-row')).toBeNull();
+  });
+
+  it('should call deleteLabel and refresh on trash icon click', async () => {
+    mockDeleteLabel.mockResolvedValue(undefined);
+    renderModal();
+    fireEvent.click(screen.getByTestId('delete-label-production'));
+
+    await waitFor(() => {
+      expect(mockDeleteLabel).toHaveBeenCalledWith('test-project', 'production');
+      expect(defaultProps.onRefresh).toHaveBeenCalled();
+    });
+  });
+
+  it('should show error on delete failure', async () => {
+    mockDeleteLabel.mockRejectedValue(new Error('Failed to delete label'));
+    renderModal();
+    fireEvent.click(screen.getByTestId('delete-label-production'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('manage-labels-error')).toBeTruthy();
+    });
+  });
+
+  it('should not render when closed', () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByText('Manage labels')).toBeNull();
+  });
+});

--- a/packages/data-registry/frontend/src/__tests__/unit/components/RegisterVolumeModal.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/RegisterVolumeModal.spec.tsx
@@ -154,7 +154,7 @@ describe('RegisterVolumeModal', () => {
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Error registering volume')).toBeTruthy();
+      expect(screen.getByText('Error registering data')).toBeTruthy();
       expect(screen.getByText('API error 409: Volume already exists')).toBeTruthy();
     });
 

--- a/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
@@ -38,6 +38,7 @@ const renderTable = (props?: Partial<React.ComponentProps<typeof RegistryTable>>
         error={undefined}
         labels={mockLabels}
         onManageCollections={jest.fn()}
+        onManageLabels={jest.fn()}
         onRegisterData={jest.fn()}
         {...props}
       />

--- a/packages/data-registry/frontend/src/app/api/dataRegistry.ts
+++ b/packages/data-registry/frontend/src/app/api/dataRegistry.ts
@@ -7,6 +7,8 @@ import {
   CreateVolumeRequest,
   VolumeInfo,
   LabelListResponse,
+  CreateLabelRequest,
+  LabelResponse,
 } from '~/app/types';
 import { URL_PREFIX, BFF_API_VERSION } from '~/app/utilities/const';
 
@@ -94,3 +96,15 @@ export const createVolume = async (
 
 export const fetchLabels = (project: string): Promise<LabelListResponse> =>
   fetchJSON(registryUrl(`/${project}/labels`));
+
+export const createLabel = async (
+  project: string,
+  data: CreateLabelRequest,
+): Promise<LabelResponse> => {
+  const response = await fetchRequest(registryUrl(`/${project}/labels`), 'POST', data);
+  return response.json();
+};
+
+export const deleteLabel = async (project: string, label: string): Promise<void> => {
+  await fetchRequest(registryUrl(`/${project}/labels/${encodeURIComponent(label)}`), 'DELETE');
+};

--- a/packages/data-registry/frontend/src/app/components/ManageLabelsModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/ManageLabelsModal.tsx
@@ -1,0 +1,265 @@
+import React from 'react';
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Alert,
+  SearchInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  TextInput,
+  Label,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import { CheckIcon, TimesIcon, TrashIcon } from '@patternfly/react-icons';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { createLabel, deleteLabel, ApiError } from '~/app/api/dataRegistry';
+import { RegistryAsset } from '~/app/hooks/useAssets';
+
+type ManageLabelsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  project: string;
+  labels: string[];
+  assets: RegistryAsset[];
+  onRefresh: () => void;
+};
+
+type LabelWithAssets = {
+  name: string;
+  assetNames: string[];
+};
+
+const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
+  isOpen,
+  onClose,
+  project,
+  labels,
+  assets,
+  onRefresh,
+}) => {
+  const [filterText, setFilterText] = React.useState('');
+  const [isCreating, setIsCreating] = React.useState(false);
+  const [newLabelName, setNewLabelName] = React.useState('');
+  const [actionError, setActionError] = React.useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [deletingLabel, setDeletingLabel] = React.useState<string | null>(null);
+
+  const labelsWithAssets = React.useMemo<LabelWithAssets[]>(
+    () =>
+      labels.map((label) => ({
+        name: label,
+        assetNames: assets.filter((a) => a.labels.includes(label)).map((a) => a.name),
+      })),
+    [labels, assets],
+  );
+
+  const filteredLabels = React.useMemo(
+    () =>
+      filterText
+        ? labelsWithAssets.filter((l) => l.name.toLowerCase().includes(filterText.toLowerCase()))
+        : labelsWithAssets,
+    [labelsWithAssets, filterText],
+  );
+
+  const handleCreateLabel = async () => {
+    const trimmed = newLabelName.trim();
+    if (!trimmed) {
+      return;
+    }
+    setIsSubmitting(true);
+    setActionError(null);
+    try {
+      await createLabel(project, { name: trimmed });
+      setNewLabelName('');
+      setIsCreating(false);
+      onRefresh();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        setActionError(`Label "${trimmed}" already exists.`);
+      } else {
+        setActionError(err instanceof Error ? err.message : 'Failed to create label');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteLabel = async (label: string) => {
+    setActionError(null);
+    setDeletingLabel(label);
+    try {
+      await deleteLabel(project, label);
+      onRefresh();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to delete label');
+    } finally {
+      setDeletingLabel(null);
+    }
+  };
+
+  const handleClose = () => {
+    setFilterText('');
+    setIsCreating(false);
+    setNewLabelName('');
+    setActionError(null);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} variant="large" data-testid="manage-labels-modal">
+      <ModalHeader
+        title="Manage labels"
+        description="Create and delete labels to manage how assets are organized across this project."
+      />
+      <ModalBody>
+        <Alert
+          variant="info"
+          isInline
+          title="Changes affect all project assets"
+          className="pf-v6-u-mb-md"
+        >
+          Deleting a label removes it from every asset using it within this project.
+        </Alert>
+        {actionError ? (
+          <Alert
+            variant="danger"
+            isInline
+            isPlain
+            title={actionError}
+            data-testid="manage-labels-error"
+          />
+        ) : null}
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarItem>
+              <SearchInput
+                placeholder="Filter by label name"
+                value={filterText}
+                onChange={(_event, value) => setFilterText(value)}
+                onClear={() => setFilterText('')}
+                data-testid="label-filter"
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  setIsCreating(true);
+                  setActionError(null);
+                }}
+                isDisabled={isCreating}
+                data-testid="create-label-button"
+              >
+                Create label
+              </Button>
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
+        <Table aria-label="Labels" data-testid="labels-table">
+          <Thead>
+            <Tr>
+              <Th>Label</Th>
+              <Th>Assets</Th>
+              <Th screenReaderText="Actions" />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {isCreating ? (
+              <Tr data-testid="create-label-row">
+                <Td dataLabel="Label" colSpan={3}>
+                  <Flex
+                    alignItems={{ default: 'alignItemsCenter' }}
+                    flexWrap={{ default: 'nowrap' }}
+                  >
+                    <FlexItem style={{ maxWidth: '200px' }}>
+                      <TextInput
+                        value={newLabelName}
+                        onChange={(_event, value) => setNewLabelName(value)}
+                        placeholder="Enter label name"
+                        aria-label="New label name"
+                        isDisabled={isSubmitting}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            handleCreateLabel();
+                          } else if (e.key === 'Escape') {
+                            setIsCreating(false);
+                            setNewLabelName('');
+                            setActionError(null);
+                          }
+                        }}
+                        data-testid="new-label-input"
+                        autoFocus
+                      />
+                    </FlexItem>
+                    <FlexItem grow={{ default: 'grow' }} />
+                    <FlexItem>
+                      <Button
+                        variant="plain"
+                        aria-label="Confirm create label"
+                        onClick={handleCreateLabel}
+                        isDisabled={isSubmitting || !newLabelName.trim()}
+                        data-testid="confirm-create-label"
+                      >
+                        <CheckIcon />
+                      </Button>
+                    </FlexItem>
+                    <FlexItem>
+                      <Button
+                        variant="plain"
+                        aria-label="Cancel create label"
+                        onClick={() => {
+                          setIsCreating(false);
+                          setNewLabelName('');
+                          setActionError(null);
+                        }}
+                        isDisabled={isSubmitting}
+                        data-testid="cancel-create-label"
+                      >
+                        <TimesIcon />
+                      </Button>
+                    </FlexItem>
+                  </Flex>
+                </Td>
+              </Tr>
+            ) : null}
+            {filteredLabels.map((labelInfo) => (
+              <Tr key={labelInfo.name} data-testid={`label-row-${labelInfo.name}`}>
+                <Td dataLabel="Label">
+                  <Label isCompact variant="outline">
+                    {labelInfo.name}
+                  </Label>
+                </Td>
+                <Td dataLabel="Assets">
+                  {labelInfo.assetNames.length > 0 ? labelInfo.assetNames.join(', ') : '–'}
+                </Td>
+                <Td isActionCell>
+                  <Button
+                    variant="plain"
+                    aria-label={`Delete label ${labelInfo.name}`}
+                    onClick={() => handleDeleteLabel(labelInfo.name)}
+                    isDisabled={deletingLabel !== null}
+                    data-testid={`delete-label-${labelInfo.name}`}
+                  >
+                    <TrashIcon />
+                  </Button>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="link" onClick={handleClose}>
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default ManageLabelsModal;

--- a/packages/data-registry/frontend/src/app/components/RegisterVolumeModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegisterVolumeModal.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { createVolume } from '~/app/api/dataRegistry';
+import { createVolume, createLabel, ApiError } from '~/app/api/dataRegistry';
 import { CreateVolumeRequest } from '~/app/types';
 import {
   registerVolumeSchema,
@@ -100,6 +100,18 @@ const RegisterVolumeModal: React.FC<RegisterVolumeModalProps> = ({
       setIsSubmitting(true);
       setError('');
       try {
+        if (data.labels.length > 0) {
+          await Promise.all(
+            data.labels.map((label) =>
+              createLabel(project, { name: label }).catch((err) => {
+                if (err instanceof ApiError && err.status === 409) {
+                  return;
+                }
+                throw err;
+              }),
+            ),
+          );
+        }
         await createVolume(project, data.collection, buildRequest(data));
         form.reset(registerVolumeDefaults);
         onCreated();
@@ -130,7 +142,7 @@ const RegisterVolumeModal: React.FC<RegisterVolumeModalProps> = ({
       />
       <ModalBody>
         {error ? (
-          <Alert variant="danger" isInline title="Error registering volume">
+          <Alert variant="danger" isInline title="Error registering data">
             {error}
           </Alert>
         ) : null}

--- a/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
@@ -35,6 +35,7 @@ type RegistryTableProps = {
   error: Error | undefined;
   labels: string[];
   onManageCollections: () => void;
+  onManageLabels: () => void;
   onRegisterData: () => void;
 };
 
@@ -107,6 +108,7 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
   error,
   labels,
   onManageCollections,
+  onManageLabels,
   onRegisterData,
 }) => {
   const [searchText, setSearchText] = React.useState('');
@@ -416,6 +418,13 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
                     data-testid="manage-collections-action"
                   >
                     Manage collections
+                  </DropdownItem>
+                  <DropdownItem
+                    key="manage-labels"
+                    onClick={onManageLabels}
+                    data-testid="manage-labels-action"
+                  >
+                    Manage labels
                   </DropdownItem>
                 </DropdownList>
               </Dropdown>

--- a/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
@@ -21,6 +21,7 @@ import { useAssets } from '~/app/hooks/useAssets';
 import { useLabels } from '~/app/hooks/useLabels';
 import RegistryTable from '~/app/components/RegistryTable';
 import ManageCollectionsModal from '~/app/components/ManageCollectionsModal';
+import ManageLabelsModal from '~/app/components/ManageLabelsModal';
 import RegisterVolumeModal from '~/app/components/RegisterVolumeModal';
 
 // TODO: Replace with isAvailableProject from @odh-dashboard/k8s-core when BFF returns filtered projects
@@ -32,6 +33,7 @@ const DataRegistryPage: React.FC = () => {
   const requestedProject = searchParams.get('project') || '';
   const [isProjectOpen, setIsProjectOpen] = React.useState(false);
   const [isCollectionsModalOpen, setIsCollectionsModalOpen] = React.useState(false);
+  const [isLabelsModalOpen, setIsLabelsModalOpen] = React.useState(false);
   const [isRegisterModalOpen, setIsRegisterModalOpen] = React.useState(false);
 
   const [namespaces, namespacesLoaded, namespacesError] = useNamespaces();
@@ -169,6 +171,7 @@ const DataRegistryPage: React.FC = () => {
                 setIsCollectionsModalOpen(true);
               }
             }}
+            onManageLabels={() => setIsLabelsModalOpen(true)}
             onRegisterData={() => setIsRegisterModalOpen(true)}
           />
           <ManageCollectionsModal
@@ -176,6 +179,14 @@ const DataRegistryPage: React.FC = () => {
             onClose={() => setIsCollectionsModalOpen(false)}
             project={selectedProject}
             collections={collections}
+            onRefresh={handleRefresh}
+          />
+          <ManageLabelsModal
+            isOpen={isLabelsModalOpen}
+            onClose={() => setIsLabelsModalOpen(false)}
+            project={selectedProject}
+            labels={labels}
+            assets={assets}
             onRefresh={handleRefresh}
           />
           <RegisterVolumeModal

--- a/packages/data-registry/frontend/src/app/types.ts
+++ b/packages/data-registry/frontend/src/app/types.ts
@@ -112,6 +112,14 @@ export type LabelListResponse = {
   labels: string[];
 };
 
+export type CreateLabelRequest = {
+  name: string;
+};
+
+export type LabelResponse = {
+  name: string;
+};
+
 export type ErrorResponse = {
   error: {
     message: string;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://redhat.atlassian.net/browse/RHAI-569

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Implements a "Manage labels" modal accessible from the registry table kebab menu, allowing users to view, create, and delete labels within a project.

Changes:

ManageLabelsModal — new modal with label table (label name as outline Label, associated assets column, trash icon for delete), inline create row (text input + confirm/cancel), filter by label name, info alert about project-wide impact
RegistryTable — added "Manage labels" item to kebab dropdown
DataRegistryPage — wired modal state, passes labels and assets as props
API layer — added createLabel() and deleteLabel() functions, plus CreateLabelRequest/LabelResponse types
RegisterVolumeModal — pre-creates labels via POST /labels before volume registration so they're explicitly registered (deletable via Manage Labels); ignores 409 for already-existing labels (will be updated once the table registration PR merges)
Delete buttons are disabled while a delete is in progress to prevent double-click
Label-to-asset mapping is derived client-side from the already-loaded assets array — no additional API call needed.

Manage labels:
<img width="945" height="433" alt="image" src="https://github.com/user-attachments/assets/f6d31870-7c2d-4286-b935-303cc003e7dc" />

Manage labels view:
<img width="2119" height="886" alt="image" src="https://github.com/user-attachments/assets/0ad0bd84-f7bd-47a7-a573-82e7a4669867" />

Creating label:
<img width="2119" height="886" alt="image" src="https://github.com/user-attachments/assets/cfb75bf9-4a0b-4357-bf36-2b56c8a91005" />

Deleting label
<img width="2119" height="886" alt="image" src="https://github.com/user-attachments/assets/1466ff99-92ac-425d-919d-62a44ef8a06b" />

Table view:
<img width="2382" height="774" alt="image" src="https://github.com/user-attachments/assets/6b6bc8e5-66fe-4449-8745-9e2471c024dc" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested full flow on local dev environment (dashboard + BFF + Feast port-forward):
- Create label via Manage Labels modal
- Delete label (standalone and asset-associated)
- Register volume with labels, then delete those labels
- Filter labels by name
- Verify label-to-asset association displays correctly (including labels on multiple assets)
- Unit tests (Jest): 13 new tests for ManageLabelsModal
- Cypress mock tests: 10 new tests for Manage Labels flow
- All existing tests pass (51 unit, 27 Cypress)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

New unit tests and cypress mock tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Manage labels** option to the data registry.
  * Users can view labels and associated assets, filter labels, create new labels, and delete existing labels.
  * Registering data now automatically creates entered labels when needed.
* **Bug Fixes**
  * Updated registration error messaging to clearly reference data registration.
  * Added handling for label conflicts and other label-management errors.
* **Tests**
  * Added comprehensive coverage for label management and registration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->