### PR TITLE
feat(gen-ai): MCP registry BFF integration and local MLflow dev stack

### DIFF
--- a/packages/gen-ai/.env.local.example
+++ b/packages/gen-ai/.env.local.example
@@ -31,24 +31,34 @@ NEMO_GUARDRAILS_URL=https://localhost:9443
 # Skip TLS certificate verification - set to true when using TLS backend via port-forward
 INSECURE_SKIP_VERIFY=false
 
-# MLflow tracking server URL
-# Option 1 (default): via dashboard backend proxy (when running npm run dev with full backend)
+# Local MLflow dev — BFF auto-starts, seeds prompts + MCP registry, and stops on shutdown.
+# Set MOCK_MLFLOW_CLIENT=true to enable. BFF manages the MLflow process on port 5001.
+# If MLflow is already running on :5001 (e.g. from make mlflow-up), BFF reuses it.
+MOCK_MLFLOW_CLIENT=true
+MLFLOW_URL=http://localhost:5001
+
+# Namespace for make deploy-k8s-mcp (fixed: mcp-servers)
+
+# Kubernetes MCP server Route URL — run `make deploy-k8s-mcp` once to deploy the server to the
+# cluster; it will print the URL to copy here. BFF registers it in the MLflow MCP registry on startup.
+# KUBERNETES_MCP_SERVER_URL=https://kubernetes-mcp-server-mcp-servers.apps.<cluster-domain>/mcp
+
+# MLflow tracking server URL (production/cluster mode — override when pointing to a real MLflow instance)
+# Option 1 (default for local dev): local MLflow managed by BFF (MOCK_MLFLOW_CLIENT=true above)
+# Option 2: via dashboard backend proxy (when running npm run dev with full backend)
 #   MLFLOW_URL=https://localhost:8443
-# Option 2: direct port-forward (e.g. when testing local MLflow changes)
-#   Run:
-#       i. oc port-forward -n <mlflow namespace> svc/mlflow 5001:8443
-#       ii. cd /mlflow/mlflow/server/js && export MLFLOW_PROXY=https://localhost:5001 && npx yarn start:federated
-MLFLOW_URL=https://localhost:8443
+# Option 3: direct port-forward to cluster MLflow
+#   oc port-forward -n <mlflow namespace> svc/mlflow 5001:8443
+#   MLFLOW_URL=http://localhost:5001
 
 # Docker distribution name for LlamaStack
 DISTRIBUTION_NAME=quay.io/opendatahub/llama-stack:latest
 
 # This should be the k8s namespace where "lsd-genai-playground-service" service is deployed in cluster you are using (used in port-forwarding)
+# Also used to create a matching MLflow workspace and seed it with prompts + MCP registry entries
+# alongside the default workspace.
 # PLAYGROUND_NAMESPACE=default
 PLAYGROUND_NAMESPACE=crimson-dev
-
-# This should be the k8s namespace where the MLflow service is deployed (used in port-forwarding)
-MLFLOW_NAMESPACE=opendatahub
 
 # OTel tracing — set to enable BFF span export to our gen-ai tracing collector
 # Requires port-forward: 

--- a/packages/gen-ai/.env.local.example
+++ b/packages/gen-ai/.env.local.example
@@ -31,8 +31,9 @@ NEMO_GUARDRAILS_URL=https://localhost:9443
 # Skip TLS certificate verification - set to true when using TLS backend via port-forward
 INSECURE_SKIP_VERIFY=false
 
-# Local MLflow dev — BFF auto-starts, seeds prompts + MCP registry, and stops on shutdown.
-# Set MOCK_MLFLOW_CLIENT=true to enable. BFF manages the MLflow process on port 5001.
+# Local MLflow dev — MOCK_MLFLOW_CLIENT=true starts the full stack on make dev-start:
+#   tracking server :5001 (seeded prompts + MCP registry) and MLflow BFF :4020.
+# dev-start-mock and dev-start-mlflow set this automatically.
 # If MLflow is already running on :5001 (e.g. from make mlflow-up), BFF reuses it.
 MOCK_MLFLOW_CLIENT=true
 MLFLOW_URL=http://localhost:5001

--- a/packages/gen-ai/Makefile
+++ b/packages/gen-ai/Makefile
@@ -17,7 +17,15 @@ include ${ENV_FILE}
 export $(shell sed 's/=.*//' ${ENV_FILE})
 endif
 
-.PHONY: help dev-install-dependencies dev-frontend dev-bff dev-start dev-start-no-portforward dev-portforward dev-start-maas dev-maas-bff dev-bff-maas deploy-k8s-mcp clean clean-all
+MLFLOW_BFF_MOCK_PORT ?= 4020
+MLFLOW_MOCK_BFF_ARGS := MOCK_MLFLOW_CLIENT=true MLFLOW_URL=http://localhost:5001 BFF_MLFLOW_DEV_URL=http://localhost:$(MLFLOW_BFF_MOCK_PORT)/api/v1
+ifeq ($(MOCK_MLFLOW_CLIENT),true)
+DEV_BFF_MLFLOW_ARGS := $(MLFLOW_MOCK_BFF_ARGS)
+else
+DEV_BFF_MLFLOW_ARGS := MLFLOW_URL=$(MLFLOW_URL)
+endif
+
+.PHONY: help dev-install-dependencies dev-frontend dev-bff dev-start dev-start-no-portforward dev-portforward dev-start-maas dev-maas-bff dev-bff-maas dev-bff-mlflow dev-start-mlflow deploy-k8s-mcp clean clean-all
 
 help: ## Display this help message
 	@echo "Available commands:"
@@ -29,7 +37,7 @@ dev-install-dependencies: ## Install dependencies for frontend
 
 .PHONY: dev-bff-mock
 dev-bff-mock: ## Run BFF with all mocks enabled (K8s, LlamaStack, MCP, MLflow, BFF clients)
-	cd bff && make run LOG_LEVEL=debug MOCK_LS_CLIENT=true MOCK_K8S_CLIENT=true MOCK_MCP_CLIENT=true MOCK_MLFLOW_CLIENT=true MOCK_BFF_CLIENTS=true AUTH_METHOD=disabled LLAMA_STACK_URL="" MAAS_URL="" DISTRIBUTION_NAME="mock-dev"
+	cd bff && make run LOG_LEVEL=debug MOCK_LS_CLIENT=true MOCK_K8S_CLIENT=true MOCK_MCP_CLIENT=true MOCK_BFF_CLIENTS=true AUTH_METHOD=disabled LLAMA_STACK_URL="" MAAS_URL="" DISTRIBUTION_NAME="mock-dev" $(MLFLOW_MOCK_BFF_ARGS)
 
 .PHONY: dev-bff
 dev-bff: ## Run BFF (requires env vars: MAAS_URL, LLAMA_STACK_URL, or use dev-bff-mock for mock mode)
@@ -39,11 +47,15 @@ endif
 ifndef LLAMA_STACK_URL
 	$(error LLAMA_STACK_URL is not set. Use 'make dev-bff-mock' for mock mode or set LLAMA_STACK_URL environment variable)
 endif
-	cd bff && make run LOG_LEVEL=debug STATIC_ASSETS_DIR=../frontend/dist MAAS_URL=$(MAAS_URL) MLFLOW_URL=$(MLFLOW_URL) LLAMA_STACK_URL=$(LLAMA_STACK_URL) ASR_MODEL_URL=$(ASR_MODEL_URL) DISTRIBUTION_NAME=$(DISTRIBUTION_NAME) AUTH_TOKEN=user_token AUTH_TOKEN_HEADER=Authorization AUTH_TOKEN_PREFIX="Bearer "
+	cd bff && make run LOG_LEVEL=debug STATIC_ASSETS_DIR=../frontend/dist MAAS_URL=$(MAAS_URL) LLAMA_STACK_URL=$(LLAMA_STACK_URL) ASR_MODEL_URL=$(ASR_MODEL_URL) DISTRIBUTION_NAME=$(DISTRIBUTION_NAME) AUTH_TOKEN=user_token AUTH_TOKEN_HEADER=Authorization AUTH_TOKEN_PREFIX="Bearer " $(DEV_BFF_MLFLOW_ARGS)
 
 .PHONY: dev-bff-inter-bff
-dev-bff-inter-bff: ## Run BFF with MaaS BFF dev URL for inter-BFF testing (mock K8s, real HTTP to MaaS BFF on port 8081)
-	cd bff && make run LOG_LEVEL=debug MOCK_LS_CLIENT=true MOCK_K8S_CLIENT=true MOCK_MCP_CLIENT=true MOCK_MLFLOW_CLIENT=true AUTH_METHOD=user_token LLAMA_STACK_URL="" MAAS_URL="" DISTRIBUTION_NAME="mock-dev" BFF_MAAS_DEV_URL=http://localhost:$${MAAS_LOCAL_PORT:-8081}/api/v1
+dev-bff-inter-bff: ## Run MLflow BFF + gen-ai BFF for MaaS inter-BFF testing (full MLflow stack, real HTTP to MaaS BFF on port 8081)
+	$(MLFLOW_MOCK_BFF_ARGS) make -j 2 dev-mlflow-bff-mock dev-bff-inter-bff-run
+
+.PHONY: dev-bff-inter-bff-run
+dev-bff-inter-bff-run:
+	cd bff && make run LOG_LEVEL=debug MOCK_LS_CLIENT=true MOCK_K8S_CLIENT=true MOCK_MCP_CLIENT=true AUTH_METHOD=user_token LLAMA_STACK_URL="" MAAS_URL="" DISTRIBUTION_NAME="mock-dev" BFF_MAAS_DEV_URL=http://localhost:$${MAAS_LOCAL_PORT:-8081}/api/v1 $(MLFLOW_MOCK_BFF_ARGS)
 
 .PHONY: dev-bff-debug
 dev-bff-debug: ## Run BFF with Delve debugger (VSCode can attach - requires Delve installation, see readme)
@@ -53,7 +65,7 @@ endif
 ifndef LLAMA_STACK_URL
 	$(error LLAMA_STACK_URL is not set. Use 'make dev-bff-mock-debug' for mock mode or set LLAMA_STACK_URL environment variable)
 endif
-	cd bff && make debug LOG_LEVEL=debug STATIC_ASSETS_DIR=../frontend/dist MAAS_URL=$(MAAS_URL) MLFLOW_URL=$(MLFLOW_URL) LLAMA_STACK_URL=$(LLAMA_STACK_URL) ASR_MODEL_URL=$(ASR_MODEL_URL) DISTRIBUTION_NAME=$(DISTRIBUTION_NAME) AUTH_TOKEN=user_token AUTH_TOKEN_HEADER=Authorization AUTH_TOKEN_PREFIX="Bearer "
+	cd bff && make debug LOG_LEVEL=debug STATIC_ASSETS_DIR=../frontend/dist MAAS_URL=$(MAAS_URL) LLAMA_STACK_URL=$(LLAMA_STACK_URL) ASR_MODEL_URL=$(ASR_MODEL_URL) DISTRIBUTION_NAME=$(DISTRIBUTION_NAME) AUTH_TOKEN=user_token AUTH_TOKEN_HEADER=Authorization AUTH_TOKEN_PREFIX="Bearer " $(DEV_BFF_MLFLOW_ARGS)
 
 .PHONY: dev-frontend
 dev-frontend: ## Run only the frontend in development mode
@@ -65,9 +77,8 @@ dev-mlflow-up: ## Start local MLflow tracking server for development
 
 .PHONY: dev-bff-mock-debug
 dev-bff-mock-debug: ## Run BFF with all mocks and Delve debugger on port 2345
-	cd bff && make debug LOG_LEVEL=debug MOCK_LS_CLIENT=true MOCK_K8S_CLIENT=true MOCK_MCP_CLIENT=true MOCK_MLFLOW_CLIENT=true MOCK_BFF_CLIENTS=true AUTH_METHOD=disabled LLAMA_STACK_URL="" MAAS_URL="" DISTRIBUTION_NAME="mock-dev"
+	cd bff && make debug LOG_LEVEL=debug MOCK_LS_CLIENT=true MOCK_K8S_CLIENT=true MOCK_MCP_CLIENT=true MOCK_BFF_CLIENTS=true AUTH_METHOD=disabled LLAMA_STACK_URL="" MAAS_URL="" DISTRIBUTION_NAME="mock-dev" $(MLFLOW_MOCK_BFF_ARGS)
 
-MLFLOW_BFF_MOCK_PORT ?= 4020
 export GOTMPDIR ?= /tmp/go-tmp
 
 .PHONY: dev-mlflow-bff-mock
@@ -76,9 +87,8 @@ dev-mlflow-bff-mock: ## Run MLflow BFF in mock mode pointing at local MLflow ser
 	cd ../mlflow/bff && make run PORT="$(MLFLOW_BFF_MOCK_PORT)" MOCK_K8S_CLIENT=true MOCK_HTTP_CLIENT=true AUTH_METHOD=disabled MLFLOW_URL=http://127.0.0.1:5001 DEV_MODE=true DEPLOYMENT_MODE=standalone LOG_LEVEL=debug
 
 .PHONY: dev-start-mock
-dev-start-mock: ## Run frontend, gen-ai BFF (mocks), and MLflow BFF with real inter-BFF for MLflow prompts
-	BFF_MLFLOW_DEV_URL="http://localhost:$(MLFLOW_BFF_MOCK_PORT)/api/v1" \
-		make -j 3 dev-mlflow-bff-mock dev-bff-mock dev-frontend
+dev-start-mock: ## Run frontend, gen-ai BFF (mocks), and MLflow BFF with real inter-BFF for MLflow
+	$(MLFLOW_MOCK_BFF_ARGS) make -j 3 dev-mlflow-bff-mock dev-bff-mock dev-frontend
 
 ############ E2E Test Targets ############
 # These targets are used by the GitHub Actions e2e workflow to start BFFs
@@ -96,8 +106,7 @@ dev-bff-e2e-cluster: ## Run BFF for e2e tests (federated mode, connected to clus
 
 .PHONY: dev-start-mock-debug
 dev-start-mock-debug: ## Run frontend, gen-ai BFF (mocks + debugger), and MLflow BFF with real inter-BFF
-	BFF_MLFLOW_DEV_URL="http://localhost:$(MLFLOW_BFF_MOCK_PORT)/api/v1" \
-		make -j 3 dev-mlflow-bff-mock dev-bff-mock-debug dev-frontend
+	$(MLFLOW_MOCK_BFF_ARGS) make -j 3 dev-mlflow-bff-mock dev-bff-mock-debug dev-frontend
 
 .PHONY: dev-portforward
 dev-portforward: ## Start port-forwarding for cluster services (Llama Stack, optional ASR)
@@ -118,7 +127,11 @@ dev-portforward: ## Start port-forwarding for cluster services (Llama Stack, opt
 .PHONY: dev-start
 dev-start: dev-portforward ## Start frontend, bff, and port-forwarding
 	@sleep 2
+ifeq ($(MOCK_MLFLOW_CLIENT),true)
+	$(MLFLOW_MOCK_BFF_ARGS) make -j 3 dev-mlflow-bff-mock dev-bff dev-frontend
+else
 	make -j 2 dev-bff dev-frontend
+endif
 
 .PHONY: dev-start-debug
 dev-start-debug: dev-portforward ## Start frontend, bff with debugger, and port-forwarding (VSCode can attach on port 2345)
@@ -128,11 +141,19 @@ dev-start-debug: dev-portforward ## Start frontend, bff with debugger, and port-
 	@echo "📍 Delve debugger will listen on port 2345"
 	@echo "📍 In VSCode: Press F5 and select 'Attach to Delve (make dev-start-debug)'"
 	@echo ""
+ifeq ($(MOCK_MLFLOW_CLIENT),true)
+	$(MLFLOW_MOCK_BFF_ARGS) make -j 3 dev-mlflow-bff-mock dev-bff-debug dev-frontend
+else
 	make -j 2 dev-bff-debug dev-frontend
+endif
 
 .PHONY: dev-start-no-portforward
 dev-start-no-portforward: ## Start frontend and bff without port-forwarding
+ifeq ($(MOCK_MLFLOW_CLIENT),true)
+	$(MLFLOW_MOCK_BFF_ARGS) make -j 3 dev-mlflow-bff-mock dev-bff dev-frontend
+else
 	make -j 2 dev-bff dev-frontend
+endif
 
 ############ MaaS Development (Inter-BFF Architecture) ############
 # gen-ai BFF communicates with MaaS exclusively through the MaaS BFF.
@@ -160,10 +181,28 @@ endif
 		AUTH_TOKEN=user_token AUTH_TOKEN_HEADER=Authorization AUTH_TOKEN_PREFIX="Bearer " \
 		BFF_MAAS_DEV_URL=http://localhost:8081/api/v1
 
+.PHONY: dev-bff-mlflow
+dev-bff-mlflow: ## Run gen-ai BFF connected to local MLflow BFF (real cluster + MCP registry; auto-starts local MLflow on :5001)
+ifndef LLAMA_STACK_URL
+	$(error LLAMA_STACK_URL is not set. Set it in .env.local)
+endif
+	cd bff && make run LOG_LEVEL=debug STATIC_ASSETS_DIR=../frontend/dist \
+		MAAS_URL=$(MAAS_URL) \
+		LLAMA_STACK_URL=$(LLAMA_STACK_URL) \
+		ASR_MODEL_URL=$(ASR_MODEL_URL) \
+		DISTRIBUTION_NAME=$(DISTRIBUTION_NAME) \
+		AUTH_TOKEN=user_token AUTH_TOKEN_HEADER=Authorization AUTH_TOKEN_PREFIX="Bearer " \
+		$(MLFLOW_MOCK_BFF_ARGS)
+
 .PHONY: dev-start-maas
 dev-start-maas: dev-portforward ## Start MaaS BFF + gen-ai BFF + frontend + port-forwards (full MaaS dev)
 	@sleep 2
 	make -j 3 dev-maas-bff dev-bff-maas dev-frontend
+
+.PHONY: dev-start-mlflow
+dev-start-mlflow: dev-portforward ## Start MLflow BFF + gen-ai BFF + frontend (real cluster + MCP registry)
+	@sleep 2
+	make -j 3 dev-mlflow-bff-mock dev-bff-mlflow dev-frontend
 
 .PHONY: deploy-k8s-mcp
 deploy-k8s-mcp: ## Deploy Kubernetes MCP server to mcp-servers namespace

--- a/packages/gen-ai/Makefile
+++ b/packages/gen-ai/Makefile
@@ -18,11 +18,11 @@ export $(shell sed 's/=.*//' ${ENV_FILE})
 endif
 
 MLFLOW_BFF_MOCK_PORT ?= 4020
-MLFLOW_MOCK_BFF_ARGS := MOCK_MLFLOW_CLIENT=true MLFLOW_URL=http://localhost:5001 BFF_MLFLOW_DEV_URL=http://localhost:$(MLFLOW_BFF_MOCK_PORT)/api/v1
+MLFLOW_MOCK_BFF_ARGS := MOCK_MLFLOW_CLIENT=true MLFLOW_URL=http://localhost:5001 BFF_MLFLOW_DEV_URL="http://localhost:$(MLFLOW_BFF_MOCK_PORT)/api/v1"
 ifeq ($(MOCK_MLFLOW_CLIENT),true)
 DEV_BFF_MLFLOW_ARGS := $(MLFLOW_MOCK_BFF_ARGS)
 else
-DEV_BFF_MLFLOW_ARGS := MLFLOW_URL=$(MLFLOW_URL)
+DEV_BFF_MLFLOW_ARGS := MLFLOW_URL="$(MLFLOW_URL)"
 endif
 
 .PHONY: help dev-install-dependencies dev-frontend dev-bff dev-start dev-start-no-portforward dev-portforward dev-start-maas dev-maas-bff dev-bff-maas dev-bff-mlflow dev-start-mlflow deploy-k8s-mcp clean clean-all
@@ -83,7 +83,7 @@ export GOTMPDIR ?= /tmp/go-tmp
 
 .PHONY: dev-mlflow-bff-mock
 dev-mlflow-bff-mock: ## Run MLflow BFF in mock mode pointing at local MLflow server (started by gen-ai BFF)
-	@mkdir -p $(GOTMPDIR)
+	@mkdir -p "$(GOTMPDIR)"
 	cd ../mlflow/bff && make run PORT="$(MLFLOW_BFF_MOCK_PORT)" MOCK_K8S_CLIENT=true MOCK_HTTP_CLIENT=true AUTH_METHOD=disabled MLFLOW_URL=http://127.0.0.1:5001 DEV_MODE=true DEPLOYMENT_MODE=standalone LOG_LEVEL=debug
 
 .PHONY: dev-start-mock
@@ -216,7 +216,7 @@ deploy-k8s-mcp: ## Deploy Kubernetes MCP server to mcp-servers namespace
 	echo ""; \
 	echo "Add to .env.local:"; \
 	echo "KUBERNETES_MCP_SERVER_URL=https://$$route_host/mcp"; \
-	echo "INSECURE_SKIP_VERIFY=true"
+	echo "# For HTTPS Routes, configure a trusted cluster or Route CA (e.g. BUNDLE_PATHS)"
 
 clean: ## Clean build artifacts and node_modules
 	@echo "Cleaning root dist..."

--- a/packages/gen-ai/Makefile
+++ b/packages/gen-ai/Makefile
@@ -17,7 +17,7 @@ include ${ENV_FILE}
 export $(shell sed 's/=.*//' ${ENV_FILE})
 endif
 
-.PHONY: help dev-install-dependencies dev-frontend dev-bff dev-start dev-start-no-portforward dev-portforward dev-start-maas dev-maas-bff dev-bff-maas clean clean-all
+.PHONY: help dev-install-dependencies dev-frontend dev-bff dev-start dev-start-no-portforward dev-portforward dev-start-maas dev-maas-bff dev-bff-maas deploy-k8s-mcp clean clean-all
 
 help: ## Display this help message
 	@echo "Available commands:"
@@ -68,9 +68,11 @@ dev-bff-mock-debug: ## Run BFF with all mocks and Delve debugger on port 2345
 	cd bff && make debug LOG_LEVEL=debug MOCK_LS_CLIENT=true MOCK_K8S_CLIENT=true MOCK_MCP_CLIENT=true MOCK_MLFLOW_CLIENT=true MOCK_BFF_CLIENTS=true AUTH_METHOD=disabled LLAMA_STACK_URL="" MAAS_URL="" DISTRIBUTION_NAME="mock-dev"
 
 MLFLOW_BFF_MOCK_PORT ?= 4020
+export GOTMPDIR ?= /tmp/go-tmp
 
 .PHONY: dev-mlflow-bff-mock
 dev-mlflow-bff-mock: ## Run MLflow BFF in mock mode pointing at local MLflow server (started by gen-ai BFF)
+	@mkdir -p $(GOTMPDIR)
 	cd ../mlflow/bff && make run PORT="$(MLFLOW_BFF_MOCK_PORT)" MOCK_K8S_CLIENT=true MOCK_HTTP_CLIENT=true AUTH_METHOD=disabled MLFLOW_URL=http://127.0.0.1:5001 DEV_MODE=true DEPLOYMENT_MODE=standalone LOG_LEVEL=debug
 
 .PHONY: dev-start-mock
@@ -162,6 +164,20 @@ endif
 dev-start-maas: dev-portforward ## Start MaaS BFF + gen-ai BFF + frontend + port-forwards (full MaaS dev)
 	@sleep 2
 	make -j 3 dev-maas-bff dev-bff-maas dev-frontend
