### PR TITLE
poll project LIST in waitForUserProjectAccess to fix RBAC timing flake

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -159,7 +159,7 @@ export const waitForUserProjectAccess = (
   interval = 2000,
 ): Cypress.Chainable<Cypress.Exec> =>
   pollUntilSuccess(
-    `oc get project ${project} --as=${user} -o name`,
+    `oc get projects --as=${user} -o name | grep -qxF 'project.project.openshift.io/${project}'`,
     `${user} access to ${project}`,
     {
       maxAttempts: attempts,


### PR DESCRIPTION

https://issues.redhat.com/browse/RHOAIENG-89505

## Description

 After granting a user access, `waitForUserProjectAccess()` polled `oc get project <name>` (GET), which passes immediately via a live SubjectAccessReview. But the dashboard's project selector reads the project **LIST** endpoint, served from openshift-apiserver's periodically-synced authorization cache that lags a new RoleBinding by ~1–2s — so the test could log in while the dashboard still saw an empty project list.

One-line fix: poll the LIST endpoint (what the dashboard reads) instead. The `grep` is needed because `oc get projects` exits 0 even when the user sees nothing.=

## How Has This Been Tested?

- ran the spec repeatedly:
  ```
  cd packages/cypress
  npm run cypress:run -- --spec "cypress/tests/e2e/modelTraining/rayJobs/testRayJobProjectAccessPermissions.cy.ts"
  ```

## Test Impact

This is itself a test-stability fix (shared Cypress util); the affected e2e specs are the coverage. No new tests needed for a one-line `oc` polling change.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project access verification to accurately confirm whether a user can view a project.
  * Prevented false access failures when checking project visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->