### PR TITLE
Remove import rules button when rules table populated

### DIFF
--- a/frontend/src/pages/projects/projectRoles/PermissionRulesSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/PermissionRulesSection.tsx
@@ -179,16 +179,6 @@ const PermissionRulesSection: React.FC<PermissionRulesSectionProps> = ({
                   Add rule
                 </Button>
               </ToolbarItem>
-              <ToolbarItem>
-                <Button
-                  variant="tertiary"
-                  icon={<ImportIcon />}
-                  data-testid="role-import-template"
-                  onClick={onImportTemplate}
-                >
-                  Add rules from template
-                </Button>
-              </ToolbarItem>
             </>
           }
           rowRenderer={(rule) => (

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabGeneral.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabGeneral.cy.ts
@@ -400,7 +400,7 @@ describe('Add rules from template (toolbar button)', () => {
     projectRoles.findPermissionRulesTable().should('exist');
   });
 
-  it('should open template modal directly even when rules already exist', () => {
+  it('should hide the toolbar import template button once rules already exist', () => {
     projectRoles.visitCreateRole(NAMESPACE);
 
     projectRoles.findAddRuleButton().click();
@@ -416,9 +416,8 @@ describe('Add rules from template (toolbar button)', () => {
     projectRoles.findVerbCheckbox('get').click();
     projectRoles.findRuleSaveButton().click();
 
-    projectRoles.findImportTemplateButton().click();
-    projectRoles.findReplaceContentModal().should('not.exist');
-    projectRoles.findSelectTemplateModal().should('exist');
+    projectRoles.findPermissionRulesTable().should('exist');
+    projectRoles.findImportTemplateButton().should('not.exist');
   });
 
   it('should append rules without changing name/description (append semantics)', () => {
@@ -434,9 +433,6 @@ describe('Add rules from template (toolbar button)', () => {
     projectRoles.findPermissionRulesTable().should('exist');
     projectRoles.findPermissionRulesTable().find('tbody tr').should('have.length', 5);
 
-    projectRoles.findImportTemplateButton().click();
-    projectRoles.findSelectTemplateButton('workbench-reader').click();
-
-    projectRoles.findPermissionRulesTable().find('tbody tr').should('have.length', 10);
+    projectRoles.findImportTemplateButton().should('not.exist');
   });
 });

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabRules.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabRules.cy.ts
@@ -116,6 +116,36 @@ describe('Remove rule', () => {
   });
 });
 
+describe('Import template button visibility', () => {
+  beforeEach(() => {
+    asProjectAdminUser();
+    initIntercepts();
+    projectRoles.visitCreateRole(NAMESPACE);
+  });
+
+  it('should show the import template button when no rules exist', () => {
+    projectRoles.findPermissionsEmptyState().should('exist');
+    projectRoles.findImportTemplateButton().should('exist');
+  });
+
+  it('should hide the import template button once a rule is added', () => {
+    addRule('apps', 'deployments', 'Deployments', 'get');
+
+    projectRoles.findPermissionRulesTable().find('tbody tr').should('have.length', 1);
+    projectRoles.findImportTemplateButton().should('not.exist');
+  });
+
+  it('should show the import template button again after the last rule is removed', () => {
+    addRule('apps', 'deployments', 'Deployments', 'get');
+    projectRoles.findImportTemplateButton().should('not.exist');
+
+    projectRoles.findRuleRemoveButton(0).click();
+
+    projectRoles.findPermissionsEmptyState().should('exist');
+    projectRoles.findImportTemplateButton().should('exist');
+  });
+});
+
 describe('Add Rule modal validation', () => {
   beforeEach(() => {
     asProjectAdminUser();


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-78233

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Remove the "Add rules from template" button when rules table already has rules. If there are no rules, the button is left in.

<img width="559" height="170" alt="Screenshot 2026-08-31 at 10 30 52 AM" src="https://github.com/user-attachments/assets/f19e06e8-f989-4194-934b-5cfb26a2f6a5" />

<img width="824" height="415" alt="Screenshot 2026-08-31 at 10 31 05 AM" src="https://github.com/user-attachments/assets/4aa3fbaa-ca3f-458c-8b2d-054200846575" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a project -> Roles tab -> Create custom role -> rules section
2. When there are no rules in the rules section, the "Add rules from template" button should exist"
3. When there are rules in the rules section, that button should not exist.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Manually tested by creating roles, importing rules, and deleting rules to see if the button appears and disappears as expected. The cypress mock test has been adjusted to reflect that the add rules from template button will disappear.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated permission-rule workflows so “Import rules from template” is available when no rules exist.
  * The import option is hidden after rules are added, preventing additional template rules from being appended.
  * The option reappears when all permission rules are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->