### PR TITLE
feat: serve the MaaS Consumer Portal via Core BFF

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ frontend/public
 backend/node_modules
 backend/dist
 node_modules/
+**/node_modules/
 
 .github/
 .vscode/

--- a/dashboard-operator/Dockerfile
+++ b/dashboard-operator/Dockerfile
@@ -25,7 +25,8 @@ COPY --from=builder /tmp/manager .
 COPY --chown=65532:0 manifests/ /opt/manifests/dashboard/
 RUN chmod -R g+w /opt/manifests/dashboard/modules/ \
     && chmod g+w /opt/manifests/dashboard/odh/params.env \
-    && chmod g+w /opt/manifests/dashboard/rhoai/params.env
+    && chmod g+w /opt/manifests/dashboard/rhoai/params.env \
+    && chmod g+w /opt/manifests/dashboard/maas-consumer-portal-consolelink/rhoai/params.env
 
 USER 65532:65532
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -161,7 +161,7 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// teardown below also ensures any portal resource carrying a stale
 	// part-of=dashboard label (from an older operator) is relabeled before the
 	// core teardown selector runs.
-	r.reconcileMaasConsumerPortalConsoleLink(ctx, dashboard, cm)
+	portalRetryAfter := r.reconcileMaasConsumerPortalConsoleLink(ctx, dashboard, cm)
 
 	if dashboard.Spec.ManagementState == "Removed" {
 		logger.Info("ManagementState is Removed, tearing down resources")
@@ -198,7 +198,7 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, fmt.Errorf("failed to update status after removal: %w", statusErr)
 		}
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: portalRetryAfter}, nil
 	}
 
 	dashboard.Status.ObservedGeneration = dashboard.Generation
@@ -245,10 +245,19 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logger.Error(statusErr, "Failed to update status")
 	}
 
+	// The portal is an optional operand, so its failures do not fail the core
+	// dashboard reconciliation. Schedule a retry, however, so transient apply
+	// and delete failures heal even when neither the Dashboard nor ConsoleLink
+	// changes afterwards.
+	if portalRetryAfter > 0 && (result.RequeueAfter == 0 || portalRetryAfter < result.RequeueAfter) {
+		result.RequeueAfter = portalRetryAfter
+	}
+
 	return result, err
 }
 
 const observabilityRetryInterval = 5 * time.Minute
