### PR TITLE
test(RHOAIENG-71417): Fix flaky MCP deployment test

### DIFF
--- a/packages/cypress/cypress/pages/mcpDeployments.ts
+++ b/packages/cypress/cypress/pages/mcpDeployments.ts
@@ -227,6 +227,13 @@ class McpServerDetailsPage {
     return cy.findByTestId('mcp-deploy-button');
   }
 
+  clickDeployButton() {
+    return this.findDeployButton()
+      .should('be.visible')
+      .and('not.have.attr', 'aria-disabled', 'true')
+      .click();
+  }
+
   findBreadcrumbServerName(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('breadcrumb-server-name');
   }

--- a/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
@@ -627,7 +627,7 @@ describe('MCP Deploy from Catalog', () => {
 
     cy.visitWithLogin(`/ai-hub/mcp-servers/catalog/${TEST_SERVER_ID}`);
 
-    mcpServerDetailsPage.findDeployButton().click();
+    mcpServerDetailsPage.clickDeployButton();
     cy.wait('@getConverter');
     mcpDeployModal.shouldBeOpen();
     mcpDeployModal.findCloseButton().click();
@@ -647,7 +647,7 @@ describe('MCP Deploy from Catalog', () => {
     ).as('getConverterSlow');
 
     cy.visitWithLogin(`/ai-hub/mcp-servers/catalog/${TEST_SERVER_ID}`);
-    mcpServerDetailsPage.findDeployButton().click();
+    mcpServerDetailsPage.clickDeployButton();
 
     mcpDeployModal.shouldBeOpen();
     mcpDeployModal.findLoadingSpinner().should('exist');
@@ -661,7 +661,7 @@ describe('MCP Deploy from Catalog', () => {
     }).as('getConverterError');
 
     cy.visitWithLogin(`/ai-hub/mcp-servers/catalog/${TEST_SERVER_ID}`);
-    mcpServerDetailsPage.findDeployButton().click();
+    mcpServerDetailsPage.clickDeployButton();
 
     cy.wait('@getConverterError');
     mcpDeployModal.shouldBeOpen();
@@ -679,7 +679,7 @@ describe('MCP Deploy from Catalog', () => {
     }).as('createDeployment');
 
     cy.visitWithLogin(`/ai-hub/mcp-servers/catalog/${TEST_SERVER_ID}`);
-    mcpServerDetailsPage.findDeployButton().click();
+    mcpServerDetailsPage.clickDeployButton();
     cy.wait('@getConverter');
     mcpDeployModal.shouldBeOpen();
     mcpDeployModal.findSubmitButton().should('be.disabled');
@@ -704,7 +704,7 @@ describe('MCP Deploy from Catalog', () => {
     }).as('createDeployment');
 
     cy.visitWithLogin(`/ai-hub/mcp-servers/catalog/${TEST_SERVER_ID}`);
-    mcpServerDetailsPage.findDeployButton().click();
+    mcpServerDetailsPage.clickDeployButton();
     cy.wait('@getConverter');
     mcpDeployModal.shouldBeOpen();
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-71417

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix an issue with flaky test of the MCP Deployment

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Making sure the button is clickable solved this test(at least locally after more than 20 runs no run failed)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Stop the flaky behaviour in the MCPDeployment tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test coverage for deploying MCP servers from the catalog.
  * Tests now verify that the deploy button is visible and enabled before clicking.
  * No user-facing behavior or test expectations changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->