### PR TITLE
fix: Ensure TLS is true for Workbenches v2

### DIFF
--- a/dashboard-operator/internal/controller/module_deploy_test.go
+++ b/dashboard-operator/internal/controller/module_deploy_test.go
@@ -106,7 +106,7 @@ func TestBuildFederationConfigMap_ExcludesDisabledModules(t *testing.T) {
 	assert.True(t, names["modelRegistry"], "deployed module must be included")
 }
 
-func TestBuildFederationConfigMap_NotebooksTLSFalse(t *testing.T) {
+func TestBuildFederationConfigMap_TLS(t *testing.T) {
 	s := testScheme(t)
 	cli := fake.NewClientBuilder().WithScheme(s).Build()
 
@@ -127,7 +127,7 @@ func TestBuildFederationConfigMap_NotebooksTLSFalse(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(data), &entries))
 
 	expected := map[string]bool{
-		"notebooks":     false,
+		"notebooks":     true,
 		"modelRegistry": true,
 		"genAi":         true,
 		"mlflow":        true,

--- a/dashboard-operator/internal/controller/modules.go
+++ b/dashboard-operator/internal/controller/modules.go
@@ -117,7 +117,7 @@ var moduleRegistry = map[string]ModuleDefinition{
 		Port:          9043,
 		ImageEnvVar:   "RELATED_IMAGE_ODH_MOD_ARCH_NOTEBOOKS_IMAGE",
 		ManifestSlug:  "notebooks",
-		TLS:           false,
+		TLS:           true,
 	},
 }
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-90232

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Following the merge of #9503, TLS is enabled for Workbenches v2, so we need the module to reconcile to prevent regression in 3.6EA2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested in a production cluster: Adding `workbenchesV2: true` flag to ODH dashboard config
- Confirm that TLS is true for BFF
- Confirm that tls: true in `federation-config`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Confirm that both tls flags are true and requests are made with `HTTPS` and not `HTTP`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled secure TLS connections for the notebooks module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->