### PR TITLE
Add nim storage pvc context type

### DIFF
--- a/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
@@ -10,6 +10,7 @@ import StorageTableRow from './StorageTableRow';
 import { columns } from './data';
 import { StorageTableData } from './types';
 import ClusterStorageModal from './ClusterStorageModal';
+import { useStorageContextType } from './useStorageContextType';
 
 type StorageTableProps = {
   pvcs: PersistentVolumeClaimKind[];
@@ -22,6 +23,7 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
   const [editPVC, setEditPVC] = React.useState<PersistentVolumeClaimKind | undefined>();
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
   const [storageClasses, storageClassesLoaded] = useStorageClasses();
+  const [storageContextTypes, storageContextTypesLoaded] = useStorageContextType();
   const [alertDismissed, setAlertDismissed] = React.useState<boolean>(false);
   const storageTableData: StorageTableData[] = pvcs.map((pvc) => ({
     pvc,
@@ -40,10 +42,10 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
   const workbenchEnabled = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
 
   const getStorageColumns = () => {
-    let storageColumns = columns;
+    let storageColumns = columns({ storageContextTypes });
 
     if (!isStorageClassesAvailable) {
-      storageColumns = columns.filter((column) => column.field !== 'storage');
+      storageColumns = storageColumns.filter((column) => column.field !== 'storage');
     }
 
     if (!workbenchEnabled) {
@@ -83,6 +85,8 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
             key={data.pvc.metadata.uid}
             rowIndex={i}
             obj={data}
+            storageContextTypes={storageContextTypes}
+            storageContextTypesLoaded={storageContextTypesLoaded}
             storageClassesLoaded={storageClassesLoaded}
             onEditPVC={setEditPVC}
             onDeletePVC={setDeleteStorage}

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -25,11 +25,13 @@ import ConnectedResources from '#~/pages/projects/screens/detail/connections/Con
 import useIsRootVolume from './useIsRootVolume';
 import StorageWarningStatus from './StorageWarningStatus';
 import { StorageTableData } from './types';
-import { isModelStorage } from './utils';
+import { getPVCContextStorageType, StorageContextType } from './useStorageContextType';
 
 type StorageTableRowProps = {
   rowIndex: number;
   obj: StorageTableData;
+  storageContextTypes?: StorageContextType[];
+  storageContextTypesLoaded: boolean;
   storageClassesLoaded: boolean;
   onDeletePVC: (pvc: PersistentVolumeClaimKind) => void;
   onEditPVC: (pvc: PersistentVolumeClaimKind) => void;
@@ -39,6 +41,8 @@ type StorageTableRowProps = {
 const StorageTableRow: React.FC<StorageTableRowProps> = ({
   rowIndex,
   obj,
+  storageContextTypes,
+  storageContextTypesLoaded,
   storageClassesLoaded,
   onDeletePVC,
   onEditPVC,
@@ -48,7 +52,6 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
   const workbenchEnabled = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
   const storageClassConfig = obj.storageClass && getStorageClassConfig(obj.storageClass);
-  const modelStorage = isModelStorage(obj.pvc);
   const actions: IAction[] = [
     {
       title: <span data-testid="edit-storage-action">Edit storage</span>,
@@ -149,14 +152,20 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
         </Content>
       </Td>
       <Td dataLabel="Storage context">
-        <Content component="p">
-          <Flex>
-            <FlexItem spacer={{ default: 'spacerSm' }}>
-              <HddIcon />
-            </FlexItem>
-            <FlexItem>{` ${modelStorage ? 'Model storage' : 'General purpose'}`}</FlexItem>
-          </Flex>
-        </Content>
+        {storageContextTypesLoaded ? (
+          <Content component="p">
+            <Flex>
+              <FlexItem spacer={{ default: 'spacerSm' }}>
+                <HddIcon />
+              </FlexItem>
+              <FlexItem>{` ${
+                getPVCContextStorageType(obj.pvc, storageContextTypes).title
+              }`}</FlexItem>
+            </Flex>
+          </Content>
+        ) : (
+          <Skeleton />
+        )}
       </Td>
       <Td dataLabel="Storage size">
         <StorageSizeBar pvc={obj.pvc} />

--- a/frontend/src/pages/projects/screens/detail/storage/__tests__/useStorageContextType.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/__tests__/useStorageContextType.spec.ts
@@ -1,0 +1,114 @@
+import type { LoadedExtension, ResolvedExtension } from '@openshift/dynamic-plugin-sdk';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import type { ClusterStorageContextExtension } from '@odh-dashboard/plugin-core/extension-points';
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
+import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
+import { PvcModelAnnotation } from '#~/pages/projects/screens/spawner/storage/types';
+import {
+  GENERAL_PURPOSE_PVC_CONTEXT_TYPE,
+  MODEL_STORAGE_PVC_CONTEXT_TYPE,
+  StorageContextType,
+  getContextStorageTypeExplanation,
+  getPVCContextStorageType,
+  useStorageContextType,
+} from '#~/pages/projects/screens/detail/storage/useStorageContextType';
+
+jest.mock('@odh-dashboard/plugin-core', () => ({
+  useResolvedExtensions: jest.fn(),
+}));
+
+const mockUseResolvedExtensions = jest.mocked(useResolvedExtensions);
+
+const makeExtension = (
+  title: string,
+  isPVCUsingStorageContextType: (pvc: PersistentVolumeClaimKind) => boolean = () => false,
+): LoadedExtension<ResolvedExtension<ClusterStorageContextExtension>> => ({
+  type: 'app.cluster-storage/storage-context',
+  uid: `ext-${title}`,
+  pluginName: 'test',
+  properties: { title, description: `${title} desc`, isPVCUsingStorageContextType },
+});
+
+const modelPVC = mockPVCK8sResource({
+  annotations: { [PvcModelAnnotation.MODEL_NAME]: 'my-model' },
+});
+const plainPVC = mockPVCK8sResource({});
+
+describe('useStorageContextType', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the two built-in types when there are no extensions', () => {
+    mockUseResolvedExtensions.mockReturnValue([[], true, []]);
+
+    const renderResult = testHook(useStorageContextType)();
+
+    expect(renderResult).hookToStrictEqual([
+      [GENERAL_PURPOSE_PVC_CONTEXT_TYPE, MODEL_STORAGE_PVC_CONTEXT_TYPE],
+      true,
+    ]);
+  });
+
+  it('should propagate the loaded flag', () => {
+    mockUseResolvedExtensions.mockReturnValue([[], false, []]);
+
+    const renderResult = testHook(useStorageContextType)();
+
+    expect(renderResult.result.current[1]).toBe(false);
+  });
+
+  it('should append extension types sorted by title after the built-ins', () => {
+    mockUseResolvedExtensions.mockReturnValue([
+      [makeExtension('Zebra'), makeExtension('Alpha')],
+      true,
+      [],
+    ]);
+
+    const [types] = testHook(useStorageContextType)().result.current;
+
+    expect(types.map((t) => t.title)).toEqual([
+      GENERAL_PURPOSE_PVC_CONTEXT_TYPE.title,
+      MODEL_STORAGE_PVC_CONTEXT_TYPE.title,
+      'Alpha',
+      'Zebra',
+    ]);
+  });
+});
+
+describe('getPVCContextStorageType', () => {
+  const types: StorageContextType[] = [
+    GENERAL_PURPOSE_PVC_CONTEXT_TYPE,
+    MODEL_STORAGE_PVC_CONTEXT_TYPE,
+  ];
+
+  it('should return the matching type for a model PVC', () => {
+    expect(getPVCContextStorageType(modelPVC, types)).toBe(MODEL_STORAGE_PVC_CONTEXT_TYPE);
+  });
+
+  it('should fall back to general purpose when nothing matches', () => {
+    expect(getPVCContextStorageType(plainPVC, types)).toBe(GENERAL_PURPOSE_PVC_CONTEXT_TYPE);
+  });
+
+  it('should fall back to general purpose when no types are provided', () => {
+    expect(getPVCContextStorageType(modelPVC)).toBe(GENERAL_PURPOSE_PVC_CONTEXT_TYPE);
+  });
+});
+
+describe('getContextStorageTypeExplanation', () => {
+  it('should list a single type', () => {
+    expect(getContextStorageTypeExplanation([GENERAL_PURPOSE_PVC_CONTEXT_TYPE])).toBe(
+      'The context indicates the purpose of the storage: general purpose.',
+    );
+  });
+
+  it('should join multiple types with a disjunction', () => {
+    expect(
+      getContextStorageTypeExplanation([
+        GENERAL_PURPOSE_PVC_CONTEXT_TYPE,
+        MODEL_STORAGE_PVC_CONTEXT_TYPE,
+      ]),
+    ).toBe('The context indicates the purpose of the storage: general purpose or model storage.');
+  });
+});

--- a/frontend/src/pages/projects/screens/detail/storage/data.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/data.ts
@@ -3,8 +3,11 @@ import { getDisplayNameFromK8sResource, getPvcAccessMode } from '@odh-dashboard/
 import { getStorageClassConfig } from '#~/pages/storageClasses/utils';
 import { getAccessModePopover } from '#~/pages/projects/screens/spawner/storage/getAccessModePopover';
 import { StorageTableData } from './types';
+import { getContextStorageTypeExplantation, StorageContextType } from './useStorageContextType';
 
-export const columns: SortableData<StorageTableData>[] = [
+export const columns = (data: {
+  storageContextTypes: StorageContextType[];
+}): SortableData<StorageTableData>[] => [
   {
     field: 'name',
     label: 'Name',
@@ -45,8 +48,7 @@ export const columns: SortableData<StorageTableData>[] = [
     width: 15,
     sortable: false,
     info: {
-      popover:
-        'The context indicates the purpose of the storage: general purpose, or model storage.',
+      popover: getContextStorageTypeExplantation(data.storageContextTypes),
       popoverProps: {
         showClose: true,
       },

--- a/frontend/src/pages/projects/screens/detail/storage/data.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/data.ts
@@ -3,7 +3,7 @@ import { getDisplayNameFromK8sResource, getPvcAccessMode } from '@odh-dashboard/
 import { getStorageClassConfig } from '#~/pages/storageClasses/utils';
 import { getAccessModePopover } from '#~/pages/projects/screens/spawner/storage/getAccessModePopover';
 import { StorageTableData } from './types';
-import { getContextStorageTypeExplantation, StorageContextType } from './useStorageContextType';
+import { getContextStorageTypeExplanation, StorageContextType } from './useStorageContextType';
 
 export const columns = (data: {
   storageContextTypes: StorageContextType[];
@@ -48,7 +48,7 @@ export const columns = (data: {
     width: 15,
     sortable: false,
     info: {
-      popover: getContextStorageTypeExplantation(data.storageContextTypes),
+      popover: getContextStorageTypeExplanation(data.storageContextTypes),
       popoverProps: {
         showClose: true,
       },

--- a/frontend/src/pages/projects/screens/detail/storage/useStorageContextType.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/useStorageContextType.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { EitherNotBoth } from '@odh-dashboard/foundation';
+import { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import {
+  ClusterStorageContextExtension,
+  isClusterStorageContextExtension,
+} from '@odh-dashboard/plugin-core/extension-points';
+import { isModelStorage } from './utils';
+
+export type StorageContextType = {
+  title: string;
+  description?: string;
+} & EitherNotBoth<
+  { isPVCUsingStorageContextType: (pvc: PersistentVolumeClaimKind) => boolean },
+  { isDefaultType: boolean }
+>;
+
+export const GENERAL_PURPOSE_PVC_CONTEXT_TYPE: StorageContextType = {
+  title: 'General purpose',
+  description: 'Appropriate for all use cases.',
+  isDefaultType: true,
+};
+
+export const MODEL_STORAGE_PVC_CONTEXT_TYPE: StorageContextType = {
+  title: 'Model storage',
+  description: 'Appropriate for model storage. Enables you to define the model name and path.',
+  isPVCUsingStorageContextType: isModelStorage,
+};
+
+export const useStorageContextType = (): [
+  storageContextTypes: StorageContextType[],
+  loaded: boolean,
+] => {
+  const [extensions, loaded] = useResolvedExtensions<ClusterStorageContextExtension>(
+    isClusterStorageContextExtension,
+  );
+
+  const storageContextTypes = React.useMemo(
+    () => [
+      GENERAL_PURPOSE_PVC_CONTEXT_TYPE,
+      MODEL_STORAGE_PVC_CONTEXT_TYPE,
+      ...extensions
+        .map(
+          ({ properties }): StorageContextType => ({
+            title: properties.title,
+            description: properties.description,
+            isPVCUsingStorageContextType: properties.isPVCUsingStorageContextType,
+          }),
+        )
+        .toSorted((a, b) => a.title.localeCompare(b.title)),
+    ],
+    [extensions],
+  );
+
+  return [storageContextTypes, loaded];
+};
+
+export const getPVCContextStorageType = (
+  pvc: PersistentVolumeClaimKind,
+  types?: StorageContextType[],
+): StorageContextType => {
+  for (const context of types ?? []) {
+    if (context.isPVCUsingStorageContextType?.(pvc)) {
+      return context;
+    }
+  }
+
+  return GENERAL_PURPOSE_PVC_CONTEXT_TYPE;
+};
+
+export const getContextStorageTypeExplantation = (types: StorageContextType[]): string =>
+  `The context indicates the purpose of the storage: ${new Intl.ListFormat('en', {
+    type: 'disjunction',
+  }).format(types.map((value) => value.title.toLocaleLowerCase()))}.`;

--- a/frontend/src/pages/projects/screens/detail/storage/useStorageContextType.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/useStorageContextType.tsx
@@ -69,7 +69,7 @@ export const getPVCContextStorageType = (
   return GENERAL_PURPOSE_PVC_CONTEXT_TYPE;
 };
 
-export const getContextStorageTypeExplantation = (types: StorageContextType[]): string =>
+export const getContextStorageTypeExplanation = (types: StorageContextType[]): string =>
   `The context indicates the purpose of the storage: ${new Intl.ListFormat('en', {
     type: 'disjunction',
   }).format(types.map((value) => value.title.toLocaleLowerCase()))}.`;

--- a/frontend/src/pages/projects/screens/spawner/storage/PVCContextField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/PVCContextField.tsx
@@ -9,6 +9,10 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import FieldGroupHelpLabelIcon from '@odh-dashboard/ui-core/components/FieldGroupHelpLabelIcon';
+import {
+  GENERAL_PURPOSE_PVC_CONTEXT_TYPE,
+  MODEL_STORAGE_PVC_CONTEXT_TYPE,
+} from '#~/pages/projects/screens/detail/storage/useStorageContextType';
 
 type PVCContextFieldProps = {
   setModelName: (name: string) => void;
@@ -59,14 +63,14 @@ const PVCContextField: React.FC<PVCContextFieldProps> = ({
           name="storage-context-general-radio"
           id="storage-context-general-radio"
           data-testid="general-purpose-radio"
-          label="General purpose"
+          label={GENERAL_PURPOSE_PVC_CONTEXT_TYPE.title}
           isChecked={isGeneralPurpose}
           onChange={() => {
             setIsGeneralPurpose(true);
             setValid(true);
             removeModelAnnotations();
           }}
-          description="Appropriate for all use cases."
+          description={GENERAL_PURPOSE_PVC_CONTEXT_TYPE.description}
         />
         <br />
         <Radio
@@ -74,7 +78,7 @@ const PVCContextField: React.FC<PVCContextFieldProps> = ({
           name="storage-context-model-storage-radio"
           id="storage-context-model-storage-radio"
           data-testid="model-storage-radio"
-          label="Model storage"
+          label={MODEL_STORAGE_PVC_CONTEXT_TYPE.title}
           isChecked={!isGeneralPurpose}
           onChange={() => {
             setIsGeneralPurpose(false);
@@ -84,7 +88,7 @@ const PVCContextField: React.FC<PVCContextFieldProps> = ({
               validatePath(modelPath);
             }
           }}
-          description="Appropriate for model storage. Enables you to define the model name and path."
+          description={MODEL_STORAGE_PVC_CONTEXT_TYPE.description}
           body={
             !isGeneralPurpose && (
               <FormSection title="Model details">

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
@@ -453,7 +453,7 @@ describe('ClusterStorage', () => {
     const clusterStorageRow = clusterStorage.getClusterStorageRow('Test Storage');
     clusterStorageRow.findStorageClassColumn().should('not.exist');
     clusterStorageRow.shouldHaveStorageTypeValue('General purpose');
-    clusterStorageRow.findConnectedResources().should('have.text', '');
+    clusterStorageRow.findConnectedResources().should('have.text', '--');
     clusterStorageRow.findSizeColumn().contains('5GiB');
 
     //sort by Name

--- a/packages/k8s-core/src/__mocks__/mockPVCK8sResource.ts
+++ b/packages/k8s-core/src/__mocks__/mockPVCK8sResource.ts
@@ -3,7 +3,7 @@ import { KnownLabels } from '../k8sTypes';
 import type { PersistentVolumeClaimKind } from '../k8sTypes';
 import { AccessMode } from '../types';
 
-type MockResourceConfigType = {
+export type MockResourceConfigType = {
   name?: string;
   namespace?: string;
   storage?: string;

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -8,6 +8,7 @@ import type { Volume } from '@odh-dashboard/k8s-core';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { mockCustomSecretK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockSecretK8sResource';
 import { mockClusterSettings } from '@odh-dashboard/internal/__mocks__/mockClusterSettings';
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
 import { mockStorageClassList } from '@odh-dashboard/internal/__mocks__/mockStorageClasses';
 import { mockPrometheusQueryVectorResponse } from '@odh-dashboard/internal/__mocks__/mockPrometheusQueryVectorResponse';
 import {
@@ -482,6 +483,33 @@ describe('NIM Models Deployments', () => {
     modelServingWizardEdit.findEnvVariableName('0').should('have.value', 'CUSTOM_VAR');
     modelServingWizardEdit.findEnvVariableValue('0').should('have.value', 'custom-value');
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
+  });
+
+  it('should NOT manage NIM PVCs in cluster storage tab NIM is disabled', () => {
+    initInterceptsToEnableNim();
+    cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableNIMModelServing: true }));
+    cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));
+    cy.interceptK8s(ProjectModel, mockNimProject({}));
+    cy.interceptK8sList(NotebookModel, mockK8sResourceList([]));
+    cy.interceptK8sList(StorageClassModel, mockStorageClassList());
+    cy.interceptOdh('POST /api/prometheus/pvc', {
+      code: 200,
+      response: mockPrometheusQueryVectorResponse({ result: [] }),
+    });
+
+    cy.interceptK8sList(
+      { model: PVCModel, ns: 'test-project' },
+      mockK8sResourceList([
+        mockNimModelPVC({
+          displayName: 'NIM Cache',
+          name: 'nim-cache',
+        }),
+      ]),
+    );
+
+    clusterStorage.visit('test-project');
+
+    clusterStorage.getClusterStorageRow('NIM Cache').shouldHaveStorageTypeValue('General purpose');
   });
 
   it('should manage NIM PVCs in cluster storage tab', () => {

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -1,20 +1,27 @@
 import {
   mockNimInferenceService,
+  mockNimModelPVC,
+  mockNimProject,
   mockNimServingRuntime,
 } from '@odh-dashboard/model-serving/__mocks__/mockLegacyNimResource';
 import type { Volume } from '@odh-dashboard/k8s-core';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { mockCustomSecretK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockSecretK8sResource';
-import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
+import { mockClusterSettings } from '@odh-dashboard/internal/__mocks__/mockClusterSettings';
+import { mockStorageClassList } from '@odh-dashboard/internal/__mocks__/mockStorageClasses';
+import { mockPrometheusQueryVectorResponse } from '@odh-dashboard/internal/__mocks__/mockPrometheusQueryVectorResponse';
 import {
   initInterceptsToDeployNimInWizard,
   initInterceptsToEnableNim,
 } from '@odh-dashboard/cypress/cypress/utils/legacyNimUtils';
 import {
   InferenceServiceModel,
+  NotebookModel,
+  ProjectModel,
   PVCModel,
   SecretModel,
   ServingRuntimeModel,
+  StorageClassModel,
 } from '@odh-dashboard/cypress/cypress/utils/models';
 import {
   modelServingGlobal,
@@ -22,6 +29,7 @@ import {
   modelServingWizard,
   modelServingWizardEdit,
 } from '@odh-dashboard/cypress/cypress/pages/modelServing';
+import { clusterStorage } from '@odh-dashboard/cypress/cypress/pages/clusterStorage';
 import {
   ModelLocationSelectOption,
   ModelTypeLabel,
@@ -397,7 +405,7 @@ describe('NIM Models Deployments', () => {
     // The PVC must be in the fetched list for the existing-storage select to render its name
     cy.interceptK8sList(
       { model: PVCModel, ns: 'test-project' },
-      mockK8sResourceList([mockPVCK8sResource({ name: 'my-nim-wizard-pvc' })]),
+      mockK8sResourceList([mockNimModelPVC({ name: 'my-nim-wizard-pvc' })]),
     );
     // Auth is enabled by default on the NIM deployment (no enable-auth=false annotation), so the
     // token auth field reads the deployment's service-account token secret ("<deployment-name>-sa")
@@ -474,5 +482,38 @@ describe('NIM Models Deployments', () => {
     modelServingWizardEdit.findEnvVariableName('0').should('have.value', 'CUSTOM_VAR');
     modelServingWizardEdit.findEnvVariableValue('0').should('have.value', 'custom-value');
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
+  });
+
+  it('should manage NIM PVCs in cluster storage tab', () => {
+    initInterceptsToEnableNim();
+    cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));
+    cy.interceptK8s(ProjectModel, mockNimProject({}));
+    // NotebookModel backs the per-row root-volume/delete-action logic and the connected resources
+    // column (useRelatedNotebooks) — mock it empty so those resolve instead of spinning
+    cy.interceptK8sList(NotebookModel, mockK8sResourceList([]));
+    cy.interceptK8sList(StorageClassModel, mockStorageClassList());
+    // Mocks the "Storage size" column response
+    cy.interceptOdh('POST /api/prometheus/pvc', {
+      code: 200,
+      response: mockPrometheusQueryVectorResponse({ result: [] }),
+    });
+
+    // A PVC caching a NIM model is annotated by the NIM deploy path
+    cy.interceptK8sList(
+      { model: PVCModel, ns: 'test-project' },
+      mockK8sResourceList([
+        mockNimModelPVC({
+          displayName: 'NIM Cache',
+          name: 'nim-cache',
+        }),
+      ]),
+    );
+
+    clusterStorage.visit('test-project');
+
+    // The nim-serving package contributes the "NIM storage" context, so the PVC is labelled by it
+    clusterStorage.getClusterStorageRow('NIM Cache').shouldHaveStorageTypeValue('NIM storage');
+
+    // TODO followup PR: can edit and update subpath
   });
 });

--- a/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
+++ b/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
@@ -6,7 +6,10 @@ import type {
   TemplateKind,
 } from '@odh-dashboard/k8s-core';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
-import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
+import {
+  mockPVCK8sResource,
+  MockResourceConfigType,
+} from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
 import { mockConfigMap } from '@odh-dashboard/k8s-core/__mocks__/mockConfigMap';
 import { mockSecretK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockSecretK8sResource';
 import { mockServingRuntimeK8sResource } from './mockServingRuntimeK8sResource';
@@ -227,12 +230,12 @@ export const mockNimProject = ({
   return project;
 };
 
-export const mockNimModelPVC = (): PersistentVolumeClaimKind => {
-  const pvc = mockPVCK8sResource({
+export const mockNimModelPVC = (options: MockResourceConfigType = {}): PersistentVolumeClaimKind =>
+  mockPVCK8sResource({
     name: 'nim-pvc',
+    ...options,
+    annotations: { ...options.annotations, 'dashboard.opendatahub.io/nim-pvc': 'true' },
   });
-  return pvc;
-};
 
 export const mockNimServingResource = (
   resource: ConfigMapKind | SecretKind,

--- a/packages/nim-serving/extensions/cluster-storage.ts
+++ b/packages/nim-serving/extensions/cluster-storage.ts
@@ -1,0 +1,21 @@
+import type { ClusterStorageContextExtension } from '@odh-dashboard/plugin-core/extension-points';
+// Allow this import as it consists of types and enums only.
+import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
+
+const extensions: ClusterStorageContextExtension[] = [
+  {
+    type: 'app.cluster-storage/storage-context',
+    properties: {
+      title: 'NIM storage',
+      description:
+        'Appropriate for caching NIM models. Enables you to define a subpath for the NIM image.',
+      isPVCUsingStorageContextType: () =>
+        import('../src/pages/clusterStorage/clusterStorage').then((m) => m.isNIMPVC),
+    },
+    flags: {
+      required: [SupportedArea.NIM_MODEL],
+    },
+  },
+];
+
+export default extensions;

--- a/packages/nim-serving/extensions/index.ts
+++ b/packages/nim-serving/extensions/index.ts
@@ -4,6 +4,7 @@ import projectKeyExtensions from './project-key';
 import wizardExtensions from './wizard';
 import nimKServeExtensions from './nim-kserve';
 import nimServiceExtensions from './nim-service';
+import clusterStorageExtensions from './cluster-storage';
 
 const extensions: Extension[] = [
   ...legacyUiExtensions,
@@ -11,6 +12,7 @@ const extensions: Extension[] = [
   ...wizardExtensions,
   ...nimKServeExtensions,
   ...nimServiceExtensions,
+  ...clusterStorageExtensions,
 ];
 
 export default extensions;

--- a/packages/nim-serving/src/nimKServe/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/nimKServe/fields/nimPVCDeployFunctions.ts
@@ -3,11 +3,13 @@ import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/exte
 import type { KServeDeployment } from '@odh-dashboard/kserve/types';
 import { createPvc } from '@odh-dashboard/internal/api';
 import {
-  NIM_PVC_ANNOTATION,
-  NIM_PVC_SUBPATH_ANNOTATION,
   NIMPVCStorageMode,
   type NIMPVCFieldValue,
 } from '../../pages/deploymentWizard/fields/NIMPVCField';
+import {
+  NIM_PVC_ANNOTATION,
+  NIM_PVC_SUBPATH_ANNOTATION,
+} from '../../pages/clusterStorage/clusterStorage';
 
 /**
  * Creates the PVC (for NEW mode) before the InferenceService + ServingRuntime

--- a/packages/nim-serving/src/pages/clusterStorage/clusterStorage.ts
+++ b/packages/nim-serving/src/pages/clusterStorage/clusterStorage.ts
@@ -1,0 +1,7 @@
+import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
+
+export const NIM_PVC_ANNOTATION = 'dashboard.opendatahub.io/nim-pvc';
+export const NIM_PVC_SUBPATH_ANNOTATION = 'dashboard.opendatahub.io/nim-subpath';
+
+export const isNIMPVC = (pvc: PersistentVolumeClaimKind): boolean =>
+  !!pvc.metadata.annotations?.[NIM_PVC_ANNOTATION];

--- a/packages/nim-serving/src/pages/clusterStorage/clusterStorage.ts
+++ b/packages/nim-serving/src/pages/clusterStorage/clusterStorage.ts
@@ -4,4 +4,4 @@ export const NIM_PVC_ANNOTATION = 'dashboard.opendatahub.io/nim-pvc';
 export const NIM_PVC_SUBPATH_ANNOTATION = 'dashboard.opendatahub.io/nim-subpath';
 
 export const isNIMPVC = (pvc: PersistentVolumeClaimKind): boolean =>
-  !!pvc.metadata.annotations?.[NIM_PVC_ANNOTATION];
+  !!pvc.metadata.annotations && Object.hasOwn(pvc.metadata.annotations, NIM_PVC_ANNOTATION);

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -23,6 +23,7 @@ import useFetch, {
 } from '@odh-dashboard/ui-core/hooks/useFetch';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { useDefaultStorageClass } from '@odh-dashboard/internal/pages/projects/screens/spawner/storage/useDefaultStorageClass';
+import { isNIMPVC, NIM_PVC_SUBPATH_ANNOTATION } from '../../clusterStorage/clusterStorage';
 
 export enum NIMPVCStorageMode {
   NEW = 'new',
@@ -78,12 +79,6 @@ type NIMPVCExternalData = {
   defaultStorageClassName: string;
   existingPVCs: ExistingPVCOption[];
 };
-
-export const NIM_PVC_ANNOTATION = 'dashboard.opendatahub.io/nim-pvc';
-export const NIM_PVC_SUBPATH_ANNOTATION = 'dashboard.opendatahub.io/nim-subpath';
-
-const isNIMPVC = (pvc: PersistentVolumeClaimKind): boolean =>
-  pvc.metadata.annotations?.[NIM_PVC_ANNOTATION] === 'true';
 
 const toPVCOption = (pvc: PersistentVolumeClaimKind): ExistingPVCOption => ({
   name: pvc.metadata.name,

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
@@ -1,13 +1,12 @@
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
 import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
 import { createPvc } from '@odh-dashboard/internal/api';
+import { NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
+import type { NIMDeployment } from '../../../api/nimservices/types';
 import {
   NIM_PVC_ANNOTATION,
   NIM_PVC_SUBPATH_ANNOTATION,
-  NIMPVCStorageMode,
-  type NIMPVCFieldValue,
-} from './NIMPVCField';
-import type { NIMDeployment } from '../../../api/nimservices/types';
+} from '../../clusterStorage/clusterStorage';
 
 export const nimPVCPreDeploy = async (
   fieldData: NIMPVCFieldValue,

--- a/packages/plugin-core/src/extension-points/cluster-storage.ts
+++ b/packages/plugin-core/src/extension-points/cluster-storage.ts
@@ -1,0 +1,26 @@
+import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
+import type { CodeRef, Extension } from '@openshift/dynamic-plugin-sdk';
+// eslint-disable-next-line no-restricted-syntax
+import { createExtensionGuard } from './utils';
+
+export type ClusterStorageContextProperties = {
+  /** Display name of the storage context, shown in the storage table and the PVC form. */
+  title: string;
+  /** Optional help text describing when to use this storage context. */
+  description?: string;
+  /** Returns `true` when the given PVC belongs to this storage context. */
+  isPVCUsingStorageContextType: CodeRef<(pvc: PersistentVolumeClaimKind) => boolean>;
+};
+
+/**
+ * Contributes a storage context type (e.g. "NIM storage") to the cluster storage tab and the
+ * cluster storage form, letting feature packages label their own PVCs without the host knowing
+ * about them.
+ */
+export type ClusterStorageContextExtension = Extension<
+  'app.cluster-storage/storage-context',
+  ClusterStorageContextProperties
+>;
+
+export const isClusterStorageContextExtension =
+  createExtensionGuard<ClusterStorageContextExtension>('app.cluster-storage/storage-context');

--- a/packages/plugin-core/src/extension-points/index.ts
+++ b/packages/plugin-core/src/extension-points/index.ts
@@ -17,6 +17,7 @@ export * from './actions';
 export * from './detail-cards';
 export * from './table-columns';
 export * from './connection-types';
+export * from './cluster-storage';
 
 // Suppress — declarative removal of (type, id)-keyed extensions
 export * from './suppress';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-88010

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a 3rd storage context type, "NIM storage". This shows up when the `dashboard.opendatahub.io/nim-pvc` annotation is present. This is done using extensions, so there is no (new) nim or model serving specific code being added into the frontend directory.

My idea is this extension can be used for the edit user story as well, adding a new property for the subpath field

<img width="817" height="270" alt="image" src="https://github.com/user-attachments/assets/b2b903ce-ff07-4cc1-a025-e512495e2afb" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Enable nimWizard
2. Enable NIM on your project
3. Deploy a NIM model, create a new PVC
4. Go to the "Cluster storage" tab
5. Check for a PVC with the same name you created in the wizard, verify it has the correct context type

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
A cypress test was added to check a mocked pvc. This verifies the functionality of the annotation and the linking of the extension is working correctly

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
cc @justinxhale there is just a new "NIM storage" string added

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage entries now display context labels and descriptions for general-purpose, model, and NIM storage.
  * Storage context explanations adapt to the storage types available on the platform.
* **Bug Fixes**
  * Storage context details now display a loading state while information is being resolved.
* **Tests**
  * Expanded coverage for NIM storage classification and related storage workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->