+const maasConsumerPortalRetryInterval = time.Minute
 
 func (r *DashboardReconciler) reconcile(
 	ctx context.Context,
@@ -523,7 +532,7 @@ func (r *DashboardReconciler) reconcileMaasConsumerPortalConsoleLink(
 	ctx context.Context,
 	dashboard *v1alpha1.Dashboard,
 	cm *conditions.Manager,
-) {
+) time.Duration {
 	logger := log.FromContext(ctx)
 
 	switch maasConsumerPortalErr := deployMaasConsumerPortalConsoleLink(ctx, r.Client, dashboard, r.ManifestsBasePath, r.Platform); {
@@ -545,6 +554,7 @@ func (r *DashboardReconciler) reconcileMaasConsumerPortalConsoleLink(
 				conditions.WithReason("MaasConsumerPortalDeleteFailed"),
 				conditions.WithMessage("failed to delete maas consumer portal ConsoleLink: %s", delErr.Error()),
 				conditions.WithSeverity(common.ConditionSeverityInfo))
+			return maasConsumerPortalRetryInterval
 		} else {
 			cm.MarkFalse(conditionMaasConsumerPortalAvailable,
 				conditions.WithReason("Disabled"),
@@ -563,7 +573,10 @@ func (r *DashboardReconciler) reconcileMaasConsumerPortalConsoleLink(
 			conditions.WithError(maasConsumerPortalErr),
 			conditions.WithSeverity(common.ConditionSeverityInfo))
 		logger.Error(maasConsumerPortalErr, "Failed to deploy maas consumer portal ConsoleLink")
+		return maasConsumerPortalRetryInterval
 	}
+
+	return 0
 }
 
 func (r *DashboardReconciler) reconcileURL(
@@ -970,11 +983,15 @@ func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 	// resources trigger re-reconciliation. During Removed state the extra
 	// reconcile is harmless — teardown is idempotent and bounded by the
 	// number of owned resources.
+	consoleLink := &unstructured.Unstructured{}
+	consoleLink.SetGroupVersionKind(consoleLinkGVK)
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Dashboard{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
+		Owns(consoleLink).
 		Complete(r)
 }

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -40,6 +40,8 @@ func (r *DashboardReconciler) MonitoringNamespace() string {
 
 const ObservabilityRetryInterval = observabilityRetryInterval
 
+const MaasConsumerPortalRetryInterval = maasConsumerPortalRetryInterval
+
 var DashboardSAName = dashboardSAName
 
 func (r *DashboardReconciler) ReconcileNamespacedRBAC(ctx context.Context, dashboard *v1alpha1.Dashboard) error {

--- a/dashboard-operator/internal/controller/maas_consumer_portal_test.go
+++ b/dashboard-operator/internal/controller/maas_consumer_portal_test.go
@@ -70,16 +70,52 @@ func TestReconcileMaasConsumerPortalConsoleLink_DomainRequired(t *testing.T) {
 	}
 
 	cm := maasConsumerPortalTestManager(t, dashboard)
-	r.reconcileMaasConsumerPortalConsoleLink(context.Background(), dashboard, cm)
+	retryAfter := r.reconcileMaasConsumerPortalConsoleLink(context.Background(), dashboard, cm)
 
 	maasConsumerPortalCond := cm.GetCondition(conditionMaasConsumerPortalAvailable)
 	require.NotNil(t, maasConsumerPortalCond)
 	assert.Equal(t, metav1.ConditionFalse, maasConsumerPortalCond.Status)
 	assert.Equal(t, "MaasConsumerPortalDomainRequired", maasConsumerPortalCond.Reason)
 	assert.Equal(t, common.ConditionSeverityInfo, maasConsumerPortalCond.Severity)
+	assert.Zero(t, retryAfter)
 
 	// Ready must be unaffected: Info-severity False dependents are ignored.
 	assert.True(t, cm.IsHappy(), "Ready must remain True when the maasConsumerPortalCond domain is missing")
+}
+
+func TestReconcileMaasConsumerPortalConsoleLink_DeployFails(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, v1alpha1.AddToScheme(s))
+
+	dashboard := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.DashboardInstanceName},
+		Spec: v1alpha1.DashboardSpec{
+			Gateway:            &v1alpha1.GatewaySpec{Domain: "apps.example.com"},
+			MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"},
+		},
+	}
+
+	// The temporary base does not contain the portal manifest directory, causing
+	// the params write in the deploy action to fail.
+	r := &DashboardReconciler{
+		Client:            fake.NewClientBuilder().WithScheme(s).Build(),
+		Scheme:            s,
+		ManifestsBasePath: t.TempDir(),
+		Platform:          cluster.SelfManagedRhoai,
+	}
+
+	cm := maasConsumerPortalTestManager(t, dashboard)
+	retryAfter := r.reconcileMaasConsumerPortalConsoleLink(context.Background(), dashboard, cm)
+
+	maasConsumerPortalCond := cm.GetCondition(conditionMaasConsumerPortalAvailable)
+	require.NotNil(t, maasConsumerPortalCond)
+	assert.Equal(t, metav1.ConditionFalse, maasConsumerPortalCond.Status)
+	assert.Equal(t, "Error", maasConsumerPortalCond.Reason)
+	assert.Contains(t, maasConsumerPortalCond.Message, "failed to write maas consumer portal params.env")
+	assert.Equal(t, common.ConditionSeverityInfo, maasConsumerPortalCond.Severity)
+	assert.Equal(t, maasConsumerPortalRetryInterval, retryAfter)
+	assert.True(t, cm.IsHappy(), "Ready must remain True even when the portal deploy fails (Info severity)")
 }
 
 func TestReconcileMaasConsumerPortalConsoleLink_Disabled(t *testing.T) {
@@ -103,13 +139,14 @@ func TestReconcileMaasConsumerPortalConsoleLink_Disabled(t *testing.T) {
 	}
 
 	cm := maasConsumerPortalTestManager(t, dashboard)
-	r.reconcileMaasConsumerPortalConsoleLink(context.Background(), dashboard, cm)
+	retryAfter := r.reconcileMaasConsumerPortalConsoleLink(context.Background(), dashboard, cm)
 
 	maasConsumerPortalCond := cm.GetCondition(conditionMaasConsumerPortalAvailable)
 	require.NotNil(t, maasConsumerPortalCond)
 	assert.Equal(t, metav1.ConditionFalse, maasConsumerPortalCond.Status)
 	assert.Equal(t, "Disabled", maasConsumerPortalCond.Reason)
 	assert.Equal(t, common.ConditionSeverityInfo, maasConsumerPortalCond.Severity)
+	assert.Zero(t, retryAfter)
 	assert.True(t, cm.IsHappy(), "Ready must remain True when the maasConsumerPortalCond is disabled")
 }
 
@@ -141,12 +178,13 @@ func TestReconcileMaasConsumerPortalConsoleLink_DisabledDeleteFails(t *testing.T
 	}
 
 	cm := maasConsumerPortalTestManager(t, dashboard)
-	r.reconcileMaasConsumerPortalConsoleLink(context.Background(), dashboard, cm)
+	retryAfter := r.reconcileMaasConsumerPortalConsoleLink(context.Background(), dashboard, cm)
 
 	maasConsumerPortalCond := cm.GetCondition(conditionMaasConsumerPortalAvailable)
 	require.NotNil(t, maasConsumerPortalCond)
 	assert.Equal(t, metav1.ConditionFalse, maasConsumerPortalCond.Status)
 	assert.Equal(t, "MaasConsumerPortalDeleteFailed", maasConsumerPortalCond.Reason)
 	assert.Equal(t, common.ConditionSeverityInfo, maasConsumerPortalCond.Severity)
+	assert.Equal(t, maasConsumerPortalRetryInterval, retryAfter)
 	assert.True(t, cm.IsHappy(), "Ready must remain True even when the portal delete fails (Info severity)")
 }

--- a/distributions/core-bff/Dockerfile.workspace
+++ b/distributions/core-bff/Dockerfile.workspace
@@ -25,14 +25,22 @@ WORKDIR /usr/src/workspace
 ### Workspace setup
 # Copy root workspace manifest first (allows npm to compute workspace graph)
 COPY --chown=default:root package.json package-lock.json* ./
-# Copy the frontend workspace manifest so its dependencies can be resolved if referenced
+# Copy the MaaS Consumer Portal workspace and the source packages used by its production build.
 COPY --chown=default:root frontend/package.json ./frontend/
+COPY --chown=default:root distributions/maas-consumer-portal/ ./distributions/maas-consumer-portal/
+COPY --chown=default:root distributions/base/ ./distributions/base/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/app-config/ ./packages/app-config/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/analytics/ ./packages/analytics/
+COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
+COPY --chown=default:root packages/maas/ ./packages/maas/
+COPY --chown=default:root packages/gen-ai/ ./packages/gen-ai/
+COPY --chown=default:root packages/eslint-config/ ./packages/eslint-config/
+COPY --chown=default:root packages/jest-config/ ./packages/jest-config/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 
@@ -56,6 +64,19 @@ RUN npm ci --ignore-scripts
 # Build the module
 RUN npm run build:prod
 
