### PR TITLE
cleanup webpack references

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -18,7 +18,7 @@ ODH Dashboard is a monorepo managed with npm workspaces and Turbo. It provides t
 
 ### Main Applications
 
-- `frontend/` — Main React 18 dashboard application (PatternFly v6, Webpack, Module Federation host)
+- `frontend/` — Main React 18 dashboard application (PatternFly v6, Rspack, Module Federation host)
 - `backend/` — Fastify server with Kubernetes client integration, proxying requests to OpenShift APIs
 
 ### Feature Plugin Packages (`packages/`)
@@ -27,7 +27,7 @@ Feature packages provide extensions and are discovered by `discoverPluginPackage
 
 #### Module Federation Remotes
 
-These packages have a `module-federation` config in `package.json`, their own webpack build under `frontend/config/`, and produce a `remoteEntry.js` that is loaded dynamically at runtime:
+These packages have a `module-federation` config in `package.json`, their own rspack build under `frontend/config/`, and produce a `remoteEntry.js` that is loaded dynamically at runtime:
 
 - `automl` — AutoML features (has Go BFF)
 - `autorag` — AutoRAG features (has Go BFF)
@@ -42,7 +42,7 @@ These packages have a `module-federation` config in `package.json`, their own we
 
 #### Bundled Plugin Packages
 
-These packages export extensions but have **no** `module-federation` config. They are compiled directly into the host bundle at build time — no separate webpack build, no `remoteEntry.js`, no standalone dev server:
+These packages export extensions but have **no** `module-federation` config. They are compiled directly into the host bundle at build time — no separate rspack build, no `remoteEntry.js`, no standalone dev server:
 
 - `feature-store` — Feature Store (read-only Feast UI; no BFF, proxies through main dashboard backend)
 - `kserve` — KServe integration
@@ -94,16 +94,16 @@ Dashboard variants — three independently-deployable distributions plus a share
 
 | Directory | Description | Has BFF? | Build System |
 |-----------|-------------|----------|--------------|
-| `base/` | Shared app shell library (PatternFly chrome, error boundary, extensibility hooks) — **not deployed on its own** | Stub only | Webpack |
-| `core-bff/` | Full Go BFF + React frontend for xKC deployments | Yes (Go 1.25+) | Make + Webpack |
-| `rhaii/` | RHAII-specific distribution | No | Webpack |
-| `maas-consumer-portal/` | Standalone MaaS Consumer Portal (bundles maas + gen-ai packages) | No | Webpack |
+| `base/` | Shared app shell library (PatternFly chrome, error boundary, extensibility hooks) — **not deployed on its own** | Stub only | Rspack |
+| `core-bff/` | Full Go BFF + React frontend for xKC deployments | Yes (Go 1.25+) | Make + Rspack |
+| `rhaii/` | RHAII-specific distribution | No | Rspack |
+| `maas-consumer-portal/` | Standalone MaaS Consumer Portal (bundles maas + gen-ai packages) | No | Rspack |
 
 - `base/` is a shared library/framework (not independently deployed) — it provides the app shell (masthead, sidebar, error boundary, theme context) that `core-bff/`, `rhaii/`, and `maas-consumer-portal/` extend
-- `rhaii/` is frontend-only — React + Webpack + Module Federation host configuration
+- `rhaii/` is frontend-only — React + Rspack + Module Federation host configuration
 - `maas-consumer-portal/` is frontend-only — bundles maas and gen-ai packages directly, connects through their BFFs (no BFF of its own)
 - `core-bff/` has both a Go BFF (`bff/`) and React frontend (`frontend/`) with its own contract tests (`contract-tests/`)
-- Each distribution has its own `package.json`, `tsconfig.json`, and webpack config; dependencies on internal packages resolve through the workspace
+- Each distribution has its own `package.json`, `tsconfig.json`, and rspack config; dependencies on internal packages resolve through the workspace
 - `core-bff/` follows contract-first development (OpenAPI → BFF stub → Frontend → Production BFF)
 
 See `distributions/core-bff/AGENTS.md` for the most detailed reference. See `.claude/rules/distributions.md` for distribution-specific conventions and `.claude/rules/bff-go.md` for Go BFF conventions (applies to core-bff BFF code).

--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -20,7 +20,7 @@ paths:
 | PatternFly v6 | Primary UI component library — import from `@patternfly/react-core`, `@patternfly/react-table`, `@patternfly/react-icons` |
 | Material UI | Secondary UI library (Kubeflow mode only) |
 | Fastify | Backend server framework |
-| Webpack | Build tooling with Module Federation |
+| Rspack | Build tooling with Module Federation |
 | Turbo | Monorepo task runner |
 
 ## Code Style

--- a/.claude/rules/cypress-mock.md
+++ b/.claude/rules/cypress-mock.md
@@ -95,7 +95,7 @@ Some modules like `gen-ai`, `model-registry`, etc. have a **BFF (Backend For Fro
 
 1. **Pure Mock Tests (Default for Mock Tests)** - NO BFF Running
    - All network requests are intercepted with Cypress `cy.intercept*` commands
-   - Frontend runs standalone with webpack dev server
+   - Frontend runs standalone with dev server
    - BFF is NOT started
    - Fastest approach, true component isolation
    - **Commands:**
@@ -145,7 +145,7 @@ packages/gen-ai/
 │   ├── src/__tests__/cypress/     # Cypress tests
 │   └── package.json               # Test scripts
 │       ├── cypress:server         # Runs BFF: "cd ../bff && make run PORT=9001"
-│       ├── cypress:server:dev     # Runs frontend only: webpack dev server
+│       ├── cypress:server:dev     # Runs frontend only: dev server
 │       ├── cypress:run:mock       # Mock tests (CY_MOCK=1, no BFF)
 │       ├── cypress:run:e2e        # E2E tests (with BFF)
 │       └── test:cypress-ci        # CI: "npm run cypress:server:dev" + mock tests
@@ -163,7 +163,7 @@ cd packages/gen-ai/frontend
 npm run test:cypress-ci            # Same as above
 
 # Development mode (separate terminals)
-npm run cypress:server:dev         # Terminal 1: Start webpack dev server
+npm run cypress:server:dev         # Terminal 1: Start dev server
 npm run cypress:run:mock           # Terminal 2: Run mock tests
 npm run cypress:open               # Terminal 2: Or open Cypress GUI
 ```

--- a/.claude/rules/distributions.md
+++ b/.claude/rules/distributions.md
@@ -52,8 +52,8 @@ For distribution-specific builds and BFF operations, work from within the distri
 `base/` is a library — run these commands for development and testing, not for standalone deployment. `rhaii/` is a deployable distribution that extends `base/`.
 
 ```bash
-npm run build         # Webpack production build
-npm run start:dev     # Webpack dev server (local development/testing only for base/)
+npm run build         # Rspack production build
+npm run start:dev     # Dev server (local development/testing only for base/)
 npx eslint src/       # Lint
 npx tsc --noEmit      # Type-check
 ```
@@ -97,7 +97,7 @@ npm run test:contract:xks       # Foundation + XKS tests
 
 ## Module Federation
 
-`base/` and `rhaii/` are Module Federation **hosts** — they load federated remotes at runtime. Webpack configs in `config/` define the host setup. `core-bff/frontend/` also supports federated mode via `config/moduleFederation.js`.
+`base/` and `rhaii/` are Module Federation **hosts** — they load federated remotes at runtime. Rspack configs in `config/` define the host setup. `core-bff/frontend/` also supports federated mode via `config/moduleFederation.js`.
 
 When modifying Module Federation config in distributions, verify that remote names and shared dependencies stay consistent with the host dashboard's expectations.
 

--- a/.claude/rules/modular-architecture.md
+++ b/.claude/rules/modular-architecture.md
@@ -11,14 +11,14 @@ paths:
 # Modular Architecture — ODH Dashboard
 
 > **Canonical docs** — read these first for full details:
-> - [docs/module-federation.md](../../docs/module-federation.md) — MF config properties, shared deps, proxy flow, webpack setup, troubleshooting
+> - [docs/module-federation.md](../../docs/module-federation.md) — MF config properties, shared deps, proxy flow, rspack setup, troubleshooting
 > - [docs/extensibility.md](../../docs/extensibility.md) — extension points, code refs, lazy loading, helper components, hooks, type guards, best practices
 
 This rule summarises the architecture at a glance and lists key files. Defer to the docs above for full explanations.
 
 ## Quick architecture summary
 
-The host app (`frontend/`) uses Webpack Module Federation (`@module-federation/enhanced`) to load remote packages at runtime. Remotes are discovered automatically from workspace packages that declare a `module-federation` key in `package.json`.
+The host app (`frontend/`) uses Module Federation (`@module-federation/enhanced`) to load remote packages at runtime. Remotes are discovered automatically from workspace packages that declare a `module-federation` key in `package.json`.
 
 | Role | Location | MF Name |
 |---|---|---|
@@ -80,7 +80,7 @@ packages/<name>/
 ├── frontend/
 │   ├── config/
 │   │   ├── moduleFederation.js
-│   │   └── webpack.{common,dev,prod}.js
+│   │   └── rspack.{common,dev,prod}.js
 │   └── src/
 │       ├── odh/
 │       │   ├── extensions.ts       # Extension definitions

--- a/.claude/rules/module-federation.md
+++ b/.claude/rules/module-federation.md
@@ -1,9 +1,10 @@
 ---
 description: Module Federation — how modules are exposed and consumed across packages in the modular architecture
-globs: "**/config/moduleFederation.js,**/config/webpack.*.js,**/module-federation.ts,**/useAppExtensions.ts,**/ExtensibilityContext.tsx,**/extensions.ts,**/extension-points.ts,**/odh/extensions.ts,**/odh/extension-points.ts"
+globs: "**/config/moduleFederation.js,**/config/rspack.*.js,**/config/webpack.*.js,**/module-federation.ts,**/useAppExtensions.ts,**/ExtensibilityContext.tsx,**/extensions.ts,**/extension-points.ts,**/odh/extensions.ts,**/odh/extension-points.ts"
 alwaysApply: false
 paths:
   - "**/config/moduleFederation.js"
+  - "**/config/rspack.*.js"
   - "**/config/webpack.*.js"
   - "**/module-federation.ts"
   - "**/useAppExtensions.ts"
@@ -17,14 +18,14 @@ paths:
 # Module Federation — Modular Architecture
 
 > **Canonical docs** — read these first for full details:
-> - [docs/module-federation.md](../../docs/module-federation.md) — MF config schema, shared deps, proxy flow, webpack setup, troubleshooting
+> - [docs/module-federation.md](../../docs/module-federation.md) — MF config schema, shared deps, proxy flow, rspack setup, troubleshooting
 > - [docs/extensibility.md](../../docs/extensibility.md) — extension points, code refs, lazy loading, helper components (`LazyCodeRefComponent`, `HookNotify`), hooks (`useExtensions`, `useResolvedExtensions`), type guards, best practices
 
 This rule provides a quick reference for working with Module Federation files. Defer to the docs above for full explanations and code examples.
 
 ## Architecture
 
-ODH Dashboard uses Webpack Module Federation (`@module-federation/enhanced`) to dynamically load remote modules at runtime. The host (`frontend/`) discovers and loads remote packages (`packages/*/`) that expose extensions via a plugin system.
+ODH Dashboard uses Module Federation (`@module-federation/enhanced`) to dynamically load remote modules at runtime. The host (`frontend/`) discovers and loads remote packages (`packages/*/`) that expose extensions via a plugin system. Upstream notebooks and model-registry still use webpack.
 
 | Role | Location | MF Name |
 |---|---|---|
@@ -35,7 +36,7 @@ The host never exposes modules (`exposes: {}`). Remotes expose `./extensions` an
 
 ## Registering a Federated Module
 
-See [docs/module-federation.md](../../docs/module-federation.md) for the full config schema and webpack template. In brief:
+See [docs/module-federation.md](../../docs/module-federation.md) for the full config schema and rspack template. In brief:
 
 1. **`package.json`** — add a `module-federation` key (name, remoteEntry, proxy, local port, service) and `"exports": { "./extensions": "..." }`
 2. **`moduleFederation.js`** — configure `OdhFederationPlugin` with `name`, `isHost`, `exposes` / `remotes`. Shared singletons are applied by the plugin.
@@ -48,7 +49,7 @@ All remotes **must** share as singletons: `react`, `react-dom`, `react-router`, 
 
 Include if used: `@openshift/dynamic-plugin-sdk`, `@openshift/dynamic-plugin-sdk-utils`, `@odh-dashboard/plugin-core`.
 
-All use `singleton: true` and `requiredVersion` from the `package.json` in webpack `compiler.context`.
+All use `singleton: true` and `requiredVersion` from the `package.json` in rspack `compiler.context`.
 
 ## Runtime Loading Flow
 
@@ -77,7 +78,7 @@ import('./bootstrap');
 - **Proxy paths** follow `/package-name/api` → `/api` rewrite pattern
 - **Local dev ports** are unique per package (9100+)
 - Pass `isHost: true` for the dashboard and for standalone remotes (`DEPLOYMENT_MODE=standalone`); federated remotes pass `isHost: false`
-- Set `output.publicPath = 'auto'` in webpack
+- Set `output.publicPath = 'auto'` in rspack
 - Lazy-load components in extensions via `component: () => import('./MyComponent')` (CodeRef pattern)
 - Use `@mf/*` TypeScript path alias for typed imports of remote modules (types in `frontend/@mf-types/`)
 

--- a/.claude/rules/module-onboarding.md
+++ b/.claude/rules/module-onboarding.md
@@ -10,7 +10,7 @@ paths:
 
 > **Canonical docs** — read these first:
 > - [docs/onboard-modular-architecture.md](../../docs/onboard-modular-architecture.md) — quickstart using `mod-arch-installer`
-> - [docs/module-federation.md](../../docs/module-federation.md) — MF config properties, shared deps, proxy, webpack setup
+> - [docs/module-federation.md](../../docs/module-federation.md) — MF config properties, shared deps, proxy, rspack setup
 > - [docs/extensibility.md](../../docs/extensibility.md) — extension points, code refs, feature gating
 
 The quickstart in `docs/onboard-modular-architecture.md` uses `npx mod-arch-installer -n <name>` to scaffold a new module. This rule provides the full manual reference and checklist beyond what the installer covers.
@@ -108,7 +108,7 @@ packages/<name>/
 │   ├── package.json
 │   ├── config/
 │   │   ├── moduleFederation.js
-│   │   └── webpack.{common,dev,prod}.js
+│   │   └── rspack.{common,dev,prod}.js
 │   └── src/
 │       ├── odh/
 │       │   ├── extensions.ts       # Extension definitions
@@ -187,12 +187,34 @@ Add the area to `frontend/src/concepts/areas/types.ts` and configure it in `fron
 
 See [docs/onboard-modular-architecture.md § Add Feature Flag](../../docs/onboard-modular-architecture.md#4-add-feature-flag) for the feature flag setup.
 
-### 7. Webpack config (federated modules)
+### 7. Rspack config (federated modules)
 
-Copy from an existing module (e.g., `packages/gen-ai/frontend/config/`). See [docs/module-federation.md § Webpack Configuration](../../docs/module-federation.md#webpack-configuration) for the full config template. Key points:
+Copy from an existing module (e.g., `packages/gen-ai/frontend/config/`). See [docs/module-federation.md § Rspack Configuration](../../docs/module-federation.md#rspack-configuration) for the full config template.
+
+Use `OdhFederationPlugin` from `@odh-dashboard/app-config/rspack` (`packages/app-config/src/rspack/OdhFederationPlugin.ts`).
+
+```javascript
+// packages/<name>/frontend/config/moduleFederation.js
+const { OdhFederationPlugin } = require('@odh-dashboard/app-config/rspack');
+
+module.exports = {
+  moduleFederationPlugins: [
+    new OdhFederationPlugin({
+      name: 'myModule', // must match package.json module-federation.name
+      isHost: process.env.DEPLOYMENT_MODE === 'standalone',
+      exposes: {
+        './extensions': './src/odh/extensions',
+        './extension-points': './src/odh/extension-points',
+      },
+    }),
+  ],
+};
+```
+
+Key points:
 
 - Expose `./extensions` and optionally `./extension-points`
-- Shared singletons must match the host
+- Shared singletons are applied by `OdhFederationPlugin` — do not maintain a manual React / PatternFly / ODH `shared` map
 - Set `runtime: false` and `output.publicPath = 'auto'`
 - Dev server port must be unique
 
@@ -235,7 +257,7 @@ The `modular-arch-quality-gates.yml` CI workflow checks that modules have:
 - [ ] Unique port assigned and configured in `Makefile` + `package.json`
 - [ ] `extensions.ts` with area, nav, and route extensions
 - [ ] `SupportedArea` enum entry + area config
-- [ ] Webpack config with correct shared singletons (if federated)
+- [ ] Rspack config with `OdhFederationPlugin` from `@odh-dashboard/app-config/rspack` (if federated)
 - [ ] BFF with `/healthcheck` and OpenAPI spec (if applicable)
 - [ ] Unit tests in `__tests__/`
 - [ ] E2E tests in `packages/cypress/cypress/tests/e2e/<name>/`

--- a/.claude/skills/dev-workflow/reference.md
+++ b/.claude/skills/dev-workflow/reference.md
@@ -47,7 +47,7 @@ See `.env.local.example` for template.
 | Variable | Default | Purpose |
 |---|---|---|
 | `BACKEND_PORT` | `4000` | Backend listen port |
-| `FRONTEND_PORT` | `4010` | Webpack dev server port |
+| `FRONTEND_PORT` | `4010` | Dev server port |
 | `ODH_HOST` | `localhost` | Dev server host |
 | `EXT_CLUSTER` | - | Set `true` to proxy to a real cluster |
 | `MODULE_FEDERATION_CONFIG` | - | Override MF remote discovery |
@@ -59,9 +59,9 @@ For `EXT_CLUSTER=true`, the dev server uses `oc whoami --show-token` and `oc get
 
 Makefile provides `make login` using `OC_URL`, `OC_USER`, `OC_PASSWORD` (or `OC_TOKEN`).
 
-## Webpack dev server
+## Dev server
 
-`frontend/config/webpack.dev.js`:
+`frontend/config/rspack.dev.js`:
 
 - Hot module replacement enabled
 - Proxies `/api`, `/_mf`, and other paths to the backend