+
+.PHONY: deploy-k8s-mcp
+deploy-k8s-mcp: ## Deploy Kubernetes MCP server to mcp-servers namespace
+	@oc apply -f bff/testdata/kubernetes-mcp-server.yaml
+	@echo ""
+	@route_host=$$(oc get route kubernetes-mcp-server -n mcp-servers -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$route_host" ]; then \
+		echo "Route not found. Inspect: oc get route -n mcp-servers"; \
+		exit 0; \
+	fi; \
+	echo ""; \
+	echo "Add to .env.local:"; \
+	echo "KUBERNETES_MCP_SERVER_URL=https://$$route_host/mcp"; \
+	echo "INSECURE_SKIP_VERIFY=true"
 
 clean: ## Clean build artifacts and node_modules
 	@echo "Cleaning root dist..."

--- a/packages/gen-ai/README.md
+++ b/packages/gen-ai/README.md
@@ -134,6 +134,36 @@ make run MOCK_MAAS_CLIENT=true
 make dev-bff-mock
 ```
 
+### Local MLflow + MCP Registry
+
+When `MOCK_MLFLOW_CLIENT=true` is set (recommended for local dev), the BFF automatically starts a local MLflow instance, seeds it with sample prompts and MCP registry entries, and shuts it down on exit. No separate process management required.
+
+**Quick start:**
+
+1. Add to `packages/gen-ai/.env.local`:
+
+   ```bash
+   MOCK_MLFLOW_CLIENT=true
+   PLAYGROUND_NAMESPACE=<your-openshift-namespace>   # optional — creates a matching MLflow workspace
+   ```
+
+2. Run as normal — seeding happens automatically on BFF startup:
+
+   ```bash
+   make dev-start        # with cluster port-forwards
+   make dev-start-mock   # fully local, no cluster required
+   ```
+
+**Optional: register a real Kubernetes MCP server (one-time cluster setup):**
+
+```bash
+# Deploys the K8s MCP server to the cluster and prints the URL to add to .env.local
+cd packages/gen-ai
+make deploy-k8s-mcp
+```
+
+For full details on seeding behavior, env variables, and manual seed commands, see [bff/README.md](bff/README.md#inter-bff-communication-gen-ai--mlflow).
+
 ## Running Frontend and BFF Together
 
 For convenience, you can start both the frontend and BFF simultaneously using these Makefile targets from the root of the gen-ai package:

--- a/packages/gen-ai/README.md
+++ b/packages/gen-ai/README.md
@@ -5,6 +5,7 @@ A modern web application with a modular architecture, featuring a React frontend
 ## Contributing
 
 Interested in contributing? See our [Contributing Guide](CONTRIBUTING.md) for:
+
 - Development setup and quick start
 - Testing requirements and workflows
 - Coding standards and conventions
@@ -134,35 +135,32 @@ make run MOCK_MAAS_CLIENT=true
 make dev-bff-mock
 ```
 
-### Local MLflow + MCP Registry
+### Local MLflow and MCP Registry
 
-When `MOCK_MLFLOW_CLIENT=true` is set (recommended for local dev), the BFF automatically starts a local MLflow instance, seeds it with sample prompts and MCP registry entries, and shuts it down on exit. No separate process management required.
+`MOCK_MLFLOW_CLIENT=true` starts the **full** local MLflow stack: tracking server on `:5001` (seeded with prompts and MCP registry rows) and MLflow BFF on `:4020`. Prompts and MCP registry APIs both work whenever this flag is active.
 
-**Quick start:**
+| Command | Cluster | MLflow |
+|---------|---------|--------|
+| `make dev-start` | Yes | Off (unless `MOCK_MLFLOW_CLIENT=true` in `.env.local`) |
+| `make dev-start` + `MOCK_MLFLOW_CLIENT=true` in `.env.local` | Yes | Full stack (same MLflow behavior as `dev-start-mlflow`) |
+| `make dev-start-mock` | No | Full stack (hardcoded in Makefile) |
+| `make dev-start-mlflow` | Yes | Full stack (hardcoded in Makefile) |
 
-1. Add to `packages/gen-ai/.env.local`:
+Add to `packages/gen-ai/.env.local` for MLflow on your usual `dev-start` workflow:
 
-   ```bash
-   MOCK_MLFLOW_CLIENT=true
-   PLAYGROUND_NAMESPACE=<your-openshift-namespace>   # optional — creates a matching MLflow workspace
-   ```
-
-2. Run as normal — seeding happens automatically on BFF startup:
-
-   ```bash
-   make dev-start        # with cluster port-forwards
-   make dev-start-mock   # fully local, no cluster required
-   ```
+```bash
+MOCK_MLFLOW_CLIENT=true
+PLAYGROUND_NAMESPACE=<your-openshift-namespace>   # optional — creates a matching MLflow workspace
+```
 
 **Optional: register a real Kubernetes MCP server (one-time cluster setup):**
 
 ```bash
-# Deploys the K8s MCP server to the cluster and prints the URL to add to .env.local
 cd packages/gen-ai
 make deploy-k8s-mcp
 ```
 
-For full details on seeding behavior, env variables, and manual seed commands, see [bff/README.md](bff/README.md#inter-bff-communication-gen-ai--mlflow).
+For seeding detail, env variables, and manual seed commands, see [bff/README.md](bff/README.md#inter-bff-communication-gen-ai--mlflow).
 
 ## Running Frontend and BFF Together
 
@@ -249,7 +247,6 @@ or
 echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> ~/.zshrc
 ```
 
-
 Then run the below, which will start the gen-ai frontend, bff with debugger, and port-forwarding (VSCode can attach on port 2345).
 
 ```bash
@@ -291,7 +288,7 @@ docker build -t gen-ai .
 docker run -p 8080:8080 gen-ai
 ```
 
-The application will be available at http://localhost:8080
+The application will be available at <http://localhost:8080>
 
 ### Docker Build Arguments
 

--- a/packages/gen-ai/bff/Makefile
+++ b/packages/gen-ai/bff/Makefile
@@ -170,7 +170,7 @@ mlflow-clean: mlflow-down ## Remove local MLflow data.
 
 .PHONY: mlflow-seed
 mlflow-seed: uv ## Seed local MLflow prompts + MCP registry (default + PLAYGROUND_NAMESPACE).
-	@curl -sf "http://127.0.0.1:$(MLFLOW_PORT)/health" >/dev/null 2>&1 || { \
+	@curl --fail --silent --show-error --connect-timeout 2 --max-time 5 "http://127.0.0.1:$(MLFLOW_PORT)/health" >/dev/null 2>&1 || { \
 		echo "ERROR: MLflow is not running on :$(MLFLOW_PORT). Start it first (make mlflow-up)."; \
 		exit 1; \
 	}

--- a/packages/gen-ai/bff/Makefile
+++ b/packages/gen-ai/bff/Makefile
@@ -23,6 +23,8 @@ MOCK_NEMO_CLIENT ?= false
 AUTH_METHOD ?= "user_token"
 PATH_PREFIX ?= ""
 DISTRIBUTION_NAME ?= "rh-dev"
+PLAYGROUND_NAMESPACE ?=
+KUBERNETES_MCP_SERVER_URL ?=
 
 # Inter-BFF Communication configuration
 BFF_MAAS_SERVICE_NAME ?= "odh-dashboard"
@@ -37,7 +39,7 @@ BFF_MAAS_AUTH_TOKEN_PREFIX ?= ""
 BFF_MLFLOW_DEV_URL ?= ""
 
 # MLflow configuration
-MLFLOW_VERSION ?= 3.12.0
+MLFLOW_VERSION ?= 3.15.1
 MLFLOW_PORT ?= 5001
 MLFLOW_DATA ?= $(shell pwd)/.mlflow
 
@@ -146,12 +148,15 @@ debug: fmt vet envtest uv ## Runs the project with Delve debugger (VSCode can at
 .PHONY: mlflow-up
 mlflow-up: uv ## Start local MLflow tracking server via uv.
 	@mkdir -p $(MLFLOW_DATA)
+	@$(UV) run --with mlflow==$(MLFLOW_VERSION) mlflow db upgrade sqlite:///$(MLFLOW_DATA)/mlflow.db 2>/dev/null || true
 	@echo "Starting MLflow server on port $(MLFLOW_PORT)... (Ctrl+C to stop)"
+	MLFLOW_ENABLE_WORKSPACES=true \
 	$(UV) run --with mlflow==$(MLFLOW_VERSION) mlflow server \
 		--host 127.0.0.1 \
 		--port $(MLFLOW_PORT) \
 		--backend-store-uri sqlite:///$(MLFLOW_DATA)/mlflow.db \
-		--default-artifact-root $(MLFLOW_DATA)/artifacts
+		--default-artifact-root $(MLFLOW_DATA)/artifacts \
+		--enable-workspaces
 
 .PHONY: mlflow-down
 mlflow-down: ## Stop local MLflow tracking server.
@@ -162,6 +167,17 @@ mlflow-down: ## Stop local MLflow tracking server.
 mlflow-clean: mlflow-down ## Remove local MLflow data.
 	rm -rf $(MLFLOW_DATA) $(MLFLOW_DATA)-test
 	@echo "MLflow data cleaned"
+
+.PHONY: mlflow-seed
+mlflow-seed: uv ## Seed local MLflow prompts + MCP registry (default + PLAYGROUND_NAMESPACE).
+	@curl -sf "http://127.0.0.1:$(MLFLOW_PORT)/health" >/dev/null 2>&1 || { \
+		echo "ERROR: MLflow is not running on :$(MLFLOW_PORT). Start it first (make mlflow-up)."; \
+		exit 1; \
+	}
+	MLFLOW_TRACKING_URI=http://127.0.0.1:$(MLFLOW_PORT) \
+	PLAYGROUND_NAMESPACE=$(PLAYGROUND_NAMESPACE) \
+	KUBERNETES_MCP_SERVER_URL=$(KUBERNETES_MCP_SERVER_URL) \
+	go test ./internal/integrations/mlflow/mlflowmocks/ -run "TestSeedMCPRegistry|TestSeedPrompts" -count=1
 
 ##@ Llama Stack
 

--- a/packages/gen-ai/bff/README.md
+++ b/packages/gen-ai/bff/README.md
@@ -165,6 +165,26 @@ SERVER_URL="http%3A%2F%2Flocalhost%3A9090%2Fsse"
 curl -i -H "Authorization: Bearer $TOKEN" "http://localhost:8080/gen-ai/api/v1/mcp/tools?namespace=default&server_url=$SERVER_URL"
 ```
 
+**Get MCP Server Tools (registry path — requires MLflow BFF):**
+
+```bash
+# server_name identifies a registry-sourced server; BFF resolves the endpoint via MLflow BFF.
+# Requires MOCK_MLFLOW_CLIENT=true (full MLflow stack — see Inter-BFF Communication section below).
+SERVER_NAME="com.example%2Fkubernetes"
+curl -i -H "Authorization: Bearer $TOKEN" \
+     "http://localhost:8080/gen-ai/api/v1/mcp/tools?namespace=default&server_name=$SERVER_NAME"
+```
+
+**Get MCP Server Status (registry path — requires MLflow BFF):**
+
+```bash
+SERVER_NAME="com.example%2Fkubernetes"
+curl -i -H "Authorization: Bearer $TOKEN" \
+     "http://localhost:8080/gen-ai/api/v1/mcp/status?namespace=default&server_name=$SERVER_NAME"
+```
+
+> `server_name` takes priority over `server_url` when both are provided. Encode the `/` in the name: `com.example/kubernetes` → `com.example%2Fkubernetes`.
+
 **Optional: With MCP Server Authentication:**
 
 ```bash
@@ -634,22 +654,21 @@ which starts the MaaS BFF alongside the gen-ai BFF (see [Inter-BFF Communication
 
 #### 6. Mock MLflow Client
 
-The MLflow mock connects to a real local MLflow instance (unlike other mocks that use hardcoded data).
-When `MOCK_MLFLOW_CLIENT=true` is set, the BFF automatically:
+When `MOCK_MLFLOW_CLIENT=true`, dev targets start the **full local MLflow stack**: tracking server on `:5001` (prompts + MCP registry DB) and MLflow BFF on `:4020` (registry API for Gen-AI inter-BFF). The Gen-AI BFF:
 
-1. Starts a local MLflow server as a child process on port 5001 (via `uv run mlflow server`)
+1. Starts a local MLflow tracking server as a child process on port 5001 (via `uv run mlflow server`)
 2. Seeds it with sample **prompt templates** (vet appointments, pet health, medication reminders)
 3. Seeds the **MCP registry** with a draft server and optionally a real Kubernetes MCP server
 4. Stops MLflow on BFF shutdown and cleans up the local database
 
-Seeding is **idempotent**: prompts and MCP servers that already exist are skipped on restart.
+`make dev-start`, `dev-start-mock`, and `dev-start-mlflow` all start MLflow BFF when this flag is set (or hardcoded). Seeding is **idempotent**: prompts and MCP servers that already exist are skipped on restart.
 
 If MLflow is already running on port 5001 (e.g. from `make mlflow-up`), the BFF reuses it and seeds without restarting. If `MLFLOW_TRACKING_URI` is already set, the BFF skips managing MLflow entirely and connects to that URI.
 
 **Environment Variables:**
 
-- `MOCK_MLFLOW_CLIENT=true`: Enables mock MLflow client (auto-starts, seeds, and stops local MLflow)
-- `MOCK_MLFLOW_CLIENT=false` (or not set): Uses configured `MLFLOW_URL`
+- `MOCK_MLFLOW_CLIENT=true`: Full local MLflow stack (tracking `:5001` + MLflow BFF `:4020` via `BFF_MLFLOW_DEV_URL`)
+- `MOCK_MLFLOW_CLIENT=false` (or not set): Uses configured `MLFLOW_URL` only; no MLflow BFF
 - `MLFLOW_URL`: MLflow tracking server URL (production/real mode)
 - `MLFLOW_TRACKING_URI`: When set, the BFF skips starting MLflow and connects to this URI instead
 - `PLAYGROUND_NAMESPACE`: OpenShift project namespace — the BFF creates a matching MLflow workspace and seeds both `default` and this workspace with prompts + MCP servers (reads from env, not a CLI flag)
@@ -667,7 +686,7 @@ make deploy-k8s-mcp
 #   INSECURE_SKIP_VERIFY=true
 ```
 
-Copy the printed values to `packages/gen-ai/.env.local`. On the next `make dev-start`, the BFF registers the server in the MCP registry automatically.
+Copy the printed values to `packages/gen-ai/.env.local`. On the next BFF restart with `MOCK_MLFLOW_CLIENT=true`, the server is registered in the MLflow MCP registry database and exposed via the Gen-AI list API (`/aaa/mcps`).
 
 #### 7. Combined Mock Mode (All Services)
 
@@ -1486,31 +1505,31 @@ make dev-start-mock
 
 ## Inter-BFF Communication (Gen-AI → MLflow)
 
-The Gen-AI BFF calls the MLflow BFF for prompts and other MLflow-backed APIs via inter-BFF HTTP (`BFF_MLFLOW_DEV_URL`).
+The Gen-AI BFF calls the MLflow BFF for prompts, MCP registry, and other MLflow-backed APIs via inter-BFF HTTP (`BFF_MLFLOW_DEV_URL`).
 
-### Local Dev Flow (recommended)
+### Local development
 
-The simplest way to develop against a local MLflow instance — **no separate MLflow process to manage**:
+`MOCK_MLFLOW_CLIENT=true` starts the **full** local MLflow stack: tracking on `:5001` (seeded with prompts and MCP registry rows) and MLflow BFF on `:4020`. Prompts and MCP registry APIs both work whenever this flag is active.
 
-1. Add to `packages/gen-ai/.env.local`:
+| Command | Cluster | MLflow |
+|---------|---------|--------|
+| `make dev-start` | Yes | Off (unless `MOCK_MLFLOW_CLIENT=true` in `.env.local`) |
+| `make dev-start` + `MOCK_MLFLOW_CLIENT=true` in `.env.local` | Yes | Full stack |
+| `make dev-start-mock` | No | Full stack (hardcoded) |
+| `make dev-start-mlflow` | Yes | Full stack (hardcoded) |
 
-   ```bash
-   MOCK_MLFLOW_CLIENT=true
-   MLFLOW_URL=http://localhost:5001
-   PLAYGROUND_NAMESPACE=<your-openshift-namespace>   # optional but recommended
-   ```
+```bash
+# Fully local — no cluster
+make dev-start-mock
 
-2. Run as normal:
+# Real cluster + port-forwards (no .env.local MLflow vars needed)
+make dev-start-mlflow
 
-   ```bash
-   # From packages/gen-ai — with cluster port-forwards
-   make dev-start
+# Your usual dev-start — add MOCK_MLFLOW_CLIENT=true to .env.local for full MLflow
+make dev-start
+```
 
-   # From packages/gen-ai — fully local, no cluster required
-   make dev-start-mock
-   ```
-
-When the BFF starts, `SetupMLflow` automatically:
+When the BFF starts with `MOCK_MLFLOW_CLIENT=true`, `SetupMLflow` automatically:
 - Starts a local MLflow server on `:5001`
 - Seeds sample **prompts** in the `default` workspace (and `PLAYGROUND_NAMESPACE` if set)
 - Seeds the **MCP registry** with a draft server (and a Kubernetes MCP server if `KUBERNETES_MCP_SERVER_URL` is set)
@@ -1521,12 +1540,13 @@ When the BFF starts, `SetupMLflow` automatically:
 | What | Workspaces | Source | Without env var |
 |------|-----------|--------|----------------|
 | Prompt templates (4 samples) | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded |
-| Draft MCP server (`io.github.example/tools-draft`) | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded |
-| Kubernetes MCP server (`com.example/kubernetes`) | `default` + `PLAYGROUND_NAMESPACE` | `KUBERNETES_MCP_SERVER_URL` env var | skipped — only the draft server is registered |
+| Draft MCP server (`com.brave.example/brave`) | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded (filtered from list — no endpoint) |
+| Active GitHub MCP server (`io.github.example/github`) | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded |
+| Kubernetes MCP server (`com.example/kubernetes`) | `default` + `PLAYGROUND_NAMESPACE` | `KUBERNETES_MCP_SERVER_URL` env var | skipped |
 
 Seeding is idempotent — prompts and MCP servers that already exist are skipped on restart.
 
-> **Failsafe:** If `KUBERNETES_MCP_SERVER_URL` is not set, seeding still succeeds with just the draft MCP server registered. You can add the env var later and restart the BFF to pick it up — no data is lost.
+> **Failsafe:** If `KUBERNETES_MCP_SERVER_URL` is not set, seeding still succeeds with the Brave draft and GitHub active servers. You can add the env var later and restart the BFF to pick it up — no data is lost.
 
 ### Optional: Deploy Kubernetes MCP Server to Cluster
 
@@ -1545,7 +1565,7 @@ KUBERNETES_MCP_SERVER_URL=https://kubernetes-mcp-server-mcp-servers.apps.<cluste
 INSECURE_SKIP_VERIFY=true
 ```
 
-Copy those two lines to `.env.local`. On the next BFF startup, the server is registered in the MCP registry automatically.
+Copy those two lines to `.env.local`. On the next BFF restart with `MOCK_MLFLOW_CLIENT=true`, the server is registered in the MLflow MCP registry and exposed via the Gen-AI `/aaa/mcps` API.
 
 ### Manual Seed (without restarting BFF)
 

--- a/packages/gen-ai/bff/README.md
+++ b/packages/gen-ai/bff/README.md
@@ -635,16 +635,39 @@ which starts the MaaS BFF alongside the gen-ai BFF (see [Inter-BFF Communication
 #### 6. Mock MLflow Client
 
 The MLflow mock connects to a real local MLflow instance (unlike other mocks that use hardcoded data).
-When `MOCK_MLFLOW_CLIENT=true` is set, the BFF automatically starts MLflow as a child process on port 5001, seeds it with sample prompts, and stops it on shutdown. If MLflow is already running (e.g. from `make mlflow-up`), the BFF will use the existing instance without seeding.
+When `MOCK_MLFLOW_CLIENT=true` is set, the BFF automatically:
 
-When `MLFLOW_TRACKING_URI` is already set, the BFF assumes MLflow is externally managed and skips the child process.
+1. Starts a local MLflow server as a child process on port 5001 (via `uv run mlflow server`)
+2. Seeds it with sample **prompt templates** (vet appointments, pet health, medication reminders)
+3. Seeds the **MCP registry** with a draft server and optionally a real Kubernetes MCP server
+4. Stops MLflow on BFF shutdown and cleans up the local database
+
+Seeding is **idempotent**: prompts and MCP servers that already exist are skipped on restart.
+
+If MLflow is already running on port 5001 (e.g. from `make mlflow-up`), the BFF reuses it and seeds without restarting. If `MLFLOW_TRACKING_URI` is already set, the BFF skips managing MLflow entirely and connects to that URI.
 
 **Environment Variables:**
 
-- `MOCK_MLFLOW_CLIENT=true`: Enables mock MLflow client (auto-starts and seeds local MLflow on port 5001)
+- `MOCK_MLFLOW_CLIENT=true`: Enables mock MLflow client (auto-starts, seeds, and stops local MLflow)
 - `MOCK_MLFLOW_CLIENT=false` (or not set): Uses configured `MLFLOW_URL`
 - `MLFLOW_URL`: MLflow tracking server URL (production/real mode)
 - `MLFLOW_TRACKING_URI`: When set, the BFF skips starting MLflow and connects to this URI instead
+- `PLAYGROUND_NAMESPACE`: OpenShift project namespace — the BFF creates a matching MLflow workspace and seeds both `default` and this workspace with prompts + MCP servers (reads from env, not a CLI flag)
+- `KUBERNETES_MCP_SERVER_URL`: Route URL for a real Kubernetes MCP server to register in the MCP registry (e.g. `https://kubernetes-mcp-server-mcp-servers.apps.<cluster>/mcp`); skipped if unset
+
+**Optional one-time cluster setup (Kubernetes MCP server):**
+
+```bash
+# From packages/gen-ai — deploys bff/testdata/kubernetes-mcp-server.yaml and prints the route URL
+make deploy-k8s-mcp
+
+# Output:
+#   Add to .env.local:
+#   KUBERNETES_MCP_SERVER_URL=https://kubernetes-mcp-server-mcp-servers.apps.<cluster>/mcp
+#   INSECURE_SKIP_VERIFY=true
+```
+
+Copy the printed values to `packages/gen-ai/.env.local`. On the next `make dev-start`, the BFF registers the server in the MCP registry automatically.
 
 #### 7. Combined Mock Mode (All Services)
 
@@ -1238,7 +1261,7 @@ curl -i -H "Authorization: Bearer FAKE_BEARER_TOKEN" "http://localhost:8080/gen-
 }
 ```
 
-> **Note:** Timestamps and exact values will vary. Sample prompts are automatically seeded when the BFF starts MLflow as a child process. If using an externally managed MLflow instance, run `make mlflow-seed` (from `bff/`) to seed data manually.
+> **Note:** Timestamps and exact values will vary. Sample prompts and MCP registry rows are seeded automatically when the gen-ai BFF starts with `MOCK_MLFLOW_CLIENT=true` (`SetupMLflow` on BFF init).
 
 #### Register Chat Prompt (Mock MLflow)
 
@@ -1433,7 +1456,7 @@ make dev-start-maas
 This starts:
 - MaaS BFF on `:8081` (connected to cluster maas-api via `MAAS_URL`)
 - Gen-AI BFF on `:8080` (connected to local MaaS BFF via `BFF_MAAS_DEV_URL=http://localhost:8081/api/v1`)
-- Frontend on `:4010`
+- Frontend on `:9102` (webpack dev server; proxies API to BFF on `:8080`)
 - Port-forwards for Llama Stack (`:8321`) and optional ASR
 
 **Manual multi-terminal setup (if you need separate control):**
@@ -1460,6 +1483,91 @@ oc port-forward -n <namespace> svc/lsd-genai-playground-service 8321:8321
 cd packages/gen-ai
 make dev-start-mock
 ```
+
+## Inter-BFF Communication (Gen-AI → MLflow)
+
+The Gen-AI BFF calls the MLflow BFF for prompts and other MLflow-backed APIs via inter-BFF HTTP (`BFF_MLFLOW_DEV_URL`).
+
+### Local Dev Flow (recommended)
+
+The simplest way to develop against a local MLflow instance — **no separate MLflow process to manage**:
+
+1. Add to `packages/gen-ai/.env.local`:
+
+   ```bash
+   MOCK_MLFLOW_CLIENT=true
+   MLFLOW_URL=http://localhost:5001
+   PLAYGROUND_NAMESPACE=<your-openshift-namespace>   # optional but recommended
+   ```
+
+2. Run as normal:
+
+   ```bash
+   # From packages/gen-ai — with cluster port-forwards
+   make dev-start
+
+   # From packages/gen-ai — fully local, no cluster required
+   make dev-start-mock
+   ```
+
+When the BFF starts, `SetupMLflow` automatically:
+- Starts a local MLflow server on `:5001`
+- Seeds sample **prompts** in the `default` workspace (and `PLAYGROUND_NAMESPACE` if set)
+- Seeds the **MCP registry** with a draft server (and a Kubernetes MCP server if `KUBERNETES_MCP_SERVER_URL` is set)
+- Shuts down MLflow and removes its local database on BFF exit
+
+### Seeding Summary
+
+| What | Workspaces | Source | Without env var |
+|------|-----------|--------|----------------|
+| Prompt templates (4 samples) | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded |
+| Draft MCP server (`io.github.example/tools-draft`) | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded |
+| Kubernetes MCP server (`com.example/kubernetes`) | `default` + `PLAYGROUND_NAMESPACE` | `KUBERNETES_MCP_SERVER_URL` env var | skipped — only the draft server is registered |
+
+Seeding is idempotent — prompts and MCP servers that already exist are skipped on restart.
+
+> **Failsafe:** If `KUBERNETES_MCP_SERVER_URL` is not set, seeding still succeeds with just the draft MCP server registered. You can add the env var later and restart the BFF to pick it up — no data is lost.
+
+### Optional: Deploy Kubernetes MCP Server to Cluster
+
+To register a real Kubernetes MCP server in the local MLflow MCP registry:
+
+```bash
+# From packages/gen-ai (one-time, requires oc login)
+make deploy-k8s-mcp
+```
+
+This deploys `bff/testdata/kubernetes-mcp-server.yaml` to the `mcp-servers` namespace and prints:
+
+```
+Add to .env.local:
+KUBERNETES_MCP_SERVER_URL=https://kubernetes-mcp-server-mcp-servers.apps.<cluster>/mcp
+INSECURE_SKIP_VERIFY=true
+```
+
+Copy those two lines to `.env.local`. On the next BFF startup, the server is registered in the MCP registry automatically.
+
+### Manual Seed (without restarting BFF)
+
+To re-seed a running local MLflow instance manually:
+
+```bash
+# From packages/gen-ai/bff — seeds both prompts and MCP registry
+make mlflow-seed
+```
+
+Requires `MLFLOW_TRACKING_URI=http://127.0.0.1:5001` (set automatically when BFF starts MLflow) or `make mlflow-up` running in another terminal.
+
+### Gen-AI MLflow Inter-BFF Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MOCK_MLFLOW_CLIENT` | Auto-start and seed local MLflow on `:5001` | `false` |
+| `MLFLOW_URL` | MLflow tracking server URL (real/production mode) | - |
+| `MLFLOW_TRACKING_URI` | When set, BFF skips managing MLflow and connects here | - |
+| `PLAYGROUND_NAMESPACE` | OpenShift namespace — creates matching MLflow workspace, seeds it alongside `default` | - |
+| `KUBERNETES_MCP_SERVER_URL` | Kubernetes MCP server route URL to register in the MCP registry | - |
+| `BFF_MLFLOW_DEV_URL` | Dev override URL for local MLflow BFF (inter-BFF mode) | - |
 
 ### Gen-AI Specific Environment Variables
 

--- a/packages/gen-ai/bff/README.md
+++ b/packages/gen-ai/bff/README.md
@@ -183,7 +183,7 @@ curl -i -H "Authorization: Bearer $TOKEN" \
      "http://localhost:8080/gen-ai/api/v1/mcp/status?namespace=default&server_name=$SERVER_NAME"
 ```
 
-> `server_name` takes priority over `server_url` when both are provided. Encode the `/` in the name: `com.example/kubernetes` → `com.example%2Fkubernetes`.
+> `server_name` takes priority over `server_url` when both are provided. Encode the `/` in the name: `com.example/kubernetes` → `com.example%2Fkubernetes`. Registry `server_name` requests resolve the endpoint via MLflow BFF only — no cluster connectivity required.
 
 **Optional: With MCP Server Authentication:**
 
@@ -683,7 +683,7 @@ make deploy-k8s-mcp
 # Output:
 #   Add to .env.local:
 #   KUBERNETES_MCP_SERVER_URL=https://kubernetes-mcp-server-mcp-servers.apps.<cluster>/mcp
-#   INSECURE_SKIP_VERIFY=true
+#   # For HTTPS Routes, configure a trusted cluster or Route CA (e.g. BUNDLE_PATHS)
 ```
 
 Copy the printed values to `packages/gen-ai/.env.local`. On the next BFF restart with `MOCK_MLFLOW_CLIENT=true`, the server is registered in the MLflow MCP registry database and exposed via the Gen-AI list API (`/aaa/mcps`).
@@ -1541,12 +1541,12 @@ When the BFF starts with `MOCK_MLFLOW_CLIENT=true`, `SetupMLflow` automatically:
 |------|-----------|--------|----------------|
 | Prompt templates (4 samples) | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded |
 | Draft MCP server (`com.brave.example/brave`) | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded (filtered from list — no endpoint) |
-| Active GitHub MCP server (`io.github.example/github`) | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded |
+| Mock GitHub MCP server (`io.github.example/github`) — fake endpoint, example only | `default` + `PLAYGROUND_NAMESPACE` | hardcoded in `mlflow_seed.go` | always seeded |
 | Kubernetes MCP server (`com.example/kubernetes`) | `default` + `PLAYGROUND_NAMESPACE` | `KUBERNETES_MCP_SERVER_URL` env var | skipped |
 
-Seeding is idempotent — prompts and MCP servers that already exist are skipped on restart.
+Seeding is idempotent — partial states from interrupted seeding are healed on restart.
 
-> **Failsafe:** If `KUBERNETES_MCP_SERVER_URL` is not set, seeding still succeeds with the Brave draft and GitHub active servers. You can add the env var later and restart the BFF to pick it up — no data is lost.
+> **Failsafe:** If `KUBERNETES_MCP_SERVER_URL` is not set, seeding still succeeds with the Brave draft and mock GitHub servers. You can add the env var later and restart the BFF to pick it up — no data is lost.
 
 ### Optional: Deploy Kubernetes MCP Server to Cluster
 
@@ -1559,10 +1559,10 @@ make deploy-k8s-mcp
 
 This deploys `bff/testdata/kubernetes-mcp-server.yaml` to the `mcp-servers` namespace and prints:
 
-```
+```text
 Add to .env.local:
 KUBERNETES_MCP_SERVER_URL=https://kubernetes-mcp-server-mcp-servers.apps.<cluster>/mcp
-INSECURE_SKIP_VERIFY=true
+# For HTTPS Routes, configure a trusted cluster or Route CA (e.g. BUNDLE_PATHS)
 ```
 
 Copy those two lines to `.env.local`. On the next BFF restart with `MOCK_MLFLOW_CLIENT=true`, the server is registered in the MLflow MCP registry and exposed via the Gen-AI `/aaa/mcps` API.

--- a/packages/gen-ai/bff/internal/api/aaa_mcps_handler.go
+++ b/packages/gen-ai/bff/internal/api/aaa_mcps_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -12,6 +13,18 @@ import (
 
 type MCPListEnvelope = Envelope[models.MCPListData, None]
 
+type configmapListResult struct {
+	servers       []models.MCPServerSummary
+	configMapInfo *models.ConfigMapInfo
+	err           error
+}
+
+type registryListResult struct {
+	servers       []models.MCPServerSummary
+	available     bool
+	registryError string
+}
+
 // MCPListHandler handles GET /genai/v1/aa/mcps?namespace=<>
 func (app *App) MCPListHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := r.Context()
@@ -22,46 +35,98 @@ func (app *App) MCPListHandler(w http.ResponseWriter, r *http.Request, ps httpro
 		return
 	}
 
-	_, _, _, err = app.parseMCPEndpointParams(r, false)
+	namespace, _, _, err := app.parseMCPEndpointParams(r, false)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
 
-	result, err := app.repositories.MCPClient.GetMCPServersFromConfigWithMetadata(
-		k8sClient,
-		ctx,
-		identity,
-		app.dashboardNamespace,
-		constants.MCPServerName,
-	)
-	if err != nil {
-		app.handleConfigMapError(w, r, err, constants.MCPServerName, app.dashboardNamespace)
-		return
-	}
+	cmCh := make(chan configmapListResult, 1)
+	regCh := make(chan registryListResult, 1)
 
-	servers := make([]models.MCPServerSummary, 0, len(result.Servers))
-	for _, serverInfo := range result.Servers {
-		status := app.determineServerStatusFromConfig(serverInfo.Config)
-		var logo *string
-		if serverInfo.Config.Logo != "" {
-			logo = &serverInfo.Config.Logo
+	go func() {
+		result, cmErr := app.repositories.MCPClient.GetMCPServersFromConfigWithMetadata(
+			k8sClient,
+			ctx,
+			identity,
+			app.dashboardNamespace,
+			constants.MCPServerName,
+		)
+		if cmErr != nil {
+			cmCh <- configmapListResult{err: cmErr}
+			return
 		}
 
-		servers = append(servers, models.MCPServerSummary{
-			Name:        serverInfo.Name,
-			URL:         serverInfo.Config.URL,
-			Transport:   app.normalizeTransportType(serverInfo.Config.Transport),
-			Description: serverInfo.Config.Description,
-			Logo:        logo,
-			Status:      status,
-		})
+		servers := make([]models.MCPServerSummary, 0, len(result.Servers))
+		for _, serverInfo := range result.Servers {
+			status := app.determineServerStatusFromConfig(serverInfo.Config)
+			var logo *string
+			if serverInfo.Config.Logo != "" {
+				logo = &serverInfo.Config.Logo
+			}
+
+			servers = append(servers, models.MCPServerSummary{
+				Name:        serverInfo.Name,
+				URL:         serverInfo.Config.URL,
+				Transport:   app.normalizeTransportType(serverInfo.Config.Transport),
+				Description: serverInfo.Config.Description,
+				Logo:        logo,
+				Status:      status,
+				Source:      models.MCPServerSourceConfigMap,
+				Tools:       []models.MCPServerToolSummary{},
+				ToolCount:   0,
+			})
+		}
+
+		cmCh <- configmapListResult{servers: servers, configMapInfo: &result.ConfigMapInfo}
+	}()
+
+	go func() {
+		mlflowClient := app.mlflowBFFClient(ctx)
+		if mlflowClient == nil {
+			regCh <- registryListResult{
+				available:     false,
+				registryError: "MLflow BFF is not configured",
+			}
+			return
+		}
+
+		registryServers, regErr := app.fetchRegistryMCPServerSummaries(ctx, namespace, mlflowClient)
+		if regErr != nil {
+			regCh <- registryListResult{
+				available:     false,
+				registryError: friendlyRegistryError(regErr),
+			}
+			return
+		}
+
+		regCh <- registryListResult{servers: registryServers, available: true}
+	}()
+
+	cmRes := <-cmCh
+	regRes := <-regCh
+
+	configmapAvailable := cmRes.err == nil
+	var configmapError string
+	if cmRes.err != nil {
+		configmapError = friendlyConfigMapError(cmRes.err, app.dashboardNamespace)
 	}
 
+	var configMapInfo *models.ConfigMapInfo
+	if configmapAvailable {
+		configMapInfo = cmRes.configMapInfo
+	}
+
+	merged := mergeMCPServerSummaries(regRes.servers, cmRes.servers)
+
 	responseData := models.MCPListData{
-		Servers:       servers,
-		TotalCount:    len(servers),
-		ConfigMapInfo: result.ConfigMapInfo,
+		Servers:            merged,
+		TotalCount:         len(merged),
+		ConfigMapInfo:      configMapInfo,
+		RegistryAvailable:  regRes.available,
+		RegistryError:      regRes.registryError,
+		ConfigmapAvailable: configmapAvailable,
+		ConfigmapError:     configmapError,
 	}
 
 	response := MCPListEnvelope{
@@ -74,7 +139,52 @@ func (app *App) MCPListHandler(w http.ResponseWriter, r *http.Request, ps httpro
 	}
 }
 
-// handleConfigMapError handles specific ConfigMap-related errors with appropriate HTTP status codes
+// friendlyRegistryError returns a human-readable message for a registry fetch error.
+// Internal error details are intentionally not exposed to the caller to avoid leaking
+// infrastructure details (hostnames, TLS errors, internal addresses).
+func friendlyRegistryError(err error) string {
+	if errors.Is(err, ErrRegistryMCPClientUnavailable) {
+		return "MLflow BFF is not configured"
+	}
+	return "MCP registry temporarily unavailable"
+}
+
+// mergeMCPServerSummaries combines registry and ConfigMap servers, preferring registry entries
+// when both sources expose the same endpoint URL.
+func mergeMCPServerSummaries(registryServers, configmapServers []models.MCPServerSummary) []models.MCPServerSummary {
+	seenURLs := make(map[string]struct{}, len(registryServers))
+	merged := make([]models.MCPServerSummary, 0, len(registryServers)+len(configmapServers))
+	merged = append(merged, registryServers...)
+	for _, server := range registryServers {
+		seenURLs[server.URL] = struct{}{}
+	}
+
+	for _, server := range configmapServers {
+		if _, exists := seenURLs[server.URL]; exists {
+			continue
+		}
+		merged = append(merged, server)
+	}
+
+	return merged
+}
+
+// friendlyConfigMapError returns a human-readable message for a ConfigMap fetch error.
+// It does not write to an http.ResponseWriter — callers surface this as a response field.
+func friendlyConfigMapError(err error, namespace string) string {
+	errMsg := err.Error()
+	if containsAny(errMsg, []string{"not found", "NotFound", "404"}) {
+		return fmt.Sprintf("ConfigMap '%s' not found in namespace '%s'", constants.MCPServerName, namespace)
+	}
+	if containsAny(errMsg, []string{"forbidden", "Forbidden", "403", "permission denied"}) {
+		return fmt.Sprintf("Access denied to ConfigMap '%s' in namespace '%s'", constants.MCPServerName, namespace)
+	}
+	return fmt.Sprintf("Failed to read ConfigMap '%s': %s", constants.MCPServerName, errMsg)
+}
+
+// handleConfigMapError writes an appropriate HTTP error response for ConfigMap fetch failures.
+// Used by endpoints where the ConfigMap is the sole data source (e.g., vector stores).
+// For multi-source list endpoints, prefer friendlyConfigMapError + graceful degradation instead.
 func (app *App) handleConfigMapError(w http.ResponseWriter, r *http.Request, err error, configMapName, namespace string) {
 	errMsg := err.Error()
 

--- a/packages/gen-ai/bff/internal/api/aaa_mcps_handler.go
+++ b/packages/gen-ai/bff/internal/api/aaa_mcps_handler.go
@@ -109,6 +109,10 @@ func (app *App) MCPListHandler(w http.ResponseWriter, r *http.Request, ps httpro
 	configmapAvailable := cmRes.err == nil
 	var configmapError string
 	if cmRes.err != nil {
+		app.logger.Error("failed to read MCP servers ConfigMap",
+			"namespace", app.dashboardNamespace,
+			"error", cmRes.err,
+		)
 		configmapError = friendlyConfigMapError(cmRes.err, app.dashboardNamespace)
 	}
 
@@ -179,7 +183,7 @@ func friendlyConfigMapError(err error, namespace string) string {
 	if containsAny(errMsg, []string{"forbidden", "Forbidden", "403", "permission denied"}) {
 		return fmt.Sprintf("Access denied to ConfigMap '%s' in namespace '%s'", constants.MCPServerName, namespace)
 	}
-	return fmt.Sprintf("Failed to read ConfigMap '%s': %s", constants.MCPServerName, errMsg)
+	return fmt.Sprintf("Failed to read ConfigMap '%s'", constants.MCPServerName)
 }
 
 // handleConfigMapError writes an appropriate HTTP error response for ConfigMap fetch failures.

--- a/packages/gen-ai/bff/internal/api/aaa_mcps_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/aaa_mcps_handler_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -12,15 +13,22 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient/bffmocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/mcp/mcpmocks"
+	"github.com/opendatahub-io/gen-ai/internal/models"
 	"github.com/opendatahub-io/gen-ai/internal/repositories"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 var _ = Describe("MCPListHandler", func() {
-	var app *App
+	var (
+		app            *App
+		mockBFFFactory *bffmocks.MockClientFactory
+		mockBFFClient  *bffmocks.MockBFFClient
+	)
 
 	BeforeEach(func() {
 		logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -33,6 +41,11 @@ var _ = Describe("MCPListHandler", func() {
 		mockK8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, logger)
 		require.NoError(GinkgoT(), err)
 
+		mockBFFFactory = bffmocks.NewMockClientFactory(logger).(*bffmocks.MockClientFactory)
+		mockBFFFactory.CreateClient(bffclient.BFFTargetMLflow, "")
+		mockBFFClient = mockBFFFactory.GetMockClient(bffclient.BFFTargetMLflow)
+		mockBFFClient.CallHandler = nil
+
 		app = &App{
 			config: config.EnvConfig{
 				Port:       4000,
@@ -42,6 +55,7 @@ var _ = Describe("MCPListHandler", func() {
 			repositories:            repositories.NewRepositoriesWithMCP(mockMCPFactory, logger),
 			kubernetesClientFactory: mockK8sFactory,
 			mcpClientFactory:        mockMCPFactory,
+			bffClientFactory:        mockBFFFactory,
 			dashboardNamespace:      "opendatahub",
 		}
 	})
@@ -82,11 +96,111 @@ var _ = Describe("MCPListHandler", func() {
 			assert.NotEmpty(t, server.Transport, "Server should have a transport")
 			assert.NotEmpty(t, server.Description, "Server should have a description")
 			assert.Contains(t, []string{"healthy", "error", "unknown"}, server.Status, "Server should have a valid status")
+			assert.Contains(t, []string{models.MCPServerSourceConfigMap, models.MCPServerSourceRegistry}, server.Source)
 		}
 
-		assert.NotEmpty(t, response.Data.ConfigMapInfo.Name, "ConfigMap info should have a name")
-		assert.NotEmpty(t, response.Data.ConfigMapInfo.Namespace, "ConfigMap info should have a namespace")
-		assert.NotEmpty(t, response.Data.ConfigMapInfo.LastUpdated, "ConfigMap info should have last updated timestamp")
+		assert.False(t, response.Data.RegistryAvailable, "Registry should be unavailable without mock response")
+		assert.NotEmpty(t, response.Data.RegistryError)
+		assert.True(t, response.Data.ConfigmapAvailable)
+		require.NotNil(t, response.Data.ConfigMapInfo)
+		assert.NotEmpty(t, response.Data.ConfigMapInfo.Name)
+	})
+
+	It("should merge registry and configmap servers when registry is available", func() {
+		t := GinkgoT()
+		mockBFFClient.CallHandler = func(_ context.Context, method, path string, _ interface{}, response interface{}) error {
+			require.Equal(t, "GET", method)
+			require.Equal(t, "/mcp-registry/servers?workspace=demo", path)
+			data := map[string]interface{}{
+				"data": map[string]interface{}{
+					"servers": []map[string]interface{}{
+						{
+							"name":        "io.github.example/github",
+							"description": "GitHub MCP server",
+							"status":      "active",
+							"access_endpoints": []map[string]interface{}{
+								{
+									"endpoint_url":   "https://github-mcp.example.com/mcp",
+									"transport_type": "streamable-http",
+									"resolved_version": map[string]interface{}{
+										"version": "1.0.0",
+										"tools": []map[string]interface{}{
+											{"name": "create_github_issue", "description": "Create issue"},
+										},
+									},
+								},
+							},
+						},
+						{
+							"name":        "com.brave.example/brave",
+							"description": "Draft server",
+							"status":      "draft",
+						},
+					},
+				},
+			}
+			return marshalToResponse(data, response)
+		}
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/aa/mcps?namespace=demo", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPListHandler(rr, req, nil)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response MCPListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		assert.True(t, response.Data.RegistryAvailable)
+
+		var registryCount, configmapCount int
+		for _, server := range response.Data.Servers {
+			switch server.Source {
+			case models.MCPServerSourceRegistry:
+				registryCount++
+				if server.Name == "io.github.example/github" {
+					assert.Equal(t, 1, server.ToolCount)
+					assert.Equal(t, "https://github-mcp.example.com/mcp", server.URL)
+				}
+			case models.MCPServerSourceConfigMap:
+				configmapCount++
+			}
+		}
+		assert.Equal(t, 1, registryCount, "MVP filter should exclude draft brave server")
+		assert.Greater(t, configmapCount, 0)
+		assert.Equal(t, len(response.Data.Servers), response.Data.TotalCount)
+	})
+
+	It("should return configmap servers with registry_available false when registry call fails", func() {
+		t := GinkgoT()
+		mockBFFClient.CallHandler = func(_ context.Context, _, _ string, _ interface{}, _ interface{}) error {
+			return fmt.Errorf("registry unavailable")
+		}
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/aa/mcps?namespace=demo", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPListHandler(rr, req, nil)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response MCPListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		assert.False(t, response.Data.RegistryAvailable)
+		assert.NotEmpty(t, response.Data.RegistryError)
+		assert.Equal(t, "MCP registry temporarily unavailable", response.Data.RegistryError)
+		assert.Greater(t, len(response.Data.Servers), 0)
+		for _, server := range response.Data.Servers {
+			assert.Equal(t, models.MCPServerSourceConfigMap, server.Source)
+		}
 	})
 
 	It("should return 400 when namespace parameter is missing", func() {
@@ -191,5 +305,291 @@ var _ = Describe("MCPListHandler", func() {
 		require.NoError(t, err)
 
 		require.NotNil(t, response.Data)
+	})
+
+	It("should return HTTP 200 with configmap_available false when ConfigMap is missing", func() {
+		t := GinkgoT()
+
+		// "llama-stack" namespace exists but has no gen-ai-aa-mcp-servers ConfigMap
+		app.dashboardNamespace = "llama-stack"
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/aa/mcps?namespace=demo", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPListHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusOK, rr.Code, "missing ConfigMap must not fail the request")
+
+		var response MCPListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		assert.False(t, response.Data.ConfigmapAvailable)
+		assert.NotEmpty(t, response.Data.ConfigmapError, "configmap_error should describe the problem")
+		assert.Contains(t, response.Data.ConfigmapError, "llama-stack")
+	})
+
+	It("should return registry servers even when ConfigMap is missing", func() {
+		t := GinkgoT()
+
+		// "llama-stack" namespace has no gen-ai-aa-mcp-servers ConfigMap
+		app.dashboardNamespace = "llama-stack"
+
+		mockBFFClient.CallHandler = func(_ context.Context, method, path string, _ interface{}, response interface{}) error {
+			require.Equal(t, "GET", method)
+			data := map[string]interface{}{
+				"data": map[string]interface{}{
+					"servers": []map[string]interface{}{
+						{
+							"name":        "io.github.example/github",
+							"description": "GitHub MCP server",
+							"status":      "active",
+							"access_endpoints": []map[string]interface{}{
+								{
+									"endpoint_url":   "https://github-mcp.example.com/mcp",
+									"transport_type": "streamable-http",
+									"resolved_version": map[string]interface{}{
+										"version": "1.0.0",
+										"tools": []map[string]interface{}{
+											{"name": "create_github_issue", "description": "Create issue"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			return marshalToResponse(data, response)
+		}
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/aa/mcps?namespace=demo", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPListHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response MCPListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+		assert.False(t, response.Data.ConfigmapAvailable, "ConfigMap should be reported unavailable")
+		assert.NotEmpty(t, response.Data.ConfigmapError)
+		assert.True(t, response.Data.RegistryAvailable, "Registry should still be available")
+		assert.Greater(t, len(response.Data.Servers), 0, "Registry servers should still be returned")
+		for _, server := range response.Data.Servers {
+			assert.Equal(t, models.MCPServerSourceRegistry, server.Source, "All servers should be registry-sourced")
+		}
+	})
+
+	It("should return 0 servers and both available flags false when both sources are unavailable", func() {
+		t := GinkgoT()
+
+		// "llama-stack" namespace has no gen-ai-aa-mcp-servers ConfigMap
+		app.dashboardNamespace = "llama-stack"
+
+		mockBFFClient.CallHandler = func(_ context.Context, _, _ string, _ interface{}, _ interface{}) error {
+			return fmt.Errorf("registry connection refused")
+		}
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/aa/mcps?namespace=demo", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPListHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusOK, rr.Code, "dual failure must not crash the endpoint")
+
+		var response MCPListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+		assert.False(t, response.Data.ConfigmapAvailable)
+		assert.False(t, response.Data.RegistryAvailable)
+		assert.NotEmpty(t, response.Data.RegistryError)
+		assert.Empty(t, response.Data.Servers)
+		assert.Equal(t, 0, response.Data.TotalCount)
+	})
+
+	It("should return configmap_available true and no configmap_error on success", func() {
+		t := GinkgoT()
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/aa/mcps?namespace=demo", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPListHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response MCPListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+		assert.True(t, response.Data.ConfigmapAvailable, "ConfigMap should be available in opendatahub namespace")
+		assert.Empty(t, response.Data.ConfigmapError, "No error should be present on success")
+		require.NotNil(t, response.Data.ConfigMapInfo)
+		assert.Equal(t, constants.MCPServerName, response.Data.ConfigMapInfo.Name)
+	})
+
+	It("should deduplicate servers with the same URL, preferring registry entries", func() {
+		t := GinkgoT()
+
+		sharedURL := "http://localhost:9090/sse"
+		mockBFFClient.CallHandler = func(_ context.Context, method, path string, _ interface{}, response interface{}) error {
+			require.Equal(t, "GET", method)
+			data := map[string]interface{}{
+				"data": map[string]interface{}{
+					"servers": []map[string]interface{}{
+						{
+							"name":        "io.github.example/github",
+							"description": "Registry copy",
+							"status":      "active",
+							"access_endpoints": []map[string]interface{}{
+								{
+									"endpoint_url":   sharedURL,
+									"transport_type": "sse",
+									"resolved_version": map[string]interface{}{
+										"version": "1.0.0",
+										"tools":   []map[string]interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			return marshalToResponse(data, response)
+		}
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/aa/mcps?namespace=demo", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPListHandler(rr, req, nil)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response MCPListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+		var matches int
+		for _, server := range response.Data.Servers {
+			if server.URL == sharedURL {
+				matches++
+				assert.Equal(t, models.MCPServerSourceRegistry, server.Source)
+			}
+		}
+		assert.Equal(t, 1, matches, "duplicate URL should appear once, from registry")
+	})
+
+	It("should aggregate registry servers across paginated MLflow BFF responses", func() {
+		t := GinkgoT()
+		callCount := 0
+		mockBFFClient.CallHandler = func(_ context.Context, method, path string, _ interface{}, response interface{}) error {
+			require.Equal(t, "GET", method)
+			callCount++
+			if callCount == 1 {
+				require.Equal(t, "/mcp-registry/servers?workspace=demo", path)
+				return marshalToResponse(map[string]interface{}{
+					"data": map[string]interface{}{
+						"servers": []map[string]interface{}{
+							{
+								"name":        "io.github.example/page-one",
+								"description": "First page server",
+								"status":      "active",
+								"access_endpoints": []map[string]interface{}{
+									{
+										"endpoint_url":   "https://page-one.example.com/mcp",
+										"transport_type": "streamable-http",
+									},
+								},
+							},
+						},
+						"next_page_token": "page2",
+					},
+				}, response)
+			}
+			require.Equal(t, "/mcp-registry/servers?workspace=demo&page_token=page2", path)
+			return marshalToResponse(map[string]interface{}{
+				"data": map[string]interface{}{
+					"servers": []map[string]interface{}{
+						{
+							"name":        "io.github.example/page-two",
+							"description": "Second page server",
+							"status":      "active",
+							"access_endpoints": []map[string]interface{}{
+								{
+									"endpoint_url":   "https://page-two.example.com/mcp",
+									"transport_type": "streamable-http",
+								},
+							},
+						},
+					},
+				},
+			}, response)
+		}
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/aa/mcps?namespace=demo", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPListHandler(rr, req, nil)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response MCPListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		assert.True(t, response.Data.RegistryAvailable)
+		assert.Equal(t, 2, callCount)
+
+		registryNames := make(map[string]struct{})
+		for _, server := range response.Data.Servers {
+			if server.Source == models.MCPServerSourceRegistry {
+				registryNames[server.Name] = struct{}{}
+			}
+		}
+		assert.Contains(t, registryNames, "io.github.example/page-one")
+		assert.Contains(t, registryNames, "io.github.example/page-two")
+	})
+
+	It("should return registry_error when MLflow BFF is not configured", func() {
+		t := GinkgoT()
+		app.bffClientFactory = nil
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/aa/mcps?namespace=demo", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPListHandler(rr, req, nil)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response MCPListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		assert.False(t, response.Data.RegistryAvailable)
+		assert.Equal(t, "MLflow BFF is not configured", response.Data.RegistryError)
 	})
 })

--- a/packages/gen-ai/bff/internal/api/api_bff_client.go
+++ b/packages/gen-ai/bff/internal/api/api_bff_client.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
+)
+
+// bffCallTimeout is the shared timeout for all inter-BFF HTTP calls.
+const bffCallTimeout = 5 * time.Second
+
+// mlflowBFFClient returns the MLflow BFF client from request context, or creates one from the factory.
+func (app *App) mlflowBFFClient(ctx context.Context) bffclient.BFFClientInterface {
+	if client := bffclient.GetClient(ctx, bffclient.BFFTargetMLflow); client != nil {
+		return client
+	}
+	if app.bffClientFactory == nil || !app.bffClientFactory.IsTargetConfigured(bffclient.BFFTargetMLflow) {
+		return nil
+	}
+
+	var authToken string
+	if identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity); ok && identity != nil {
+		authToken = identity.Token
+	}
+
+	return app.bffClientFactory.CreateClient(bffclient.BFFTargetMLflow, authToken)
+}

--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -500,9 +500,9 @@ func (app *App) Routes() http.Handler {
 	apiRouter.GET(constants.NemoGuardrailsStatusPath, app.AttachNamespace(app.NemoGuardrailsStatusHandler))
 
 	// MCP Client endpoints
-	apiRouter.GET(constants.MCPToolsPath, app.AttachNamespace(app.MCPToolsHandler))
-	apiRouter.GET(constants.MCPStatusPath, app.AttachNamespace(app.MCPStatusHandler))
-	apiRouter.GET(constants.MCPServersListPath, app.AttachNamespace(app.MCPListHandler))
+	apiRouter.GET(constants.MCPToolsPath, app.AttachNamespace(app.RequireAccessToService(app.MCPToolsHandler)))
+	apiRouter.GET(constants.MCPStatusPath, app.AttachNamespace(app.RequireAccessToService(app.MCPStatusHandler)))
+	apiRouter.GET(constants.MCPServersListPath, app.AttachNamespace(app.RequireAccessToService(app.MCPListHandler)))
 
 	// External Vector Stores
 	apiRouter.GET(constants.VectorStoresAAPath, app.AttachNamespace(app.VectorStoresAAHandler))

--- a/packages/gen-ai/bff/internal/api/friendly_configmap_error_test.go
+++ b/packages/gen-ai/bff/internal/api/friendly_configmap_error_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFriendlyConfigMapError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		err       error
+		namespace string
+		want      string
+		notWant   string
+	}{
+		{
+			name:      "not found",
+			err:       errors.New("configmaps \"gen-ai-aa-mcp-servers\" not found"),
+			namespace: "demo",
+			want:      "ConfigMap 'gen-ai-aa-mcp-servers' not found in namespace 'demo'",
+		},
+		{
+			name:      "forbidden",
+			err:       errors.New("forbidden: User cannot get configmaps"),
+			namespace: "demo",
+			want:      "Access denied to ConfigMap 'gen-ai-aa-mcp-servers' in namespace 'demo'",
+		},
+		{
+			name:      "fallback redacts internal details",
+			err:       errors.New(`User "system:serviceaccount:opendatahub:gen-ai-bff" cannot get resource "configmaps"`),
+			namespace: "opendatahub",
+			want:      "Failed to read ConfigMap 'gen-ai-aa-mcp-servers'",
+			notWant:   "system:serviceaccount",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := friendlyConfigMapError(tt.err, tt.namespace)
+			assert.Equal(t, tt.want, got)
+			if tt.notWant != "" {
+				assert.NotContains(t, got, tt.notWant)
+			}
+		})
+	}
+}

--- a/packages/gen-ai/bff/internal/api/mcp_helpers.go
+++ b/packages/gen-ai/bff/internal/api/mcp_helpers.go
@@ -23,6 +23,9 @@ var ErrRegistryMCPServerNotFound = errors.New("registry MCP server not found")
 // ErrRegistryMCPClientUnavailable indicates the MLflow BFF client is not configured or reachable.
 var ErrRegistryMCPClientUnavailable = errors.New("MLflow BFF client unavailable")
 
+// ErrInvalidRegistryServerName indicates the server_name parameter failed validation.
+var ErrInvalidRegistryServerName = errors.New("invalid server_name parameter")
+
 // handleRegistryResolveError maps registry resolution failures to HTTP responses.
 func (app *App) handleRegistryResolveError(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.Is(err, ErrRegistryMCPServerNotFound) {
@@ -33,7 +36,7 @@ func (app *App) handleRegistryResolveError(w http.ResponseWriter, r *http.Reques
 		app.serviceUnavailableResponse(w, r, err)
 		return
 	}
-	if strings.Contains(err.Error(), "invalid server_name parameter") {
+	if errors.Is(err, ErrInvalidRegistryServerName) {
 		app.badRequestResponse(w, r, err)
 		return
 	}
@@ -144,6 +147,10 @@ func isRegistryServerListable(server models.MLflowMCPServer) bool {
 }
 
 func (app *App) mapRegistryServerToSummary(server models.MLflowMCPServer) models.MCPServerSummary {
+	if len(server.AccessEndpoints) == 0 {
+		return models.MCPServerSummary{}
+	}
+
 	endpoint := server.AccessEndpoints[0]
 	tools := make([]models.MCPServerToolSummary, 0)
 	version := ""
@@ -182,7 +189,7 @@ func (app *App) resolveRegistryServerConfig(
 
 	serverSegment, err := mcpRegistryServerNamePathSegment(serverName)
 	if err != nil {
-		return models.MCPServerConfig{}, fmt.Errorf("invalid server_name parameter: %w", err)
+		return models.MCPServerConfig{}, fmt.Errorf("%w: %w", ErrInvalidRegistryServerName, err)
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, bffCallTimeout)
@@ -227,6 +234,27 @@ func mcpRegistryServerNamePathSegment(name string) (string, error) {
 		parts[i] = escaped
 	}
 	return strings.Join(parts, "/"), nil
+}
+
+// setupMCPIdentityWithTokenValidation extracts request identity and MCP bearer token
+// without requiring a Kubernetes client (used for registry-backed MCP requests).
+func (app *App) setupMCPIdentityWithTokenValidation(ctx context.Context, r *http.Request) (*integrations.RequestIdentity, error) {
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil {
+		if app.config.AuthMethod == config.AuthMethodDisabled {
+			identity = &integrations.RequestIdentity{}
+		} else {
+			return nil, fmt.Errorf("missing RequestIdentity in context")
+		}
+	}
+
+	mcpIdentity, err := app.mcpClientFactory.ExtractRequestIdentity(r.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	identity.MCPToken = mcpIdentity.MCPToken
+	return identity, nil
 }
 
 // setupMCPEndpoint performs common setup for MCP endpoints: identity extraction, k8s client setup, and repository validation

--- a/packages/gen-ai/bff/internal/api/mcp_helpers.go
+++ b/packages/gen-ai/bff/internal/api/mcp_helpers.go
@@ -2,18 +2,44 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
+	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
 	kubernetes "github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/mcp"
 	"github.com/opendatahub-io/gen-ai/internal/models"
 )
 
-// parseMCPEndpointParams extracts and validates query parameters common to MCP endpoints
+// ErrRegistryMCPServerNotFound indicates a registry MCP server could not be resolved.
+var ErrRegistryMCPServerNotFound = errors.New("registry MCP server not found")
+
+// ErrRegistryMCPClientUnavailable indicates the MLflow BFF client is not configured or reachable.
+var ErrRegistryMCPClientUnavailable = errors.New("MLflow BFF client unavailable")
+
+// handleRegistryResolveError maps registry resolution failures to HTTP responses.
+func (app *App) handleRegistryResolveError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, ErrRegistryMCPServerNotFound) {
+		app.notFoundResponse(w, r)
+		return
+	}
+	if errors.Is(err, ErrRegistryMCPClientUnavailable) {
+		app.serviceUnavailableResponse(w, r, err)
+		return
+	}
+	if strings.Contains(err.Error(), "invalid server_name parameter") {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+	app.serverErrorResponse(w, r, err)
+}
+
 func (app *App) parseMCPEndpointParams(r *http.Request, requireServerURL bool) (namespace, serverURL, decodedURL string, err error) {
 	namespace = r.URL.Query().Get("namespace")
 	serverURL = r.URL.Query().Get("server_url")
@@ -36,11 +62,185 @@ func (app *App) parseMCPEndpointParams(r *http.Request, requireServerURL bool) (
 	return namespace, serverURL, decodedURL, nil
 }
 
+// parseMCPToolsStatusParams extracts query parameters for MCP tools/status endpoints.
+// Either server_url (ConfigMap path) or server_name (registry path) must be provided.
+func (app *App) parseMCPToolsStatusParams(r *http.Request) (namespace, serverURL, decodedURL, serverName string, err error) {
+	namespace = r.URL.Query().Get("namespace")
+	if namespace == "" {
+		return "", "", "", "", fmt.Errorf("namespace parameter is required")
+	}
+
+	serverName = r.URL.Query().Get("server_name")
+	serverURL = r.URL.Query().Get("server_url")
+	if serverName == "" && serverURL == "" {
+		return "", "", "", "", fmt.Errorf("server_url or server_name parameter is required")
+	}
+
+	if serverURL != "" {
+		decodedURL, err = url.QueryUnescape(serverURL)
+		if err != nil {
+			return "", "", "", "", fmt.Errorf("invalid server_url parameter: %w", err)
+		}
+	}
+
+	return namespace, serverURL, decodedURL, serverName, nil
+}
+
+// maxRegistryPages caps the number of pages fetched from the MLflow BFF registry to prevent
+// an infinite loop if the server returns a cyclic or perpetually non-empty next_page_token.
+const maxRegistryPages = 100
+
+// fetchRegistryMCPServerSummaries lists active registry MCP servers from the MLflow BFF.
+func (app *App) fetchRegistryMCPServerSummaries(
+	ctx context.Context,
+	workspace string,
+	mlflowClient bffclient.BFFClientInterface,
+) ([]models.MCPServerSummary, error) {
+	servers := make([]models.MCPServerSummary, 0)
+	pageToken := ""
+
+	for page := 0; ; page++ {
+		if page >= maxRegistryPages {
+			return nil, fmt.Errorf("registry pagination exceeded %d pages", maxRegistryPages)
+		}
+
+		callCtx, cancel := context.WithTimeout(ctx, bffCallTimeout)
+		path := "/mcp-registry/servers?workspace=" + url.QueryEscape(workspace)
+		if pageToken != "" {
+			path += "&page_token=" + url.QueryEscape(pageToken)
+		}
+
+		var envelope models.MLflowMCPServersEnvelope
+		err := mlflowClient.Call(callCtx, "GET", path, nil, &envelope)
+		cancel()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, server := range envelope.Data.Servers {
+			if !isRegistryServerListable(server) {
+				continue
+			}
+			servers = append(servers, app.mapRegistryServerToSummary(server))
+		}
+
+		pageToken = envelope.Data.NextPageToken
+		if pageToken == "" {
+			break
+		}
+	}
+
+	return servers, nil
+}
+
+func isRegistryServerListable(server models.MLflowMCPServer) bool {
+	if server.Status != "active" {
+		return false
+	}
+	if len(server.AccessEndpoints) == 0 || server.AccessEndpoints[0].EndpointURL == "" {
+		return false
+	}
+	return true
+}
+
+func (app *App) mapRegistryServerToSummary(server models.MLflowMCPServer) models.MCPServerSummary {
+	endpoint := server.AccessEndpoints[0]
+	tools := make([]models.MCPServerToolSummary, 0)
+	version := ""
+
+	if endpoint.ResolvedVersion != nil {
+		version = endpoint.ResolvedVersion.Version
+		for _, tool := range endpoint.ResolvedVersion.Tools {
+			tools = append(tools, models.MCPServerToolSummary{
+				Name:        tool.Name,
+				Description: tool.Description,
+			})
+		}
+	}
+
+	return models.MCPServerSummary{
+		Name:        server.Name,
+		URL:         endpoint.EndpointURL,
+		Transport:   app.normalizeTransportType(endpoint.TransportType),
+		Description: server.Description,
+		Logo:        nil,
+		Status:      "healthy",
+		Source:      models.MCPServerSourceRegistry,
+		Version:     version,
+		Tools:       tools,
+		ToolCount:   len(tools),
+	}
+}
+
+// resolveRegistryServerConfig fetches a single MCP server from the MLflow BFF registry.
+func (app *App) resolveRegistryServerConfig(
+	ctx context.Context,
+	workspace string,
+	serverName string,
+	mlflowClient bffclient.BFFClientInterface,
+) (models.MCPServerConfig, error) {
+	if mlflowClient == nil {
+		return models.MCPServerConfig{}, fmt.Errorf("%w", ErrRegistryMCPClientUnavailable)
+	}
+
+	serverSegment, err := mcpRegistryServerNamePathSegment(serverName)
+	if err != nil {
+		return models.MCPServerConfig{}, fmt.Errorf("invalid server_name parameter: %w", err)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, bffCallTimeout)
+	defer cancel()
+
+	path := "/mcp-registry/servers/" + serverSegment + "?workspace=" + url.QueryEscape(workspace)
+	var envelope models.MLflowMCPServerEnvelope
+	err = mlflowClient.Call(callCtx, "GET", path, nil, &envelope)
+	if err != nil {
+		var bffErr *bffclient.BFFClientError
+		if errors.As(err, &bffErr) && bffErr.Code == bffclient.ErrCodeNotFound {
+			return models.MCPServerConfig{}, fmt.Errorf("%w: %s", ErrRegistryMCPServerNotFound, serverName)
+		}
+		return models.MCPServerConfig{}, err
+	}
+
+	server := envelope.Data
+	if len(server.AccessEndpoints) == 0 || server.AccessEndpoints[0].EndpointURL == "" {
+		return models.MCPServerConfig{}, fmt.Errorf("%w: no access endpoint for %s", ErrRegistryMCPServerNotFound, serverName)
+	}
+
+	endpoint := server.AccessEndpoints[0]
+	return models.MCPServerConfig{
+		URL:       endpoint.EndpointURL,
+		Transport: app.normalizeTransportType(endpoint.TransportType),
+	}, nil
+}
+
+// mcpRegistryServerNamePathSegment escapes each "/"-separated part of an
+// unvalidated MCP registry server name independently, preserving the "/" the
+// MLflow BFF's catch-all route expects while still escaping unsafe characters.
+func mcpRegistryServerNamePathSegment(name string) (string, error) {
+	parts := strings.Split(name, "/")
+	for i, p := range parts {
+		if p == "" {
+			return "", fmt.Errorf("invalid MCP registry server name %q: empty path segment", name)
+		}
+		escaped := url.PathEscape(p)
+		if escaped == "." || escaped == ".." {
+			escaped = strings.ReplaceAll(escaped, ".", "%2E")
+		}
+		parts[i] = escaped
+	}
+	return strings.Join(parts, "/"), nil
+}
+
 // setupMCPEndpoint performs common setup for MCP endpoints: identity extraction, k8s client setup, and repository validation
 func (app *App) setupMCPEndpoint(ctx context.Context) (*integrations.RequestIdentity, kubernetes.KubernetesClientInterface, error) {
 	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
 	if !ok || identity == nil {
-		return nil, nil, fmt.Errorf("missing RequestIdentity in context")
+		if app.config.AuthMethod == config.AuthMethodDisabled {
+			identity = &integrations.RequestIdentity{}
+		} else {
+			return nil, nil, fmt.Errorf("missing RequestIdentity in context")
+		}
 	}
 
 	k8sClient, err := app.kubernetesClientFactory.GetClient(ctx)

--- a/packages/gen-ai/bff/internal/api/mcp_helpers.go
+++ b/packages/gen-ai/bff/internal/api/mcp_helpers.go
@@ -151,10 +151,7 @@ func (app *App) mapRegistryServerToSummary(server models.MLflowMCPServer) models
 	if endpoint.ResolvedVersion != nil {
 		version = endpoint.ResolvedVersion.Version
 		for _, tool := range endpoint.ResolvedVersion.Tools {
-			tools = append(tools, models.MCPServerToolSummary{
-				Name:        tool.Name,
-				Description: tool.Description,
-			})
+			tools = append(tools, models.MCPServerToolSummary(tool))
 		}
 	}
 

--- a/packages/gen-ai/bff/internal/api/mcp_status_handler.go
+++ b/packages/gen-ai/bff/internal/api/mcp_status_handler.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	kubernetes "github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/gen-ai/internal/models"
 )
 
@@ -13,13 +15,22 @@ type MCPStatusEnvelope = Envelope[*models.ConnectionStatus, None]
 func (app *App) MCPStatusHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := r.Context()
 
-	identity, k8sClient, err := app.setupMCPEndpointWithTokenValidation(ctx, r)
+	namespace, _, decodedURL, serverName, err := app.parseMCPToolsStatusParams(r)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
 
-	namespace, _, decodedURL, serverName, err := app.parseMCPToolsStatusParams(r)
+	var (
+		identity  *integrations.RequestIdentity
+		k8sClient kubernetes.KubernetesClientInterface
+	)
+
+	if serverName != "" {
+		identity, err = app.setupMCPIdentityWithTokenValidation(ctx, r)
+	} else {
+		identity, k8sClient, err = app.setupMCPEndpointWithTokenValidation(ctx, r)
+	}
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return

--- a/packages/gen-ai/bff/internal/api/mcp_status_handler.go
+++ b/packages/gen-ai/bff/internal/api/mcp_status_handler.go
@@ -9,7 +9,7 @@ import (
 
 type MCPStatusEnvelope = Envelope[*models.ConnectionStatus, None]
 
-// MCPStatusHandler handles GET /genai/v1/mcp/status?namespace=<>&server_url=<>
+// MCPStatusHandler handles GET /genai/v1/mcp/status?namespace=<>&server_url=<> or server_name=<>
 func (app *App) MCPStatusHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := r.Context()
 
@@ -19,16 +19,27 @@ func (app *App) MCPStatusHandler(w http.ResponseWriter, r *http.Request, ps http
 		return
 	}
 
-	_, _, decodedURL, err := app.parseMCPEndpointParams(r, true)
+	namespace, _, decodedURL, serverName, err := app.parseMCPToolsStatusParams(r)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
 
-	serverConfig, err := app.findMCPServerConfig(ctx, k8sClient, identity, decodedURL, app.dashboardNamespace)
-	if err != nil {
-		app.notFoundResponse(w, r)
-		return
+	var serverConfig models.MCPServerConfig
+
+	if serverName != "" {
+		mlflowClient := app.mlflowBFFClient(ctx)
+		serverConfig, err = app.resolveRegistryServerConfig(ctx, namespace, serverName, mlflowClient)
+		if err != nil {
+			app.handleRegistryResolveError(w, r, err)
+			return
+		}
+	} else {
+		serverConfig, err = app.findMCPServerConfig(ctx, k8sClient, identity, decodedURL, app.dashboardNamespace)
+		if err != nil {
+			app.notFoundResponse(w, r)
+			return
+		}
 	}
 
 	connectionStatus, err := app.repositories.MCPClient.CheckMCPServerStatus(ctx, identity, serverConfig)

--- a/packages/gen-ai/bff/internal/api/mcp_status_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/mcp_status_handler_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient/bffmocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/mcp/mcpmocks"
 	"github.com/opendatahub-io/gen-ai/internal/repositories"
@@ -21,7 +23,10 @@ import (
 )
 
 var _ = Describe("MCPStatusHandler", func() {
-	var app *App
+	var (
+		app           *App
+		mockBFFClient *bffmocks.MockBFFClient
+	)
 
 	BeforeEach(func() {
 		logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -34,6 +39,11 @@ var _ = Describe("MCPStatusHandler", func() {
 		mockK8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, logger)
 		require.NoError(GinkgoT(), err)
 
+		mockBFFFactory := bffmocks.NewMockClientFactory(logger).(*bffmocks.MockClientFactory)
+		mockBFFFactory.CreateClient(bffclient.BFFTargetMLflow, "")
+		mockBFFClient = mockBFFFactory.GetMockClient(bffclient.BFFTargetMLflow)
+		mockBFFClient.CallHandler = nil
+
 		app = &App{
 			config: config.EnvConfig{
 				Port:       4000,
@@ -43,6 +53,7 @@ var _ = Describe("MCPStatusHandler", func() {
 			repositories:            repositories.NewRepositoriesWithMCP(mockMCPFactory, logger),
 			kubernetesClientFactory: mockK8sFactory,
 			mcpClientFactory:        mockMCPFactory,
+			bffClientFactory:        mockBFFFactory,
 			dashboardNamespace:      "opendatahub",
 		}
 	})
@@ -190,7 +201,7 @@ var _ = Describe("MCPStatusHandler", func() {
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 	})
 
-	It("should return 400 when server_url parameter is missing", func() {
+	It("should return 400 when server_url and server_name are missing", func() {
 		t := GinkgoT()
 		rr := httptest.NewRecorder()
 
@@ -205,6 +216,99 @@ var _ = Describe("MCPStatusHandler", func() {
 
 		app.MCPStatusHandler(rr, req, nil)
 
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	It("should return 404 for registry server_name with no access endpoint", func() {
+		t := GinkgoT()
+		mockBFFClient.CallHandler = func(_ context.Context, _, _ string, _ interface{}, response interface{}) error {
+			return marshalToResponse(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name":             "com.brave.example/brave",
+					"access_endpoints": []map[string]interface{}{},
+				},
+			}, response)
+		}
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/mcp/status?namespace=demo&server_name=com.brave.example/brave", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPStatusHandler(rr, req, nil)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	It("should prefer server_name over server_url when both are provided", func() {
+		t := GinkgoT()
+		serverURL := "http://localhost:9091/mcp"
+		mockBFFClient.CallHandler = func(_ context.Context, _, path string, _ interface{}, response interface{}) error {
+			assert.Equal(t, "/mcp-registry/servers/com.example/kubernetes?workspace=demo", path)
+			return marshalToResponse(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name": "com.example/kubernetes",
+					"access_endpoints": []map[string]interface{}{
+						{
+							"endpoint_url":   serverURL,
+							"transport_type": "streamable-http",
+						},
+					},
+				},
+			}, response)
+		}
+
+		encodedFakeURL := url.QueryEscape("https://nonexistent-server.com/mcp")
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest(
+			"GET",
+			"/genai/v1/mcp/status?namespace=demo&server_name=com.example/kubernetes&server_url="+encodedFakeURL,
+			nil,
+		)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPStatusHandler(rr, req, nil)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response MCPStatusEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		assert.Equal(t, serverURL, response.Data.ServerURL)
+	})
+
+	It("should return 503 when registry resolution requires MLflow BFF but it is unavailable", func() {
+		t := GinkgoT()
+		app.bffClientFactory = nil
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/mcp/status?namespace=demo&server_name=com.example/kubernetes", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPStatusHandler(rr, req, nil)
+		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	})
+
+	It("should return 400 for invalid registry server_name with empty path segment", func() {
+		t := GinkgoT()
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/mcp/status?namespace=demo&server_name=com.example//kubernetes", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPStatusHandler(rr, req, nil)
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 	})
 

--- a/packages/gen-ai/bff/internal/api/mcp_tools_handler.go
+++ b/packages/gen-ai/bff/internal/api/mcp_tools_handler.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	kubernetes "github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/gen-ai/internal/models"
 )
 
@@ -13,13 +15,22 @@ type MCPToolsEnvelope = Envelope[*models.ToolsStatus, None]
 func (app *App) MCPToolsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := r.Context()
 
-	identity, k8sClient, err := app.setupMCPEndpointWithTokenValidation(ctx, r)
+	namespace, _, decodedURL, serverName, err := app.parseMCPToolsStatusParams(r)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
 
-	namespace, _, decodedURL, serverName, err := app.parseMCPToolsStatusParams(r)
+	var (
+		identity  *integrations.RequestIdentity
+		k8sClient kubernetes.KubernetesClientInterface
+	)
+
+	if serverName != "" {
+		identity, err = app.setupMCPIdentityWithTokenValidation(ctx, r)
+	} else {
+		identity, k8sClient, err = app.setupMCPEndpointWithTokenValidation(ctx, r)
+	}
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return

--- a/packages/gen-ai/bff/internal/api/mcp_tools_handler.go
+++ b/packages/gen-ai/bff/internal/api/mcp_tools_handler.go
@@ -9,7 +9,7 @@ import (
 
 type MCPToolsEnvelope = Envelope[*models.ToolsStatus, None]
 
-// MCPToolsHandler handles GET /genai/v1/mcp/tools?namespace=<>&server_url=<>
+// MCPToolsHandler handles GET /genai/v1/mcp/tools?namespace=<>&server_url=<> or server_name=<>
 func (app *App) MCPToolsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := r.Context()
 
@@ -19,16 +19,27 @@ func (app *App) MCPToolsHandler(w http.ResponseWriter, r *http.Request, ps httpr
 		return
 	}
 
-	_, _, decodedURL, err := app.parseMCPEndpointParams(r, true)
+	namespace, _, decodedURL, serverName, err := app.parseMCPToolsStatusParams(r)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return
 	}
 
-	serverConfig, err := app.findMCPServerConfig(ctx, k8sClient, identity, decodedURL, app.dashboardNamespace)
-	if err != nil {
-		app.notFoundResponse(w, r)
-		return
+	var serverConfig models.MCPServerConfig
+
+	if serverName != "" {
+		mlflowClient := app.mlflowBFFClient(ctx)
+		serverConfig, err = app.resolveRegistryServerConfig(ctx, namespace, serverName, mlflowClient)
+		if err != nil {
+			app.handleRegistryResolveError(w, r, err)
+			return
+		}
+	} else {
+		serverConfig, err = app.findMCPServerConfig(ctx, k8sClient, identity, decodedURL, app.dashboardNamespace)
+		if err != nil {
+			app.notFoundResponse(w, r)
+			return
+		}
 	}
 
 	toolsStatus, err := app.repositories.MCPClient.ListMCPServerToolsWithStatus(ctx, identity, serverConfig)

--- a/packages/gen-ai/bff/internal/api/mcp_tools_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/mcp_tools_handler_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient/bffmocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/mcp/mcpmocks"
 	"github.com/opendatahub-io/gen-ai/internal/repositories"
@@ -21,7 +23,10 @@ import (
 )
 
 var _ = Describe("MCPToolsHandler", func() {
-	var app *App
+	var (
+		app           *App
+		mockBFFClient *bffmocks.MockBFFClient
+	)
 
 	BeforeEach(func() {
 		logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -34,6 +39,11 @@ var _ = Describe("MCPToolsHandler", func() {
 		mockK8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, logger)
 		require.NoError(GinkgoT(), err)
 
+		mockBFFFactory := bffmocks.NewMockClientFactory(logger).(*bffmocks.MockClientFactory)
+		mockBFFFactory.CreateClient(bffclient.BFFTargetMLflow, "")
+		mockBFFClient = mockBFFFactory.GetMockClient(bffclient.BFFTargetMLflow)
+		mockBFFClient.CallHandler = nil
+
 		app = &App{
 			config: config.EnvConfig{
 				Port:       4000,
@@ -43,6 +53,7 @@ var _ = Describe("MCPToolsHandler", func() {
 			repositories:            repositories.NewRepositoriesWithMCP(mockMCPFactory, logger),
 			kubernetesClientFactory: mockK8sFactory,
 			mcpClientFactory:        mockMCPFactory,
+			bffClientFactory:        mockBFFFactory,
 			dashboardNamespace:      "opendatahub",
 		}
 	})
@@ -203,7 +214,7 @@ var _ = Describe("MCPToolsHandler", func() {
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 	})
 
-	It("should return 400 when server_url parameter is missing", func() {
+	It("should return 400 when server_url and server_name are missing", func() {
 		t := GinkgoT()
 		rr := httptest.NewRecorder()
 
@@ -218,6 +229,95 @@ var _ = Describe("MCPToolsHandler", func() {
 
 		app.MCPToolsHandler(rr, req, nil)
 
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	It("should resolve registry server by server_name and return live tools", func() {
+		t := GinkgoT()
+		serverURL := "http://localhost:9091/mcp"
+		mockBFFClient.CallHandler = func(_ context.Context, _, path string, _ interface{}, response interface{}) error {
+			assert.Equal(t, "/mcp-registry/servers/com.example/kubernetes?workspace=demo", path)
+			return marshalToResponse(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name": "com.example/kubernetes",
+					"access_endpoints": []map[string]interface{}{
+						{
+							"endpoint_url":   serverURL,
+							"transport_type": "streamable-http",
+						},
+					},
+				},
+			}, response)
+		}
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/mcp/tools?namespace=demo&server_name=com.example/kubernetes", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPToolsHandler(rr, req, nil)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response MCPToolsEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+		assert.Equal(t, "success", response.Data.Status)
+		assert.Equal(t, serverURL, response.Data.ServerURL)
+	})
+
+	It("should return 404 for registry server_name with no access endpoint", func() {
+		t := GinkgoT()
+		mockBFFClient.CallHandler = func(_ context.Context, _, _ string, _ interface{}, response interface{}) error {
+			return marshalToResponse(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name":             "com.brave.example/brave",
+					"access_endpoints": []map[string]interface{}{},
+				},
+			}, response)
+		}
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/mcp/tools?namespace=demo&server_name=com.brave.example/brave", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPToolsHandler(rr, req, nil)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	It("should return 503 when registry resolution requires MLflow BFF but it is unavailable", func() {
+		t := GinkgoT()
+		app.bffClientFactory = nil
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/mcp/tools?namespace=demo&server_name=com.example/kubernetes", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPToolsHandler(rr, req, nil)
+		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	})
+
+	It("should return 400 for invalid registry server_name with empty path segment", func() {
+		t := GinkgoT()
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/genai/v1/mcp/tools?namespace=demo&server_name=com.example//kubernetes", nil)
+		require.NoError(t, err)
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		app.MCPToolsHandler(rr, req, nil)
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 	})
 
@@ -282,5 +382,114 @@ var _ = Describe("MCPToolsHandler", func() {
 		require.NoError(t, err)
 
 		assert.Equal(t, serverURL, response.Data.ServerURL)
+	})
+})
+
+var _ = Describe("ResolveRegistryServerConfig", func() {
+	var (
+		app           *App
+		mockBFFClient *bffmocks.MockBFFClient
+	)
+
+	BeforeEach(func() {
+		logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		mockFactory := bffmocks.NewMockClientFactory(logger).(*bffmocks.MockClientFactory)
+		mockFactory.CreateClient(bffclient.BFFTargetMLflow, "")
+		mockBFFClient = mockFactory.GetMockClient(bffclient.BFFTargetMLflow)
+		app = &App{logger: logger}
+	})
+
+	It("returns config when server has an access endpoint", func() {
+		t := GinkgoT()
+		serverURL := "https://kubernetes-mcp.example.com/mcp"
+		mockBFFClient.CallHandler = func(_ context.Context, method, path string, _ interface{}, response interface{}) error {
+			assert.Equal(t, "GET", method)
+			assert.Equal(t, "/mcp-registry/servers/com.example/kubernetes?workspace=default", path)
+			return marshalToResponse(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name": "com.example/kubernetes",
+					"access_endpoints": []map[string]interface{}{
+						{
+							"endpoint_url":   serverURL,
+							"transport_type": "streamable-http",
+						},
+					},
+				},
+			}, response)
+		}
+
+		cfg, err := app.resolveRegistryServerConfig(context.Background(), "default", "com.example/kubernetes", mockBFFClient)
+		require.NoError(t, err)
+		assert.Equal(t, serverURL, cfg.URL)
+		assert.Equal(t, "streamable-http", cfg.Transport)
+	})
+
+	It("returns not found when server has no access endpoint", func() {
+		t := GinkgoT()
+		mockBFFClient.CallHandler = func(_ context.Context, _, _ string, _ interface{}, response interface{}) error {
+			return marshalToResponse(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name":             "com.brave.example/brave",
+					"access_endpoints": []map[string]interface{}{},
+				},
+			}, response)
+		}
+
+		_, err := app.resolveRegistryServerConfig(context.Background(), "default", "com.brave.example/brave", mockBFFClient)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRegistryMCPServerNotFound)
+	})
+
+	It("returns not found when MLflow BFF reports missing server", func() {
+		t := GinkgoT()
+		mockBFFClient.CallHandler = func(_ context.Context, _, _ string, _ interface{}, _ interface{}) error {
+			return bffclient.NewNotFoundError(bffclient.BFFTargetMLflow, "not found")
+		}
+
+		_, err := app.resolveRegistryServerConfig(context.Background(), "default", "foo/bar", mockBFFClient)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRegistryMCPServerNotFound)
+	})
+
+	It("returns unavailable when MLflow BFF client is nil", func() {
+		t := GinkgoT()
+		_, err := app.resolveRegistryServerConfig(context.Background(), "default", "foo/bar", nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRegistryMCPClientUnavailable)
+	})
+})
+
+var _ = Describe("McpRegistryServerNamePathSegment", func() {
+	It("escapes each path segment while preserving slashes", func() {
+		t := GinkgoT()
+		got, err := mcpRegistryServerNamePathSegment("com.example/kubernetes")
+		require.NoError(t, err)
+		assert.Equal(t, "com.example/kubernetes", got)
+	})
+
+	It("rejects empty path segments", func() {
+		t := GinkgoT()
+		_, err := mcpRegistryServerNamePathSegment("com.example//kubernetes")
+		require.Error(t, err)
+	})
+})
+
+var _ = Describe("ParseMCPToolsStatusParams", func() {
+	It("requires namespace and one of server_url or server_name", func() {
+		t := GinkgoT()
+		app := &App{}
+
+		req := httptest.NewRequest("GET", "/test?namespace=demo&server_name=com.example/kubernetes", nil)
+		namespace, serverURL, decodedURL, serverName, err := app.parseMCPToolsStatusParams(req)
+		require.NoError(t, err)
+		assert.Equal(t, "demo", namespace)
+		assert.Empty(t, serverURL)
+		assert.Empty(t, decodedURL)
+		assert.Equal(t, "com.example/kubernetes", serverName)
+
+		req = httptest.NewRequest("GET", "/test?namespace=demo", nil)
+		_, _, _, _, err = app.parseMCPToolsStatusParams(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "server_url or server_name parameter is required")
 	})
 })

--- a/packages/gen-ai/bff/internal/api/mlflow_prompts_handler.go
+++ b/packages/gen-ai/bff/internal/api/mlflow_prompts_handler.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
@@ -19,9 +18,6 @@ import (
 
 // validPromptName matches alphanumerics, hyphens, underscores, and dots (MLflow naming rules).
 var validPromptName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
-
-// bffCallTimeout is the timeout for all MLflow BFF inter-BFF HTTP calls.
-const bffCallTimeout = 5 * time.Second
 
 // MLflowPromptsEnvelope is the response envelope for MLflow prompts
 type MLflowPromptsEnvelope = Envelope[models.MLflowPromptsResponse, None]

--- a/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_process.go
+++ b/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_process.go
@@ -2,6 +2,7 @@ package mlflowmocks
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -16,11 +18,12 @@ import (
 )
 
 const (
-	defaultMLflowPort    = 5001
-	defaultMLflowVersion = "3.9.0"
-	healthTimeout        = 90 * time.Second
-	healthPoll           = 2 * time.Second
-	shutdownWait         = 5 * time.Second
+	defaultMLflowPort         = 5001
+	defaultMLflowVersion      = "3.15.1"
+	healthTimeout             = 90 * time.Second
+	healthPoll                = 2 * time.Second
+	shutdownWait              = 5 * time.Second
+	kubernetesMCPProbeTimeout = 3 * time.Second
 )
 
 func mlflowPort() int {
@@ -49,9 +52,21 @@ type MLflowState struct {
 	Cancel  context.CancelFunc
 }
 
-// SetupMLflow starts a local MLflow server as a child process.
-// If MLFLOW_TRACKING_URI is already set or MLflow is already running on the target port,
-// it returns nil (no-op). The caller is responsible for calling CleanupMLflowState on shutdown.
+// SetupMLflow starts a local MLflow server as a child process and seeds it with dev data.
+//
+// On startup it:
+//   - Starts MLflow via `uv run mlflow server` on the port from MLFLOW_PORT (default 5001)
+//   - Seeds sample prompt templates (idempotent: skips prompts that already exist)
+//   - Seeds the MCP registry for the `default` workspace and the workspace named by
+//     PLAYGROUND_NAMESPACE (both read from the environment via os.Getenv)
+//   - Registers a Kubernetes MCP server if KUBERNETES_MCP_SERVER_URL is set
+//
+// Pre-flight shortcuts:
+//   - If MLFLOW_TRACKING_URI is already set, assumes externally managed — no-op.
+//   - If MLflow is already running on the target port (e.g. from `make mlflow-up`), reuses
+//     the existing instance and seeds it without restarting.
+//
+// The caller is responsible for calling CleanupMLflowState on shutdown.
 func SetupMLflow(logger *slog.Logger) (*MLflowState, error) {
 	port := mlflowPort()
 	version := mlflowVersion()
@@ -69,11 +84,22 @@ func SetupMLflow(logger *slog.Logger) (*MLflowState, error) {
 			"Its database may contain stale data from previous dev sessions, which can cause test failures. "+
 			fmt.Sprintf("Stop the external MLflow process (lsof -t -i :%d | xargs kill) and re-run for a clean state.", port),
 			slog.Int("port", port))
+		cwd, cwdErr := os.Getwd()
+		if cwdErr == nil {
+			dataDir := filepath.Join(cwd, ".mlflow")
+			if uvBin, uvErr := testutil.ResolveUVBinary(); uvErr == nil {
+				upgradeMLflowDB(dataDir, version, uvBin, logger)
+			}
+		}
 		trackingURI := fmt.Sprintf("http://127.0.0.1:%d", port)
 		os.Setenv("MLFLOW_TRACKING_URI", trackingURI)
 		if err := SeedPrompts(trackingURI, logger); err != nil {
 			return nil, fmt.Errorf("failed to seed already-running MLflow: %w", err)
 		}
+		if err := SeedMCPRegistry(trackingURI, logger); err != nil {
+			logger.Warn("Failed to seed MLflow MCP registry (non-fatal)", slog.String("error", err.Error()))
+		}
+		probeKubernetesMCPServer(logger)
 		return nil, nil
 	}
 
@@ -92,6 +118,8 @@ func SetupMLflow(logger *slog.Logger) (*MLflowState, error) {
 		return nil, fmt.Errorf("failed to create MLflow data directory: %w", err)
 	}
 
+	upgradeMLflowDB(dataDir, version, uvBin, logger)
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	cmd := exec.CommandContext(ctx, uvBin,
@@ -101,7 +129,9 @@ func SetupMLflow(logger *slog.Logger) (*MLflowState, error) {
 		"--port", fmt.Sprintf("%d", port),
 		"--backend-store-uri", fmt.Sprintf("sqlite:///%s/mlflow.db", dataDir),
 		"--default-artifact-root", filepath.Join(dataDir, "artifacts"),
+		"--enable-workspaces",
 	)
+	cmd.Env = append(os.Environ(), "MLFLOW_ENABLE_WORKSPACES=true")
 
 	// Create a process group so we can kill the entire tree on shutdown.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -140,6 +170,12 @@ func SetupMLflow(logger *slog.Logger) (*MLflowState, error) {
 		cancel()
 		return nil, fmt.Errorf("failed to seed MLflow: %w", err)
 	}
+
+	if err := SeedMCPRegistry(trackingURI, logger); err != nil {
+		logger.Warn("Failed to seed MLflow MCP registry (non-fatal)", slog.String("error", err.Error()))
+	}
+
+	probeKubernetesMCPServer(logger)
 
 	return &MLflowState{
 		Cmd:     cmd,
@@ -200,6 +236,22 @@ func CleanupMLflowState(
 	}
 }
 
+func upgradeMLflowDB(dataDir string, version, uvBin string, logger *slog.Logger) {
+	storeURI := fmt.Sprintf("sqlite:///%s/mlflow.db", dataDir)
+	cmd := exec.Command(uvBin,
+		"run", "--with", "mlflow=="+version,
+		"mlflow", "db", "upgrade", storeURI,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		logger.Warn("MLflow db upgrade failed (non-fatal; fresh DBs may not need migration)",
+			slog.String("store_uri", storeURI),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
 func isMLflowHealthy(port int) bool {
 	client := &http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
@@ -222,4 +274,60 @@ func waitForMLflowHealth(port int, logger *slog.Logger) error {
 		time.Sleep(healthPoll)
 	}
 	return fmt.Errorf("MLflow did not respond to health check within %v", healthTimeout)
+}
+
+func probeKubernetesMCPServer(logger *slog.Logger) {
+	serverURL := strings.TrimSpace(os.Getenv("KUBERNETES_MCP_SERVER_URL"))
+	if serverURL == "" {
+		return
+	}
+
+	client := kubernetesMCPProbeClient()
+	req, err := http.NewRequest(http.MethodGet, serverURL, nil)
+	if err != nil {
+		logger.Warn("Kubernetes MCP server probe failed",
+			slog.String("url", serverURL),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Warn("Kubernetes MCP server is not reachable — run make deploy-k8s-mcp and set KUBERNETES_MCP_SERVER_URL in .env.local",
+			slog.String("url", serverURL),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 500 {
+		logger.Info("Kubernetes MCP server is reachable", slog.String("url", serverURL))
+		return
+	}
+
+	logger.Warn("Kubernetes MCP server returned unexpected status",
+		slog.String("url", serverURL),
+		slog.Int("status", resp.StatusCode),
+	)
+}
+
+func kubernetesMCPProbeClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if insecureSkipVerifyFromEnv() {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+	return &http.Client{
+		Timeout:   kubernetesMCPProbeTimeout,
+		Transport: transport,
+	}
+}
+
+func insecureSkipVerifyFromEnv() bool {
+	v := strings.TrimSpace(os.Getenv("INSECURE_SKIP_VERIFY"))
+	return strings.EqualFold(v, "true") || v == "1"
 }

--- a/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed.go
+++ b/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed.go
@@ -19,6 +19,8 @@ import (
 
 const seedTimeout = 30 * time.Second
 
+const maxWorkspaceErrorBodyBytes = 4096
+
 const (
 	kubernetesMCPRegistryName = "com.example/kubernetes"
 	githubMCPRegistryName     = "io.github.example/github"
@@ -26,7 +28,7 @@ const (
 	kubernetesMCPVersion      = "1.0.0"
 	githubMCPVersion          = "1.0.0"
 	braveMCPVersion           = "0.1.0"
-	githubMCPFakeEndpoint     = "https://github-mcp.example.com/mcp"
+	githubMCPExampleEndpoint  = "https://github-mcp.example.com/mcp"
 )
 
 // SeedMCPRegistry registers sample MCP servers in the local MLflow MCP Registry.
@@ -39,9 +41,9 @@ const (
 // if that env var is non-empty.
 //
 // Servers registered per workspace:
-//   - Brave draft server (com.brave.example/brave) — no access endpoint
-//   - GitHub active server (io.github.example/github) — fake endpoint + 3 registry tools
-//   - A Kubernetes MCP server (com.example/kubernetes) — seeded only when
+//   - Mock Brave draft server (com.brave.example/brave) — no access endpoint
+//   - Mock GitHub server (io.github.example/github) — fake endpoint + 3 registry tools
+//   - Real Kubernetes MCP server (com.example/kubernetes) — seeded only when
 //     KUBERNETES_MCP_SERVER_URL is set; skipped with a log message otherwise
 //
 // Errors are returned to the caller; SetupMLflow logs them as warnings (non-fatal).
@@ -91,7 +93,10 @@ func ensureMLflowWorkspace(trackingURI, workspace string, logger *slog.Logger) e
 	}
 
 	url := strings.TrimSuffix(trackingURI, "/") + "/ajax-api/3.0/mlflow/workspaces"
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	ctx, cancel := context.WithTimeout(context.Background(), seedTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -108,7 +113,7 @@ func ensureMLflowWorkspace(trackingURI, workspace string, logger *slog.Logger) e
 		return nil
 	}
 
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxWorkspaceErrorBodyBytes))
 	if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(respBody), "RESOURCE_ALREADY_EXISTS") {
 		logger.Debug("MLflow workspace already exists", slog.String("workspace", workspace))
 		return nil
@@ -136,15 +141,15 @@ func seedMCPRegistryInWorkspace(trackingURI, workspace, kubernetesMCPServerURL s
 	ctx, cancel := context.WithTimeout(context.Background(), seedTimeout)
 	defer cancel()
 
-	return seedKubernetesMCPInRegistry(ctx, client.MCPRegistry(), kubernetesMCPServerURL, logger)
+	return seedMockAndRealMCPServersInRegistry(ctx, client.MCPRegistry(), kubernetesMCPServerURL, logger)
 }
 
-func seedKubernetesMCPInRegistry(ctx context.Context, reg *mcpregistry.Client, kubernetesMCPServerURL string, logger *slog.Logger) error {
-	if err := seedBraveDraftMCPServer(ctx, reg, logger); err != nil {
+func seedMockAndRealMCPServersInRegistry(ctx context.Context, reg *mcpregistry.Client, kubernetesMCPServerURL string, logger *slog.Logger) error {
+	if err := seedMockBraveDraftMCPServer(ctx, reg, logger); err != nil {
 		return err
 	}
 
-	if err := seedGitHubActiveMCPServer(ctx, reg, logger); err != nil {
+	if err := seedMockGitHubMCPServer(ctx, reg, logger); err != nil {
 		return err
 	}
 
@@ -154,7 +159,7 @@ func seedKubernetesMCPInRegistry(ctx context.Context, reg *mcpregistry.Client, k
 		return nil
 	}
 
-	if err := seedActiveMCPServer(
+	if err := seedRealMCPServer(
 		ctx,
 		reg,
 		logger,
@@ -175,28 +180,24 @@ func seedKubernetesMCPInRegistry(ctx context.Context, reg *mcpregistry.Client, k
 	return nil
 }
 
-func seedBraveDraftMCPServer(ctx context.Context, reg *mcpregistry.Client, logger *slog.Logger) error {
-	if _, err := reg.GetMCPServer(ctx, braveMCPRegistryName); err == nil {
-		logger.Debug("MCP registry server already exists, skipping seed",
-			slog.String("name", braveMCPRegistryName),
-		)
-		return nil
+func seedMockBraveDraftMCPServer(ctx context.Context, reg *mcpregistry.Client, logger *slog.Logger) error {
+	description := "Brave browser MCP server (draft, not yet deployed)"
+	if err := ensureMCPServerParent(ctx, reg, braveMCPRegistryName, description); err != nil {
+		return err
 	}
 
-	_, err := reg.CreateMCPServer(ctx, braveMCPRegistryName,
-		mcpregistry.WithServerDescription("Brave browser MCP server (draft, not yet deployed)"),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create brave draft MCP server %s: %w", braveMCPRegistryName, err)
+	if mcpServerVersionExists(ctx, reg, braveMCPRegistryName, braveMCPVersion) {
+		logger.Debug("Brave draft MCP server version already exists", slog.String("name", braveMCPRegistryName))
+		return nil
 	}
 
 	serverJSON := map[string]any{
 		"name":        braveMCPRegistryName,
-		"description": "Brave browser MCP server (draft, not yet deployed)",
+		"description": description,
 		"version":     braveMCPVersion,
 	}
 
-	_, err = reg.CreateMCPServerVersion(ctx, braveMCPRegistryName, serverJSON,
+	_, err := reg.CreateMCPServerVersion(ctx, braveMCPRegistryName, serverJSON,
 		mcpregistry.WithVersionStatus(mcpregistry.MCPServerVersionStatusDraft),
 	)
 	if err != nil {
@@ -207,19 +208,14 @@ func seedBraveDraftMCPServer(ctx context.Context, reg *mcpregistry.Client, logge
 	return nil
 }
 
-func seedGitHubActiveMCPServer(ctx context.Context, reg *mcpregistry.Client, logger *slog.Logger) error {
-	if _, err := reg.GetMCPServer(ctx, githubMCPRegistryName); err == nil {
-		logger.Debug("MCP registry server already exists, skipping seed", slog.String("name", githubMCPRegistryName))
-		return nil
-	}
-
+func seedMockGitHubMCPServer(ctx context.Context, reg *mcpregistry.Client, logger *slog.Logger) error {
 	githubTools := []mcpregistry.MCPTool{
 		{Name: "create_github_issue", Description: "Create a new GitHub issue"},
 		{Name: "search_repositories", Description: "Search GitHub repositories"},
 		{Name: "get_file_contents", Description: "Get contents of a file from a repo"},
 	}
 
-	return seedActiveMCPServer(
+	return ensureMCPServerWithActiveVersion(
 		ctx,
 		reg,
 		logger,
@@ -227,20 +223,23 @@ func seedGitHubActiveMCPServer(ctx context.Context, reg *mcpregistry.Client, log
 		"GitHub MCP Server",
 		"GitHub MCP server for issue and repo management.",
 		githubMCPVersion,
-		githubMCPFakeEndpoint,
+		githubMCPExampleEndpoint,
 		githubTools,
 	)
 }
 
-func seedActiveMCPServer(
+func seedRealMCPServer(
 	ctx context.Context,
 	reg *mcpregistry.Client,
 	logger *slog.Logger,
 	name, displayName, description, version, endpointURL string,
 	tools []mcpregistry.MCPTool,
 ) error {
+	return ensureMCPServerWithActiveVersion(ctx, reg, logger, name, displayName, description, version, endpointURL, tools)
+}
+
+func ensureMCPServerParent(ctx context.Context, reg *mcpregistry.Client, name, description string) error {
 	if _, err := reg.GetMCPServer(ctx, name); err == nil {
-		logger.Debug("MCP registry server already exists, skipping seed", slog.String("name", name))
 		return nil
 	}
 
@@ -250,24 +249,47 @@ func seedActiveMCPServer(
 	if err != nil {
 		return fmt.Errorf("failed to create MCP server %s: %w", name, err)
 	}
+	return nil
+}
 
-	serverJSON := map[string]any{
-		"name":        name,
-		"description": description,
-		"version":     version,
+func ensureMCPServerWithActiveVersion(
+	ctx context.Context,
+	reg *mcpregistry.Client,
+	logger *slog.Logger,
+	name, displayName, description, version, endpointURL string,
+	tools []mcpregistry.MCPTool,
+) error {
+	if err := ensureMCPServerParent(ctx, reg, name, description); err != nil {
+		return err
 	}
 
-	versionOpts := []mcpregistry.CreateMCPServerVersionOption{
-		mcpregistry.WithVersionDisplayName(displayName),
-		mcpregistry.WithVersionStatus(mcpregistry.MCPServerVersionStatusActive),
-	}
-	if len(tools) > 0 {
-		versionOpts = append(versionOpts, mcpregistry.WithVersionTools(tools))
+	if !mcpServerVersionExists(ctx, reg, name, version) {
+		serverJSON := map[string]any{
+			"name":        name,
+			"description": description,
+			"version":     version,
+		}
+
+		versionOpts := []mcpregistry.CreateMCPServerVersionOption{
+			mcpregistry.WithVersionDisplayName(displayName),
+			mcpregistry.WithVersionStatus(mcpregistry.MCPServerVersionStatusActive),
+		}
+		if len(tools) > 0 {
+			versionOpts = append(versionOpts, mcpregistry.WithVersionTools(tools))
+		}
+
+		if _, err := reg.CreateMCPServerVersion(ctx, name, serverJSON, versionOpts...); err != nil {
+			return fmt.Errorf("failed to create MCP server version %s: %w", name, err)
+		}
+		logger.Debug("Seeded MCP server version", slog.String("name", name), slog.String("version", version))
 	}
 
-	_, err = reg.CreateMCPServerVersion(ctx, name, serverJSON, versionOpts...)
-	if err != nil {
-		return fmt.Errorf("failed to create MCP server version %s: %w", name, err)
+	if endpointURL == "" {
+		return nil
+	}
+
+	if mcpServerEndpointExists(ctx, reg, name, endpointURL) {
+		return nil
 	}
 
 	transport := mcpregistry.MCPTransportStreamableHTTP
@@ -275,15 +297,33 @@ func seedActiveMCPServer(
 		transport = mcpregistry.MCPTransportSSE
 	}
 
-	_, err = reg.CreateMCPAccessEndpoint(ctx, name, endpointURL,
+	if _, err := reg.CreateMCPAccessEndpoint(ctx, name, endpointURL,
 		mcpregistry.WithAccessEndpointTransportType(transport),
 		mcpregistry.WithAccessEndpointServerVersion(version),
-	)
-	if err != nil {
+	); err != nil {
 		return fmt.Errorf("failed to create MCP access endpoint for %s: %w", name, err)
 	}
 
+	logger.Debug("Seeded MCP server access endpoint", slog.String("name", name), slog.String("endpoint", endpointURL))
 	return nil
+}
+
+func mcpServerVersionExists(ctx context.Context, reg *mcpregistry.Client, name, version string) bool {
+	_, err := reg.GetMCPServerVersion(ctx, name, version)
+	return err == nil
+}
+
+func mcpServerEndpointExists(ctx context.Context, reg *mcpregistry.Client, name, endpointURL string) bool {
+	server, err := reg.GetMCPServer(ctx, name)
+	if err != nil {
+		return false
+	}
+	for _, endpoint := range server.AccessEndpoints {
+		if endpoint.EndpointURL == endpointURL {
+			return true
+		}
+	}
+	return false
 }
 
 // SeedPrompts registers sample prompts in the local MLflow instance.
@@ -292,10 +332,33 @@ func seedActiveMCPServer(
 // skipped entirely (all its versions), so restarting the BFF against an already-running
 // MLflow instance does not create duplicate prompt versions.
 func SeedPrompts(trackingURI string, logger *slog.Logger) error {
-	client, err := mlflow.NewClient(
+	playgroundNamespace := strings.TrimSpace(os.Getenv("PLAYGROUND_NAMESPACE"))
+	workspaces := devMLflowWorkspaces(playgroundNamespace)
+	for _, workspace := range workspaces {
+		if err := ensureMLflowWorkspace(trackingURI, workspace, logger); err != nil {
+			return fmt.Errorf("failed to ensure MLflow workspace %q: %w", workspace, err)
+		}
+		if err := seedPromptsInWorkspace(trackingURI, workspace, logger); err != nil {
+			return fmt.Errorf("failed to seed prompts for workspace %q: %w", workspace, err)
+		}
+	}
+
+	logger.Info("Seeded MLflow with sample prompts", slog.Any("workspaces", workspaces))
+	return nil
+}
+
+func seedPromptsInWorkspace(trackingURI, workspace string, logger *slog.Logger) error {
+	clientOpts := []mlflow.Option{
 		mlflow.WithTrackingURI(trackingURI),
 		mlflow.WithInsecure(),
-	)
+	}
+	if workspace != "" && workspace != "default" {
+		clientOpts = append(clientOpts, mlflow.WithHeaders(map[string]string{
+			"X-MLFLOW-WORKSPACE": workspace,
+		}))
+	}
+
+	client, err := mlflow.NewClient(clientOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to create MLflow client: %w", err)
 	}
@@ -388,11 +451,11 @@ func SeedPrompts(trackingURI string, logger *slog.Logger) error {
 	}
 
 	for _, p := range prompts {
-		// Idempotency guard: if the prompt already has any version, skip it entirely.
-		// This prevents duplicate versions from accumulating on BFF restarts against
-		// an already-running MLflow instance.
 		if _, err := reg.LoadPrompt(ctx, p.name); err == nil {
-			logger.Debug("Prompt already exists, skipping seed", slog.String("name", p.name))
+			logger.Debug("Prompt already exists, skipping seed",
+				slog.String("name", p.name),
+				slog.String("workspace", workspace),
+			)
 			continue
 		}
 
@@ -417,13 +480,13 @@ func SeedPrompts(trackingURI string, logger *slog.Logger) error {
 			}
 			logger.Debug("Seeded prompt version",
 				slog.String("name", p.name),
+				slog.String("workspace", workspace),
 				slog.Int("version", pv.Version),
 				slog.String("commit", v.commit),
 			)
 		}
 	}
 
-	logger.Info("Seeded MLflow with sample prompts", slog.Int("count", len(prompts)))
 	return nil
 }
 

--- a/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed.go
+++ b/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed.go
@@ -1,18 +1,256 @@
 package mlflowmocks
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/opendatahub-io/mlflow-go/mlflow"
+	"github.com/opendatahub-io/mlflow-go/mlflow/mcpregistry"
 	"github.com/opendatahub-io/mlflow-go/mlflow/promptregistry"
 )
 
 const seedTimeout = 30 * time.Second
 
+const (
+	kubernetesMCPRegistryName = "com.example/kubernetes"
+	draftMCPRegistryName      = "io.github.example/tools-draft"
+	kubernetesMCPVersion      = "1.0.0"
+	draftMCPVersion           = "0.1.0"
+)
+
+// SeedMCPRegistry registers sample MCP servers in the local MLflow MCP Registry.
+//
+// It reads PLAYGROUND_NAMESPACE and KUBERNETES_MCP_SERVER_URL directly from the
+// environment via os.Getenv (these are dev-only values exported by the parent Makefile
+// from packages/gen-ai/.env.local).
+//
+// Workspaces seeded: always "default"; additionally the PLAYGROUND_NAMESPACE workspace
+// if that env var is non-empty.
+//
+// Servers registered per workspace:
+//   - A draft server (io.github.example/tools-draft) — always seeded
+//   - A Kubernetes MCP server (com.example/kubernetes) — seeded only when
+//     KUBERNETES_MCP_SERVER_URL is set; skipped with a log message otherwise
+//
+// Errors are returned to the caller; SetupMLflow logs them as warnings (non-fatal).
+func SeedMCPRegistry(trackingURI string, logger *slog.Logger) error {
+	playgroundNamespace := strings.TrimSpace(os.Getenv("PLAYGROUND_NAMESPACE"))
+	kubernetesMCPServerURL := strings.TrimSpace(os.Getenv("KUBERNETES_MCP_SERVER_URL"))
+	workspaces := devMLflowWorkspaces(playgroundNamespace)
+	for _, workspace := range workspaces {
+		if err := ensureMLflowWorkspace(trackingURI, workspace, logger); err != nil {
+			return fmt.Errorf("failed to ensure MLflow workspace %q: %w", workspace, err)
+		}
+		if err := seedMCPRegistryInWorkspace(trackingURI, workspace, kubernetesMCPServerURL, logger); err != nil {
+			return fmt.Errorf("failed to seed MCP registry for workspace %q: %w", workspace, err)
+		}
+	}
+
+	logger.Info("Seeded MLflow MCP registry", slog.Any("workspaces", workspaces))
+	return nil
+}
+
+func devMLflowWorkspaces(playgroundNamespace string) []string {
+	seen := map[string]bool{"default": true}
+	workspaces := []string{"default"}
+
+	add := func(workspace string) {
+		workspace = strings.TrimSpace(workspace)
+		if workspace == "" || seen[workspace] {
+			return
+		}
+		seen[workspace] = true
+		workspaces = append(workspaces, workspace)
+	}
+
+	add(playgroundNamespace)
+
+	return workspaces
+}
+
+func ensureMLflowWorkspace(trackingURI, workspace string, logger *slog.Logger) error {
+	if workspace == "" || workspace == "default" {
+		return nil
+	}
+
+	body, err := json.Marshal(map[string]string{"name": workspace})
+	if err != nil {
+		return err
+	}
+
+	url := strings.TrimSuffix(trackingURI, "/") + "/ajax-api/3.0/mlflow/workspaces"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+		logger.Info("Created MLflow workspace", slog.String("workspace", workspace))
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(respBody), "RESOURCE_ALREADY_EXISTS") {
+		logger.Debug("MLflow workspace already exists", slog.String("workspace", workspace))
+		return nil
+	}
+
+	return fmt.Errorf("create workspace %q: status %d: %s", workspace, resp.StatusCode, string(respBody))
+}
+
+func seedMCPRegistryInWorkspace(trackingURI, workspace, kubernetesMCPServerURL string, logger *slog.Logger) error {
+	clientOpts := []mlflow.Option{
+		mlflow.WithTrackingURI(trackingURI),
+		mlflow.WithInsecure(),
+	}
+	if workspace != "" && workspace != "default" {
+		clientOpts = append(clientOpts, mlflow.WithHeaders(map[string]string{
+			"X-MLFLOW-WORKSPACE": workspace,
+		}))
+	}
+
+	client, err := mlflow.NewClient(clientOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to create MLflow client for MCP registry seed: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), seedTimeout)
+	defer cancel()
+
+	return seedKubernetesMCPInRegistry(ctx, client.MCPRegistry(), kubernetesMCPServerURL, logger)
+}
+
+func seedKubernetesMCPInRegistry(ctx context.Context, reg *mcpregistry.Client, kubernetesMCPServerURL string, logger *slog.Logger) error {
+	if err := seedDraftMCPServer(ctx, reg, logger); err != nil {
+		return err
+	}
+
+	kubernetesURL := strings.TrimSpace(kubernetesMCPServerURL)
+	if kubernetesURL == "" {
+		logger.Info("KUBERNETES_MCP_SERVER_URL unset — skipping kubernetes MCP registry seed")
+		return nil
+	}
+
+	if err := seedActiveMCPServer(
+		ctx,
+		reg,
+		logger,
+		kubernetesMCPRegistryName,
+		"Kubernetes MCP Server",
+		"Manage resources in a Kubernetes cluster.",
+		kubernetesMCPVersion,
+		kubernetesURL,
+	); err != nil {
+		return err
+	}
+
+	logger.Info("Seeded kubernetes MCP server in registry",
+		slog.String("name", kubernetesMCPRegistryName),
+		slog.String("endpoint", kubernetesURL),
+	)
+	return nil
+}
+
+func seedDraftMCPServer(ctx context.Context, reg *mcpregistry.Client, logger *slog.Logger) error {
+	if _, err := reg.GetMCPServer(ctx, draftMCPRegistryName); err == nil {
+		logger.Debug("MCP registry server already exists, skipping seed",
+			slog.String("name", draftMCPRegistryName),
+		)
+		return nil
+	}
+
+	_, err := reg.CreateMCPServer(ctx, draftMCPRegistryName,
+		mcpregistry.WithServerDescription("Draft MCP server for filter and status UI testing."),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create draft MCP server %s: %w", draftMCPRegistryName, err)
+	}
+
+	serverJSON := map[string]any{
+		"name":        draftMCPRegistryName,
+		"description": "Draft tools server for local dev.",
+		"version":     draftMCPVersion,
+	}
+
+	_, err = reg.CreateMCPServerVersion(ctx, draftMCPRegistryName, serverJSON,
+		mcpregistry.WithVersionStatus(mcpregistry.MCPServerVersionStatusDraft),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create draft MCP server version %s: %w", draftMCPRegistryName, err)
+	}
+
+	logger.Debug("Seeded draft MCP registry server", slog.String("name", draftMCPRegistryName))
+	return nil
+}
+
+func seedActiveMCPServer(
+	ctx context.Context,
+	reg *mcpregistry.Client,
+	logger *slog.Logger,
+	name, displayName, description, version, endpointURL string,
+) error {
+	if _, err := reg.GetMCPServer(ctx, name); err == nil {
+		logger.Debug("MCP registry server already exists, skipping seed", slog.String("name", name))
+		return nil
+	}
+
+	_, err := reg.CreateMCPServer(ctx, name,
+		mcpregistry.WithServerDescription(description),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create MCP server %s: %w", name, err)
+	}
+
+	serverJSON := map[string]any{
+		"name":        name,
+		"description": description,
+		"version":     version,
+	}
+
+	_, err = reg.CreateMCPServerVersion(ctx, name, serverJSON,
+		mcpregistry.WithVersionDisplayName(displayName),
+		mcpregistry.WithVersionStatus(mcpregistry.MCPServerVersionStatusActive),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create MCP server version %s: %w", name, err)
+	}
+
+	transport := mcpregistry.MCPTransportStreamableHTTP
+	if strings.HasSuffix(endpointURL, "/sse") || strings.Contains(endpointURL, "/sse/") {
+		transport = mcpregistry.MCPTransportSSE
+	}
+
+	_, err = reg.CreateMCPAccessEndpoint(ctx, name, endpointURL,
+		mcpregistry.WithAccessEndpointTransportType(transport),
+		mcpregistry.WithAccessEndpointServerVersion(version),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create MCP access endpoint for %s: %w", name, err)
+	}
+
+	return nil
+}
+
 // SeedPrompts registers sample prompts in the local MLflow instance.
+//
+// Seeding is idempotent: any prompt whose name already exists in the registry is
+// skipped entirely (all its versions), so restarting the BFF against an already-running
+// MLflow instance does not create duplicate prompt versions.
 func SeedPrompts(trackingURI string, logger *slog.Logger) error {
 	client, err := mlflow.NewClient(
 		mlflow.WithTrackingURI(trackingURI),
@@ -110,6 +348,14 @@ func SeedPrompts(trackingURI string, logger *slog.Logger) error {
 	}
 
 	for _, p := range prompts {
+		// Idempotency guard: if the prompt already has any version, skip it entirely.
+		// This prevents duplicate versions from accumulating on BFF restarts against
+		// an already-running MLflow instance.
+		if _, err := reg.LoadPrompt(ctx, p.name); err == nil {
+			logger.Debug("Prompt already exists, skipping seed", slog.String("name", p.name))
+			continue
+		}
+
 		for _, v := range p.versions {
 			var pv *promptregistry.PromptVersion
 			var regErr error

--- a/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed.go
+++ b/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed.go
@@ -21,9 +21,12 @@ const seedTimeout = 30 * time.Second
 
 const (
 	kubernetesMCPRegistryName = "com.example/kubernetes"
-	draftMCPRegistryName      = "io.github.example/tools-draft"
+	githubMCPRegistryName     = "io.github.example/github"
+	braveMCPRegistryName      = "com.brave.example/brave"
 	kubernetesMCPVersion      = "1.0.0"
-	draftMCPVersion           = "0.1.0"
+	githubMCPVersion          = "1.0.0"
+	braveMCPVersion           = "0.1.0"
+	githubMCPFakeEndpoint     = "https://github-mcp.example.com/mcp"
 )
 
 // SeedMCPRegistry registers sample MCP servers in the local MLflow MCP Registry.
@@ -36,7 +39,8 @@ const (
 // if that env var is non-empty.
 //
 // Servers registered per workspace:
-//   - A draft server (io.github.example/tools-draft) — always seeded
+//   - Brave draft server (com.brave.example/brave) — no access endpoint
+//   - GitHub active server (io.github.example/github) — fake endpoint + 3 registry tools
 //   - A Kubernetes MCP server (com.example/kubernetes) — seeded only when
 //     KUBERNETES_MCP_SERVER_URL is set; skipped with a log message otherwise
 //
@@ -136,7 +140,11 @@ func seedMCPRegistryInWorkspace(trackingURI, workspace, kubernetesMCPServerURL s
 }
 
 func seedKubernetesMCPInRegistry(ctx context.Context, reg *mcpregistry.Client, kubernetesMCPServerURL string, logger *slog.Logger) error {
-	if err := seedDraftMCPServer(ctx, reg, logger); err != nil {
+	if err := seedBraveDraftMCPServer(ctx, reg, logger); err != nil {
+		return err
+	}
+
+	if err := seedGitHubActiveMCPServer(ctx, reg, logger); err != nil {
 		return err
 	}
 
@@ -155,6 +163,7 @@ func seedKubernetesMCPInRegistry(ctx context.Context, reg *mcpregistry.Client, k
 		"Manage resources in a Kubernetes cluster.",
 		kubernetesMCPVersion,
 		kubernetesURL,
+		nil,
 	); err != nil {
 		return err
 	}
@@ -166,36 +175,61 @@ func seedKubernetesMCPInRegistry(ctx context.Context, reg *mcpregistry.Client, k
 	return nil
 }
 
-func seedDraftMCPServer(ctx context.Context, reg *mcpregistry.Client, logger *slog.Logger) error {
-	if _, err := reg.GetMCPServer(ctx, draftMCPRegistryName); err == nil {
+func seedBraveDraftMCPServer(ctx context.Context, reg *mcpregistry.Client, logger *slog.Logger) error {
+	if _, err := reg.GetMCPServer(ctx, braveMCPRegistryName); err == nil {
 		logger.Debug("MCP registry server already exists, skipping seed",
-			slog.String("name", draftMCPRegistryName),
+			slog.String("name", braveMCPRegistryName),
 		)
 		return nil
 	}
 
-	_, err := reg.CreateMCPServer(ctx, draftMCPRegistryName,
-		mcpregistry.WithServerDescription("Draft MCP server for filter and status UI testing."),
+	_, err := reg.CreateMCPServer(ctx, braveMCPRegistryName,
+		mcpregistry.WithServerDescription("Brave browser MCP server (draft, not yet deployed)"),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create draft MCP server %s: %w", draftMCPRegistryName, err)
+		return fmt.Errorf("failed to create brave draft MCP server %s: %w", braveMCPRegistryName, err)
 	}
 
 	serverJSON := map[string]any{
-		"name":        draftMCPRegistryName,
-		"description": "Draft tools server for local dev.",
-		"version":     draftMCPVersion,
+		"name":        braveMCPRegistryName,
+		"description": "Brave browser MCP server (draft, not yet deployed)",
+		"version":     braveMCPVersion,
 	}
 
-	_, err = reg.CreateMCPServerVersion(ctx, draftMCPRegistryName, serverJSON,
+	_, err = reg.CreateMCPServerVersion(ctx, braveMCPRegistryName, serverJSON,
 		mcpregistry.WithVersionStatus(mcpregistry.MCPServerVersionStatusDraft),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create draft MCP server version %s: %w", draftMCPRegistryName, err)
+		return fmt.Errorf("failed to create brave draft MCP server version %s: %w", braveMCPRegistryName, err)
 	}
 
-	logger.Debug("Seeded draft MCP registry server", slog.String("name", draftMCPRegistryName))
+	logger.Debug("Seeded brave draft MCP registry server", slog.String("name", braveMCPRegistryName))
 	return nil
+}
+
+func seedGitHubActiveMCPServer(ctx context.Context, reg *mcpregistry.Client, logger *slog.Logger) error {
+	if _, err := reg.GetMCPServer(ctx, githubMCPRegistryName); err == nil {
+		logger.Debug("MCP registry server already exists, skipping seed", slog.String("name", githubMCPRegistryName))
+		return nil
+	}
+
+	githubTools := []mcpregistry.MCPTool{
+		{Name: "create_github_issue", Description: "Create a new GitHub issue"},
+		{Name: "search_repositories", Description: "Search GitHub repositories"},
+		{Name: "get_file_contents", Description: "Get contents of a file from a repo"},
+	}
+
+	return seedActiveMCPServer(
+		ctx,
+		reg,
+		logger,
+		githubMCPRegistryName,
+		"GitHub MCP Server",
+		"GitHub MCP server for issue and repo management.",
+		githubMCPVersion,
+		githubMCPFakeEndpoint,
+		githubTools,
+	)
 }
 
 func seedActiveMCPServer(
@@ -203,6 +237,7 @@ func seedActiveMCPServer(
 	reg *mcpregistry.Client,
 	logger *slog.Logger,
 	name, displayName, description, version, endpointURL string,
+	tools []mcpregistry.MCPTool,
 ) error {
 	if _, err := reg.GetMCPServer(ctx, name); err == nil {
 		logger.Debug("MCP registry server already exists, skipping seed", slog.String("name", name))
@@ -222,10 +257,15 @@ func seedActiveMCPServer(
 		"version":     version,
 	}
 
-	_, err = reg.CreateMCPServerVersion(ctx, name, serverJSON,
+	versionOpts := []mcpregistry.CreateMCPServerVersionOption{
 		mcpregistry.WithVersionDisplayName(displayName),
 		mcpregistry.WithVersionStatus(mcpregistry.MCPServerVersionStatusActive),
-	)
+	}
+	if len(tools) > 0 {
+		versionOpts = append(versionOpts, mcpregistry.WithVersionTools(tools))
+	}
+
+	_, err = reg.CreateMCPServerVersion(ctx, name, serverJSON, versionOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to create MCP server version %s: %w", name, err)
 	}

--- a/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed_test.go
+++ b/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed_test.go
@@ -1,0 +1,31 @@
+package mlflowmocks
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestSeedMCPRegistry(t *testing.T) {
+	trackingURI := os.Getenv("MLFLOW_TRACKING_URI")
+	if trackingURI == "" {
+		t.Skip("MLFLOW_TRACKING_URI not set")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	if err := SeedMCPRegistry(trackingURI, logger); err != nil {
+		t.Fatalf("SeedMCPRegistry failed: %v", err)
+	}
+}
+
+func TestSeedPrompts(t *testing.T) {
+	trackingURI := os.Getenv("MLFLOW_TRACKING_URI")
+	if trackingURI == "" {
+		t.Skip("MLFLOW_TRACKING_URI not set")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	if err := SeedPrompts(trackingURI, logger); err != nil {
+		t.Fatalf("SeedPrompts failed: %v", err)
+	}
+}

--- a/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed_test.go
+++ b/packages/gen-ai/bff/internal/integrations/mlflow/mlflowmocks/mlflow_seed_test.go
@@ -1,10 +1,185 @@
 package mlflowmocks
 
 import (
+	"context"
+	"encoding/json"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/opendatahub-io/mlflow-go/mlflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDevMLflowWorkspaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		playgroundNamespace string
+		want                []string
+	}{
+		{
+			name:                "default only when playground unset",
+			playgroundNamespace: "",
+			want:                []string{"default"},
+		},
+		{
+			name:                "includes playground namespace",
+			playgroundNamespace: "crimson-dev",
+			want:                []string{"default", "crimson-dev"},
+		},
+		{
+			name:                "deduplicates when playground is default",
+			playgroundNamespace: "default",
+			want:                []string{"default"},
+		},
+		{
+			name:                "trims whitespace",
+			playgroundNamespace: "  crimson-dev  ",
+			want:                []string{"default", "crimson-dev"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := devMLflowWorkspaces(tt.playgroundNamespace)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMCPSeedReconciliation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		basePath    = "/ajax-api/3.0/mlflow/mcp-servers"
+		serverName  = "com.example/reconcile-test"
+		version     = "1.0.0"
+		endpointURL = "https://example.com/mcp"
+		description = "reconcile test server"
+		displayName = "Reconcile Test"
+	)
+
+	type registryState struct {
+		servers   map[string]bool
+		versions  map[string]map[string]bool
+		endpoints map[string][]map[string]string
+	}
+
+	state := &registryState{
+		servers:   map[string]bool{serverName: true},
+		versions:  map[string]map[string]bool{serverName: {}},
+		endpoints: map[string][]map[string]string{serverName: {}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON := func(v any) { _ = json.NewEncoder(w).Encode(v) }
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == basePath+"/"+serverName:
+			endpoints := make([]map[string]string, 0, len(state.endpoints[serverName]))
+			endpoints = append(endpoints, state.endpoints[serverName]...)
+			writeJSON(map[string]any{
+				"name":             serverName,
+				"description":      description,
+				"access_endpoints": endpoints,
+			})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, basePath+"/"+serverName+"/versions/"):
+			versionName := strings.TrimPrefix(r.URL.Path, basePath+"/"+serverName+"/versions/")
+			if state.versions[serverName][versionName] {
+				writeJSON(map[string]any{
+					"name":    serverName,
+					"version": versionName,
+					"status":  "active",
+					"server_json": map[string]any{
+						"name":    serverName,
+						"version": versionName,
+					},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(map[string]string{
+				"error_code": "RESOURCE_DOES_NOT_EXIST",
+				"message":    "version not found",
+			})
+		case r.Method == http.MethodPost && r.URL.Path == basePath+"/"+serverName+"/versions":
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				ServerJSON map[string]any `json:"server_json"`
+			}
+			_ = json.Unmarshal(body, &req)
+			versionValue, _ := req.ServerJSON["version"].(string)
+			state.versions[serverName][versionValue] = true
+			writeJSON(map[string]any{
+				"name":    serverName,
+				"version": versionValue,
+				"status":  "active",
+				"server_json": map[string]any{
+					"name":    serverName,
+					"version": versionValue,
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == basePath+"/"+serverName+"/endpoints":
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]string
+			_ = json.Unmarshal(body, &req)
+			state.endpoints[serverName] = append(state.endpoints[serverName], map[string]string{
+				"id":          "endpoint-1",
+				"server_name": serverName,
+				"url":         req["url"],
+			})
+			writeJSON(map[string]any{
+				"id":             "endpoint-1",
+				"server_name":    serverName,
+				"url":            req["url"],
+				"transport_type": "streamable-http",
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	mlflowClient, err := mlflow.NewClient(
+		mlflow.WithTrackingURI(server.URL),
+		mlflow.WithInsecure(),
+	)
+	require.NoError(t, err)
+
+	reg := mlflowClient.MCPRegistry()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.Background()
+
+	require.False(t, mcpServerVersionExists(ctx, reg, serverName, version))
+	require.False(t, mcpServerEndpointExists(ctx, reg, serverName, endpointURL))
+
+	err = ensureMCPServerWithActiveVersion(
+		ctx, reg, logger,
+		serverName, displayName, description, version, endpointURL, nil,
+	)
+	require.NoError(t, err)
+
+	assert.True(t, mcpServerVersionExists(ctx, reg, serverName, version))
+	assert.True(t, mcpServerEndpointExists(ctx, reg, serverName, endpointURL))
+
+	// Second run must be idempotent and not duplicate sub-resources.
+	err = ensureMCPServerWithActiveVersion(
+		ctx, reg, logger,
+		serverName, displayName, description, version, endpointURL, nil,
+	)
+	require.NoError(t, err)
+	assert.Len(t, state.endpoints[serverName], 1)
+}
 
 func TestSeedMCPRegistry(t *testing.T) {
 	trackingURI := os.Getenv("MLFLOW_TRACKING_URI")
@@ -15,6 +190,11 @@ func TestSeedMCPRegistry(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	if err := SeedMCPRegistry(trackingURI, logger); err != nil {
 		t.Fatalf("SeedMCPRegistry failed: %v", err)
+	}
+
+	// Re-run to verify partial-heal reconciliation is idempotent.
+	if err := SeedMCPRegistry(trackingURI, logger); err != nil {
+		t.Fatalf("SeedMCPRegistry second run failed: %v", err)
 	}
 }
 
@@ -27,5 +207,9 @@ func TestSeedPrompts(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	if err := SeedPrompts(trackingURI, logger); err != nil {
 		t.Fatalf("SeedPrompts failed: %v", err)
+	}
+
+	if err := SeedPrompts(trackingURI, logger); err != nil {
+		t.Fatalf("SeedPrompts second run failed: %v", err)
 	}
 }

--- a/packages/gen-ai/bff/internal/models/aaa_mcp.go
+++ b/packages/gen-ai/bff/internal/models/aaa_mcp.go
@@ -58,19 +58,38 @@ type MCPServerConfig struct {
 	Logo        string `json:"logo,omitempty"`        // Optional logo URL for the MCP server
 }
 
+const (
+	MCPServerSourceRegistry  = "registry"
+	MCPServerSourceConfigMap = "configmap"
+)
+
+// MCPServerToolSummary is registry metadata for a tool (list endpoint only).
+type MCPServerToolSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
 // MCPServerSummary represents a single MCP server for frontend table display
 type MCPServerSummary struct {
-	Name        string  `json:"name"`
-	URL         string  `json:"url"`
-	Transport   string  `json:"transport"`
-	Description string  `json:"description"`
-	Logo        *string `json:"logo"`   // nullable
-	Status      string  `json:"status"` // "healthy", "error", "unknown" - from ConfigMap only
+	Name        string                 `json:"name"`
+	URL         string                 `json:"url"`
+	Transport   string                 `json:"transport"`
+	Description string                 `json:"description"`
+	Logo        *string                `json:"logo"`   // nullable
+	Status      string                 `json:"status"` // "healthy", "error", "unknown"
+	Source      string                 `json:"source"` // "registry" or "configmap"
+	Version     string                 `json:"version,omitempty"`
+	Tools       []MCPServerToolSummary `json:"tools"`
+	ToolCount   int                    `json:"tool_count"`
 }
 
 // MCPListData represents the response data for the MCP servers list endpoint
 type MCPListData struct {
-	Servers       []MCPServerSummary `json:"servers"`
-	TotalCount    int                `json:"total_count"`
-	ConfigMapInfo ConfigMapInfo      `json:"config_map_info"`
+	Servers            []MCPServerSummary `json:"servers"`
+	TotalCount         int                `json:"total_count"`
+	ConfigMapInfo      *ConfigMapInfo     `json:"config_map_info"`
+	RegistryAvailable  bool               `json:"registry_available"`
+	RegistryError      string             `json:"registry_error,omitempty"`
+	ConfigmapAvailable bool               `json:"configmap_available"`
+	ConfigmapError     string             `json:"configmap_error,omitempty"`
 }

--- a/packages/gen-ai/bff/internal/models/mlflow.go
+++ b/packages/gen-ai/bff/internal/models/mlflow.go
@@ -89,3 +89,47 @@ type MLflowPromptVersionsResponse struct {
 	Versions      []MLflowPromptVersionMeta `json:"versions"`
 	NextPageToken string                    `json:"next_page_token,omitempty"`
 }
+
+// MLflowMCPTool is a tool entry from the MLflow MCP Registry (metadata only).
+type MLflowMCPTool struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// MLflowMCPServerVersion is a resolved MCP server version from the registry.
+type MLflowMCPServerVersion struct {
+	Version string          `json:"version"`
+	Tools   []MLflowMCPTool `json:"tools,omitempty"`
+}
+
+// MLflowMCPEndpointSummary is an access endpoint embedded in an MCP server list entry.
+type MLflowMCPEndpointSummary struct {
+	EndpointURL     string                  `json:"endpoint_url"`
+	TransportType   string                  `json:"transport_type,omitempty"`
+	ResolvedVersion *MLflowMCPServerVersion `json:"resolved_version,omitempty"`
+}
+
+// MLflowMCPServer is an MCP Registry server entry from the MLflow BFF.
+type MLflowMCPServer struct {
+	Name            string                     `json:"name"`
+	Description     string                     `json:"description,omitempty"`
+	Status          string                     `json:"status,omitempty"`
+	LatestVersion   string                     `json:"latest_version,omitempty"`
+	AccessEndpoints []MLflowMCPEndpointSummary `json:"access_endpoints,omitempty"`
+}
+
+// MLflowMCPServersData is the list payload from GET /mcp-registry/servers.
+type MLflowMCPServersData struct {
+	Servers       []MLflowMCPServer `json:"servers"`
+	NextPageToken string            `json:"next_page_token,omitempty"`
+}
+
+// MLflowMCPServersEnvelope wraps the MCP servers list response from MLflow BFF.
+type MLflowMCPServersEnvelope struct {
+	Data MLflowMCPServersData `json:"data"`
+}
+
+// MLflowMCPServerEnvelope wraps a single MCP server response from MLflow BFF.
+type MLflowMCPServerEnvelope struct {
+	Data MLflowMCPServer `json:"data"`
+}

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -1986,13 +1986,11 @@ paths:
   # =============================================================================
 
   /gen-ai/api/v1/mcp/tools:
-    summary: Get tools from MCP server by URL
+    summary: Get tools from MCP server by URL or registry name
     description: >-
-      Retrieves the available tools from a specific MCP (Model Context Protocol) server by its URL.
-      Uses the MCP client to connect to the server specified by the server_url parameter and fetch its tool definitions.
+      Retrieves the available tools from a specific MCP (Model Context Protocol) server.
+      Use server_url for ConfigMap-configured servers or server_name for MLflow MCP Registry servers.
       Returns tool information including names, descriptions, and input schemas.
-
-      The server_url parameter should be the full URL-encoded endpoint for the MCP server.
 
       Requires valid authentication token for MCP client operations.
       Optionally accepts MCP server authentication via X-MCP-Bearer header.
@@ -2004,19 +2002,26 @@ paths:
       parameters:
         - name: namespace
           in: query
-          description: Kubernetes namespace
+          description: Kubernetes namespace / MLflow workspace
           required: true
           schema:
             type: string
             example: 'demo'
         - name: server_url
           in: query
-          description: Full URL-encoded endpoint for the MCP server
-          required: true
+          description: Full URL-encoded endpoint for a ConfigMap-configured MCP server
+          required: false
           schema:
             type: string
             format: uri
             example: 'http%3A%2F%2Flocalhost%3A9090%2Fsse'
+        - name: server_name
+          in: query
+          description: MCP Registry server name (e.g. com.example/kubernetes)
+          required: false
+          schema:
+            type: string
+            example: 'io.github.example/github'
         - name: X-MCP-Bearer
           in: header
           description: Optional Bearer token for MCP server authentication. Must include 'Bearer ' prefix.
@@ -2037,17 +2042,15 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
       operationId: getMCPTools
-      summary: Get MCP Tools by URL
-      description: Gets the available tools from the MCP server specified by URL.
+      summary: Get MCP Tools
+      description: Gets live tools from an MCP server by ConfigMap URL or registry server name.
 
   /gen-ai/api/v1/mcp/status:
-    summary: Get connection status from MCP server by URL
+    summary: Get connection status from MCP server by URL or registry name
     description: >-
-      Retrieves the connection status of a specific MCP (Model Context Protocol) server by its URL.
-      Uses the MCP client to connect to the server specified by the server_url parameter and check its availability.
+      Retrieves the connection status of a specific MCP (Model Context Protocol) server.
+      Use server_url for ConfigMap-configured servers or server_name for MLflow MCP Registry servers.
       Returns connection status information including connectivity state, response message, and last check timestamp.
-
-      The server_url parameter should be the full URL-encoded endpoint for the MCP server.
 
       Requires valid authentication token for MCP client operations.
       Optionally accepts MCP server authentication via X-MCP-Bearer header.
@@ -2059,19 +2062,26 @@ paths:
       parameters:
         - name: namespace
           in: query
-          description: Kubernetes namespace
+          description: Kubernetes namespace / MLflow workspace
           required: true
           schema:
             type: string
             example: 'demo'
         - name: server_url
           in: query
-          description: Full URL-encoded endpoint for the MCP server
-          required: true
+          description: Full URL-encoded endpoint for a ConfigMap-configured MCP server
+          required: false
           schema:
             type: string
             format: uri
             example: 'http%3A%2F%2Flocalhost%3A9090%2Fsse'
+        - name: server_name
+          in: query
+          description: MCP Registry server name (e.g. com.example/kubernetes)
+          required: false
+          schema:
+            type: string
+            example: 'io.github.example/github'
         - name: X-MCP-Bearer
           in: header
           description: Optional Bearer token for MCP server authentication. Must include 'Bearer ' prefix.
@@ -2092,8 +2102,8 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
       operationId: getMCPStatus
-      summary: Get MCP Server Status by URL
-      description: Gets the connection status of the MCP server specified by URL.
+      summary: Get MCP Server Status
+      description: Gets connection status for an MCP server by ConfigMap URL or registry server name.
 
   /gen-ai/api/v1/aaa/vectorstores:
     get:
@@ -2175,7 +2185,9 @@ paths:
       summary: Get Enhanced List of Available MCP Servers from AI Available Assets
       description: >-
         Retrieves an enhanced list of available MCP (Model Context Protocol) servers from AI Available Assets.
-        Returns a flattened server array with comprehensive metadata from the ConfigMap.
+        Merges servers from the MLflow MCP Registry and the dashboard ConfigMap. Either source may be
+        unavailable; the endpoint always returns HTTP 200 with availability flags and optional error fields
+        describing degraded sources.
       parameters:
         - $ref: '#/components/parameters/NamespaceParam'
       responses:
@@ -2186,40 +2198,6 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '403':
-          description: Access denied to ConfigMap
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorEnvelope'
-              examples:
-                config_map_access_denied:
-                  summary: ConfigMap Access Denied
-                  value:
-                    error:
-                      code: '403'
-                      message: "Access denied to ConfigMap 'gen-ai-aa-mcp-servers-e' in namespace 'mcp-servers'"
-                      details:
-                        config_map_name: 'gen-ai-aa-mcp-servers-e'
-                        namespace: 'mcp-servers'
-                        reason: 'Insufficient permissions'
-        '404':
-          description: ConfigMap not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorEnvelope'
-              examples:
-                config_map_not_found:
-                  summary: ConfigMap Not Found
-                  value:
-                    error:
-                      code: '404'
-                      message: "ConfigMap 'gen-ai-aa-mcp-servers-e' not found in namespace 'mcp-servers'"
-                      details:
-                        config_map_name: 'gen-ai-aa-mcp-servers-e'
-                        namespace: 'mcp-servers'
-                        reason: 'ConfigMap does not exist'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -4959,7 +4937,8 @@ components:
       required:
         - servers
         - total_count
-        - config_map_info
+        - registry_available
+        - configmap_available
       properties:
         servers:
           type: array
@@ -4969,10 +4948,28 @@ components:
         total_count:
           type: integer
           example: 2
-          description: Total number of MCP servers in the ConfigMap
+          description: Total number of MCP servers from all sources
+        registry_available:
+          type: boolean
+          example: true
+          description: Whether the MLflow MCP Registry was reachable when building the list
+        configmap_available:
+          type: boolean
+          example: true
+          description: Whether the MCP servers ConfigMap was successfully read; false when the ConfigMap is missing, forbidden, or otherwise unreadable
+        configmap_error:
+          type: string
+          example: "ConfigMap 'gen-ai-aa-mcp-servers' not found in namespace 'opendatahub'"
+          description: Human-readable reason the ConfigMap could not be read; omitted when configmap_available is true
+        registry_error:
+          type: string
+          example: "MLflow BFF is not configured"
+          description: Human-readable reason the MCP registry could not be read; omitted when registry_available is true
         config_map_info:
-          $ref: '#/components/schemas/ConfigMapInfo'
-          description: Metadata about the source ConfigMap
+          allOf:
+            - $ref: '#/components/schemas/ConfigMapInfo'
+          nullable: true
+          description: Metadata about the source ConfigMap; null when configmap_available is false
 
     MCPServerSummary:
       type: object
@@ -4982,11 +4979,14 @@ components:
         - transport
         - description
         - status
+        - source
+        - tools
+        - tool_count
       properties:
         name:
           type: string
           example: 'brave'
-          description: MCP server name (ConfigMap key)
+          description: MCP server name (ConfigMap key or registry server name)
         url:
           type: string
           format: uri
@@ -5011,7 +5011,37 @@ components:
           type: string
           enum: ['healthy', 'error', 'unknown']
           example: 'healthy'
-          description: Server status based on ConfigMap data only (no MCP calls made)
+          description: Server status based on source metadata only (no live MCP calls on the list endpoint)
+        source:
+          type: string
+          enum: ['registry', 'configmap']
+          example: 'registry'
+          description: Origin of the MCP server entry
+        version:
+          type: string
+          example: '1.0.0'
+          description: Registry server version (empty for ConfigMap entries)
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/MCPServerToolSummary'
+          description: Registry metadata tools (list endpoint only; live tools via mcp/tools)
+        tool_count:
+          type: integer
+          example: 3
+          description: Number of tools in registry metadata (0 for ConfigMap entries or live-only servers)
+
+    MCPServerToolSummary:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: 'create_github_issue'
+        description:
+          type: string
+          example: 'Create a new GitHub issue'
 
     ConfigMapInfo:
       type: object
@@ -6316,33 +6346,65 @@ components:
               value:
                 data:
                   servers:
+                    - name: 'io.github.example/github'
+                      url: 'https://github-mcp.example.com/mcp'
+                      transport: 'streamable-http'
+                      description: 'GitHub MCP server'
+                      logo: null
+                      status: 'healthy'
+                      source: 'registry'
+                      version: '1.0.0'
+                      tools:
+                        - name: 'create_github_issue'
+                          description: 'Create issue'
+                      tool_count: 1
                     - name: 'brave'
                       url: 'http://localhost:9090/sse'
                       transport: 'sse'
                       description: 'Search the Internet.'
                       logo: null
                       status: 'healthy'
-                    - name: 'kubernetes'
-                      url: 'http://localhost:9091/mcp'
-                      transport: 'streamable-http'
-                      description: 'Manage resources in a Kubernetes cluster.'
-                      logo: 'https://kubernetes.io/_common-resources/images/flower.svg'
-                      status: 'healthy'
+                      source: 'configmap'
+                      tools: []
+                      tool_count: 0
                   total_count: 2
+                  registry_available: true
+                  configmap_available: true
                   config_map_info:
                     name: 'gen-ai-aa-mcp-servers-e'
                     namespace: 'mcp-servers'
                     last_updated: '2024-01-15T10:30:00Z'
+            degraded_configmap_response:
+              summary: Registry available but ConfigMap missing
+              value:
+                data:
+                  servers:
+                    - name: 'io.github.example/github'
+                      url: 'https://github-mcp.example.com/mcp'
+                      transport: 'streamable-http'
+                      description: 'GitHub MCP server'
+                      logo: null
+                      status: 'healthy'
+                      source: 'registry'
+                      version: '1.0.0'
+                      tools: []
+                      tool_count: 0
+                  total_count: 1
+                  registry_available: true
+                  configmap_available: false
+                  configmap_error: "ConfigMap 'gen-ai-aa-mcp-servers' not found in namespace 'opendatahub'"
+                  config_map_info: null
             empty_response:
-              summary: Empty ConfigMap
+              summary: Both sources unavailable
               value:
                 data:
                   servers: []
                   total_count: 0
-                  config_map_info:
-                    name: 'gen-ai-aa-mcp-servers-e'
-                    namespace: 'mcp-servers'
-                    last_updated: '2024-01-15T10:30:00Z'
+                  registry_available: false
+                  registry_error: 'MLflow BFF is not configured'
+                  configmap_available: false
+                  configmap_error: "ConfigMap 'gen-ai-aa-mcp-servers' not found in namespace 'opendatahub'"
+                  config_map_info: null
 
     CreateResponseResponse:
       description: Created AI response with clean LlamaStack structure

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -2017,7 +2017,9 @@ paths:
             example: 'http%3A%2F%2Flocalhost%3A9090%2Fsse'
         - name: server_name
           in: query
-          description: MCP Registry server name (e.g. com.example/kubernetes)
+          description: >-
+            MCP Registry server name (e.g. com.example/kubernetes).
+            Takes precedence over server_url when both are supplied.
           required: false
           schema:
             type: string
@@ -2077,7 +2079,9 @@ paths:
             example: 'http%3A%2F%2Flocalhost%3A9090%2Fsse'
         - name: server_name
           in: query
-          description: MCP Registry server name (e.g. com.example/kubernetes)
+          description: >-
+            MCP Registry server name (e.g. com.example/kubernetes).
+            Takes precedence over server_url when both are supplied.
           required: false
           schema:
             type: string

--- a/packages/gen-ai/bff/testdata/kubernetes-mcp-server.yaml
+++ b/packages/gen-ai/bff/testdata/kubernetes-mcp-server.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: mcp-servers
 rules:
   - apiGroups: [""]
-    resources: ["pods", "services", "endpoints", "configmaps", "secrets"]
+    resources: ["pods", "services", "endpoints", "configmaps"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "replicasets", "statefulsets"]
@@ -72,7 +72,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: server
-          image: quay.io/containers/kubernetes_mcp_server:latest
+          image: quay.io/containers/kubernetes_mcp_server:v0.0.65
           imagePullPolicy: IfNotPresent
           args:
             - "--config"

--- a/packages/gen-ai/bff/testdata/kubernetes-mcp-server.yaml
+++ b/packages/gen-ai/bff/testdata/kubernetes-mcp-server.yaml
@@ -1,0 +1,135 @@
+# Kubernetes MCP server for local dev / shared cluster.
+# Requirements: OpenShift or OCP (Route resource).
+# Apply: make deploy-k8s-mcp  OR  oc apply -f bff/testdata/kubernetes-mcp-server.yaml
+# Cleanup: oc delete namespace mcp-servers
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-servers
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-mcp-server
+  namespace: mcp-servers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8s-mcp-namespace-view
+  namespace: mcp-servers
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints", "configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8s-mcp-namespace-view-binding
+  namespace: mcp-servers
+subjects:
+  - kind: ServiceAccount
+    name: k8s-mcp-server
+    namespace: mcp-servers
+roleRef:
+  kind: Role
+  name: k8s-mcp-namespace-view
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-mcp-server
+  namespace: mcp-servers
+data:
+  config.toml: |
+    port = "8080"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-mcp-server
+  namespace: mcp-servers
+  labels:
+    app: kubernetes-mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubernetes-mcp-server
+  template:
+    metadata:
+      labels:
+        app: kubernetes-mcp-server
+    spec:
+      serviceAccountName: k8s-mcp-server
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: server
+          image: quay.io/containers/kubernetes_mcp_server:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--config"
+            - "/etc/kubernetes-mcp-server/config.toml"
+            - "--read-only"
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kubernetes-mcp-server
+      volumes:
+        - name: config
+          configMap:
+            name: kubernetes-mcp-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-mcp-server
+  namespace: mcp-servers
+  labels:
+    app: kubernetes-mcp-server
+spec:
+  selector:
+    app: kubernetes-mcp-server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kubernetes-mcp-server
+  namespace: mcp-servers
+  labels:
+    app: kubernetes-mcp-server
+spec:
+  to:
+    kind: Service
+    name: kubernetes-mcp-server
+  port:
+    targetPort: http
+  tls:
+    termination: edge

--- a/packages/gen-ai/docs/developer/BFF_OVERVIEW.md
+++ b/packages/gen-ai/docs/developer/BFF_OVERVIEW.md
@@ -47,9 +47,12 @@ The Gen AI BFF is a Go-based middleware service that sits between our React fron
 
 **Key Integration Points:**
 1. **Llama Stack** - LLM orchestration, RAG, vector stores, model inference
-2. **MaaS (Model as a Service)** - Hosted model inference, token management
-3. **Kubernetes** - CRD management (LlamaStackDistribution resources)
-4. **MCP (Model Context Protocol)** - External tool integration
+2. **MaaS (Model as a Service)** - Hosted model inference, token management (via MaaS BFF inter-BFF)
+3. **Kubernetes** - CRD management (LlamaStackDistribution resources), ConfigMap-backed MCP servers
+4. **MCP (Model Context Protocol)** - External tool integration; registry-sourced servers resolved via MLflow BFF
+5. **MLflow** - Prompts and MCP registry via local MLflow stack (`MOCK_MLFLOW_CLIENT=true` → tracking `:5001` + MLflow BFF `:4020`)
+
+For inter-BFF client patterns, service discovery, and network policy, see [docs/inter-bff-communication.md](../../../../docs/inter-bff-communication.md).
 
 ---
 
@@ -165,7 +168,9 @@ bff/
 │   │   └── maas_models.go         # MaaS operations
 │   ├── integrations/              # External service clients
 │   │   ├── llamastack/            # Llama Stack client
-│   │   ├── maas/                  # MaaS client
+│   │   ├── maas/                  # MaaS client (legacy; models/tokens use inter-BFF)
+│   │   ├── bffclient/             # Inter-BFF HTTP clients (MaaS BFF, MLflow BFF)
+│   │   ├── mlflow/                # Embedded MLflow SDK (local prompts dev)
 │   │   ├── kubernetes/            # K8s client
 │   │   └── mcp/                   # MCP client
 │   ├── models/                    # Data structures (DTOs)
@@ -622,20 +627,19 @@ make run \
 ---
 
 #### Option 3: Full Stack (Frontend + BFF)
-```bash
-# From gen-ai root directory
-cd packages/gen-ai
 
-# Start everything at once
-make dev-start
+From `packages/gen-ai`, use the Makefile targets below. Each starts the frontend dev server and Gen-AI BFF; some also start a sibling BFF or cluster port-forwards:
 
-# This starts:
-# - Frontend dev server (port 8080)
-# - BFF server (port 8043)
-# - Port forwarding to K8s services
-```
+| Target | Cluster | Sibling BFF | Typical use |
+|--------|---------|-------------|-------------|
+| `make dev-start` | Yes (port-forward) | — (MLflow if `MOCK_MLFLOW_CLIENT=true` in `.env.local`) | Day-to-day UI + BFF against real Llama Stack |
+| `make dev-start-maas` | Yes | MaaS BFF `:8081` | Models/tokens via MaaS inter-BFF |
+| `make dev-start-mock` | No | MLflow BFF `:4020` | Fully offline; full MLflow stack |
+| `make dev-start-mlflow` | Yes (port-forward) | MLflow BFF `:4020` | Full MLflow stack on a real cluster |
 
-**When to use:** Full feature development, UI integration testing
+For MaaS and MLflow BFF setup, seeding, and MCP registry env vars, see [bff/README.md → Inter-BFF Communication](../../bff/README.md#inter-bff-communication-gen-ai--maas).
+
+**When to use:** Full feature development, UI integration testing.
 
 ---
 
@@ -651,13 +655,20 @@ PATH_PREFIX=/gen-ai                # URL path prefix
 
 # External Services
 LLAMA_STACK_URL=http://...         # Llama Stack API base URL
-MAAS_URL=http://...                # MaaS API base URL
+MAAS_URL=http://...                # MaaS API base URL (legacy; models use inter-BFF)
+MLFLOW_URL=http://localhost:5001   # MLflow tracking URL (local stack when MOCK_MLFLOW_CLIENT=true)
+
+# Inter-BFF (local dev overrides — see inter-bff-communication.md)
+BFF_MAAS_DEV_URL=http://localhost:8081/api/v1
+BFF_MLFLOW_DEV_URL=http://localhost:4020/api/v1
+MOCK_BFF_CLIENTS=false             # Use mock inter-BFF clients (no second BFF process)
 
 # Mock Configuration
 MOCK_LS_CLIENT=true                # Use mock Llama Stack client
 MOCK_MAAS_CLIENT=true              # Use mock MaaS client
 MOCK_K8S_CLIENT=true               # Use mock Kubernetes client
 MOCK_MCP_CLIENT=true               # Use mock MCP client
+MOCK_MLFLOW_CLIENT=true            # Full local MLflow stack (:5001 tracking + :4020 MLflow BFF)
 
 # Authentication
 AUTH_METHOD=user_token             # disabled | user_token
@@ -719,11 +730,19 @@ GEMINI_API_KEY=<key> make llamastack-record
 - Response transformations
 - Error handling
 - Mock client behavior
+- Inter-BFF handlers via `bffclient/bffmocks/` — registry list pagination, `server_name` resolution, graceful degradation when BFF client is nil
 
 ---
 
-#### 2. **Integration Tests** 
-** Working in progress **
+#### 2. **Integration Tests**
+
+No automated integration test suite boots Gen-AI BFF + MLflow BFF + MLflow tracking end-to-end. Verify MCP registry flows manually:
+
+- Start the stack: `make dev-start-mock` (offline), `make dev-start-mlflow` (cluster), or `make dev-start` with `MOCK_MLFLOW_CLIENT=true` in `.env.local`
+- Check `GET /gen-ai/api/v1/aaa/mcps?namespace=default` returns `registry_available: true` with servers tagged `source: "registry"`
+- Verify tools/status with `server_name` (registry path); see [bff/README.md](../../bff/README.md#inter-bff-communication-gen-ai--mlflow) for curl examples and the full [smoke script gist](https://gist.github.com/Lucifergene/905504de7f4c3e85c9e43e234374e11b)
+
+Contract tests under `packages/gen-ai/contract-tests/` cover MLflow prompt inter-BFF shapes.
 
 ---
 
@@ -751,6 +770,7 @@ curl -H "Authorization: Bearer FAKE_BEARER_TOKEN" \
 - `internal/integrations/maas/maasmocks/` - MaaS mocks
 - `internal/integrations/kubernetes/k8smocks/` - K8s mocks
 - `internal/integrations/mcp/mcpmocks/` - MCP mocks
+- `internal/integrations/bffclient/bffmocks/` - Inter-BFF mocks (MaaS BFF, MLflow BFF)
 
 ---
 
@@ -869,6 +889,7 @@ make dev-start-debug
 2. **README Files**
    - Main: `packages/gen-ai/README.md`
    - BFF: `packages/gen-ai/bff/README.md`
+   - Inter-BFF (repo-wide): `docs/inter-bff-communication.md`
 
 3. **OpenAPI Documentation**
    - Spec: `packages/gen-ai/bff/openapi/src/gen-ai.yaml`
@@ -896,7 +917,7 @@ make dev-start-debug
 
 ---
 
-*Last Updated: December 2025*  
+*Last Updated: September 2026*  
 *Version: 1.0*  
 *Maintainer: Gen AI Team*
 

--- a/packages/gen-ai/docs/developer/BFF_OVERVIEW.md
+++ b/packages/gen-ai/docs/developer/BFF_OVERVIEW.md
@@ -15,6 +15,7 @@ The Gen AI BFF is a Go-based middleware service that sits between our React fron
 - **Business Logic**: Implements domain-specific operations and data transformations
 
 **Why a BFF Pattern?**
+
 - ✅ Centralized security and authentication
 - ✅ Cleaner API contracts tailored for the frontend
 - ✅ Reduced frontend complexity (no direct multi-service orchestration)
@@ -46,6 +47,7 @@ The Gen AI BFF is a Go-based middleware service that sits between our React fron
 ```
 
 **Key Integration Points:**
+
 1. **Llama Stack** - LLM orchestration, RAG, vector stores, model inference
 2. **MaaS (Model as a Service)** - Hosted model inference, token management (via MaaS BFF inter-BFF)
 3. **Kubernetes** - CRD management (LlamaStackDistribution resources), ConfigMap-backed MCP servers
@@ -59,6 +61,7 @@ For inter-BFF client patterns, service discovery, and network policy, see [docs/
 ### Technology Stack
 
 **Core Technologies:**
+
 ```go
 // Go 1.26+ (Backend)
 ├── julienschmidt/httprouter      // High-performance HTTP routing
@@ -68,11 +71,13 @@ For inter-BFF client patterns, service discovery, and network policy, see [docs/
 ```
 
 **Key Dependencies:**
+
 - **OpenAI Go SDK**: We use the official SDK to communicate with Llama Stack's OpenAI-compatible API
 - **Controller-runtime**: For Kubernetes CRD operations
 - **Envtest**: For testing with a real Kubernetes API server
 
 **Build & Development Tools:**
+
 - **Go toolchain**: fmt, vet, test
 - **golangci-lint**: Static analysis and linting
 - **Delve**: Debugging support
@@ -83,6 +88,7 @@ For inter-BFF client patterns, service discovery, and network policy, see [docs/
 ### Key Design Patterns
 
 #### 1. **Factory Pattern** (Client Creation)
+
 ```go
 // LlamaStackClientFactory creates real or mock clients
 type LlamaStackClientFactory interface {
@@ -98,6 +104,7 @@ type LlamaStackClientFactory interface {
 ---
 
 #### 2. **Repository Pattern** (Business Logic Layer)
+
 ```go
 // Domain-specific repositories encapsulate business logic
 type ModelsRepository struct {
@@ -110,6 +117,7 @@ type VectorStoresRepository struct {
 ```
 
 **Structure:**
+
 ```
 Handler → Repository → Client → External Service
 (HTTP)    (Logic)      (API)     (LlamaStack/MaaS/K8s)
@@ -120,6 +128,7 @@ Handler → Repository → Client → External Service
 ---
 
 #### 3. **Interface-Based Design** (Abstraction)
+
 ```go
 // All clients implement this interface
 type LlamaStackClientInterface interface {
@@ -130,6 +139,7 @@ type LlamaStackClientInterface interface {
 ```
 
 **Why?** Enables:
+
 - Easy mocking in tests
 - Swapping implementations without changing consumers
 - Clear contracts between layers
@@ -137,17 +147,20 @@ type LlamaStackClientInterface interface {
 ---
 
 #### 4. **Middleware Chain Pattern**
+
 ```go
 // Request flow through middleware chain
 router → authMiddleware → corsMiddleware → loggingMiddleware → handler
 ```
 
 **Middleware Stack:**
+
 1. **CORS**: Cross-origin request handling
 2. **Authentication**: Token validation (OAuth/Bearer)
-3. **Logging**: Request/response logging with slog
-4. **Recovery**: Panic recovery and error handling
-5. **Telemetry**: Metrics and tracing (future)
+3. **Namespace access**: `RequireAccessToService` SAR gate
+4. **Logging**: Request/response logging with slog
+5. **Recovery**: Panic recovery and error handling
+6. **Telemetry**: Metrics and tracing (future)
 
 ---
 
@@ -183,6 +196,7 @@ bff/
 ```
 
 **Key Points:**
+
 - **Clean architecture**: Clear separation of concerns
 - **No circular dependencies**: Layered structure (handlers → repos → clients)
 - **Testable**: Each layer can be tested independently
@@ -195,6 +209,7 @@ bff/
 ### Getting Started with Go (For Non-Go Developers)
 
 **Go is Simple by Design:**
+
 - Strong typing with excellent tooling
 - Garbage collected (no manual memory management)
 - Built-in testing framework
@@ -202,6 +217,7 @@ bff/
 - Easy to read and learn
 
 **Key Go Concepts:**
+
 ```go
 // 1. Interfaces (similar to TypeScript interfaces)
 type Reader interface {
@@ -236,6 +252,7 @@ go doSomethingAsync()
 ### Coding Standards
 
 #### 1. **Code Formatting**
+
 ```bash
 # ALWAYS format before committing
 make fmt
@@ -248,6 +265,7 @@ make fmt
 ---
 
 #### 2. **Static Analysis**
+
 ```bash
 # Check for issues
 make lint
@@ -257,6 +275,7 @@ make lint-fix
 ```
 
 **Catches:**
+
 - Unused variables/imports
 - Potential bugs
 - Performance issues
@@ -267,6 +286,7 @@ make lint-fix
 #### 3. **Naming Conventions**
 
 **Files:**
+
 ```
 lsd_models_handler.go       # Llama Stack Distribution models handler
 maas_tokens_handler.go      # MaaS tokens handler
@@ -274,6 +294,7 @@ mcp_status_handler_test.go  # Test file (always ends with _test.go)
 ```
 
 **Functions/Methods:**
+
 ```go
 // Exported (public) - starts with uppercase
 func ListModels(ctx context.Context) ([]Model, error)
@@ -283,6 +304,7 @@ func transformModelResponse(raw RawModel) Model
 ```
 
 **Constants:**
+
 ```go
 const (
     APIVersion = "v1"
@@ -293,6 +315,7 @@ const (
 ---
 
 #### 4. **Error Handling**
+
 ```go
 // ✅ GOOD: Always handle errors
 result, err := someOperation()
@@ -306,6 +329,7 @@ result, _ := someOperation()  // Don't do this!
 ```
 
 **Error Wrapping:**
+
 ```go
 // Wrap errors to add context
 return fmt.Errorf("failed to create vector store: %w", err)
@@ -319,6 +343,7 @@ if errors.Is(err, ErrNotFound) {
 ---
 
 #### 5. **Logging**
+
 ```go
 // Use structured logging with slog
 logger.Info("processing request",
@@ -338,6 +363,7 @@ logger.Error("failed to process",
 #### 6. **Testing Conventions**
 
 **Test File Structure:**
+
 ```go
 package api_test  // Note: _test package
 
@@ -365,6 +391,7 @@ func TestListModels(t *testing.T) {
 ```
 
 **Table-Driven Tests:**
+
 ```go
 func TestValidateRequest(t *testing.T) {
     tests := []struct {
@@ -395,6 +422,7 @@ func TestValidateRequest(t *testing.T) {
 #### 1. **Creating a New Endpoint**
 
 **Step 1: Define the model (DTO)**
+
 ```go
 // internal/models/my_feature.go
 package models
@@ -414,6 +442,7 @@ type MyFeatureResponse struct {
 ---
 
 **Step 2: Create the repository (business logic)**
+
 ```go
 // internal/repositories/my_feature.go
 package repositories
@@ -441,6 +470,7 @@ func (r *MyFeatureRepository) CreateFeature(ctx context.Context, req models.MyFe
 ---
 
 **Step 3: Create the handler (HTTP layer)**
+
 ```go
 // internal/api/my_feature_handler.go
 package api
@@ -470,6 +500,7 @@ func (app *App) handleCreateFeature(w http.ResponseWriter, r *http.Request) {
 ---
 
 **Step 4: Register the route**
+
 ```go
 // internal/api/app.go
 func (app *App) Routes() http.Handler {
@@ -487,6 +518,7 @@ func (app *App) Routes() http.Handler {
 ---
 
 **Step 5: Write tests**
+
 ```go
 // internal/api/my_feature_handler_test.go
 package api_test
@@ -521,6 +553,7 @@ func TestCreateFeature(t *testing.T) {
 ---
 
 **Step 6: Update OpenAPI spec**
+
 ```yaml
 # openapi/src/gen-ai.yaml
 paths:
@@ -549,6 +582,7 @@ paths:
 #### 2. **Code Review Checklist**
 
 Before submitting a PR:
+
 - [ ] Code is formatted (`make fmt`)
 - [ ] Linter passes (`make lint`)
 - [ ] Tests pass (`make test`)
@@ -567,6 +601,7 @@ Before submitting a PR:
 ### Local Development Setup
 
 #### Prerequisites
+
 ```bash
 # 1. Install Go 1.26+
 brew install go
@@ -583,6 +618,7 @@ go version  # Should show go1.26 or higher
 ### Running the BFF Locally
 
 #### Option 1: Quick Start (Most Common)
+
 ```bash
 cd packages/gen-ai/bff
 
@@ -595,6 +631,7 @@ make dev-bff-mock
 ```
 
 **What this does:**
+
 - Formats code
 - Runs linter
 - Downloads envtest binaries (for K8s testing)
@@ -606,6 +643,7 @@ make dev-bff-mock
 ---
 
 #### Option 2: With Real Services
+
 ```bash
 cd packages/gen-ai/bff
 
@@ -631,13 +669,13 @@ make run \
 From `packages/gen-ai`, use the Makefile targets below. Each starts the frontend dev server and Gen-AI BFF; some also start a sibling BFF or cluster port-forwards:
 
 | Target | Cluster | Sibling BFF | Typical use |
-|--------|---------|-------------|-------------|
+| -------- | --------- | ------------- | ------------- |
 | `make dev-start` | Yes (port-forward) | — (MLflow if `MOCK_MLFLOW_CLIENT=true` in `.env.local`) | Day-to-day UI + BFF against real Llama Stack |
 | `make dev-start-maas` | Yes | MaaS BFF `:8081` | Models/tokens via MaaS inter-BFF |
 | `make dev-start-mock` | No | MLflow BFF `:4020` | Fully offline; full MLflow stack |
 | `make dev-start-mlflow` | Yes (port-forward) | MLflow BFF `:4020` | Full MLflow stack on a real cluster |
 
-For MaaS and MLflow BFF setup, seeding, and MCP registry env vars, see [bff/README.md → Inter-BFF Communication](../../bff/README.md#inter-bff-communication-gen-ai--maas).
+For MaaS and MLflow BFF setup, seeding, and MCP registry env vars, see the [MaaS](../../bff/README.md#inter-bff-communication-gen-ai--maas) and [MLflow](../../bff/README.md#inter-bff-communication-gen-ai--mlflow) sections.
 
 **When to use:** Full feature development, UI integration testing.
 
@@ -646,6 +684,7 @@ For MaaS and MLflow BFF setup, seeding, and MCP registry env vars, see [bff/READ
 ### Configuration Options
 
 **All environment variables / flags:**
+
 ```bash
 # Server Configuration
 PORT=8080                          # BFF server port
@@ -691,6 +730,7 @@ INSECURE_SKIP_VERIFY=false         # Skip TLS verification (dev only!)
 ### Testing Strategy
 
 #### 1. **Unit Tests** (Recommended: >80% coverage)
+
 ```bash
 # Run all tests
 make test
@@ -713,6 +753,7 @@ go tool cover -html=coverage.out
 > `go test ./...` — the Makefile sets required environment variables.
 
 **Llama Stack Test Server:**
+
 ```bash
 # Start Llama Stack locally in replay mode (for manual debugging)
 make llamastack-up
@@ -725,6 +766,7 @@ GEMINI_API_KEY=<key> make llamastack-record
 ```
 
 **What we test:**
+
 - Repository business logic
 - Request validation
 - Response transformations
@@ -749,12 +791,14 @@ Contract tests under `packages/gen-ai/contract-tests/` cover MLflow prompt inter
 #### 3. **Mock Testing**
 
 **Why Mock?**
+
 - Fast (no network calls)
 - Reliable (no external dependencies)
 - Comprehensive (test edge cases)
 - Offline development
 
 **Mock Tokens:**
+
 ```bash
 # Use this token with mock clients
 export TOKEN="FAKE_BEARER_TOKEN"
@@ -765,6 +809,7 @@ curl -H "Authorization: Bearer FAKE_BEARER_TOKEN" \
 ```
 
 **Mock Data Locations:**
+
 - `internal/integrations/llamastack/lsmocks/` - Llama Stack mocks
 - `testdata/llamastack/recordings/` - Pre-recorded Llama Stack API responses (replay mode)
 - `internal/integrations/maas/maasmocks/` - MaaS mocks
@@ -777,6 +822,7 @@ curl -H "Authorization: Bearer FAKE_BEARER_TOKEN" \
 #### 4. **Manual API Testing**
 
 **Using curl:**
+
 ```bash
 # Get models
 curl -i -H "Authorization: Bearer $TOKEN" \
@@ -806,6 +852,7 @@ curl -i -H "Authorization: Bearer $TOKEN" \
 ```
 
 **Using Swagger UI:**
+
 ```bash
 # Start BFF
 make run
@@ -821,6 +868,7 @@ http://localhost:8080/gen-ai/swagger-ui/
 ### Debugging
 
 #### 1. **Basic Logging**
+
 ```bash
 # Run with debug logging
 make run LOG_LEVEL=debug
@@ -834,6 +882,7 @@ make run LOG_LEVEL=debug 2>&1 | grep -i error
 #### 2. **VSCode Debugging** (Recommended!)
 
 **Step 1: Add debug configuration**
+
 ```json
 // .vscode/launch.json
 {
@@ -855,23 +904,27 @@ make run LOG_LEVEL=debug 2>&1 | grep -i error
 ```
 
 **Step 2: Install Delve**
+
 ```bash
 go install github.com/go-delve/delve/cmd/dlv@latest
 ```
 
 **Step 3: Start debug session**
+
 ```bash
 cd packages/gen-ai
 make dev-start-debug
 ```
 
 **Step 4: Attach debugger**
+
 - Open VSCode
 - Go to "Run and Debug" (Cmd+Shift+D)
 - Select "Attach to Delve"
 - Press F5
 
 **Now you can:**
+
 - Set breakpoints
 - Step through code
 - Inspect variables
@@ -882,6 +935,7 @@ make dev-start-debug
 ## 📚 Additional Resources
 
 ### Essential Reading
+
 1. **Architecture Decision Records** (`docs/adr/`)
    - ADR-0002: System Architecture
    - ADR-0003: Core User Flows
@@ -893,22 +947,25 @@ make dev-start-debug
 
 3. **OpenAPI Documentation**
    - Spec: `packages/gen-ai/bff/openapi/src/gen-ai.yaml`
-   - Live UI: http://localhost:8080/gen-ai/swagger-ui/
+   - Live UI: <http://localhost:8080/gen-ai/swagger-ui/>
 
 ### Go Learning Resources
+
 - [Go Tour](https://go.dev/tour/) - Interactive tutorial
 - [Effective Go](https://go.dev/doc/effective_go) - Best practices
 - [Go by Example](https://gobyexample.com/) - Practical examples
 
 ### Project-Specific
-- Llama Stack: https://llama-stack.readthedocs.io/
-- OpenAI API: https://platform.openai.com/docs/api-reference
-- Kubernetes Client-Go: https://github.com/kubernetes/client-go
-- Controller Runtime: https://book.kubebuilder.io/
+
+- Llama Stack: <https://llama-stack.readthedocs.io/>
+- OpenAI API: <https://platform.openai.com/docs/api-reference>
+- Kubernetes Client-Go: <https://github.com/kubernetes/client-go>
+- Controller Runtime: <https://book.kubebuilder.io/>
 
 ---
 
 **Key Takeaways:**
+
 1. BFF is the bridge between frontend and AI services
 2. Mock clients make development easy and fast
 3. Follow the patterns in the codebase
@@ -920,4 +977,3 @@ make dev-start-debug
 *Last Updated: September 2026*  
 *Version: 1.0*  
 *Maintainer: Gen AI Team*
-


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-89894

## Summary

This PR delivers two related pieces of work for [RHAISTRAT-1678](https://redhat.atlassian.net/browse/RHAISTRAT-1678):

1. **MCP Registry BFF integration** — Gen-AI BFF merges MLflow MCP Registry servers with ConfigMap-backed servers and exposes registry-aware tools/status routing.
2. **Local MLflow dev stack** — `MOCK_MLFLOW_CLIENT=true` always starts the full local MLflow stack (tracking `:5001` + MLflow BFF `:4020`), with idempotent prompt and MCP registry seeding.

---

## Review fixes (ikeola13 + CodeRabbit)

Addressed in `1adc0092a`:

**Seeding & reconciliation**
- `SeedPrompts` and `SeedMCPRegistry` now loop `devMLflowWorkspaces()` — seeds `default` + `PLAYGROUND_NAMESPACE` with per-workspace `X-MLFLOW-WORKSPACE` header
- Partial-heal reconciliation: parent/version/endpoint checked independently on restart (interrupted seeding is healed, not skipped forever)
- Renamed mock vs real seed helpers (`seedMockBraveDraftMCPServer`, `seedMockGitHubMCPServer`, `seedRealMCPServer`)

**Auth & registry hardening**
- `RequireAccessToService` SAR gate on `/aaa/mcps`, `/mcp/tools`, `/mcp/status`
- Registry-only `server_name` path defers K8s client creation (no cluster needed for tools/status via MLflow BFF)
- `ErrInvalidRegistryServerName` sentinel + `AccessEndpoints[0]` guard in list mapping
- `configmap_error` fallback redacts raw K8s internals (logged server-side only)

**Dev / testdata**
- `kubernetes-mcp-server.yaml`: removed `secrets` from Role; pinned image to `v0.0.65`
- `deploy-k8s-mcp` / README: replaced `INSECURE_SKIP_VERIFY=true` setup hint with trusted Route CA / `BUNDLE_PATHS` note
- Makefile curl timeouts + quoted vars in `mlflow-seed` probe

**CI unit tests (no live MLflow required)**
- `TestDevMLflowWorkspaces`, `TestMCPSeedReconciliation`, `TestFriendlyConfigMapError`

---

## API contract changes (UI follow-up)

### `GET /gen-ai/api/v1/aaa/mcps?namespace={ns}`

**Behavior change:** Always returns **HTTP 200** with graceful degradation. Previously returned 404 when the ConfigMap was missing.

**Auth:** Requires namespace SAR (`RequireAccessToService`).

**New required fields on `data`:**

| Field | Type | Description |
|-------|------|-------------|
| `registry_available` | `boolean` | MLflow MCP Registry was reachable via MLflow BFF |
| `configmap_available` | `boolean` | MCP servers ConfigMap was readable |
| `registry_error` | `string?` | Present when `registry_available: false` |
| `configmap_error` | `string?` | Present when `configmap_available: false` — user-safe message only (no raw K8s paths/SAs) |

**`config_map_info`:** Now **nullable** (`null` when `configmap_available: false`).

**New required fields on each `servers[]` entry (`MCPServerSummary`):**

| Field | Type | Description |
|-------|------|-------------|
| `source` | `"registry"` \| `"configmap"` | Origin of the server row |
| `tools` | `MCPServerToolSummary[]` | Registry metadata tools (empty for ConfigMap rows) |
| `tool_count` | `number` | Tool count from registry metadata |
| `version` | `string?` | Registry version (omitted/empty for ConfigMap) |

**Merge rules:**
- Fetches ConfigMap + MLflow registry **in parallel**
- URL dedup: registry entry wins when the same endpoint URL appears in both sources
- Draft registry servers (e.g. `com.brave.example/brave`) are **excluded** from the list

---

### `GET /gen-ai/api/v1/mcp/tools?namespace={ns}`

**New query param:** `server_name` (registry server name, e.g. `com.example/kubernetes`)

| Param | When to use |
|-------|-------------|
| `server_url` | ConfigMap-backed servers (`source: "configmap"`) |
| `server_name` | Registry-backed servers (`source: "registry"`) — resolves via MLflow BFF only, no cluster connectivity required |

- Exactly one of `server_url` or `server_name` is required (400 if both missing)
- `server_name` takes priority when both are provided
- `server_name` is path-segment encoded per `/` (e.g. `com.example%2Fkubernetes`)
- Malformed `server_name` (empty path segment, e.g. `foo//bar`) → 400
- Requires namespace SAR (`RequireAccessToService`)

---

### `GET /gen-ai/api/v1/mcp/status?namespace={ns}`

Same `server_name` / `server_url` contract as `/mcp/tools` above (including precedence, validation, and SAR gate).

---

### Example list response (registry + ConfigMap)

```json
{
  "data": {
    "servers": [
      {
        "name": "io.github.example/github",
        "url": "https://github-mcp.example.com/mcp",
        "transport": "streamable-http",
        "description": "GitHub MCP server",
        "logo": null,
        "status": "healthy",
        "source": "registry",
        "version": "1.0.0",
        "tools": [],
        "tool_count": 0
      },
      {
        "name": "kubernetes",
        "url": "http://localhost:9091/mcp",
        "transport": "streamable-http",
        "description": "Manage resources in a Kubernetes cluster.",
        "logo": null,
        "status": "healthy",
        "source": "configmap",
        "tools": [],
        "tool_count": 0
      }
    ],
    "total_count": 2,
    "registry_available": true,
    "configmap_available": true,
    "config_map_info": { "name": "...", "namespace": "...", "last_updated": "..." }
  }
}
```

OpenAPI: [`packages/gen-ai/bff/openapi/src/gen-ai.yaml`](packages/gen-ai/bff/openapi/src/gen-ai.yaml)

---

## Local dev changes

`MOCK_MLFLOW_CLIENT=true` → **full MLflow stack** :

| Command | MLflow |
|---------|--------|
| `make dev-start` (no flag) | Off |
| `make dev-start` + `MOCK_MLFLOW_CLIENT=true` in `.env.local` | Full stack |
| `make dev-start-mock` | Full stack (hardcoded) |
| `make dev-start-mlflow` | Full stack (hardcoded) |

**New targets:**
- `make deploy-k8s-mcp` — deploy Kubernetes MCP server to cluster; prints `KUBERNETES_MCP_SERVER_URL` and trusted CA / `BUNDLE_PATHS` note (not `INSECURE_SKIP_VERIFY`)
- `make dev-start-mlflow` — MLflow BFF + gen-ai BFF + frontend (cluster + MCP registry)

**Seeding (idempotent + partial-heal on BFF startup when `MOCK_MLFLOW_CLIENT=true`):**
- Sample prompts and MCP registry rows seeded to **`default` + `PLAYGROUND_NAMESPACE`** workspaces
- MCP registry: `com.brave.example/brave` (draft, filtered from list), `io.github.example/github` (mock/fake endpoint), optional `com.example/kubernetes` when `KUBERNETES_MCP_SERVER_URL` is set (real cluster URL)

---

## How Has This Been Tested?

### Unit tests
```bash
cd packages/gen-ai/bff && make lint && make test
```

New CI-runnable tests (no live MLflow): `TestDevMLflowWorkspaces`, `TestMCPSeedReconciliation`, `TestFriendlyConfigMapError`

### API smoke tests (gist)
Script: https://gist.github.com/Lucifergene/905504de7f4c3e85c9e43e234374e11b

**Prerequisites:** `oc login`, dev stack running from `packages/gen-ai`

```bash
# Recommended — real MCP client (MOCK_MCP_CLIENT=false)
make dev-start-mlflow

# Run smoke tests
curl -sL https://gist.githubusercontent.com/Lucifergene/905504de7f4c3e85c9e43e234374e11b/raw/test-mcp-registry-api.sh \
  | bash -s --
```

**Env overrides:**
```bash
GENAI_BFF_BASE=http://localhost:8080/gen-ai/api/v1   # default
NAMESPACE=default                                     # or PLAYGROUND_NAMESPACE from .env.local
TOKEN=$(oc whoami -t)                                 # required for auth-gate tests (4a–4c)
PLAYGROUND_NAMESPACE=your-ns                          # optional; enables workspace seeding test 5a
```

**Verified results:**
| Stack | Gist result |
|-------|-------------|
| `dev-bff-mlflow` (real MCP + cluster) | **27 passed, 0 failed** (with `NAMESPACE=default`, `PLAYGROUND_NAMESPACE=<ns>`) |
| `dev-bff-mlflow` | **26 passed, 0 failed** (when `NAMESPACE` == `PLAYGROUND_NAMESPACE`; 5a skipped) |

Gist covers: list/tools/status happy paths, auth gate (4a–4c), `configmap_error` redaction (1c-redact), `server_name` precedence (2g, 3g), malformed `server_name` → 400 (2h, 3h), multi-workspace seeding (5a).

### Manual
- `make deploy-k8s-mcp` → add `KUBERNETES_MCP_SERVER_URL` to `.env.local` → `make dev-start` → registry servers visible at `http://localhost:5001/#/mcp-registry?workspace=<PLAYGROUND_NAMESPACE>`

---

## Request review criteria

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

[RHAISTRAT-1678]: https://redhat.atlassian.net/browse/RHAISTRAT-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MLflow MCP Registry support with server names, versions, tools, and metadata.
  * MCP tools and status requests can resolve servers by name or URL.
  * MCP server listings now combine registry and ConfigMap sources.
  * Added local MLflow workspace support with prompt and MCP registry seeding.

* **Bug Fixes**
  * Improved resilience when either server source is unavailable, with clear status and error details.
  * Prevented duplicate prompt seeding during restarts.

* **Documentation**
  * Added local MLflow and optional Kubernetes MCP deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