+# MaaS Consumer Portal compilation consumes MaaS and GenAI frontend source directly. They are
+# independently locked workspaces, so install their production-build inputs in
+# their own node_modules directories before compiling the portal.
+WORKDIR /usr/src/workspace/packages/maas/frontend
+RUN npm ci --ignore-scripts
+WORKDIR /usr/src/workspace/packages/gen-ai/frontend
+RUN npm ci --ignore-scripts
+
+# The MaaS Consumer Portal is a root workspace and its Rspack config writes to public/
+# (rather than the Core BFF frontend's dist/ directory).
+WORKDIR /usr/src/workspace
+RUN npm run build:prod --workspace @odh-dashboard/maas-consumer-portal-distribution
+
 # BFF build stage
 FROM ${GOLANG_BASE_IMAGE} AS bff-builder
 
@@ -77,7 +98,7 @@ COPY ${BFF_SOURCE_CODE}/internal/ internal/
 COPY ${BFF_SOURCE_CODE}/openapi/ openapi/
 
 # Build the Go application
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/bff ./cmd
 
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}
@@ -85,9 +106,14 @@ FROM ${DISTROLESS_BASE_IMAGE}
 ARG UI_SOURCE_CODE
 
 WORKDIR /
-COPY --from=bff-builder /usr/src/app/bff ./
+COPY --from=bff-builder /tmp/bff ./bff
 COPY --from=bff-builder /usr/src/app/openapi/ ./openapi/
 COPY --from=ui-builder /usr/src/workspace/${UI_SOURCE_CODE}/dist ./static/
+COPY --from=ui-builder /usr/src/workspace/distributions/maas-consumer-portal/public ./static/maas-consumer-portal/
+
+# Fail the image build if the MaaS Consumer Portal production bundle was not packaged.
+RUN test -s /static/maas-consumer-portal/index.html
+
 USER 65532:65532
 
 # Set environment variables