@@ -74,7 +74,7 @@ Makefile provides `make login` using `OC_URL`, `OC_USER`, `OC_PASSWORD` (or `OC_
 `frontend/config/moduleFederation.js` runs `npm query .workspace --json` and filters packages with a `module-federation` key in `package.json`. Override with `MODULE_FEDERATION_CONFIG` env var (JSON string).
 
 In dev mode, the backend reads the same config and proxies:
-- `/_mf/{name}/*` → each package's local webpack dev server (static assets + `remoteEntry.js`)
+- `/_mf/{name}/*` → each package's local dev server (static assets + `remoteEntry.js`)
 - API paths (e.g., `/model-registry/api/*`) → each package's BFF
 
 The `local` field in `module-federation` config tells the backend where to proxy:
@@ -88,7 +88,7 @@ The `local` field in `module-federation` config tells the backend where to proxy
 | Component | Port | Role | Has `start:dev`? |
 |---|---|---|---|
 | Backend | 4000 | Node.js/Fastify reverse proxy | Yes |
-| Host frontend | 4010 | Webpack dev server (host) | Yes |
+| Host frontend | 4010 | Dev server (host) | Yes |
 
 To see all current port assignments and detect conflicts:
 
@@ -110,7 +110,7 @@ The source of truth for each package is:
   BACKEND_PORT=4050
   ```
 
-  The frontend's webpack proxy target (`_BACKEND_PORT`) and the backend itself both pick up this override. The model-registry BFF keeps port 4000 (hardcoded in its Makefile). Avoid using 4020 — mlflow's BFF uses that port.
+  The frontend's rspack proxy target (`_BACKEND_PORT`) and the backend itself both pick up this override. The model-registry BFF keeps port 4000 (hardcoded in its Makefile). Avoid using 4020 — mlflow's BFF uses that port.
 
 ### Running multi-component dev
 
@@ -149,7 +149,7 @@ cd packages/gen-ai && make dev-start-mock
 
 ### Makefile targets per package
 
-Each package with a BFF provides Makefile targets that run **both** the Go BFF and the frontend webpack dev server in parallel:
+Each package with a BFF provides Makefile targets that run **both** the Go BFF and the frontend dev server in parallel:
 
 | Target | What it runs |
 |---|---|
@@ -172,7 +172,7 @@ Federated package extensions are gated behind feature flags (e.g., maas requires
 1. Start the host: `npm run dev`
 2. In a separate terminal, start the package: `cd packages/<pkg> && make dev-start-mock-federated`
 3. Enable required feature flags via the Feature Flag Launcher in the dashboard UI
-4. **Frontend changes** — webpack HMR rebuilds `remoteEntry.js` and hot-reloads in the host automatically
+4. **Frontend changes** — rspack HMR rebuilds `remoteEntry.js` and hot-reloads in the host automatically
 5. **BFF (Go) changes** — restart the BFF process (kill and re-run, or restart only the BFF via `make dev-bff-federated`)
 6. The backend is already proxying to the package's local ports based on the `module-federation.local` config
 
@@ -204,7 +204,7 @@ Enables typed imports via `@mf/*` path aliases (e.g., `@mf/modelRegistry`).
 | `DEPLOYMENT_MODE=federated` | Tells a package's frontend to build as a federated remote |
 | `MODULE_FEDERATION_CONFIG` | JSON override for MF remote discovery (backend + frontend) |
 | `MF_UPDATE_TYPES=true` | Generates TypeScript types for remote modules |
-| `MF_DEV` | Enables `MF_REMOTES` injection in webpack (used by Cypress) |
+| `MF_DEV` | Enables `MF_REMOTES` injection in rspack (used by Cypress) |
 | `MOCK_K8S_CLIENT=true` | BFF flag to mock Kubernetes client |
 | `AUTH_METHOD` | BFF auth: `internal`, `user_token`, or `disabled` |
 

--- a/.claude/skills/docs-update/SKILL.md
+++ b/.claude/skills/docs-update/SKILL.md
@@ -47,7 +47,7 @@ $ARGUMENTS (optional):
      - `backend/src/**` → `backend/docs/overview.md`.
      - `packages/<name>/**` → `packages/<name>/docs/overview.md`.
    - Also check non-indexed docs if the change affects env vars, deployment config,
-     OpenAPI specs, webpack/MF config, or auth middleware — search nearby READMEs and
+     OpenAPI specs, rspack/MF config, or auth middleware — search nearby READMEs and
      `docs/` directories for references to the changed files.
 
 3. **For each affected doc**:

--- a/.claude/skills/jira-triage/jira-project-reference.md
+++ b/.claude/skills/jira-triage/jira-project-reference.md
@@ -447,7 +447,7 @@ Matched against issue summary, description text, and **Jira labels** (non-area l
 | `dashboard-area-distributed-workloads` | distributed workload, Kueue, workload metrics, cluster queue, local queue, quota | `ClusterQueue`, `LocalQueue`, `Workload` |
 | `dashboard-area-user-management` | user management, group settings, RBAC, permissions, role binding | `Role`, `RoleBinding`, `ClusterRole` |
 | `dashboard-area-home` | home page, landing page, overview page, welcome, getting started | |
-| `dashboard-area-infrastructure` | webpack, build, CI, docker, module federation, navigation, sidebar, header, app shell, plugin, extension | |
+| `dashboard-area-infrastructure` | webpack, rspack, build, CI, docker, module federation, navigation, sidebar, header, app shell, plugin, extension | |
 | `dashboard-area-patternfly` | PatternFly, PF, component library, design system | |
 | `dashboard-area-pf6` | PF6, PatternFly 6, PatternFly migration, PF upgrade | |
 | `dashboard-area-bff` | BFF, backend-for-frontend, Go backend, shared middleware, common middleware, RequireAccessToService, RequireValidIdentity, SelfSubjectAccessReview, SSAR, BFF route, BFF module | |

--- a/.claude/skills/jira-validate-priority-severity/SKILL.md
+++ b/.claude/skills/jira-validate-priority-severity/SKILL.md
@@ -275,14 +275,14 @@ Given a task RHOAIENG-55577 ("Cypress flake in globalDistributedWorkloads.cy.ts"
 
 Priority is already set and plausible for a test flake — no operations produced.
 
-Given a task RHOAIENG-55600 ("Update webpack config for module federation") with priority=Undefined:
+Given a task RHOAIENG-55600 ("Update rspack config for module federation") with priority=Undefined:
 
 ```json
 {
   "operations": [
     {
       "issueKey": "RHOAIENG-55600",
-      "summary": "Update webpack config for module federation",
+      "summary": "Update rspack config for module federation",
       "action": "SET_FIELDS",
       "params": { "fields": { "priority": { "name": "Normal" } } },
       "reason": "Build tooling update with no urgency signal — default priority"

--- a/.claude/skills/module-onboarding/reference.md
+++ b/.claude/skills/module-onboarding/reference.md
@@ -188,7 +188,7 @@ STYLE_THEME=patternfly
 
 Federated modules use `Dockerfile.workspace` — a multi-stage build:
 
-1. **Stage 1 (Node)**: Build the frontend webpack bundle
+1. **Stage 1 (Node)**: Build the frontend rspack bundle
    - Copy root workspace manifests, install deps
    - Copy package source, run `npm run build` with `DEPLOYMENT_MODE=standalone`
 2. **Stage 2 (Go)**: Build the BFF binary (if included)
@@ -224,7 +224,7 @@ docker build --file ./packages/<name>/Dockerfile.workspace .
 
 ## Shared Singletons (moduleFederation.js)
 
-`OdhFederationPlugin` applies the shared singleton policy automatically. Do not maintain a manual `shared` map for React / PatternFly / ODH packages. Ensure those packages are listed in the frontend `package.json` `dependencies` (plugin modules) so they are picked up from webpack `compiler.context`.
+`OdhFederationPlugin` applies the shared singleton policy automatically. Do not maintain a manual `shared` map for React / PatternFly / ODH packages. Ensure those packages are listed in the frontend `package.json` `dependencies` (plugin modules) so they are picked up from rspack `compiler.context`.
 
 Pass `isHost: process.env.DEPLOYMENT_MODE === 'standalone'` so standalone builds eager-share and bundle imports, while federated remotes use `import: false`.
 
@@ -239,7 +239,7 @@ This checklist maps to skill phases. Items marked with a phase are handled autom
 | 3 | Unique frontend port allocated (9100–9399) | Phase 1 |
 | 4 | Unique BFF port allocated (4000–4099) if BFF included | Phase 1 |
 | 5 | `tsconfig.json`, `jest.config.ts`, `.eslintrc.js` present | Phase 2 |
-| 6 | Webpack configs under `frontend/config/` | Phase 2 |
+| 6 | Rspack configs under `frontend/config/` | Phase 2 |
 | 7 | Extensions file with area, nav, route stubs | Phase 2 |
 | 8 | Feature flag added to `DashboardCommonConfig` in `k8sTypes.ts` | Phase 3 |
 | 9 | `SupportedArea` enum entry added in `types.ts` | Phase 3 |
@@ -281,7 +281,7 @@ This checklist maps to skill phases. Items marked with a phase are handled autom
 
 **Fix**: The skill falls back to manual scaffolding. Alternatively, install it explicitly: `npm install -g mod-arch-installer` and retry.
 
-### Webpack build fails with "shared module not found"
+### Rspack build fails with "shared module not found"
 
 **Symptom**: Build error mentioning missing shared module.
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -273,10 +273,16 @@ reviews:
         2. Cache inputs/outputs must be accurate — incorrect caching causes stale builds.
         3. Changes here affect all package build ordering and CI performance.
 
-    # ── Webpack config ────────────────────────────────────────────
+    # ── Bundler config ────────────────────────────────────────────
     - path: "**/webpack.{common,dev,prod}.{ts,js}"
       instructions: |
-        WEBPACK CONFIG:
+        WEBPACK CONFIG (Cypress preprocessor and upstream packages only):
+        (Suppression) Do not suggest alternative bundler configurations
+        or plugin replacements. Only flag security issues and broken build logic.
+
+    - path: "**/rspack.{common,dev,prod}.{ts,js}"
+      instructions: |
+        RSPACK CONFIG:
         (Suppression) Do not suggest alternative bundler configurations
         or plugin replacements. Only flag security issues and broken build logic.
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,6 +73,8 @@ updates:
         applies-to: version-updates
         patterns:
           - "webpack*"
+          - "@rspack/*"
+          - "rspack*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/workflows/pr-build-validation.yml
+++ b/.github/workflows/pr-build-validation.yml
@@ -426,7 +426,7 @@ jobs:
           echo "::group::Validating Module Federation artifacts"
 
           # Check for main app bundle (always required)
-          # Webpack outputs app.[contenthash].js, not app.bundle.js
+          # Rspack outputs app.[contenthash].js, not app.bundle.js
           if ! ls /tmp/odh-dist/app.*.js >/dev/null 2>&1; then
             echo "❌ FAIL: app.*.js not found - build did not complete"
             FAILURES=$((FAILURES + 1))
@@ -446,12 +446,12 @@ jobs:
               echo "✅ PASS: remoteEntry.js present and valid ($SIZE bytes)"
             fi
 
-            # Check webpack chunks
+            # Check rspack chunks
             CHUNK_COUNT=$(find /tmp/odh-dist -name "*.js" -o -name "*.bundle.js" | wc -l | tr -d ' ')
             if [ "${CHUNK_COUNT:-0}" -lt 2 ]; then
-              echo "⚠️  WARNING: Very few webpack chunks found (${CHUNK_COUNT:-0})"
+              echo "⚠️  WARNING: Very few rspack chunks found (${CHUNK_COUNT:-0})"
             else
-              echo "✅ PASS: Found ${CHUNK_COUNT:-0} webpack chunks"
+              echo "✅ PASS: Found ${CHUNK_COUNT:-0} rspack chunks"
             fi
           else
             echo "ℹ️  INFO: No remoteEntry.js found (no federated modules configured)"
@@ -572,7 +572,7 @@ jobs:
             echo "❌ TOTAL FAILURES: $FAILURES"
             echo ""
             echo "BUILD_MODE=RHOAI did not correctly apply RHOAI branding."
-            echo "Check Dockerfile environment variable setup and webpack configuration."
+            echo "Check Dockerfile environment variable setup and rspack configuration."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ odh-dashboard/
 | TypeScript    | Type safety                                |
 | PatternFly v6 | Primary UI component library (RHOAI/ODH)   |
 | Material UI   | Secondary UI library (Kubeflow mode)       |
-| Webpack       | Build tooling with Module Federation       |
+| Rspack        | Build tooling with Module Federation       |
 | Cypress       | E2E and component testing                  |
 | Jest          | Unit testing                               |
 | Turbo         | Monorepo task runner                       |
@@ -107,7 +107,7 @@ Rules live in `.claude/rules/`. Read the relevant rule file before starting the 
 | **envtest Integration Tests** | `envtest-integration-tests.md` | When writing or modifying envtest integration tests in `dashboard-operator/` |
 | **Jira Creation**           | `jira-creation.md`            | When asked to create Jira issues, tickets, bugs, stories, tasks, or epics      |
 | **Modular Architecture**    | `modular-architecture.md`     | When working on the plugin/extension system or package integration              |
-| **Module Federation**       | `module-federation.md`        | When configuring Module Federation, webpack remotes, or shared dependencies    |
+| **Module Federation**       | `module-federation.md`        | When configuring Module Federation, rspack remotes, or shared dependencies     |
 | **Module Onboarding**       | `module-onboarding.md`        | When creating a new package/module in the monorepo                             |
 | **Operator Controller**     | `operator-controller.md`      | When working on Go operator/controller-runtime code in `dashboard-operator/`   |
 | **Pull Requests**           | `pull-requests.md`            | When creating a pull request — must follow `.github/pull_request_template.md`  |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This is a **monorepo** using npm workspaces and Turbo for orchestration:
 
 ```
 odh-dashboard/
-├── frontend/           # Main dashboard frontend (React + Webpack Module Federation)
+├── frontend/           # Main dashboard frontend (React + Module Federation)
 ├── backend/            # Main dashboard backend (Node.js/Express)
 ├── packages/           # Feature packages (~25 packages)
 │   ├── gen-ai/        # Generative AI features (has BFF)
@@ -130,7 +130,7 @@ Key technologies:
 - **React 18** - Frontend framework
 - **TypeScript** - Type safety
 - **PatternFly v6** - UI components
-- **Webpack Module Federation** - Runtime code sharing
+- **Module Federation** - Runtime code sharing
 - **Turbo** - Monorepo task orchestration
 - **Cypress** - E2E testing
 - **Jest** - Unit testing

--- a/distributions/base/README.md
+++ b/distributions/base/README.md
@@ -16,11 +16,11 @@ This starts:
 | Service | URL | Description |
 |---------|-----|-------------|
 | BFF stub | `http://localhost:4000` | Minimal `/api/status` endpoint |
-| App shell | `http://localhost:4010` | Rspack dev server with HMR |
+| App shell | `http://localhost:4010` | Dev server with HMR |
 
 ### Environment variables
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `BFF_PORT` | `4000` | Port for the stub BFF server |
-| `SHELL_PORT` | `4010` | Port for the rspack dev server |
+| `SHELL_PORT` | `4010` | Port for the dev server |

--- a/distributions/core-bff/frontend/config/dotenv.js
+++ b/distributions/core-bff/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} filePath
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (filePath) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/distributions/maas-consumer-portal/config/rspack.dev.js
+++ b/distributions/maas-consumer-portal/config/rspack.dev.js
@@ -8,7 +8,7 @@ const RELATIVE_DIRNAME = path.resolve(__dirname, '..');
 const DIST_DIR = path.resolve(RELATIVE_DIRNAME, 'public');
 const PORT = process.env.SHELL_PORT || 4020;
 
