### PR TITLE
fix(cypress): use curl for AutoX pipeline readiness

### DIFF
--- a/packages/cypress/cypress/utils/autoXPipelines.ts
+++ b/packages/cypress/cypress/utils/autoXPipelines.ts
@@ -95,7 +95,7 @@ export const provisionProjectForAutoX = (
  * (up to 5 min) to confirm pipelines exist before any BFF request is made.
  */
 export const waitForManagedPipelines = (projectName: string): void => {
-  const pipelineListCmd = `oc exec deploy/ds-pipeline-dspa -n ${projectName} -c ds-pipeline-api-server -- wget --no-check-certificate -qO- https://localhost:8888/apis/v2beta1/pipelines 2>/dev/null`;
+  const pipelineListCmd = `oc exec deploy/ds-pipeline-dspa -n ${projectName} -c ds-pipeline-api-server -- curl -ksSf https://localhost:8888/apis/v2beta1/pipelines 2>/dev/null`;
   const maxAttempts = 20;
   const intervalMs = 15000;
 


### PR DESCRIPTION
## Description

The AutoX Cypress readiness helper used wget inside the ds-pipeline-api-server container to discover managed pipelines. On the current EA2 CI cluster, wget exits with a missing libpsl.so.5 dependency even though the KFP API and managed pipelines are healthy.

This changes the probe to use curl with insecure TLS, silent output, show errors, and fail-on-HTTP-error behavior. The current container image already provides curl.

## How Has This Been Tested?

- The equivalent curl probe was run inside the live EA2 ds-pipeline-api-server container and returned all four managed pipelines.
- The repository commit hook ran ESLint successfully.
- Full Cypress execution was not run locally; the next validation is the PR AutoML and AutoRAG CI suites on the EA2 cluster.

## Test Impact

No new test was added. This is a one-line command substitution in the shared waitForManagedPipelines helper used by the AutoML and AutoRAG E2E flows. The PR CI suites provide the relevant end-to-end coverage.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when checking managed pipeline availability during automated workflows.
  * Updated the internal network request command while preserving secure certificate handling and quiet output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->