--- a/distributions/core-bff/bff/internal/api/module_proxy.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy.go
@@ -192,20 +192,27 @@ func validateProxyPaths(entries []normalizedProxyEntry) error {
 	}
 
 	for _, e := range entries {
-		pathWithSlash := e.service.Path + "/"
-		prefixedPath := PathPrefix + pathWithSlash
+		prefixedPath := PathPrefix + e.service.Path
 
 		for _, reserved := range reservedBFFPrefixes {
-			if strings.HasPrefix(pathWithSlash, reserved) || strings.HasPrefix(reserved, pathWithSlash) {
+			if proxyPathsOverlap(e.service.Path, reserved) {
 				return fmt.Errorf("module proxy path %s in entry %s collides with reserved BFF route %s", e.service.Path, e.entryName, reserved)
 			}
-			if reserved != PathPrefix+"/" && (strings.HasPrefix(prefixedPath, reserved) || strings.HasPrefix(reserved, prefixedPath)) {
+			if reserved != PathPrefix+"/" && strings.TrimSuffix(prefixedPath, "/") == strings.TrimSuffix(reserved, "/") {
 				return fmt.Errorf("module proxy path %s in entry %s collides with reserved BFF route %s (via %s prefix)", e.service.Path, e.entryName, reserved, PathPrefix)
 			}
 		}
 	}
 
 	return nil
+}
+
+// proxyPathsOverlap reports whether two proxy paths share a complete path segment.
+func proxyPathsOverlap(a, b string) bool {
+	a = strings.TrimSuffix(a, "/")
+	b = strings.TrimSuffix(b, "/")
+
+	return a == b || strings.HasPrefix(a, b+"/") || strings.HasPrefix(b, a+"/")
 }
 
 func validateServiceRefs(entries []normalizedProxyEntry) error {

--- a/distributions/core-bff/bff/internal/api/module_proxy.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy.go
@@ -172,8 +172,14 @@ func validateProxyPaths(entries []normalizedProxyEntry) error {
 		if e.service.Path == "" {
 			return fmt.Errorf("entry %s has empty proxy path", e.entryName)
 		}
+		if e.service.Path == "/" {
+			return fmt.Errorf("entry %s uses root path / which conflicts with the SPA catch-all", e.entryName)
+		}
 		if !strings.HasPrefix(e.service.Path, "/") {
 			return fmt.Errorf("entry %s has non-rooted proxy path %s (must start with /)", e.entryName, e.service.Path)
+		}
+		if strings.HasSuffix(e.service.Path, "/") {
+			return fmt.Errorf("entry %s has trailing slash in proxy path %s (will be appended automatically)", e.entryName, e.service.Path)
 		}
 	}
 

--- a/distributions/core-bff/bff/internal/api/module_proxy.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy.go
@@ -216,8 +216,8 @@ func validateServiceRefs(entries []normalizedProxyEntry) error {
 		if !rfc1123Label.MatchString(e.service.Service.Namespace) {
 			return fmt.Errorf("entry %s has invalid service namespace %q (must be a valid RFC 1123 label)", e.entryName, e.service.Service.Namespace)
 		}
-		if e.service.Service.Port == 0 {
-			return fmt.Errorf("entry %s has zero service port", e.entryName)
+		if e.service.Service.Port <= 0 || e.service.Service.Port > 65535 {
+			return fmt.Errorf("entry %s has invalid service port %d (must be 1-65535)", e.entryName, e.service.Service.Port)
 		}
 
 		if e.service.Authorize {

--- a/distributions/core-bff/bff/internal/api/module_proxy_test.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy_test.go
@@ -382,6 +382,22 @@ func TestValidateProxyEntries(t *testing.T) {
 			errSubstr: "non-rooted proxy path",
 		},
 		{
+			name: "root proxy path rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "rootPath", service: moduleProxyServiceEntry{Path: "/", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "uses root path / which conflicts with the SPA catch-all",
+		},
+		{
+			name: "trailing slash in proxy path rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "trailingSlash", service: moduleProxyServiceEntry{Path: "/gen-ai/api/", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			},
+			wantErr:   true,
+			errSubstr: "has trailing slash in proxy path /gen-ai/api/ (will be appended automatically)",
+		},
+		{
 			name: "module path /core-bff/api collides with reserved prefix",
 			entries: []normalizedProxyEntry{
 				{entryName: "selfCollide", service: moduleProxyServiceEntry{Path: "/core-bff/api", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},

--- a/distributions/core-bff/bff/internal/api/module_proxy_test.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy_test.go
@@ -436,7 +436,23 @@ func TestValidateProxyEntries(t *testing.T) {
 				{entryName: "badPort", service: moduleProxyServiceEntry{Path: "/ok/api", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 0}}},
 			},
 			wantErr:   true,
-			errSubstr: "zero service port",
+			errSubstr: "invalid service port 0 (must be 1-65535)",
+		},
+		{
+			name: "negative service port rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "badPort", service: moduleProxyServiceEntry{Path: "/ok/api", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: -1}}},
+			},
+			wantErr:   true,
+			errSubstr: "invalid service port -1 (must be 1-65535)",
+		},
+		{
+			name: "service port above TCP range rejected",
+			entries: []normalizedProxyEntry{
+				{entryName: "badPort", service: moduleProxyServiceEntry{Path: "/ok/api", Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 65536}}},
+			},
+			wantErr:   true,
+			errSubstr: "invalid service port 65536 (must be 1-65535)",
 		},
 		{
 			name: "invalid RFC 1123 service name rejected",
@@ -747,7 +763,7 @@ func TestInitModuleProxies_InvalidServiceFields(t *testing.T) {
 					},
 				},
 			},
-			errSubstr: "zero service port",
+			errSubstr: "invalid service port 0 (must be 1-65535)",
 		},
 	}
 

--- a/distributions/core-bff/bff/internal/api/module_proxy_test.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy_test.go
@@ -553,6 +553,7 @@ func TestReservedPathCollisionBothDirections(t *testing.T) {
 	}{
 		{name: "module is prefix of reserved", path: "/api"},
 		{name: "reserved is prefix of module", path: "/api/k8s/custom"},
+		{name: "matches healthcheck route exactly", path: HealthCheckPath},
 	}
 
 	for _, tt := range tests {
@@ -563,6 +564,26 @@ func TestReservedPathCollisionBothDirections(t *testing.T) {
 			err := validateProxyEntries(entries)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "collides with reserved BFF route")
+		})
+	}
+}
+
+func TestReservedPathCollisionUsesPathSegmentBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "healthcheck lookalike", path: "/healthcheck-module"},
+		{name: "OpenAPI descendant", path: "/openapi/docs"},
+		{name: "Swagger UI lookalike", path: "/swagger-ui-module"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := []normalizedProxyEntry{
+				{entryName: "nonCollision", service: moduleProxyServiceEntry{Path: tt.path, Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
+			}
+			require.NoError(t, validateProxyEntries(entries))
 		})
 	}
 }

--- a/distributions/maas-consumer-portal/config/checkSingletonDuplicatesPlugin.js
+++ b/distributions/maas-consumer-portal/config/checkSingletonDuplicatesPlugin.js
@@ -1,0 +1,73 @@
+const path = require('path');
+
+/**
+ * Fails the build when more than one physical copy of an eager singleton package
+ * (react, @patternfly/react-core, @openshift/dynamic-plugin-sdk, ...) ends up in
+ * the bundle.
+ *
+ * A distribution may statically compose frontend sources that are installed as
+ * independent npm projects with their own node_modules. Without the resolve.alias
+ * dedupe in rspack.common.js, imports from those sources resolve to their nested
+ * copies of react/PatternFly/plugin-sdk — duplicating singletons and breaking React
+ * hooks and PatternFly/plugin-sdk contexts at runtime.
+ *
+ * The aliases cover the bare specifier plus the known imported subpaths. This
+ * plugin is the safety net: if a new (aliased-but-uncovered) subpath slips through
+ * to a nested copy, the build fails here instead of silently shipping two runtimes.
+ */
+class CheckSingletonDuplicatesPlugin {
+  /**
+   * @param {string[]} packages Eager singleton package names that must resolve to a single copy.
+   */
+  constructor(packages) {
+    this.packages = packages;
+  }
+
+  apply(compiler) {
+    const pluginName = 'CheckSingletonDuplicatesPlugin';
+
+    compiler.hooks.afterCompile.tap(pluginName, (compilation) => {
+      // package name -> set of distinct package roots that provided a bundled module
+      const rootsByPackage = new Map();
+
+      for (const module of compilation.modules) {
+        const { resource } = module;
+        if (!resource) {
+          continue;
+        }
+
+        for (const pkg of this.packages) {
+          // e.g. "/node_modules/@patternfly/react-core/" — trailing separator avoids
+          // matching sibling packages that share a prefix (react vs react-dom).
+          const marker = `${path.sep}${path.join('node_modules', pkg)}${path.sep}`;
+          const idx = resource.lastIndexOf(marker);
+          if (idx === -1) {
+            continue;
+          }
+
+          // Root of the copy that actually provided this file (innermost node_modules).
+          const root = resource.slice(0, idx + marker.length - 1);
+          if (!rootsByPackage.has(pkg)) {
+            rootsByPackage.set(pkg, new Set());
+          }
+          rootsByPackage.get(pkg).add(root);
+        }
+      }
+
+      const duplicates = [...rootsByPackage.entries()].filter(([, roots]) => roots.size > 1);
+      if (duplicates.length > 0) {
+        const details = duplicates
+          .map(([pkg, roots]) => `  ${pkg}:\n${[...roots].map((r) => `    ${r}`).join('\n')}`)
+          .join('\n');
+        compilation.errors.push(
+          new Error(
+            `[singleton-dedupe] Multiple copies of eager singleton packages were bundled. ` +
+              `Add the missing subpath to SHARED_RUNTIME_ALIASES in rspack.common.js:\n${details}`,
+          ),
+        );
+      }
+    });
+  }
+}
+
+module.exports = CheckSingletonDuplicatesPlugin;