-// Derived from frontend/config/webpack.dev.js — token acquisition, route
+// Derived from frontend/config/rspack.dev.js — token acquisition, route
 // discovery, and proxy setup are duplicated across 7+ bundler configs in the
 // repo. Extract into a shared dev-proxy utility in packages/app-config.
 

--- a/distributions/rhaii/Makefile
+++ b/distributions/rhaii/Makefile
@@ -20,7 +20,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: dev-start
-dev-start: ## Start in mock mode (BFF + rspack dev server, no cluster needed)
+dev-start: ## Start in mock mode (BFF + dev server, no cluster needed)
 	npm run start:dev
 
 ##@ Build

--- a/docs/KONFLUX_BUILD_SIMULATION.md
+++ b/docs/KONFLUX_BUILD_SIMULATION.md
@@ -59,7 +59,7 @@ Runs BEFORE Docker build to catch issues in <1 minute:
   - Validates: Environment variable handling, branding differences
 
 - ✅ **Multi-stage build testing**
-  - Builder stage: Compiles TypeScript, builds webpack bundles
+  - Builder stage: Compiles TypeScript, builds rspack bundles
   - Runtime stage: Serves production artifacts
   - Catches: Missing COPY commands, permission issues
 
@@ -97,7 +97,7 @@ Runs BEFORE Docker build to catch issues in <1 minute:
   - Minimum size: 100 bytes
   - Catches: Build failures that produce empty manifests
 
-- ✅ **Missing webpack chunk detection**
+- ✅ **Missing rspack chunk detection**
   - Parses: `remoteEntry.js` for chunk references
   - Validates: All referenced chunks exist as `*.bundle.js` files
   - Prevents: Runtime ChunkLoadError (RHOAIENG-59862)
@@ -325,7 +325,7 @@ RUN rm -rf node_modules/esbuild node_modules/@esbuild node_modules/.bin/esbuild
 ```
 
 **Fix:**
-1. Check webpack config for output settings
+1. Check rspack config for output settings
 2. Verify `publicPath` is correct
 3. Ensure all chunks are generated:
    ```bash

