### PR TITLE
feat(RHOAIENG-89750): expose agent sandbox CRD availability in gen-ai BFF

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
@@ -79,6 +80,10 @@ type App struct {
 	memoryStore             cache.MemoryStore
 	rootCAs                 *x509.CertPool
 	clusterDomain           string
+	sandboxMu               sync.RWMutex
+	sandboxesAvailable      bool
+	sandboxWatcherDone      chan struct{}
+	sandboxWatcherWg        sync.WaitGroup
 	fileUploadJobTracker    *services.FileUploadJobTracker
 	// cleanupFuncs holds shutdown callbacks for mock processes (envtest, MLflow, LlamaStack)
 	cleanupFuncs []func()
@@ -379,6 +384,16 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		fileUploadJobTracker:    fileUploadJobTracker,
 		cleanupFuncs:            cleanupFuncs,
 	}
+
+	// Seed sandbox availability synchronously at startup, then keep it current via watcher.
+	if cfg.MockK8sClient {
+		app.sandboxesAvailable = true
+		logger.Info("Mock mode: assuming agent sandbox CRD is available")
+	} else {
+		app.refreshSandboxState()
+		app.startSandboxWatcher()
+	}
+
 	return app, nil
 }
 
@@ -403,6 +418,12 @@ func resolveMLflowURL(cfg config.EnvConfig, logger *slog.Logger) string {
 
 func (app *App) Shutdown() error {
 	app.logger.Info("shutting down app...")
+
+	if app.sandboxWatcherDone != nil {
+		close(app.sandboxWatcherDone)
+		app.sandboxWatcherWg.Wait()
+	}
+
 	for i := len(app.cleanupFuncs) - 1; i >= 0; i-- {
 		app.cleanupFuncs[i]()
 	}

--- a/packages/gen-ai/bff/internal/api/config_handler.go
+++ b/packages/gen-ai/bff/internal/api/config_handler.go
@@ -12,7 +12,8 @@ type BFFConfigEnvelope Envelope[*models.BFFConfigModel, None]
 // BFFConfigHandler handles requests for BFF configuration
 func (app *App) BFFConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	config := &models.BFFConfigModel{
-		IsCustomLSD: app.config.LlamaStackURL != "",
+		IsCustomLSD:        app.config.LlamaStackURL != "",
+		SandboxesAvailable: app.isSandboxAvailable(),
 	}
 
 	configEnvelope := BFFConfigEnvelope{

--- a/packages/gen-ai/bff/internal/api/config_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/config_handler_test.go
@@ -142,3 +142,67 @@ func TestBFFConfigHandler_ContentType(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "application/json", rs.Header.Get("Content-Type"))
 }
+
+func TestBFFConfigHandler_SandboxesAvailable_True(t *testing.T) {
+	llamaStackClientFactory := lsmocks.NewMockClientFactory()
+	app := App{
+		config:                  config.EnvConfig{Port: 4000},
+		llamaStackClientFactory: llamaStackClientFactory,
+		repositories:            repositories.NewRepositories(),
+		sandboxesAvailable:      true,
+	}
+
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, constants.ConfigPath, nil)
+	assert.NoError(t, err)
+
+	app.BFFConfigHandler(rr, req, nil)
+
+	rs := rr.Result()
+	defer func() { _ = rs.Body.Close() }()
+
+	body, err := io.ReadAll(rs.Body)
+	assert.NoError(t, err)
+
+	var response struct {
+		Data *models.BFFConfigModel `json:"data"`
+	}
+	err = json.Unmarshal(body, &response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotNil(t, response.Data)
+	assert.True(t, response.Data.SandboxesAvailable, "SandboxesAvailable should be true")
+}
+
+func TestBFFConfigHandler_SandboxesAvailable_False(t *testing.T) {
+	llamaStackClientFactory := lsmocks.NewMockClientFactory()
+	app := App{
+		config:                  config.EnvConfig{Port: 4000},
+		llamaStackClientFactory: llamaStackClientFactory,
+		repositories:            repositories.NewRepositories(),
+		sandboxesAvailable:      false,
+	}
+
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, constants.ConfigPath, nil)
+	assert.NoError(t, err)
+
+	app.BFFConfigHandler(rr, req, nil)
+
+	rs := rr.Result()
+	defer func() { _ = rs.Body.Close() }()
+
+	body, err := io.ReadAll(rs.Body)
+	assert.NoError(t, err)
+
+	var response struct {
+		Data *models.BFFConfigModel `json:"data"`
+	}
+	err = json.Unmarshal(body, &response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotNil(t, response.Data)
+	assert.False(t, response.Data.SandboxesAvailable, "SandboxesAvailable should be false")
+}

--- a/packages/gen-ai/bff/internal/api/lsd_responses_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_responses_handler_test.go
@@ -2108,14 +2108,7 @@ func TestProcessResponseCitations(t *testing.T) {
 }
 
 func TestMockRAGCitationPipeline(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	mockClient := lsmocks.NewMockLlamaStackClient()
-
-	app := App{
-		config:       config.EnvConfig{Port: 4000},
-		logger:       logger,
-		repositories: repositories.NewRepositories(),
-	}
 
 	t.Run("non-streaming RAG strips markers and produces annotations", func(t *testing.T) {
 		params := llamastack.CreateResponseParams{
@@ -2196,7 +2189,6 @@ func TestMockRAGCitationPipeline(t *testing.T) {
 		assert.Equal(t, "mock_document.txt", ann.Filename, "filename must be resolved from attributes")
 	})
 
-	_ = app // ensure app is referenced for future handler-level tests
 }
 
 // TestIsEventTypeSupported_ReasoningEvents verifies reasoning event types are supported

--- a/packages/gen-ai/bff/internal/api/sandbox_state.go
+++ b/packages/gen-ai/bff/internal/api/sandbox_state.go
@@ -7,6 +7,8 @@ import (
 	helper "github.com/opendatahub-io/gen-ai/internal/helpers"
 )
 
+const sandboxProbeTimeout = 10 * time.Second
+
 const sandboxDiscoveryInterval = 30 * time.Second
 
 // sandboxState groups the fields on App that are protected by sandboxMu.
@@ -21,7 +23,9 @@ func (app *App) isSandboxAvailable() bool {
 }
 
 func (app *App) refreshSandboxState() {
-	available := helper.CheckAgentSandboxCRDAvailable(context.Background(), app.logger)
+	ctx, cancel := context.WithTimeout(context.Background(), sandboxProbeTimeout)
+	defer cancel()
+	available := helper.CheckAgentSandboxCRDAvailable(ctx, app.logger)
 
 	app.sandboxMu.Lock()
 	defer app.sandboxMu.Unlock()

--- a/packages/gen-ai/bff/internal/api/sandbox_state.go
+++ b/packages/gen-ai/bff/internal/api/sandbox_state.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	helper "github.com/opendatahub-io/gen-ai/internal/helpers"
+)
+
+const sandboxDiscoveryInterval = 30 * time.Second
+
+// sandboxState groups the fields on App that are protected by sandboxMu.
+//
+// Read access:  isSandboxAvailable (RLock)
+// Write access: refreshSandboxState (Lock)
+
+func (app *App) isSandboxAvailable() bool {
+	app.sandboxMu.RLock()
+	defer app.sandboxMu.RUnlock()
+	return app.sandboxesAvailable
+}
+
+func (app *App) refreshSandboxState() {
+	available := helper.CheckAgentSandboxCRDAvailable(context.Background(), app.logger)
+
+	app.sandboxMu.Lock()
+	defer app.sandboxMu.Unlock()
+
+	if available == app.sandboxesAvailable {
+		return
+	}
+
+	app.sandboxesAvailable = available
+	app.logger.Info("agent sandbox CRD availability changed", "sandboxesAvailable", available)
+}
+
+func (app *App) startSandboxWatcher() {
+	app.sandboxWatcherDone = make(chan struct{})
+	app.sandboxWatcherWg.Add(1)
+	ticker := time.NewTicker(sandboxDiscoveryInterval)
+	go func() {
+		defer app.sandboxWatcherWg.Done()
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				app.safeRefreshSandboxState()
+			case <-app.sandboxWatcherDone:
+				return
+			}
+		}
+	}()
+	app.logger.Info("started agent sandbox CRD watcher", "interval", sandboxDiscoveryInterval)
+}
+
+func (app *App) safeRefreshSandboxState() {
+	defer func() {
+		if r := recover(); r != nil {
+			app.logger.Error("panic during agent sandbox CRD check", "recover", r)
+		}
+	}()
+	app.refreshSandboxState()
+}

--- a/packages/gen-ai/bff/internal/helpers/k8s.go
+++ b/packages/gen-ai/bff/internal/helpers/k8s.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -50,9 +51,9 @@ func CheckAgentSandboxCRDAvailable(ctx context.Context, logger *slog.Logger) boo
 		logger.Warn("agent sandbox CRD check request failed", "error", err)
 		return false
 	}
-	defer resp.Body.Close()
-
 	available := resp.StatusCode == http.StatusOK
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
 	logger.Debug("agent sandbox CRD availability check complete", "available", available, "statusCode", resp.StatusCode)
 	return available
 }