--- a/distributions/maas-consumer-portal/config/rspack.common.js
+++ b/distributions/maas-consumer-portal/config/rspack.common.js
@@ -127,7 +127,7 @@ module.exports = (overrides = {}) =>
         // Force framework singletons to a single copy (see SHARED_RUNTIME_ALIASES above). Other
         // dependencies resolve from their owning package.
         alias: SHARED_RUNTIME_ALIASES,
-        modules: [PORTAL_NODE_MODULES, 'node_modules'],
+        modules: ['node_modules'],
       },
       plugins: [
         new ContextualTildeResolverPlugin(tildeMappings),

--- a/distributions/maas-consumer-portal/config/rspack.common.js
+++ b/distributions/maas-consumer-portal/config/rspack.common.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { rspack } = require('@rspack/core');
 const { merge } = require('rspack-merge');
 const ContextualTildeResolverPlugin = require('./contextualTildeResolverPlugin');
+const CheckSingletonDuplicatesPlugin = require('./checkSingletonDuplicatesPlugin');
 const createRspackCommon = require('../../base/config/rspack.common.js');
 const GenerateDistributionExtensionsPlugin = require('../../base/config/generateDistributionExtensionsPlugin.js');
 
@@ -11,19 +12,74 @@ const TITLE = 'MaaS Consumer Portal';
 
 const DIST_DIR = path.resolve(__dirname, '..');
 const PORTAL_NODE_MODULES = path.resolve(DIST_DIR, 'node_modules');
+
+// MaaS and GenAI frontend sources are statically bundled into this distribution, but they are
+// installed as independent npm projects with their own node_modules (see Dockerfile.workspace).
+// Without deduping, their imports of react/PatternFly/plugin-sdk resolve to those nested copies,
+// duplicating the framework singletons and breaking React hooks and PF/plugin-sdk contexts.
+//
+// The set of packages that MUST be a single copy is derived from the eager, no-fallback singletons
+// in packages/app-config/src/webpack/shared-modules-meta.ts (the same source of truth used by the
+// Module Federation host), so the list stays in sync automatically instead of drifting.
+// Required by absolute path: app-config's package "exports" map does not expose this file as a
+// subpath, and Node strips the .ts types at require time.
+const { sharedPluginModules, getSharedModuleMetadata } = require(path.resolve(
+  REPO_ROOT,
+  'packages/app-config/src/webpack/shared-modules-meta.ts',
+));
+
+const EAGER_SINGLETON_PACKAGES = Object.keys(sharedPluginModules).filter((name) => {
+  const meta = getSharedModuleMetadata(name);
+  return meta.eager && !meta.allowFallback;
+});
+
+// Resolve from the portal's own node_modules so every copy collapses to the workspace-hoisted one.
+const resolveSingle = (request) => require.resolve(request, { paths: [PORTAL_NODE_MODULES] });
+
+// Resolve a package's root directory (the node_modules/<name> folder), independent of its "exports"
+// map — locate the entry then trim back to the package root marker.
+const resolveDir = (name) => {
+  const entry = require.resolve(name, { paths: [PORTAL_NODE_MODULES] });
+  const marker = `${path.sep}${path.join('node_modules', name)}`;
+  return entry.slice(0, entry.lastIndexOf(marker) + marker.length);
+};
+
+// A bare-specifier alias ("react$") only matches `import 'react'` — it does NOT catch subpath
+// imports like `@patternfly/react-core/dist/esm/...` or `@patternfly/react-styles/css/...`, which is
+// how PatternFly is consumed almost everywhere. Those subpaths would fall through to the nested
+// per-package node_modules and duplicate the singleton. Aliasing the package DIRECTORY (no `$`)
+// covers the bare specifier plus every on-disk subpath in one entry.
+//
+// TRADEOFF — directory aliasing bypasses each package's "exports" map for SUBPATH requests (a bare
+// import still resolves the aliased directory's package.json, so its "exports" "." entry IS honored;
+// only subpaths are resolved as raw filesystem paths). This is a deliberate choice:
+//   * The clean alternative — a resolver plugin that redirects to the pinned copy and lets the normal
+//     resolver apply "exports" — is unavailable: rspack's Rust resolver does not support webpack-style
+//     resolve.plugins (see contextualTildeResolverPlugin.js).
+//   * Enumerating an exact "exports"-honoring `$` alias per subpath is impractical because of
+//     PatternFly's large, ever-changing CSS subpath surface — the very reason for aliasing the
+//     directory.
+//   * For react / react-dom / @patternfly/* / @openshift/*, the imported subpaths are identity
+//     mappings in "exports" (./dist/... → the same file), so directory aliasing is behaviorally
+//     equivalent to honoring "exports".
+//   * react-router is the one package with a divergent "exports" map (dev/prod builds at non-mirroring
+//     paths); its only remapped subpath actually imported, /dom, is handled below with an exact
+//     "exports"-honoring override.
+// Residual risk: a future, not-yet-imported subpath of a package whose "exports" remaps it to a
+// different physical file. CheckSingletonDuplicatesPlugin catches the duplication that would cause.
+// The root-cause fix (installing the composed frontends as hoisted workspace members, so there are no
+// nested node_modules to dedupe) would remove this whole block and honor "exports" natively.
+//
+// Exports-remapped subpaths whose on-disk path differs from the request path — e.g. react-router/dom
+// resolves via "exports" to dist/.../dom-export.mjs and has no file at the literal ./dom path, so
+// directory aliasing can't resolve it — are listed here and aliased with an exact `$` entry
+// (require.resolve honors "exports"). The exact entries are ordered first so they win over the
+// directory alias for the same package.
+const SUBPATH_RUNTIME_ALIASES = ['react-router/dom'];
+
 const SHARED_RUNTIME_ALIASES = {
-  react$: require.resolve('react'),
-  'react/jsx-runtime$': require.resolve('react/jsx-runtime'),
-  'react/jsx-dev-runtime$': require.resolve('react/jsx-dev-runtime'),
-  'react-dom$': require.resolve('react-dom'),
-  'react-dom/client$': require.resolve('react-dom/client'),
-  'react-router$': require.resolve('react-router'),
-  'react-router/dom$': require.resolve('react-router/dom'),
-  'react-router-dom$': require.resolve('react-router-dom'),
-  '@openshift/dynamic-plugin-sdk$': require.resolve('@openshift/dynamic-plugin-sdk'),
-  '@openshift/dynamic-plugin-sdk-utils$': require.resolve('@openshift/dynamic-plugin-sdk-utils'),
-  '@patternfly/react-core$': require.resolve('@patternfly/react-core'),
-  '@patternfly/react-styles$': require.resolve('@patternfly/react-styles'),
+  ...Object.fromEntries(SUBPATH_RUNTIME_ALIASES.map((name) => [`${name}$`, resolveSingle(name)])),
+  ...Object.fromEntries(EAGER_SINGLETON_PACKAGES.map((name) => [name, resolveDir(name)])),
 };
 
 // ~/ imports are aliases that resolve to a single directory per build.
@@ -68,15 +124,14 @@ module.exports = (overrides = {}) =>
         ],
       },
       resolve: {
-        // MaaS and GenAI source is statically bundled into this distribution. These match the
-        // eager singleton packages in packages/app-config/src/webpack/shared-modules-meta.ts.
-        // Other dependencies resolve from their owning package (for example GenAI's Markdown
-        // and Monaco dependencies).
+        // Force framework singletons to a single copy (see SHARED_RUNTIME_ALIASES above). Other
+        // dependencies resolve from their owning package.
         alias: SHARED_RUNTIME_ALIASES,
         modules: [PORTAL_NODE_MODULES, 'node_modules'],
       },
       plugins: [
         new ContextualTildeResolverPlugin(tildeMappings),
+        new CheckSingletonDuplicatesPlugin(EAGER_SINGLETON_PACKAGES),
         new rspack.DefinePlugin({
           'process.env.ODH_PRODUCT_NAME': JSON.stringify(TITLE),
         }),

--- a/distributions/maas-consumer-portal/config/rspack.common.js
+++ b/distributions/maas-consumer-portal/config/rspack.common.js
@@ -10,6 +10,21 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 const TITLE = 'MaaS Consumer Portal';
 
 const DIST_DIR = path.resolve(__dirname, '..');
+const PORTAL_NODE_MODULES = path.resolve(DIST_DIR, 'node_modules');
+const SHARED_RUNTIME_ALIASES = {
+  react$: require.resolve('react'),
+  'react/jsx-runtime$': require.resolve('react/jsx-runtime'),
+  'react/jsx-dev-runtime$': require.resolve('react/jsx-dev-runtime'),
+  'react-dom$': require.resolve('react-dom'),
+  'react-dom/client$': require.resolve('react-dom/client'),
+  'react-router$': require.resolve('react-router'),
+  'react-router/dom$': require.resolve('react-router/dom'),
+  'react-router-dom$': require.resolve('react-router-dom'),
+  '@openshift/dynamic-plugin-sdk$': require.resolve('@openshift/dynamic-plugin-sdk'),
+  '@openshift/dynamic-plugin-sdk-utils$': require.resolve('@openshift/dynamic-plugin-sdk-utils'),
+  '@patternfly/react-core$': require.resolve('@patternfly/react-core'),
+  '@patternfly/react-styles$': require.resolve('@patternfly/react-styles'),
+};
 
 // ~/ imports are aliases that resolve to a single directory per build.
 // When multiple packages compile in one build, ~/ becomes ambiguous. Each
@@ -53,7 +68,12 @@ module.exports = (overrides = {}) =>
         ],
       },
       resolve: {
-        modules: [path.resolve(DIST_DIR, 'node_modules'), 'node_modules'],
+        // MaaS and GenAI source is statically bundled into this distribution. These match the
+        // eager singleton packages in packages/app-config/src/webpack/shared-modules-meta.ts.
+        // Other dependencies resolve from their owning package (for example GenAI's Markdown
+        // and Monaco dependencies).
+        alias: SHARED_RUNTIME_ALIASES,
+        modules: [PORTAL_NODE_MODULES, 'node_modules'],
       },
       plugins: [
         new ContextualTildeResolverPlugin(tildeMappings),

--- a/distributions/maas-consumer-portal/src/components/UserDropdown.tsx
+++ b/distributions/maas-consumer-portal/src/components/UserDropdown.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
-import { useSettings, logout } from 'mod-arch-core';
+import { useSettings } from 'mod-arch-core';
+
+export const PORTAL_SIGN_OUT_PATH = '/oauth2/sign_out';
+
+export const portalLogout = (): void => {
+  window.location.href = PORTAL_SIGN_OUT_PATH;
+};
 
 const UserDropdown: React.FC = () => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -25,7 +31,7 @@ const UserDropdown: React.FC = () => {
       )}
     >
       <DropdownList>