--- a/docs/adr/0001-use-monorepo-with-npm-workspaces.md
+++ b/docs/adr/0001-use-monorepo-with-npm-workspaces.md
@@ -75,4 +75,4 @@ odh-dashboard/
 - [docs/architecture.md](../architecture.md)
 - [npm workspaces documentation](https://docs.npmjs.com/cli/v10/using-npm/workspaces)
 - [Turbo documentation](https://turbo.build/repo/docs)
-- [ADR 0002: Use Webpack Module Federation](0002-use-webpack-module-federation.md)
+- [ADR 0002: Use Module Federation](0002-use-rspack-module-federation.md)

--- a/docs/adr/0002-use-rspack-module-federation.md
+++ b/docs/adr/0002-use-rspack-module-federation.md
@@ -1,6 +1,6 @@
-# 2. Use Webpack Module Federation
+# 2. Use Module Federation
 
-Date: 2024-11-15 (documented 2026-03-11)
+Date: 2024-11-15 (documented 2026-03-11; bundler updated to Rspack 2026-09-01)
 
 ## Status
 
@@ -23,13 +23,16 @@ We needed a way to:
 
 ## Decision
 
-Use **Webpack Module Federation** as the micro-frontend architecture.
+Use **Module Federation** (`@module-federation/enhanced`) as the micro-frontend architecture.
+
+The original 2024 decision was Webpack Module Federation. Non-upstream modules and the dashboard host now build with Rspack; the Module Federation architecture (host, remotes, shared singletons, `package.json` discovery) is unchanged. Upstream `notebooks` and `model-registry` still use webpack.
 
 Architecture:
 - **Host**: Main dashboard application (`frontend/`)
-- **Remotes**: Feature packages (`packages/gen-ai`, `packages/model-registry`, etc.)
-- **Shared dependencies**: React, PatternFly, routing libraries
+- **Remotes**: Feature packages (`packages/gen-ai`, `packages/maas`, etc.)
+- **Shared dependencies**: React, PatternFly, routing libraries, applied by `OdhFederationPlugin`
 - **Discovery**: Automatic via `package.json` `module-federation` field
+- **Plugin**: `@odh-dashboard/app-config/rspack` (`packages/app-config/src/rspack/OdhFederationPlugin.ts`) for the host and package remotes; `@odh-dashboard/app-config/webpack` for notebooks and model-registry upstream only
 
 ## Consequences
 
@@ -40,6 +43,7 @@ Architecture:
 - **Performance**: Only load features user actually uses
 - **Versioning**: Can run different versions of features
 - **Sharing**: Shared dependencies reduce bundle size
+- **Build speed**: Rspack is webpack-compatible with faster local rebuilds
 
 **Negative:**
 - **Complexity**: More complex build setup
@@ -47,6 +51,7 @@ Architecture:
 - **Version conflicts**: Shared dependency versions must be compatible
 - **Type safety**: TypeScript types across remote boundaries need management
 - **Learning curve**: Team needs to understand Module Federation
+- **Dual bundlers**: Cypress test preprocessing and two upstream packages still use webpack
 
 **Neutral:**
 - Requires coordination on shared dependency versions
@@ -76,13 +81,15 @@ All remotes must share:
 - `react-router` (singleton)
 - `@patternfly/react-core` (singleton)
 
+`OdhFederationPlugin` applies this policy from the `package.json` in rspack `compiler.context`. Do not maintain a manual shared map for those packages.
+
 ## Alternatives Considered
 
 ### Single-Spa
 **Rejected because:**
 - More framework-agnostic (we're all React)
 - More boilerplate per feature
-- Module Federation better integrates with Webpack
+- Module Federation better integrates with the Rspack/webpack build
 
 ### Iframe-based plugins
 **Rejected because:**
@@ -101,6 +108,6 @@ All remotes must share:
 ## References
 
 - [docs/module-federation.md](../module-federation.md)
-- [Webpack Module Federation](https://webpack.js.org/concepts/module-federation/)
-- [Module Federation examples](https://module-federation.io/)
+- [Module Federation](https://rspack.rs/guide/features/module-federation)
+- [Module Federation](https://module-federation.io/)
 - [ADR 0001: Use Monorepo](0001-use-monorepo-with-npm-workspaces.md)

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -18,7 +18,7 @@ Key architectural decisions for the ODH Dashboard monorepo. For formal ADRs, see
 
 ## Why Module Federation?
 
-**Decision**: Use Webpack Module Federation for runtime code-splitting
+**Decision**: Use Module Federation for runtime code-splitting (via `@module-federation/enhanced`; see [ADR 0002](adr/0002-use-rspack-module-federation.md))
 
 **Rationale**:
 - **Plugin architecture**: External teams can build features independently

--- a/docs/bff-e2e-testing.md
+++ b/docs/bff-e2e-testing.md
@@ -12,7 +12,7 @@ The E2E test pipeline uses a "build-then-serve" model:
 4. **E2E Proxy**: A lightweight reverse proxy on `:4040` sits in front of the stack, injecting auth headers and routing requests to the backend, BFFs, or cluster
 5. **Cypress**: Tests hit `http://localhost:4040` (proxy), which forwards to the local stack
 
-No webpack dev servers are used in CI. BFFs serve both their API routes and static frontend files via `STATIC_ASSETS_DIR`.
+No bundler dev servers are used in CI. BFFs serve both their API routes and static frontend files via `STATIC_ASSETS_DIR`.
 
 ## Architecture
 

--- a/docs/cypress-tutorial.md
+++ b/docs/cypress-tutorial.md
@@ -527,7 +527,7 @@ The `packages/cypress/cypress/support/e2e.ts` file is automatically loaded befor
   - `beforeEach()`: Applies filtering, sets up mocks (`CY_MOCK=1`), configures module federation, logs test info
   - `afterEach()`: Handles skipped suites, tracks execution
   - `after()`: Runs soft assertions
-- **Error Handling**: Ignores `ChunkLoadError` and webpack-dev-server fallback errors
+- **Error Handling**: Ignores `ChunkLoadError` and dev-server fallback errors
 - **Command Logging**: Logs `cy.step()`, `cy.exec()`, and `cy.log()` to terminal
 
 #### Skipped Tests in JUnit Results
@@ -644,7 +644,7 @@ npm run cypress:run -- --env grepTags="@Smoke",skipTags="@Bug" --browser chrome
 npm run cypress:run -- --spec "cypress/tests/e2e/testProjectCreation.cy.ts" --browser chrome
 ```
 
-**If using localhost with webpack** (dev workflow), start the dev server first:
+**If using localhost with rspack** (dev workflow), start the dev server first:
 
 ```bash
 npm run start:dev:ext  # Proxies to your logged-in cluster

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -434,11 +434,11 @@ const ModelCard: React.FC<{ extension: ModelExtension }> = ({ extension }) => {
 
 ## Chunk Naming Strategy
 
-The build system uses a **single-chunk-per-plugin** strategy for extension code references. This section applies to extension packages that are bundled into the host application (i.e., workspace packages with a `./extensions` export). For Module Federation remotes, chunking is handled by each remote's own webpack build.
+The build system uses a **single-chunk-per-plugin** strategy for extension code references. This section applies to extension packages that are bundled into the host application (i.e., workspace packages with a `./extensions` export). For Module Federation remotes, chunking is handled by each remote's own rspack build.
 
 ### Scope
 
-The chunk grouping strategy **only affects dynamic imports originating from extension definition files** (files matching `extensions.ts` or files in an `extensions/` directory). Any other code-splitting within a plugin — such as `React.lazy()` route splitting inside components — retains normal webpack behavior and is not merged into the plugin chunk.
+The chunk grouping strategy **only affects dynamic imports originating from extension definition files** (files matching `extensions.ts` or files in an `extensions/` directory). Any other code-splitting within a plugin — such as `React.lazy()` route splitting inside components — retains normal rspack behavior and is not merged into the plugin chunk.
 
 ### Default Behavior
 
@@ -474,7 +474,7 @@ All three imports (`./src/deployments`, `./src/deploy`, `./src/hardware`) are bu
 
 ### Custom Chunk Names with `webpackChunkName`
 
-Extension authors can override the default grouping using webpack's [`webpackChunkName`](https://webpack.js.org/api/module-methods/#webpackchunkname) magic comment. This is useful when a plugin is large enough to benefit from logical separation into multiple chunks.
+Extension authors can override the default grouping using Rspack's webpack-compatible [`webpackChunkName`](https://webpack.js.org/api/module-methods/#webpackchunkname) magic comment. This is useful when a plugin is large enough to benefit from logical separation into multiple chunks.
 
 ```typescript
 const extensions = [

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -81,7 +81,7 @@ custom notes in Known Issues / Gotchas or a separate doc if they should survive 
 | Term | Definition |
 |------|-----------|
 | **BFF** | Backend-for-Frontend — a Go HTTP server that serves frontend assets, handles auth, and proxies k8s/external API calls. |
-| **Module Federation** | Webpack 5 feature loading packages as micro-frontends at runtime. |
+| **Module Federation** | Runtime feature loading packages as micro-frontends (Rspack / `@module-federation/enhanced`). |
 | **PatternFly (PF)** | Primary React component library (v6). |
 | **Material UI (MUI)** | Secondary UI library used in Kubeflow deployment mode. |
 | **SSAR** | SelfSubjectAccessReview — k8s API for permission checks without Group API. |

--- a/docs/module-federation.md
+++ b/docs/module-federation.md
@@ -29,7 +29,7 @@ Shared module policy is centralized in `@odh-dashboard/app-config` and enforced 
 
 - **`OdhFederationPlugin`** — host and remotes. Import from `@odh-dashboard/app-config/rspack` (dashboard host and package remotes) or `@odh-dashboard/app-config/webpack` (notebooks and model-registry upstream only). Pass `isHost: true` for the dashboard and for standalone remotes; pass `isHost: false` when the package is a federated remote.
 
-The plugin configures shared modules, singleton flags, and version constraints so individual `moduleFederation.js` files do not maintain shared dependency lists manually. Entries from the default PatternFly / React / SDK map are shared only when they appear in `dependencies` of the `package.json` in webpack `compiler.context`. ODH packages are shared from workspace discovery (see table below), not gated on each remote's `dependencies`.
+The plugin configures shared modules, singleton flags, and version constraints so individual `moduleFederation.js` files do not maintain shared dependency lists manually. Entries from the default PatternFly / React / SDK map are shared only when they appear in `dependencies` of the `package.json` in the bundler `compiler.context`. ODH packages are shared from workspace discovery (see table below), not gated on each remote's `dependencies`.
 
 #### What is automatically shared
 
@@ -212,11 +212,11 @@ Federated modules can extend the host application by exposing extensions through
 
 ### Exposing Extensions
 
-Your module's webpack configuration must expose extensions:
+Your module's rspack configuration must expose extensions:
 
 ```javascript
-// webpack config (packages/my-module/frontend/config/moduleFederation.js)
-const { OdhFederationPlugin } = require('@odh-dashboard/app-config/webpack');
+// rspack config (packages/my-module/frontend/config/moduleFederation.js)
+const { OdhFederationPlugin } = require('@odh-dashboard/app-config/rspack');
 
 module.exports = {
   moduleFederationPlugins: [
@@ -263,7 +263,7 @@ For detailed information about:
 
 Please refer to the [Extensibility Documentation](./extensibility.md).
 
-## Webpack Configuration
+## Rspack Configuration
 
 ### Required Dependencies
 
@@ -273,7 +273,7 @@ In the remote's **frontend** `package.json`:
 npm install --save-dev @module-federation/enhanced
 ```
 
-In the module's **parent** `package.json`, add `@odh-dashboard/app-config` as a `devDependency` (resolved via workspace hoisting when the frontend webpack config requires it):
+In the module's **parent** `package.json`, add `@odh-dashboard/app-config` as a `devDependency` (resolved via workspace hoisting when the frontend rspack config requires it):
 
 ```json
 {
@@ -291,7 +291,7 @@ Remote modules use `OdhFederationPlugin` with `isHost` derived from `DEPLOYMENT_
 
 ```javascript
 // packages/my-module/frontend/config/moduleFederation.js
-const { OdhFederationPlugin } = require('@odh-dashboard/app-config/webpack');
+const { OdhFederationPlugin } = require('@odh-dashboard/app-config/rspack');
 
 module.exports = {
   moduleFederationPlugins: [
@@ -354,7 +354,7 @@ module.exports = {
 1. Add camelCase `module-federation` configuration to the parent `package.json`
 2. Add `@module-federation/enhanced` to the frontend `package.json` `devDependencies`
 3. Add `@odh-dashboard/app-config` to the parent `package.json` `devDependencies` (requires Node.js 22.18.0+; no separate app-config build)
-4. Create a `moduleFederation.js` using `OdhFederationPlugin` from `@odh-dashboard/app-config/webpack` (`isHost: process.env.DEPLOYMENT_MODE === 'standalone'`)
+4. Create a `moduleFederation.js` using `OdhFederationPlugin` from `@odh-dashboard/app-config/rspack` (`isHost: process.env.DEPLOYMENT_MODE === 'standalone'`)
 5. Create extensions and extension-points files under `src/odh/`
 6. Build and serve your module locally
 
@@ -368,20 +368,20 @@ module.exports = {
 
 The monorepo contains two types of packages:
 
-- **Federated remotes** (webpack + MF config): Packages like `gen-ai`, `maas`, `mlflow` that build separately and the host loads at runtime.
-- **Library packages** (no webpack, no MF config): Packages like `llmd-serving`, `model-serving`, `kserve`, `plugin-core` that expose raw TypeScript via `package.json` `exports`.
+- **Federated remotes** (rspack + MF config): Packages like `gen-ai`, `maas`, `mlflow` that build separately and the host loads at runtime. Upstream `notebooks` and `model-registry` still use webpack.
+- **Library packages** (no rspack, no MF config): Packages like `llmd-serving`, `model-serving`, `kserve`, `plugin-core` that expose raw TypeScript via `package.json` `exports`.
 
-When a federated remote imports from a library package, webpack must compile the library's TypeScript and the code can end up duplicated between the host and remote bundles. Host-provided ODH packages (on the host dependency graph or that export `./extensions`) are shared as singletons with `import: false` on remotes so the remote consumes the host copy.
+When a federated remote imports from a library package, rspack must compile the library's TypeScript and the code can end up duplicated between the host and remote bundles. Host-provided ODH packages (on the host dependency graph or that export `./extensions`) are shared as singletons with `import: false` on remotes so the remote consumes the host copy.
 
-### Webpack Exclude Regex
+### Rspack Exclude Regex
 
-All `webpack.common.js` files use a negative lookahead in the TS/JS rule to allow `@odh-dashboard/*` packages to be compiled:
+All `rspack.common.js` files use a negative lookahead in the TS/JS rule to allow `@odh-dashboard/*` packages to be compiled:
 
 ```javascript
 exclude: [/node_modules\/(?!@odh-dashboard)/, /__tests__/, /__mocks__/],
 ```
 
-This ensures webpack can parse TypeScript from `@odh-dashboard/*` packages resolved through `node_modules`.
+This ensures rspack can parse TypeScript from `@odh-dashboard/*` packages resolved through `node_modules`.
 
 ### Adding a New Library Package
 
@@ -389,7 +389,7 @@ When creating a new `@odh-dashboard/*` library package that will be consumed by 
 
 1. Add the package to the monorepo under `packages/`. npm workspaces will hoist it into `node_modules/@odh-dashboard/`.
 2. For remotes to use `import: false` against it, the package must be host-provided: either appear in the host's `@odh-dashboard/*` dependency closure, or export `./extensions` (included in the host via the virtual `plugin-extensions` module). Otherwise it is only shared as a singleton with import/fallback if reached from a federated package's dependency tree.
-3. Ensure the consumer's `webpack.common.js` has the `node_modules\/(?!@odh-dashboard)` exclude pattern.
+3. Ensure the consumer's `rspack.common.js` has the `node_modules\/(?!@odh-dashboard)` exclude pattern.
 
 ## Troubleshooting
 
@@ -398,5 +398,5 @@ When creating a new `@odh-dashboard/*` library package that will be consumed by 
 1. **Module not loading**: Verify the camelCase module name matches between `package.json` `module-federation.name` and `OdhFederationPlugin`
 2. **Shared dependency conflicts**: Confirm the module is listed in that package's `dependencies` (plugins only share packages present there) and that `@odh-dashboard/app-config` is installed as a parent `devDependency`
 3. **Proxy issues**: Check that the backend service is running and accessible
-4. **Asset loading issues**: If you see failing requests for `__federation_expose_` files without the module name in the path, add `output.publicPath = 'auto'` to your webpack configuration
-5. **Module parse failed for `@odh-dashboard/*` packages**: Ensure `webpack.common.js` uses `exclude: [/node_modules\/(?!@odh-dashboard)/]` instead of `exclude: [/node_modules/]` in the TS/JS rule
+4. **Asset loading issues**: If you see failing requests for `__federation_expose_` files without the module name in the path, add `output.publicPath = 'auto'` to your rspack configuration
+5. **Module parse failed for `@odh-dashboard/*` packages**: Ensure `rspack.common.js` uses `exclude: [/node_modules\/(?!@odh-dashboard)/]` instead of `exclude: [/node_modules/]` in the TS/JS rule

--- a/docs/multi-agent-workflows.md
+++ b/docs/multi-agent-workflows.md
@@ -189,7 +189,7 @@ Some operations must run in one session at a time:
 
 ### Session Limits
 
-Run 3–4 concurrent sessions maximum. Each session consumes memory and CPU for file watching, TypeScript compilation, and webpack builds. Monitor system resources and reduce sessions if the machine slows down.
+Run 3–4 concurrent sessions maximum. Each session consumes memory and CPU for file watching, TypeScript compilation, and rspack builds. Monitor system resources and reduce sessions if the machine slows down.
 
 ### Context Management
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -425,9 +425,9 @@ Theming is handled automatically by `PersesProvider`. It reads the current Patte
 | `defaultRefreshInterval` | `string` | `'60s'` | Initial refresh interval |
 | `syncToUrl` | `boolean` | `false` | Sync time range and variables to URL query params |
 
-### Webpack and Module Federation changes
+### Rspack and Module Federation changes
 
-When embedding Perses in a federated package, additional webpack configuration is required. The Perses libraries and their transitive dependencies (MUI, ECharts, React Query, `use-query-params`) must be shared as singletons to avoid duplicate React contexts and CSS conflicts.
+When embedding Perses in a federated package, additional rspack configuration is required. The Perses libraries and their transitive dependencies (MUI, ECharts, React Query, `use-query-params`) must be shared as singletons to avoid duplicate React contexts and CSS conflicts.
 
 > **Note:** These workarounds are likely necessary due to issues with how Module Federation resolves deep transitive dependencies across package boundaries. This is being actively investigated and may be simplified in the future.
 
@@ -449,12 +449,12 @@ shared: {
 
 #### CSS loader includes
 
-The observability package ships CSS from Perses component libraries. Your webpack CSS rules must include the observability package path so its styles are processed correctly.
+The observability package ships CSS from Perses component libraries. Your rspack CSS rules must include the observability package path so its styles are processed correctly.
 
-In both `webpack.dev.js` and `webpack.prod.js`, add the observability path to the CSS rule's `include` array:
+In both `rspack.dev.js` and `rspack.prod.js`, add the observability path to the CSS rule's `include` array:
 
 ```js
-// webpack.dev.js
+// rspack.dev.js
 {
   test: /\.css$/,
   include: [
@@ -470,7 +470,7 @@ In both `webpack.dev.js` and `webpack.prod.js`, add the observability path to th
 ```
 
 ```js
-// webpack.prod.js
+// rspack.prod.js
 {
   test: /\.css$/,
   include: [

--- a/docs/package-topology.md
+++ b/docs/package-topology.md
@@ -19,7 +19,7 @@ The distributions architecture organizes code into the following groups:
 | **App shell** | Shared framework (masthead, sidebar, routing, error boundary) that distributions extend. | `distributions/base/` |
 | **Feature packages** | Domain-specific frontend functionality. Depend on core shared libraries. | `model-serving`, `kserve`, `gen-ai`, `maas`, `model-registry`, etc. |
 | **Core shared libraries** | Extension framework, shared UI, K8s types, pure utilities. | `plugin-core`, `ui-core`, `k8s-core`, `openshift-core` (future), `foundation` |
-| **Dev tooling** | Build-time tooling: webpack configuration, Module Federation setup, dev server infrastructure. | `app-config` |
+| **Dev tooling** | Build-time tooling: rspack configuration, Module Federation setup, dev server infrastructure. | `app-config` |
 
 The diagram below shows how these groups relate — arrows point from consumer to
 dependency, and runtime dependencies flow downward:
@@ -140,7 +140,7 @@ effort. PR reviewers enforce these rules using this document as reference.
 | **openshift-core** | "Is it an OpenShift-specific type or runtime behavior?" | OpenShift-specific types and utilities that layer on top of `k8s-core`. |
 | **plugin-core** | "Does it need to know how the plugin system works?" | Extension points, plugin store, discovery hooks (`useExtensions`, `useResolvedExtensions`), code ref resolution (`LazyCodeRefComponent`), feature areas (`SupportedArea`, `useIsAreaAvailable`). |
 | **ui-core** | "Does it just render data using shared UI patterns?" | Shared React components (tables, resource display, form helpers), shared utilities (formatting, validation), and extension renderers (`ExtensibleDetailTabs`, `ExtensibleActions`). |
-| **app-config** | "Does it run only at build time?" | Build-time tooling: webpack configuration, Module Federation setup, dev server infrastructure. If it runs in the browser at runtime, it does not belong here. |
+| **app-config** | "Does it run only at build time?" | Build-time tooling: rspack configuration, Module Federation setup, dev server infrastructure. If it runs in the browser at runtime, it does not belong here. |
 
 ### Where does this code go?
 
@@ -174,7 +174,7 @@ flowchart TD
     q9 -->|"Runtime behavior"| occore3["openshift-core"]
     q9 -->|No| uicore["ui-core"]
 
-    q7 -->|No| q10{"Build/config tooling?\n(webpack, MF, dev server)"}
+    q7 -->|No| q10{"Build/config tooling?\n(rspack, MF, dev server)"}
     q10 -->|Yes| appconfig["app-config"]
     q10 -->|No| review["⚠ needs architectural review"]
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -172,7 +172,7 @@ npm run test:cypress-ci -- --spec "**/testfile.cy.ts"
 
 Cypress tests require a frontend server to be running.
 
-Using the webpack development server allows for auto rebuilding the dashboard frontend as code changes are made.
+Using the rspack development server allows for auto rebuilding the dashboard frontend as code changes are made.
 
 To have turbo run a cypress server for the frontend folder and all federated modules run the following from the root of the repository:
 

--- a/frontend/config/dotenv.js
+++ b/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} filePath
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (dotEnvFilePath) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/packages/agent-ops/frontend/config/dotenv.js
+++ b/packages/agent-ops/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} filePath
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (filePath) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/packages/app-config/src/rspack/OdhFederationPlugin.ts
+++ b/packages/app-config/src/rspack/OdhFederationPlugin.ts
@@ -10,7 +10,7 @@ const { BaseOdhFederationPlugin } = require('../webpack/BaseOdhFederationPlugin.
 export type { OdhFederationPluginOptions };
 
 /**
- * Rspack Module Federation plugin for host and remote builds.
+ * Module Federation plugin for host and remote builds.
  *
  * Usage:
  *   new OdhFederationPlugin({ name: 'host', isHost: true, remotes, dts })

--- a/packages/app-config/src/webpack/BaseOdhFederationPlugin.ts
+++ b/packages/app-config/src/webpack/BaseOdhFederationPlugin.ts
@@ -55,7 +55,7 @@ export type ModuleFederationPluginClass<TCompiler> = new (config: ModuleFederati
  * - **Remote** (`isHost: false`): `import: false` for must-share / host-provided
  *   modules.
  *
- * React / PatternFly / SDK versions come from `package.json` in webpack
+ * React / PatternFly / SDK versions come from `package.json` in the bundler
  * `compiler.options.context`.
  */
 abstract class BaseOdhFederationPlugin<TCompiler extends FederationCompiler> {

--- a/packages/app-config/src/webpack/getRuntimeOdhPackages.ts
+++ b/packages/app-config/src/webpack/getRuntimeOdhPackages.ts
@@ -46,12 +46,12 @@ const findMonorepoRoot = (): string => {
   }
   throw new Error(
     `Could not locate monorepo root from ${process.cwd()}. ` +
-      'Ensure webpack is invoked from a directory within the monorepo.',
+      'Ensure the bundler is invoked from a directory within the monorepo.',
   );
 };
 
 /**
- * Read `dependencies` from the package.json in `startDir` (webpack `compiler.options.context`).
+ * Read `dependencies` from the package.json in `startDir` (bundler `compiler.options.context`).
  */
 const collectDependenciesFromContext = (startDir: string): Record<string, string> =>
   readPackageJson(startDir)?.dependencies ?? {};

--- a/packages/automl/README.md
+++ b/packages/automl/README.md
@@ -47,7 +47,7 @@ packages/automl/
 │   └── Makefile             # BFF build commands
 ├── frontend/                # React Frontend application
 │   ├── src/                 # Source code
-│   ├── config/              # Webpack & Module Federation
+│   ├── config/              # Rspack & Module Federation
 │   └── package.json         # Frontend dependencies
 ├── docs/                    # Documentation
 ├── Dockerfile               # Multi-stage container build

--- a/packages/automl/bff/README.md
+++ b/packages/automl/bff/README.md
@@ -244,7 +244,7 @@ From the `packages/automl/` directory:
 make dev-start-federated
 ```
 
-This starts both the BFF (port 4003) and the frontend webpack dev server (port 9108) in federated mode. The BFF connects to in-cluster services using dynamic port-forwarding and uses your cluster credentials for RBAC.
+This starts both the BFF (port 4003) and the frontend dev server (port 9108) in federated mode. The BFF connects to in-cluster services using dynamic port-forwarding and uses your cluster credentials for RBAC.
 
 **Pipeline name prefixes:** The BFF discovers AutoML pipelines by matching display names that start with configurable prefixes. AutoML has two pipeline types with separate prefixes:
 

--- a/packages/automl/frontend/README.md
+++ b/packages/automl/frontend/README.md
@@ -26,7 +26,7 @@ npm install && npm run start:dev
 | Command             | Description                              |
 | ------------------- | ---------------------------------------- |
 | `npm install`       | Install dependencies                     |
-| `npm run start:dev` | Start webpack dev server with hot reload |
+| `npm run start:dev` | Start dev server with hot reload |
 
 ### Build & Bundle
 
@@ -105,7 +105,7 @@ import icon from '~/app/assets/icons/workflow.svg';
 <span dangerouslySetInnerHTML={{ __html: icon }} />
 ```
 
-> **⚠️ Security Note**: This pattern is safe only for SVG files imported at build time via webpack. Never use `dangerouslySetInnerHTML` with SVG content from external or user-supplied sources.
+> **⚠️ Security Note**: This pattern is safe only for SVG files imported at build time via rspack. Never use `dangerouslySetInnerHTML` with SVG content from external or user-supplied sources.
 
 **CSS background SVG** (must be in `bgimages/` directory):
 
@@ -123,7 +123,7 @@ import icon from '~/app/assets/icons/workflow.svg';
 
 ### Custom CSS from Third-Party Packages
 
-When importing CSS from a new npm package, you may encounter webpack errors. Register the package's stylesheet path in `config/stylePaths.js` to enable proper CSS module parsing.
+When importing CSS from a new npm package, you may encounter rspack errors. Register the package's stylesheet path in `config/stylePaths.js` to enable proper CSS module parsing.
 
 ### Theming
 
@@ -153,7 +153,7 @@ This project maintains high code quality standards through automated tooling:
 
 ### Module Federation
 
-This application uses Webpack's Module Federation for:
+This application uses Module Federation for:
 
 - Dynamic module loading
 - Shared dependencies across micro-frontends

--- a/packages/automl/frontend/config/dotenv.js
+++ b/packages/automl/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} filePath
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (filePath) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/packages/autorag/README.md
+++ b/packages/autorag/README.md
@@ -47,7 +47,7 @@ packages/autorag/
 │   └── Makefile             # BFF build commands
 ├── frontend/                # React Frontend application
 │   ├── src/                 # Source code
-│   ├── config/              # Webpack & Module Federation
+│   ├── config/              # Rspack & Module Federation
 │   └── package.json         # Frontend dependencies
 ├── docs/                    # Documentation
 ├── Dockerfile               # Multi-stage container build

--- a/packages/autorag/bff/README.md
+++ b/packages/autorag/bff/README.md
@@ -334,7 +334,7 @@ From the `packages/autorag/` directory:
 make dev-start-federated
 ```
 
-This starts both the BFF (port 4001) and the frontend webpack dev server (port 9107) in federated mode. The BFF connects to in-cluster services using dynamic port-forwarding and uses your cluster credentials for RBAC.
+This starts both the BFF (port 4001) and the frontend dev server (port 9107) in federated mode. The BFF connects to in-cluster services using dynamic port-forwarding and uses your cluster credentials for RBAC.
 
 **Pipeline name prefix:** The BFF discovers AutoRAG pipelines by matching display names that start with a configurable prefix. The default is `documents-rag-optimization-pipeline`. If your pipelines use a different naming convention, override it:
 

--- a/packages/autorag/frontend/README.md
+++ b/packages/autorag/frontend/README.md
@@ -26,7 +26,7 @@ npm install && npm run start:dev
 | Command             | Description                              |
 | ------------------- | ---------------------------------------- |
 | `npm install`       | Install dependencies                     |
-| `npm run start:dev` | Start webpack dev server with hot reload |
+| `npm run start:dev` | Start dev server with hot reload |
 
 ### Build & Bundle
 
@@ -105,7 +105,7 @@ import icon from '~/app/assets/icons/workflow.svg';
 <span dangerouslySetInnerHTML={{ __html: icon }} />
 ```
 
-> **⚠️ Security Note**: This pattern is safe only for SVG files imported at build time via webpack. Never use `dangerouslySetInnerHTML` with SVG content from external or user-supplied sources.
+> **⚠️ Security Note**: This pattern is safe only for SVG files imported at build time via rspack. Never use `dangerouslySetInnerHTML` with SVG content from external or user-supplied sources.
 
 **CSS background SVG** (must be in `bgimages/` directory):
 
@@ -123,7 +123,7 @@ import icon from '~/app/assets/icons/workflow.svg';
 
 ### Custom CSS from Third-Party Packages
 
-When importing CSS from a new npm package, you may encounter webpack errors. Register the package's stylesheet path in `config/stylePaths.js` to enable proper CSS module parsing.
+When importing CSS from a new npm package, you may encounter rspack errors. Register the package's stylesheet path in `config/stylePaths.js` to enable proper CSS module parsing.
 
 ### Theming
 
@@ -153,7 +153,7 @@ This project maintains high code quality standards through automated tooling:
 
 ### Module Federation
 
-This application uses Webpack's Module Federation for:
+This application uses Module Federation for:
 
 - Dynamic module loading
 - Shared dependencies across micro-frontends

--- a/packages/autorag/frontend/config/dotenv.js
+++ b/packages/autorag/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} filePath
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (filePath) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/packages/autorag/frontend/docs/architecture.md
+++ b/packages/autorag/frontend/docs/architecture.md
@@ -62,4 +62,4 @@ The AutoRAG UI is a React application that provides a user interface for configu
 
 ## Module Federation
 
-The app uses Webpack Module Federation for dynamic loading and integration with the ODH Dashboard. It can run standalone or as a federated module within the main dashboard.
+The app uses Module Federation for dynamic loading and integration with the ODH Dashboard. It can run standalone or as a federated module within the main dashboard.

--- a/packages/data-registry/frontend/config/dotenv.js
+++ b/packages/data-registry/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} filePath
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (filePath) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/packages/eval-hub/frontend/config/dotenv.js
+++ b/packages/eval-hub/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} filePath
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (filePath) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/packages/feature-store/AGENTS.md
+++ b/packages/feature-store/AGENTS.md
@@ -4,7 +4,7 @@ Package-specific guidance for AI agents working on `@odh-dashboard/feature-store
 
 ## Key Constraints
 
-- **Bundled library, not a Module Federation remote.** Do not create webpack configs, `moduleFederation.js`, dev servers, or `remoteEntry.js`. The package compiles directly into the host dashboard bundle.
+- **Bundled library, not a Module Federation remote.** Do not create rspack configs, `moduleFederation.js`, dev servers, or `remoteEntry.js`. The package compiles directly into the host dashboard bundle.
 - **No BFF.** There is no Go backend in this package. All API calls use `proxyGET` from `@odh-dashboard/internal/api/proxyUtils` and route through the main dashboard backend.
 - **Admin UI is feature-flagged.** The browse UI (list/inspect Feast objects) is always available when the package is enabled. Create, manage, and delete operations are gated behind the `featureStoreAdmin` feature flag and RBAC (SSAR) checks. Admin routes (`/create`, `/manage`) use `conditionalArea(SupportedArea.FEATURE_STORE_ADMIN)` and `accessAllowedRouteHoC`.
 - **Backend proxy code lives elsewhere.** Proxy routes are in `backend/src/routes/api/featurestores/`, not in this package. Changes to how Feast requests are proxied require modifying the main backend.

--- a/packages/feature-store/README.md
+++ b/packages/feature-store/README.md
@@ -4,7 +4,7 @@ Read-only UI for browsing and inspecting ML features backed by a [Feast](https:/
 
 ## Architecture
 
-Feature Store is a **bundled library package** -- not a Module Federation remote. It compiles directly into the main dashboard bundle at build time. There is no separate webpack config, dev server, or `remoteEntry.js`.
+Feature Store is a **bundled library package** -- not a Module Federation remote. It compiles directly into the main dashboard bundle at build time. There is no separate rspack config, dev server, or `remoteEntry.js`.
 
 - **No BFF**: All API calls use `proxyGET` from `@odh-dashboard/internal/api/proxyUtils`. Traffic flows: browser -> main dashboard backend -> Feast REST API (`/api/v1/...`).
 - **Read-only**: List and inspect projects, entities, feature views, features, feature services, data sources, saved datasets, lineage, and metrics. No create/update/delete.

--- a/packages/feature-store/docs/overview.md
+++ b/packages/feature-store/docs/overview.md
@@ -13,7 +13,7 @@
 - **Discovery**: Backend resolves upstream host from a Kubernetes `FeatureStore` CR (or equivalent) using label `feature-store-ui=enabled` on the target service.
 - **Browse UI**: List and inspect projects, entities, feature views, features, feature services, data sources, saved datasets, lineage, search, and overview metrics.
 - **Admin UI** (flag-gated): Create, manage, and delete FeatureStore CRs. Gated by `featureStoreAdmin` flag (`SupportedArea.FEATURE_STORE_ADMIN`) and `accessAllowedRouteHoC` SSAR checks. Disabled by default.
-- **No Webpack remote**: Library package; `extensions.ts` registers with the host; `package.json` exports `./extensions`, `./routes`, `./types/*`, `./components/*`, and `./screens/lineage/*` for the plugin system.
+- **No Module Federation remote**: Library package; `extensions.ts` registers with the host; `package.json` exports `./extensions`, `./routes`, `./types/*`, `./components/*`, and `./screens/lineage/*` for the plugin system.
 
 ## Key Concepts
 

--- a/packages/gen-ai/.claude/skills/cluster-deploy-genai/SKILL.md
+++ b/packages/gen-ai/.claude/skills/cluster-deploy-genai/SKILL.md
@@ -327,7 +327,7 @@ rm -f packages/gen-ai/Dockerfile.dev-deploy
 
 ## Troubleshooting
 
-### Podman machine OOM (SIGKILL on webpack)
+### Podman machine OOM (SIGKILL on rspack)
 
 Increase podman machine memory:
 

--- a/packages/gen-ai/docs/adr/0002-system-architecture.md
+++ b/packages/gen-ai/docs/adr/0002-system-architecture.md
@@ -68,7 +68,7 @@ The system is implemented using a multi-container architecture with modern web t
 
 ### Frontend Container (React 18 + TypeScript)
 - **UI Framework**: PatternFly-based React application using `@patternfly/chatbot` components
-- **Build System**: Webpack 5 with TypeScript compilation, hot-reload, and asset optimization
+- **Build System**: Rspack with TypeScript compilation, hot-reload, and asset optimization
 - **API Communication**: Dual approach with axios HTTP client and llama-stack-client npm package
 - **State Management**: React Context API for authentication state (no Redux)
 - **Routing**: React Router v7 for client-side navigation
@@ -101,7 +101,7 @@ The system is implemented using a multi-container architecture with modern web t
 - **Development Mode**: Configurable mock clients for all services with factory-based creation
 
 ### Modular UI Deployment (ODH Dashboard Integration)
-- **Module Federation**: Deployed as a federated module within ODH Dashboard using Webpack 5 Module Federation
+- **Module Federation**: Deployed as a federated module within ODH Dashboard using Module Federation
 - **Multi-Container Pod**: Runs as a sidecar container alongside the main ODH Dashboard in the same Kubernetes pod
 - **Shared Resources**: Uses shared TLS certificates, ConfigMaps, and service networking
 - **Federation Config**: Configured via `federation-configmap.yaml` with routing rules and remote entry points

--- a/packages/gen-ai/frontend/README.md
+++ b/packages/gen-ai/frontend/README.md
@@ -49,7 +49,7 @@ npm run ci-checks
 # Clean the dist directory
 npm run clean
 
-# Generate a webpack bundle profile
+# Generate a rspack bundle profile
 npm run build:bundle-profile
 
 # Build a production bundle and serve it from the mock BFF
@@ -104,12 +104,12 @@ body {
 
 ## Adding custom CSS
 
-When importing CSS from a third-party package for the first time, you may encounter the error `Module parse failed: Unexpected token... You may need an appropriate loader to handle this file typ...`. You need to register the path to the stylesheet directory in [stylePaths.js](./stylePaths.js). We specify these explicitly for performance reasons to avoid webpack needing to crawl through the entire node_modules directory when parsing CSS modules.
+When importing CSS from a third-party package for the first time, you may encounter the error `Module parse failed: Unexpected token... You may need an appropriate loader to handle this file typ...`. You need to register the path to the stylesheet directory in [stylePaths.js](./stylePaths.js). We specify these explicitly for performance reasons to avoid rspack needing to crawl through the entire node_modules directory when parsing CSS modules.
 
 ## Code quality tools
 
 - For accessibility compliance, we use [react-axe](https://github.com/dequelabs/react-axe)
-- To keep our bundle size in check, we use [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer)
+- To keep our bundle size in check, we use [@rsdoctor/rspack-plugin](https://github.com/web-infra-dev/rsdoctor)
 - To keep our code formatting in check, we use [prettier](https://github.com/prettier/prettier)
 - To keep our code logic and test coverage in check, we use [jest](https://github.com/facebook/jest)
 - To ensure code styles remain consistent, we use [eslint](https://eslint.org/)

--- a/packages/gen-ai/frontend/config/dotenv.js
+++ b/packages/gen-ai/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} path
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (path) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -18,7 +18,7 @@ if (typeof global.structuredClone === 'undefined') {
   global.structuredClone = (obj: unknown) => JSON.parse(JSON.stringify(obj));
 }
 
-// Mock webpack-injected global variables
+// Mock bundler-injected global variables
 declare global {
   // eslint-disable-next-line no-var, @typescript-eslint/naming-convention
   var __COMMIT_HASH__: string;

--- a/packages/llmd-serving/docs/overview.md
+++ b/packages/llmd-serving/docs/overview.md
@@ -9,7 +9,7 @@
 
 - **No BFF**: CRUD for `LLMInferenceService` in `src/api/` uses the OpenShift dynamic plugin SDK from the browser with the main dashboard's in-cluster credentials.
 - **Extension points**: `extensions/extensions.ts` registers `model-serving.platform/watch-deployments`, `model-serving.deployment/deploy`, `model-serving.deployment/form-data`, `model-serving.deployment/wizard-field`, and `model-serving.deployments-table/start-stop-action`; host `model-serving` orchestrates; this package supplies LLM-d-specific behavior only.
-- **No Webpack remote**: Dashboard loads via monorepo exports (e.g. `./extensions`, `./types`, test helpers under `./__tests__/utils`).
+- **No Module Federation remote**: Dashboard loads via monorepo exports (e.g. `./extensions`, `./types`, test helpers under `./__tests__/utils`).
 - **API**: Group `serving.kserve.io`, resource `llminferenceservices`, version `v1alpha2`; shapes in `src/types.ts` as `LLMInferenceServiceKind`.
 
 ## Key Concepts

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -72,7 +72,7 @@ paths:
            dev impersonation feature (`DEV_IMPERSONATE_USER`) is active.
 
         2. `x-forwarded-access-token` — fallback for standalone federated dev mode
-           where the webpack proxy injects the real user's token directly.
+           where the rspack proxy injects the real user's token directly.
       responses:
         '200':
           description: Access check result

--- a/packages/maas/frontend/config/dotenv.js
+++ b/packages/maas/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} filePath
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (filePath) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/packages/mlflow-embedded/README.md
+++ b/packages/mlflow-embedded/README.md
@@ -22,7 +22,7 @@ This package uses the MF name `mlflowEmbedded`. The external MLflow frontend mus
 
 ## Development
 
-This package has no build step of its own -- its TSX files are compiled by the host dashboard's webpack. To develop:
+This package has no build step of its own -- its TSX files are compiled by the host dashboard's rspack. To develop:
 
 1. Start the external MLflow frontend (dev server on `localhost:9300`)
 2. Start the dashboard: `npm run dev` (from repo root)

--- a/packages/mlflow/frontend/config/dotenv.js
+++ b/packages/mlflow/frontend/config/dotenv.js
@@ -50,7 +50,7 @@ const getTsCompilerOptions = (directory) => {
 };
 
 /**
- * Setup a webpack dotenv plugin config.
+ * Setup a dotenv plugin config for rspack.
  *
  * @param {string} filePath
  * @returns {*}
@@ -69,7 +69,7 @@ const setupWebpackDotenvFile = (filePath) => {
 };
 
 /**
- * Setup multiple webpack dotenv file parameters.
+ * Setup multiple rspack dotenv file parameters.
  *
  * @param {string} directory
  * @param {string} env

--- a/packages/model-serving/docs/overview.md
+++ b/packages/model-serving/docs/overview.md
@@ -8,7 +8,7 @@
 ## Design Intent
 
 - **No package-local BFF:** all API traffic goes through the main dashboard backend (e.g. `/api/k8s/`) or equivalent cluster proxy; the UI never talks to a dedicated model-serving Go/Node service.
-- **Not a separate Webpack remote:** imported as `@odh-dashboard/model-serving`; registers extensions via the dynamic plugin SDK (`extensions/index.ts` aggregates `extensions/odh.ts`, `model-registry.ts`, `model-catalog.ts`).
+- **Not a separate Module Federation remote:** imported as `@odh-dashboard/model-serving`; registers extensions via the dynamic plugin SDK (`extensions/index.ts` aggregates `extensions/odh.ts`, `model-registry.ts`, `model-catalog.ts`).
 - Platform packages (notably `packages/kserve`) implement extension points such as `model-serving.platform`, `watch-deployments`, and `deployment/deploy` so the shared wizard and deployments table create `InferenceService` / `ServingRuntime` resources correctly for KServe vs other platforms.
 - **Data flow:** Kubernetes → main backend → React; platform-specific behaviour is injected through those extension points instead of branching inside every component.
 

--- a/packages/ui-core/src/utilities/const.ts
+++ b/packages/ui-core/src/utilities/const.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-// We need to disable the prefer-destructuring rule here due to an issue with how environment variables are handled in the build process with webpack.
+// We need to disable the prefer-destructuring rule here due to an issue with how environment variables are handled in the build process with rspack.
 import { KnownLabels } from '@odh-dashboard/k8s-core';
 
 function resolvePositivePollInterval(value: unknown): number | undefined {

--- a/scripts/validate-module-ports.js
+++ b/scripts/validate-module-ports.js
@@ -34,7 +34,7 @@ function getWorkspacePackages() {
 
 /**
  * Extracts all local dev ports from a module-federation config.
- * A single package may define multiple ports (e.g. webpack dev server + proxy target).
+ * A single package may define multiple ports (e.g. dev server + proxy target).
  * Returns an array of { port, source } objects.
  */
 function extractLocalPorts(mfConfig) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79824

## Description

Align remaining webpack wording with the Rspack Module Federation migration. After remotes and the dashboard host moved to Rspack (#9326), docs, agent rules, CI comments, and a few source comments still described webpack as the primary bundler.

**What changed**
- Renamed ADR 0002 to `docs/adr/0002-use-rspack-module-federation.md` and updated it to record the bundler change while keeping the Module Federation architecture decision.
- Updated canonical docs (`docs/module-federation.md`, architecture, onboarding, package READMEs) so host/package remotes are documented as Rspack, with webpack called out only where it still applies (Cypress preprocessor, upstream `notebooks` and `model-registry`).
- Pointed module-federation examples and onboarding at `OdhFederationPlugin` from `@odh-dashboard/app-config/rspack`.
- Updated agent rules/skills, CodeRabbit bundler paths, Dependabot ignore patterns (`@rspack/*`, `rspack*`), and PR build-validation log messages.
- Comment-only cleanups in dotenv helpers, federation plugin comments, Jest setup, `validate-module-ports.js`, and a MaaS OpenAPI description string (no API contract change).

**What did not change**
- No bundler config, federation runtime, or user-facing behavior.
- Webpack remains for Cypress test preprocessing and the two upstream packages above.

## How Has This Been Tested?

Documentation and comment cleanup; no UI or runtime behavior change.

Verification:
- Reviewed `git diff` for the `cleanup webpack references` commit (66 files).
- Confirmed remaining webpack mentions are intentional (Cypress, `notebooks`, `model-registry`, historical ADR context).
- Confirmed `packages/maas/bff/openapi.yaml` change is description text only (`webpack proxy` → `rspack proxy`).

Suggested reviewer check: search for stale “webpack” guidance in `docs/`, `.claude/rules/`, and module READMEs; webpack should remain only for Cypress and the two upstream packages.

## Test Impact

No new unit or Cypress tests. The diff is docs, comments, CI log strings, CodeRabbit paths, and Dependabot ignore patterns. There is no application logic to cover with tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build, Module Federation, development, testing, onboarding, and distribution guidance to consistently reflect the current Rspack-based frontend setup.
  * Clarified that selected upstream packages may continue using Webpack while other frontends use Rspack.
  * Refreshed troubleshooting, architecture decisions, workflow examples, and configuration references.
* **Chores**
  * Updated validation messaging and dependency-management guidance to recognize Rspack terminology and packages.
  * No runtime behavior or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->