### PR TITLE
Fix(RHOAIENG-90194): use in-cluster Service URL for MCP server E2E test

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -342,11 +342,10 @@ export const removeMCPServerConfigMapEntry = (configMapName: string, serverKey: 
  * and adds the Deployment, Service, and Route on top.
  * Idempotent — skips resources that already exist.
  *
- * The Route is ephemeral test infrastructure (torn down in after()) and uses
- * edge TLS + read-only mode. It is needed because the BFF may run outside the
- * cluster (local dev) and cannot reach in-cluster Service DNS.
- *
- * Returns the Route URL with `/mcp` suffix.
+ * Returns the in-cluster Service URL with `/mcp` suffix. The Route is still
+ * created (for manual debugging) but the Service URL is used for the test
+ * to avoid TLS failures on clusters where the ingress CA is not in the
+ * BFF's trusted CA bundle.
  */
 export const deployMCPServer = (
   mcpNamespace: string,
@@ -379,14 +378,9 @@ export const deployMCPServer = (
     timeout: 130000,
   });
 
-  return cy
-    .exec(`oc get route ${name} -n ${mcpNamespace} -o jsonpath='{.spec.host}'`)
-    .then((result) => {
-      const host = result.stdout.trim().replace(/^'|'$/g, '');
-      const url = `https://${host}/mcp`;
-      cy.log(`MCP server URL: ${url}`);
-      return cy.wrap(url);
-    });
+  const url = `http://${name}.${mcpNamespace}.svc.cluster.local:8080/mcp`;
+  cy.log(`MCP server URL: ${url}`);
+  return cy.wrap(url);
 };
 
 /**


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-90194

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix([RHOAIENG-90194](https://redhat.atlassian.net/browse/RHOAIENG-90194)): use in-cluster Service URL for MCP server E2E test
The MCP test was failing on connected clusters where the BFF pod's trusted CA bundle did not include the ingress controller CA, causing x509 TLS verification errors when connecting via the OpenShift Route. Switch to the in-cluster Service URL (HTTP) which bypasses TLS and works regardless of cluster CA configuration.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
in jenkins

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-90194]: https://redhat.atlassian.net/browse/RHOAIENG-90194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server connectivity in automated environments by using the internal service URL.
  * Prevented TLS-related connection failures caused by unavailable ingress certificate authorities.
  * Retained the external route for manual debugging and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->