-        <DropdownItem key="logout" onClick={() => logout().finally(() => window.location.reload())}>
+        <DropdownItem key="logout" onClick={portalLogout}>
           Log out
         </DropdownItem>
       </DropdownList>

--- a/distributions/maas-consumer-portal/src/components/UserDropdown.tsx
+++ b/distributions/maas-consumer-portal/src/components/UserDropdown.tsx
@@ -4,8 +4,12 @@ import { useSettings } from 'mod-arch-core';
 
 export const PORTAL_SIGN_OUT_PATH = '/oauth2/sign_out';
 
-export const portalLogout = (): void => {
-  window.location.href = PORTAL_SIGN_OUT_PATH;
+const navigateTo = (path: string): void => {
+  window.location.href = path;
+};
+
+export const portalLogout = (redirect = navigateTo): void => {
+  redirect(PORTAL_SIGN_OUT_PATH);
 };
 
 const UserDropdown: React.FC = () => {
@@ -31,7 +35,7 @@ const UserDropdown: React.FC = () => {
       )}
     >
       <DropdownList>
-        <DropdownItem key="logout" onClick={portalLogout}>
+        <DropdownItem key="logout" onClick={() => portalLogout()}>
           Log out
         </DropdownItem>
       </DropdownList>

--- a/distributions/maas-consumer-portal/src/components/__tests__/UserDropdown.spec.tsx
+++ b/distributions/maas-consumer-portal/src/components/__tests__/UserDropdown.spec.tsx
@@ -6,21 +6,10 @@ import { PORTAL_SIGN_OUT_PATH, portalLogout } from '../UserDropdown';
 
 describe('portalLogout', () => {
   it('should redirect through the gateway-supported sign-out endpoint', () => {
-    const location = { href: '' };
-    const locationDescriptor = Object.getOwnPropertyDescriptor(window, 'location');
-    if (!locationDescriptor) {
-      throw new Error('window.location descriptor is unavailable');
-    }
+    const redirect = jest.fn();
 
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: location,
-    });
+    portalLogout(redirect);
 
-    portalLogout();
-
-    expect(location.href).toBe(PORTAL_SIGN_OUT_PATH);
-
-    Object.defineProperty(window, 'location', locationDescriptor);
+    expect(redirect).toHaveBeenCalledWith(PORTAL_SIGN_OUT_PATH);
   });
 });

