### PR TITLE
Temporarily remove group from import rule from template modal

### DIFF
--- a/frontend/src/pages/projects/projectRoles/TemplateCategoryGroup.tsx
+++ b/frontend/src/pages/projects/projectRoles/TemplateCategoryGroup.tsx
@@ -10,6 +10,7 @@ import {
   FlexItem,
   Split,
   SplitItem,
+  DataListToggle,
 } from '@patternfly/react-core';
 import type { RoleTemplate, RoleTemplateCategory } from './roleTemplateCatalog';
 
@@ -24,37 +25,38 @@ const TemplateCategoryGroup: React.FC<TemplateCategoryGroupProps> = ({
   actionLabel,
   onSelectTemplate,
 }) => {
-  const [isExpanded] = React.useState(true);
+  const [isExpanded, setIsExpanded] = React.useState(true);
 
   return (
     <>
-      {/* --- Uncomment once more than 1 group of rule templates is added --- */}
-      {/* <DataListItem */}
-      {/*   aria-labelledby={`category-${category.id}`} */}
-      {/*   isExpanded={isExpanded} */}
-      {/*   data-testid={`template-category-${category.id}`} */}
-      {/* > */}
-      {/*   <DataListItemRow> */}
-      {/*     <DataListToggle */}
-      {/*       id={`toggle-${category.id}`} */}
-      {/*       onClick={() => setIsExpanded((prev) => !prev)} */}
-      {/*       isExpanded={isExpanded} */}
-      {/*       aria-label={`Toggle ${category.name}`} */}
-      {/*       data-testid={`toggle-category-${category.id}`} */}
-      {/*       // Override PF's buggy default of aria-controls="false" when no controlled region exists */}
-      {/*       buttonProps={{ 'aria-controls': undefined }} */}
-      {/*     /> */}
-      {/*     <DataListItemCells */}
-      {/*       dataListCells={[ */}
-      {/*         <DataListCell key="name"> */}
-      {/*           <Content component="p" id={`category-${category.id}`}> */}
-      {/*             {category.name} */}
-      {/*           </Content> */}
-      {/*         </DataListCell>, */}
-      {/*       ]} */}
-      {/*     /> */}
-      {/*   </DataListItemRow> */}
-      {/* </DataListItem> */}
+      <DataListItem
+        aria-labelledby={`category-${category.id}`}
+        isExpanded={isExpanded}
+        data-testid={`template-category-${category.id}`}
+        /* --- Remove once more than 1 group of rule templates is added --- */
+        className="pf-v6-u-display-none"
+      >
+        <DataListItemRow>
+          <DataListToggle
+            id={`toggle-${category.id}`}
+            onClick={() => setIsExpanded((prev) => !prev)}
+            isExpanded={isExpanded}
+            aria-label={`Toggle ${category.name}`}
+            data-testid={`toggle-category-${category.id}`}
+            // Override PF's buggy default of aria-controls="false" when no controlled region exists
+            buttonProps={{ 'aria-controls': undefined }}
+          />
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell key="name">
+                <Content component="p" id={`category-${category.id}`}>
+                  {category.name}
+                </Content>
+              </DataListCell>,
+            ]}
+          />
+        </DataListItemRow>
+      </DataListItem>
       {isExpanded &&
         category.templates.map((template) => (
           <DataListItem key={template.id} data-testid={`template-item-${template.id}`}>

--- a/frontend/src/pages/projects/projectRoles/TemplateCategoryGroup.tsx
+++ b/frontend/src/pages/projects/projectRoles/TemplateCategoryGroup.tsx
@@ -4,7 +4,6 @@ import {
   DataListItemRow,
   DataListItemCells,
   DataListCell,
-  DataListToggle,
   Button,
   Content,
   Flex,
@@ -25,42 +24,44 @@ const TemplateCategoryGroup: React.FC<TemplateCategoryGroupProps> = ({
   actionLabel,
   onSelectTemplate,
 }) => {
-  const [isExpanded, setIsExpanded] = React.useState(true);
+  const [isExpanded] = React.useState(true);
 
   return (
     <>
-      <DataListItem
-        aria-labelledby={`category-${category.id}`}
-        isExpanded={isExpanded}
-        data-testid={`template-category-${category.id}`}
-      >
-        <DataListItemRow>
-          <DataListToggle
-            id={`toggle-${category.id}`}
-            onClick={() => setIsExpanded((prev) => !prev)}
-            isExpanded={isExpanded}
-            aria-label={`Toggle ${category.name}`}
-            data-testid={`toggle-category-${category.id}`}
-            // Override PF's buggy default of aria-controls="false" when no controlled region exists
-            buttonProps={{ 'aria-controls': undefined }}
-          />
-          <DataListItemCells
-            dataListCells={[
-              <DataListCell key="name">
-                <Content component="p" id={`category-${category.id}`}>
-                  {category.name}
-                </Content>
-              </DataListCell>,
-            ]}
-          />
-        </DataListItemRow>
-      </DataListItem>
+      {/* --- Uncomment once more than 1 group of rule templates is added --- */}
+      {/* <DataListItem */}
+      {/*   aria-labelledby={`category-${category.id}`} */}
+      {/*   isExpanded={isExpanded} */}
+      {/*   data-testid={`template-category-${category.id}`} */}
+      {/* > */}
+      {/*   <DataListItemRow> */}
+      {/*     <DataListToggle */}
+      {/*       id={`toggle-${category.id}`} */}
+      {/*       onClick={() => setIsExpanded((prev) => !prev)} */}
+      {/*       isExpanded={isExpanded} */}
+      {/*       aria-label={`Toggle ${category.name}`} */}
+      {/*       data-testid={`toggle-category-${category.id}`} */}
+      {/*       // Override PF's buggy default of aria-controls="false" when no controlled region exists */}
+      {/*       buttonProps={{ 'aria-controls': undefined }} */}
+      {/*     /> */}
+      {/*     <DataListItemCells */}
+      {/*       dataListCells={[ */}
+      {/*         <DataListCell key="name"> */}
+      {/*           <Content component="p" id={`category-${category.id}`}> */}
+      {/*             {category.name} */}
+      {/*           </Content> */}
+      {/*         </DataListCell>, */}
+      {/*       ]} */}
+      {/*     /> */}
+      {/*   </DataListItemRow> */}
+      {/* </DataListItem> */}
       {isExpanded &&
         category.templates.map((template) => (
           <DataListItem key={template.id} data-testid={`template-item-${template.id}`}>
             <DataListItemRow>
               <DataListItemCells
-                className="pf-v6-u-pl-3xl"
+                // Change to pf-v6-u-pl-3xl once more than 1 group of templates is added
+                className="pf-v6-u-pl-sm"
                 dataListCells={[
                   <DataListCell key="info" isFilled>
                     <Split hasGutter>

--- a/frontend/src/pages/projects/projectRoles/__tests__/SelectTemplateModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/SelectTemplateModal.spec.tsx
@@ -40,7 +40,6 @@ describe('SelectTemplateModal', () => {
   it('should render template categories and items', () => {
     render(<SelectTemplateModal mode="select" onSelectTemplate={jest.fn()} onClose={jest.fn()} />);
 
-    expect(screen.getByText('Workbench management templates')).toBeInTheDocument();
     expect(screen.getByText('Workbench maintainer')).toBeInTheDocument();
     expect(screen.getByText('Workbench reader')).toBeInTheDocument();
     expect(screen.getByText('Workbench updater')).toBeInTheDocument();
@@ -63,7 +62,9 @@ describe('SelectTemplateModal', () => {
     const searchInput = screen.getByPlaceholderText('Find by name');
     fireEvent.change(searchInput, { target: { value: 'nonexistent' } });
 
-    expect(screen.queryByText('Workbench management templates')).not.toBeInTheDocument();
+    expect(screen.queryByText('Workbench maintainer')).not.toBeInTheDocument();
+    expect(screen.queryByText('Workbench reader')).not.toBeInTheDocument();
+    expect(screen.queryByText('Workbench updater')).not.toBeInTheDocument();
   });
 
   it('should call onSelectTemplate when a template button is clicked', () => {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabGeneral.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabGeneral.cy.ts
@@ -317,7 +317,6 @@ describe('Select role template (header button)', () => {
     projectRoles.findSelectRoleTemplateButton().click();
     projectRoles.findSelectTemplateModal().should('exist');
 
-    cy.contains('Workbench management templates').should('exist');
     cy.contains('Workbench maintainer').should('exist');
     cy.contains('Workbench reader').should('exist');
     cy.contains('Workbench updater').should('exist');


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-78251

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
As of now, the Add rules from template modal only has one type of rulesets (workbenches). Due to this, the group header was removed. In the future, if there are new groups of templates, then the hidden attribute added in this PR should be removed. The fix described was to simply hide the section header for this release 

Before:
<img width="500"  alt="Screenshot 2026-08-31 at 3 05 14 PM" src="https://github.com/user-attachments/assets/6839b88f-7483-458b-b981-8aba4d21b3b9" />

After:
<img width="500" alt="Screenshot 2026-08-31 at 3 01 49 PM" src="https://github.com/user-attachments/assets/8d19a53e-e971-41c7-b4a2-b48fe84eb319" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Project -> Roles -> Create custom role -> Add rule from template
2. You should see the current rule templates but no grouping header

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Adjusted unit and cypress tests to not test for the header.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated template category presentation by hiding empty or unavailable category groups.
  - Reduced left padding for template items to create a more compact, consistent layout.
  - Simplified template filtering behavior so no-match results hide all template items without displaying an obsolete category label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->