--- a/packages/gen-ai/bff/internal/helpers/k8s.go
+++ b/packages/gen-ai/bff/internal/helpers/k8s.go
@@ -1,7 +1,11 @@
 package helper
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
 
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -12,6 +16,46 @@ import (
 	clientRest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+// CheckAgentSandboxCRDAvailable reports whether the agents.x-k8s.io/v1beta1 API group
+// is served by the cluster. It tries the pod's in-cluster service account first and
+// falls back to the local kubeconfig for out-of-cluster development. Returns false on
+// any discovery error or non-200 response. The caller is responsible for caching the result.
+func CheckAgentSandboxCRDAvailable(ctx context.Context, logger *slog.Logger) bool {
+	cfg, err := clientRest.InClusterConfig()
+	if err != nil {
+		logger.Debug("not running in-cluster, falling back to kubeconfig for agent sandbox CRD check", "error", err)
+		cfg, err = GetKubeconfig()
+		if err != nil {
+			logger.Warn("failed to get kubeconfig for agent sandbox CRD check", "error", err)
+			return false
+		}
+	}
+
+	httpClient, err := clientRest.HTTPClientFor(cfg)
+	if err != nil {
+		logger.Warn("failed to build HTTP client for agent sandbox CRD check", "error", err)
+		return false
+	}
+
+	url := strings.TrimRight(cfg.Host, "/") + "/apis/agents.x-k8s.io/v1beta1"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		logger.Warn("failed to create agent sandbox CRD check request", "error", err)
+		return false
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		logger.Warn("agent sandbox CRD check request failed", "error", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	available := resp.StatusCode == http.StatusOK
+	logger.Debug("agent sandbox CRD availability check complete", "available", available, "statusCode", resp.StatusCode)
+	return available
+}
 
 // GetKubeconfig returns the current KUBECONFIG configuration based on the default loading rules.
 func GetKubeconfig() (*clientRest.Config, error) {

--- a/packages/gen-ai/bff/internal/models/llamastack_distribution.go
+++ b/packages/gen-ai/bff/internal/models/llamastack_distribution.go
@@ -166,5 +166,6 @@ type OGXServerDeleteResponse struct {
 
 // BFFConfigModel represents BFF application-level configuration
 type BFFConfigModel struct {
-	IsCustomLSD bool `json:"isCustomLSD"`
+	IsCustomLSD        bool `json:"isCustomLSD"`
+	SandboxesAvailable bool `json:"sandboxesAvailable"`
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-89750

## Description

Adds `sandboxesAvailable: bool` to the gen-ai BFF `/api/v1/config` response so the frontend can gate Agent Sandbox UI on whether `agents.x-k8s.io/v1beta1` is served by the cluster.

**How it works:**
- At startup, the BFF probes `GET /apis/agents.x-k8s.io/v1beta1` synchronously to seed the cached value. Falls back to the local kubeconfig when not running in-cluster (dev mode).
- A background goroutine re-checks every 30 seconds under a `sync.RWMutex`, following the same pattern as the MLflow CR watcher in the mlflow BFF. Only logs on state transitions to avoid per-poll noise.
- Watcher is stopped cleanly in `Shutdown()`.
- In mock/envtest mode, `sandboxesAvailable` defaults to `true`.

**Validated on cluster:**
```
$ curl http://localhost:4010/gen-ai/api/v1/config
{"data":{"isCustomLSD":true,"sandboxesAvailable":true}}

$ kubectl get --raw /apis/agents.x-k8s.io/v1beta1 | jq .groupVersion
"agents.x-k8s.io/v1beta1"
```

## How Has This Been Tested?

- Manual request against local BFF connected to a real cluster — `sandboxesAvailable: true` confirmed when `agents.x-k8s.io/v1beta1` is present
- Verified `GET /apis/agents.x-k8s.io/v1beta1` returns `APIResourceList` with `Sandbox` resource on the test cluster
- Unit tests added for `sandboxesAvailable: true` and `sandboxesAvailable: false` in `config_handler_test.go`

## Test Impact

Added two unit tests to `config_handler_test.go`:
- `TestBFFConfigHandler_SandboxesAvailable_True` — verifies `sandboxesAvailable: true` is returned when set on `App`
- `TestBFFConfigHandler_SandboxesAvailable_False` — verifies `sandboxesAvailable: false` is returned when unset

No Cypress tests needed — this is a BFF-only change with no frontend UI impact yet.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sandbox availability information to the application configuration.
  * Sandbox support is detected automatically and refreshed periodically while the application is running.
  * Configuration responses now indicate whether sandboxes are available.

* **Bug Fixes**
  * Improved handling of sandbox availability checks when cluster services are unavailable or checks encounter errors.

* **Tests**
  * Added coverage for configurations with sandbox availability enabled and disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->