--- a/distributions/maas-consumer-portal/src/components/__tests__/UserDropdown.spec.tsx
+++ b/distributions/maas-consumer-portal/src/components/__tests__/UserDropdown.spec.tsx
@@ -1,0 +1,26 @@
+jest.mock('mod-arch-core', () => ({
+  useSettings: jest.fn(),
+}));
+
+import { PORTAL_SIGN_OUT_PATH, portalLogout } from '../UserDropdown';
+
+describe('portalLogout', () => {
+  it('should redirect through the gateway-supported sign-out endpoint', () => {
+    const location = { href: '' };
+    const locationDescriptor = Object.getOwnPropertyDescriptor(window, 'location');
+    if (!locationDescriptor) {
+      throw new Error('window.location descriptor is unavailable');
+    }
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: location,
+    });
+
+    portalLogout();
+
+    expect(location.href).toBe(PORTAL_SIGN_OUT_PATH);
+
+    Object.defineProperty(window, 'location', locationDescriptor);
+  });
+});


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-90190

## Description

Build and package the MaaS Consumer Portal with the existing `odh-core-bff` image.

- Build the portal production bundle alongside the existing Core-BFF frontend and copy it to `/static/maas-consumer-portal`.
- Install the MaaS and GenAI frontend build inputs required by the statically composed portal.
- Keep static composition safe by resolving the eager federation singleton runtime packages from one copy, while retaining package-local dependencies such as GenAI's Markdown and Monaco stack.
- Fail the container build if the portal `index.html` was not packaged.
- Change portal logout to use the gateway-supported `/oauth2/sign_out` endpoint.
- Make the temporary MaaS Consumer Portal ConsoleLink `params.env` location writable for an arbitrary OpenShift runtime UID.
- Ignore nested `node_modules` directories from Docker build context.
- Retry MaaS Consumer Portal ConsoleLink reconciliation and requeue when the ConsoleLink drifts.
- Validate Core-BFF module proxy service port ranges and proxy paths before registering routes.
- Avoid false module-proxy path collision failures for valid sibling routes.

The portal uses the same Core-BFF image as the dashboard; no portal-specific related image, repository, or tag is introduced.

## How Has This Been Tested?

Automated checks:

- `npm run test-unit --workspace @odh-dashboard/maas-consumer-portal-distribution -- --runInBand`
- `npm run type-check --workspace @odh-dashboard/maas-consumer-portal-distribution`
- `npm run lint --workspace @odh-dashboard/maas-consumer-portal-distribution`
- `npx rspack --config distributions/maas-consumer-portal/config/rspack.prod.js --output-path /private/tmp/portal rspack-runtime-check`
- Core-BFF tests: `make test` from `distributions/core-bff/bff` (provisions envtest assets, then runs all Go packages)
- Dashboard operator unit tests: `make test` from `dashboard-operator` (runs all non-integration Go packages with race detection and coverage)
- Dashboard operator envtest integration tests: `make test-integration` from `dashboard-operator`

Local Core-BFF and mocked BFF validation was performed with the following 3-terminal setup. Run the commands from the `opendatahub-io-odh-dashboard` repository root.

The commands are optimized for ARM64 development machines. On AMD64, use the corresponding AMD64 image tag, change `--platform linux/arm64` to `--platform linux/amd64`, and change the envtest download from `--arch arm64` to `--arch amd64`.

Build the image from [distributions/core-bff/Dockerfile.workspace](distributions/core-bff/Dockerfile.workspace):

```bash
export CORE_BFF_IMAGE=odh-core-bff:portal-task1-arm64-test

podman build \
  --platform linux/arm64 \
  --file distributions/core-bff/Dockerfile.workspace \
  --tag "$CORE_BFF_IMAGE" \
  .
```

Terminal 1 — MaaS mock BFF:

```bash
cd packages/maas
make dev-bff-federated-mock
```

Terminal 2 — GenAI mock BFF:

```bash
cd packages/gen-ai/bff
make run \
  MOCK_K8S_CLIENT=true \
  MOCK_LS_CLIENT=true \
  MOCK_MCP_CLIENT=true \
  MOCK_MLFLOW_CLIENT=true \
  MOCK_BFF_CLIENTS=true
```

Terminal 3 — Core-BFF with the portal bundle and temporary local federation configuration:

```bash
export CORE_BFF_IMAGE=odh-core-bff:portal-task1-arm64-test
export FEDERATION_CONFIG=/private/tmp/portal-federation.json
export ENVTEST_BIN_DIR=/private/tmp/odh-core-bff-envtest

cat > "$FEDERATION_CONFIG" <<'EOF'
[
  {
    "name": "maas",
    "proxyService": [{
      "authorize": false,
      "path": "/maas/api",
      "pathRewrite": "/api",
      "tls": false,
      "service": { "name": "maas", "namespace": "local", "port": 8081 },
      "headers": {
        "kubeflow-userid": "user@example.com",
        "x-forwarded-access-token": "mock-token"
      }
    }]
  },
  {
    "name": "genAi",
    "proxyService": [{
      "authorize": false,
      "path": "/gen-ai/api",
      "pathRewrite": "/api",
      "tls": false,
      "service": { "name": "gen-ai", "namespace": "local", "port": 8080 },
      "headers": {
        "x-forwarded-access-token": "mock-token"
      }
    }]
  }
]
EOF

export ENVTEST_ASSETS="$(
  go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19 \
    use --os linux --arch arm64 \
    --bin-dir "$ENVTEST_BIN_DIR" \
    -p path 1.29.3
)"

podman rm --force odh-core-bff-portal-local 2>/dev/null || true

podman run --detach \
  --name odh-core-bff-portal-local \
  --publish 18080:18080 \
  --add-host maas.local.svc.cluster.local:host-gateway \
  --add-host gen-ai.local.svc.cluster.local:host-gateway \
  --env ENVTEST_ASSETS=/envtest \
  --volume "$ENVTEST_ASSETS:/envtest:ro" \
  --volume "$FEDERATION_CONFIG:/etc/odh/portal-federation.json:ro" \
  --tmpfs /tmp:rw,size=512m \
  "$CORE_BFF_IMAGE" \
  --port=18080 \
  --auth-method=disabled \
  --mock-k8s-client \
  --static-assets-dir=/static/maas-consumer-portal \
  --mf-remotes-config=/etc/odh/portal-federation.json

ssh \
  -i ~/.local/share/containers/podman/machine/machine \
  -p 50691 \
  -o ExitOnForwardFailure=yes \
  -o StrictHostKeyChecking=no \
  -N \
  -L 18081:127.0.0.1:18080 \
  core@127.0.0.1
```

Open `http://localhost:18081` and verify the portal shell and MaaS/GenAI pages. Verify the Core-BFF and both proxied BFFs directly:

```bash
curl http://localhost:18081/healthcheck
curl http://localhost:18081/maas/api/v1/user
curl http://localhost:18081/gen-ai/api/v1/config
```

Note: In mock mode, the MaaS BFF's `is-maas-admin` endpoint returns `Unauthorized` because it bypasses the mock Kubernetes client factory. This limitation is independent of Core-BFF proxy connectivity.

## Test Impact

Added a unit test for portal logout redirection. The portal production build was validated with Rspack and inspected to ensure nested MaaS/GenAI React, router, and Dynamic Plugin SDK runtimes were not bundled. The local container smoke validated the portal SPA, `/healthcheck`, and MaaS and GenAI proxy routes.

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:

- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MaaS Consumer Portal production assets to the Core BFF image.
  - Portal logout now redirects directly to the sign-out endpoint.

- **Bug Fixes**
  - Improved portal deployment and deletion retries for more reliable reconciliation.
  - Prevented duplicate shared frontend dependencies during portal builds.
  - Strengthened module proxy validation for invalid paths, reserved routes, and port ranges.

- **Tests**
  - Expanded coverage for portal retries, logout behavior, dependency duplication, and proxy validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->