### PR TITLE
feat: categorize PVCs by type in NIM deployment wizard storage field

### DIFF
--- a/packages/cypress/cypress/pages/modelServing/NIMWizardFields.ts
+++ b/packages/cypress/cypress/pages/modelServing/NIMWizardFields.ts
@@ -46,4 +46,8 @@ export class NIMWizardFields extends SubComponentBase {
   findExistingPVCSelect(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findScope().findByTestId('nim-existing-pvc-select');
   }
+
+  findExistingPVCInput(): Cypress.Chainable<JQuery<HTMLInputElement>> {
+    return this.findExistingPVCSelect().find('input');
+  }
 }

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -465,7 +465,7 @@ describe('NIM Models Deployments', () => {
     modelServingWizardEdit.nim
       .findStorageModeSelect()
       .should('contain.text', 'Deploy the NIM image from an existing cluster storage');
-    modelServingWizardEdit.nim.findExistingPVCSelect().should('contain.text', 'my-nim-wizard-pvc');
+    modelServingWizardEdit.nim.findExistingPVCInput().should('have.value', 'my-nim-wizard-pvc');
     modelServingWizardEdit.nim.findSubPathInput().should('have.value', 'arctic-embed-l');
 
     modelServingWizardEdit.findNextButton().should('be.enabled').click();

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -116,7 +116,7 @@ const useNIMPVCExternalData = (dependencies?: {
         name: sc.metadata.name,
         displayName: sc.metadata.annotations?.['openshift.io/display-name'] || sc.metadata.name,
       })),
-      existingPVCs: categorizePVCs(pvcList.filter((pvc) => Boolean(pvc.metadata.name))),
+      existingPVCs: categorizePVCs(pvcList),
     };
   }, [projectName]);
 
@@ -357,6 +357,7 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
                   });
                 }}
                 isDisabled={isDisabled}
+                isRequired={false}
                 placeholder="Select cluster storage..."
                 collapsibleGroupsThreshold={12}
               />

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -9,21 +9,27 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import SimpleSelect from '@odh-dashboard/ui-core/components/SimpleSelect';
+import TypeaheadSelect from '@odh-dashboard/ui-core/components/TypeaheadSelect';
 import NumberInputWrapper from '@odh-dashboard/ui-core/components/NumberInputWrapper';
 import type { SimpleSelectOption } from '@odh-dashboard/ui-core/components/SimpleSelect';
+import type { TypeaheadSelectOption } from '@odh-dashboard/ui-core/components/TypeaheadSelect';
 import type { ProjectSectionType } from '@odh-dashboard/model-serving/shared/wizard-fields';
 import type { WizardField } from '@odh-dashboard/model-serving/shared/types/form-data';
 import { NIMModelLocationKey } from '@odh-dashboard/model-serving/shared/wizard-fields';
 import { getStorageClasses } from '@odh-dashboard/internal/api/k8s/storageClasses';
 import { getDashboardPvcs } from '@odh-dashboard/internal/api/k8s/pvcs';
-import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import useFetch, {
   FetchStateCallbackPromise,
   NotReadyError,
 } from '@odh-dashboard/ui-core/hooks/useFetch';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { useDefaultStorageClass } from '@odh-dashboard/internal/pages/projects/screens/spawner/storage/useDefaultStorageClass';
-import { isNIMPVC, NIM_PVC_SUBPATH_ANNOTATION } from '../../clusterStorage/clusterStorage';
+import { categorizePVCs, type ExistingPVCOption } from './nimPVCUtils';
+
+export {
+  NIM_PVC_ANNOTATION,
+  NIM_PVC_SUBPATH_ANNOTATION,
+} from '../../clusterStorage/clusterStorage';
 
 export enum NIMPVCStorageMode {
   NEW = 'new',
@@ -69,35 +75,10 @@ type StorageClassOption = {
   displayName: string;
 };
 
-type ExistingPVCOption = {
-  name: string;
-  subPath?: string;
-};
-
 type NIMPVCExternalData = {
   storageClasses: StorageClassOption[];
   defaultStorageClassName: string;
   existingPVCs: ExistingPVCOption[];
-};
-
-const toPVCOption = (pvc: PersistentVolumeClaimKind): ExistingPVCOption => ({
-  name: pvc.metadata.name,
-  subPath: pvc.metadata.annotations?.[NIM_PVC_SUBPATH_ANNOTATION],
-});
-
-const sortPVCsNIMFirst = (pvcs: PersistentVolumeClaimKind[]): ExistingPVCOption[] => {
-  const nimPVCs: ExistingPVCOption[] = [];
-  const otherPVCs: ExistingPVCOption[] = [];
-
-  for (const pvc of pvcs) {
-    if (isNIMPVC(pvc)) {
-      nimPVCs.push(toPVCOption(pvc));
-    } else {
-      otherPVCs.push(toPVCOption(pvc));
-    }
-  }
-
-  return [...nimPVCs, ...otherPVCs];
 };
 
 type FetchedStorageData = {
@@ -135,7 +116,7 @@ const useNIMPVCExternalData = (dependencies?: {
         name: sc.metadata.name,
         displayName: sc.metadata.annotations?.['openshift.io/display-name'] || sc.metadata.name,
       })),
-      existingPVCs: sortPVCsNIMFirst(pvcList),
+      existingPVCs: categorizePVCs(pvcList),
     };
   }, [projectName]);
 
@@ -258,9 +239,10 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
     label: sc.displayName,
   }));
 
-  const existingPVCOptions: SimpleSelectOption[] = existingPVCs.map((pvc) => ({
-    key: pvc.name,
-    label: pvc.name,
+  const existingPVCOptions: TypeaheadSelectOption[] = existingPVCs.map((pvc) => ({
+    value: pvc.name,
+    content: pvc.name,
+    group: pvc.category,
   }));
 
   return (
@@ -297,91 +279,94 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
         )}
       </FormGroup>
 
-      {fieldValue.storageMode === NIMPVCStorageMode.NEW ? (
-        <>
-          <FormGroup label="Cluster storage name" fieldId="nim-pvc-name" isRequired>
-            <TextInput
-              id="nim-pvc-name"
-              data-testid="nim-pvc-name-input"
-              value={fieldValue.pvcName}
-              onChange={(_event, val) => updateField({ pvcName: val })}
-              placeholder="nim-pvc"
+      <div className="pf-v6-u-pl-xl">
+        {fieldValue.storageMode === NIMPVCStorageMode.NEW ? (
+          <>
+            <FormGroup label="Cluster storage name" fieldId="nim-pvc-name" isRequired>
+              <TextInput
+                id="nim-pvc-name"
+                data-testid="nim-pvc-name-input"
+                value={fieldValue.pvcName}
+                onChange={(_event, val) => updateField({ pvcName: val })}
+                placeholder="nim-pvc"
+                isDisabled={isDisabled}
+              />
+              <HelperText>
+                <HelperTextItem>
+                  This cluster storage can be reused for future deployments of this NIM image.
+                </HelperTextItem>
+              </HelperText>
+            </FormGroup>
+
+            <SubPathField
+              subPath={fieldValue.subPath}
+              onSubPathChange={(val) => updateField({ subPath: val })}
               isDisabled={isDisabled}
             />
-            <HelperText>
-              <HelperTextItem>
-                This cluster storage can be reused for future deployments of this NIM image.
-              </HelperTextItem>
-            </HelperText>
-          </FormGroup>
 
-          <SubPathField
-            subPath={fieldValue.subPath}
-            onSubPathChange={(val) => updateField({ subPath: val })}
-            isDisabled={isDisabled}
-          />
+            <FormGroup label="Storage class" fieldId="nim-storage-class" isRequired>
+              <SimpleSelect
+                dataTestId="nim-storage-class-select"
+                options={storageClassOptions}
+                value={fieldValue.storageClassName}
+                onChange={(val) => updateField({ storageClassName: val })}
+                isDisabled={isDisabled}
+                isFullWidth
+                placeholder="Select storage class"
+              />
+            </FormGroup>
 
-          <FormGroup label="Storage class" fieldId="nim-storage-class" isRequired>
-            <SimpleSelect
-              dataTestId="nim-storage-class-select"
-              options={storageClassOptions}
-              value={fieldValue.storageClassName}
-              onChange={(val) => updateField({ storageClassName: val })}
+            <FormGroup label="NVIDIA NIM storage size" fieldId="nim-storage-size" isRequired>
+              <NumberInputWrapper
+                id="nim-storage-size"
+                data-testid="nim-storage-size-input"
+                value={fieldValue.storageSizeGi}
+                min={MIN_STORAGE_SIZE_GI}
+                onChange={(val) =>
+                  updateField({
+                    storageSizeGi: Math.max(MIN_STORAGE_SIZE_GI, val ?? DEFAULT_STORAGE_SIZE_GI),
+                  })
+                }
+                unit="GiB"
+                isDisabled={isDisabled}
+              />
+              <HelperText>
+                <HelperTextItem>
+                  Specify the size of the PVC. Make sure it is larger than the NIM image size
+                  specified by NVIDIA.
+                </HelperTextItem>
+              </HelperText>
+            </FormGroup>
+          </>
+        ) : (
+          <>
+            <FormGroup label="Cluster storage name" fieldId="nim-existing-pvc" isRequired>
+              <TypeaheadSelect
+                dataTestId="nim-existing-pvc-select"
+                selectOptions={existingPVCOptions}
+                selected={fieldValue.pvcName || undefined}
+                onSelect={(_, val) => {
+                  const pvcName = String(val);
+                  const selectedPVC = existingPVCMap.get(pvcName);
+                  updateField({
+                    pvcName,
+                    subPath: selectedPVC?.subPath ?? DEFAULT_SUBPATH,
+                  });
+                }}
+                isDisabled={isDisabled}
+                placeholder="Select cluster storage..."
+                collapsibleGroupsThreshold={12}
+              />
+            </FormGroup>
+
+            <SubPathField
+              subPath={fieldValue.subPath}
+              onSubPathChange={(val) => updateField({ subPath: val })}
               isDisabled={isDisabled}
-              isFullWidth
-              placeholder="Select storage class"
             />
-          </FormGroup>
-
-          <FormGroup label="NVIDIA NIM storage size" fieldId="nim-storage-size" isRequired>
-            <NumberInputWrapper
-              id="nim-storage-size"
-              data-testid="nim-storage-size-input"
-              value={fieldValue.storageSizeGi}
-              min={MIN_STORAGE_SIZE_GI}
-              onChange={(val) =>
-                updateField({
-                  storageSizeGi: Math.max(MIN_STORAGE_SIZE_GI, val ?? DEFAULT_STORAGE_SIZE_GI),
-                })
-              }
-              unit="GiB"
-              isDisabled={isDisabled}
-            />
-            <HelperText>
-              <HelperTextItem>
-                Specify the size of the PVC. Make sure it is larger than the NIM image size
-                specified by NVIDIA.
-              </HelperTextItem>
-            </HelperText>
-          </FormGroup>
-        </>
-      ) : (
-        <>
-          <FormGroup label="Cluster storage name" fieldId="nim-existing-pvc" isRequired>
-            <SimpleSelect
-              dataTestId="nim-existing-pvc-select"
-              options={existingPVCOptions}
-              value={fieldValue.pvcName}
-              onChange={(val) => {
-                const selectedPVC = existingPVCMap.get(val);
-                updateField({
-                  pvcName: val,
-                  subPath: selectedPVC?.subPath ?? DEFAULT_SUBPATH,
-                });
-              }}
-              isDisabled={isDisabled}
-              isFullWidth
-              placeholder="Select..."
-            />
-          </FormGroup>
-
-          <SubPathField
-            subPath={fieldValue.subPath}
-            onSubPathChange={(val) => updateField({ subPath: val })}
-            isDisabled={isDisabled}
-          />
-        </>
-      )}
+          </>
+        )}
+      </div>
     </FormSection>
   );
 };

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -116,7 +116,7 @@ const useNIMPVCExternalData = (dependencies?: {
         name: sc.metadata.name,
         displayName: sc.metadata.annotations?.['openshift.io/display-name'] || sc.metadata.name,
       })),
-      existingPVCs: categorizePVCs(pvcList),
+      existingPVCs: categorizePVCs(pvcList.filter((pvc) => Boolean(pvc.metadata.name))),
     };
   }, [projectName]);
 
@@ -347,6 +347,9 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
                 selected={fieldValue.pvcName || undefined}
                 onSelect={(_, val) => {
                   const pvcName = String(val);
+                  if (pvcName === fieldValue.pvcName) {
+                    return;
+                  }
                   const selectedPVC = existingPVCMap.get(pvcName);
                   updateField({
                     pvcName,

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -360,6 +360,7 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
                 isRequired={false}
                 placeholder="Select cluster storage..."
                 collapsibleGroupsThreshold={12}
+                maxMenuHeight="300px"
               />
             </FormGroup>
 

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCUtils.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCUtils.spec.ts
@@ -34,4 +34,26 @@ describe('categorizePVCs', () => {
 
     expect(categorizePVCs(pvcs)[0].category).toBe(PVCCategory.NIM);
   });
+
+  it('skips PVCs without a metadata name', () => {
+    const pvcs = [
+      makePVC('valid-pvc'),
+      { ...makePVC(''), metadata: { ...makePVC('').metadata, name: '' } },
+    ];
+
+    expect(categorizePVCs(pvcs)).toEqual([
+      { name: 'valid-pvc', subPath: undefined, category: PVCCategory.GENERAL },
+    ]);
+  });
+
+  it('includes subPath from the NIM PVC annotation', () => {
+    const pvcs = [
+      makePVC('nim-pvc', {
+        [NIM_PVC_ANNOTATION]: 'true',
+        'dashboard.opendatahub.io/nim-subpath': 'arctic-embed-l',
+      }),
+    ];
+
+    expect(categorizePVCs(pvcs)[0].subPath).toBe('arctic-embed-l');
+  });
 });

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCUtils.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCUtils.spec.ts
@@ -1,5 +1,5 @@
 import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
-import { NIM_PVC_ANNOTATION } from '../../clusterStorage/clusterStorage';
+import { NIM_PVC_ANNOTATION } from '../../../clusterStorage/clusterStorage';
 import { PVCCategory, categorizePVCs } from '../nimPVCUtils';
 
 const makePVC = (name: string, annotations: Record<string, string> = {}) =>

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCUtils.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCUtils.spec.ts
@@ -1,0 +1,37 @@
+import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
+import { NIM_PVC_ANNOTATION } from '../../clusterStorage/clusterStorage';
+import { PVCCategory, categorizePVCs } from '../nimPVCUtils';
+
+const makePVC = (name: string, annotations: Record<string, string> = {}) =>
+  mockPVCK8sResource({ name, annotations });
+
+describe('categorizePVCs', () => {
+  it('categorizes PVCs into NIM, general purpose, and model serving groups in order', () => {
+    const pvcs = [
+      makePVC('model-serving-pvc', { 'dashboard.opendatahub.io/model-path': '/models/foo' }),
+      makePVC('general-pvc'),
+      makePVC('nim-pvc', { [NIM_PVC_ANNOTATION]: 'true' }),
+    ];
+
+    expect(categorizePVCs(pvcs)).toEqual([
+      { name: 'nim-pvc', subPath: undefined, category: PVCCategory.NIM },
+      { name: 'general-pvc', subPath: undefined, category: PVCCategory.GENERAL },
+      {
+        name: 'model-serving-pvc',
+        subPath: undefined,
+        category: PVCCategory.MODEL_SERVING,
+      },
+    ]);
+  });
+
+  it('prefers NIM category when both NIM and model-path annotations are present', () => {
+    const pvcs = [
+      makePVC('dual-annotated', {
+        [NIM_PVC_ANNOTATION]: 'true',
+        'dashboard.opendatahub.io/model-path': '/models/foo',
+      }),
+    ];
+
+    expect(categorizePVCs(pvcs)[0].category).toBe(PVCCategory.NIM);
+  });
+});

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCUtils.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCUtils.ts
@@ -1,0 +1,52 @@
+import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
+import { isNIMPVC, NIM_PVC_SUBPATH_ANNOTATION } from '../../clusterStorage/clusterStorage';
+
+const MODEL_PATH_ANNOTATION = 'dashboard.opendatahub.io/model-path';
+
+export enum PVCCategory {
+  NIM = 'NIM storage',
+  GENERAL = 'General purpose',
+  MODEL_SERVING = 'Model serving',
+}
+
+export type ExistingPVCOption = {
+  name: string;
+  subPath?: string;
+  category: PVCCategory;
+};
+
+const isModelServingPVC = (pvc: PersistentVolumeClaimKind): boolean =>
+  !!pvc.metadata.annotations?.[MODEL_PATH_ANNOTATION];
+
+const toPVCOption = (pvc: PersistentVolumeClaimKind): ExistingPVCOption => ({
+  name: pvc.metadata.name,
+  subPath: pvc.metadata.annotations?.[NIM_PVC_SUBPATH_ANNOTATION],
+  category: isNIMPVC(pvc)
+    ? PVCCategory.NIM
+    : isModelServingPVC(pvc)
+    ? PVCCategory.MODEL_SERVING
+    : PVCCategory.GENERAL,
+});
+
+export const categorizePVCs = (pvcs: PersistentVolumeClaimKind[]): ExistingPVCOption[] => {
+  const nimPVCs: ExistingPVCOption[] = [];
+  const generalPVCs: ExistingPVCOption[] = [];
+  const modelServingPVCs: ExistingPVCOption[] = [];
+
+  for (const pvc of pvcs) {
+    if (!pvc.metadata.name) {
+      continue;
+    }
+    const option = toPVCOption(pvc);
+    if (option.category === PVCCategory.NIM) {
+      nimPVCs.push(option);
+    } else if (option.category === PVCCategory.MODEL_SERVING) {
+      modelServingPVCs.push(option);
+    } else {
+      generalPVCs.push(option);
+    }
+  }
+
+  // Order: NIM first, general purpose second, model serving last
+  return [...nimPVCs, ...generalPVCs, ...modelServingPVCs];
+};

--- a/packages/ui-core/src/components/TypeaheadSelect.tsx
+++ b/packages/ui-core/src/components/TypeaheadSelect.tsx
@@ -115,6 +115,8 @@ const defaultFilterFunction = (filterValue: string, options: TypeaheadSelectOpti
 
 const GROUP_TOGGLE_VALUE_PREFIX = '__typeahead-group-toggle-';
 
+const DEFAULT_MAX_MENU_HEIGHT = '300px';
+
 const isGroupToggleValue = (value: string | number): boolean =>
   String(value).startsWith(GROUP_TOGGLE_VALUE_PREFIX);
 
@@ -142,6 +144,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   dataTestId,
   inputIcon,
   collapsibleGroupsThreshold,
+  maxMenuHeight = DEFAULT_MAX_MENU_HEIGHT,
   ...props
 }: TypeaheadSelectProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -176,8 +179,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     collapsibleGroupsThreshold !== undefined &&
     selectOptions.filter((o) => !!o.group).length >= collapsibleGroupsThreshold;
 
-  const toggleGroup = React.useCallback((group: string, e: React.MouseEvent) => {
-    e.stopPropagation();
+  const toggleGroup = React.useCallback((group: string) => {
     setCollapsedGroups((prev) => {
       const next = new Set(prev);
       if (next.has(group)) {
@@ -271,6 +273,62 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     noOptionsAvailableMessage,
   ]);
 
+  const groupedSelections = React.useMemo(() => {
+    const group: Record<string, TypeaheadSelectOption[]> = {};
+    const noGroup: TypeaheadSelectOption[] = [];
+
+    filteredSelections.forEach((option) => {
+      if (option.group) {
+        if (option.group in group) {
+          group[option.group].push(option);
+        } else {
+          group[option.group] = [option];
+        }
+      } else {
+        noGroup.push(option);
+      }
+    });
+
+    return { group, noGroup };
+  }, [filteredSelections]);
+
+  const isGroupCollapsed = React.useCallback(
+    (group: string) => isCollapsible && !(isFiltering && filterValue) && collapsedGroups.has(group),
+    [isCollapsible, isFiltering, filterValue, collapsedGroups],
+  );
+
+  const visibleMenuItems = React.useMemo((): TypeaheadSelectOption[] => {
+    const items: TypeaheadSelectOption[] = [];
+
+    if (isCreateOptionOnTop) {
+      const createOpt = groupedSelections.noGroup.find((o) => o.isCreateOption);
+      if (createOpt) {
+        items.push(createOpt);
+      }
+    }
+
+    Object.entries(groupedSelections.group).forEach(([groupName, groupOptions]) => {
+      if (isCollapsible) {
+        items.push({
+          value: `${GROUP_TOGGLE_VALUE_PREFIX}${groupName}`,
+          content: groupName,
+        });
+        if (!isGroupCollapsed(groupName)) {
+          items.push(...groupOptions);
+        }
+      } else {
+        items.push(...groupOptions);
+      }
+    });
+
+    const ungrouped = isCreateOptionOnTop
+      ? groupedSelections.noGroup.filter((o) => !o.isCreateOption)
+      : groupedSelections.noGroup;
+    items.push(...ungrouped);
+
+    return items;
+  }, [groupedSelections, isCollapsible, isCreateOptionOnTop, isGroupCollapsed]);
+
   React.useEffect(() => {
     if (isFiltering) {
       openMenu();
@@ -281,7 +339,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
 
   const setActiveAndFocusedItem = (itemIndex: number) => {
     setFocusedItemIndex(itemIndex);
-    const focusedItem = filteredSelections[itemIndex];
+    const focusedItem = visibleMenuItems[itemIndex];
     setActiveItemId(String(focusedItem.value));
   };
 
@@ -378,45 +436,39 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       return;
     }
 
-    if (key === 'ArrowUp') {
-      // When no index is set or at the first index, focus to the last, otherwise decrement focus index
-      if (focusedItemIndex === null || focusedItemIndex === 0) {
-        indexToFocus = filteredSelections.length - 1;
-      } else {
-        indexToFocus = focusedItemIndex - 1;
-      }
+    const navigableItems = visibleMenuItems.filter(
+      (option) => !option.isDisabled && !option.isAriaDisabled,
+    );
+    if (!navigableItems.length) {
+      return;
+    }
 
-      // Skip disabled options
-      while (filteredSelections[indexToFocus].isDisabled) {
-        indexToFocus--;
-        if (indexToFocus === -1) {
-          indexToFocus = filteredSelections.length - 1;
-        }
-      }
+    const currentValue =
+      focusedItemIndex !== null ? visibleMenuItems[focusedItemIndex]?.value : undefined;
+    const currentNavIndex = navigableItems.findIndex((option) => option.value === currentValue);
+
+    if (key === 'ArrowUp') {
+      const nextNavIndex = currentNavIndex <= 0 ? navigableItems.length - 1 : currentNavIndex - 1;
+      indexToFocus = visibleMenuItems.findIndex(
+        (option) => option.value === navigableItems[nextNavIndex].value,
+      );
     }
 
     if (key === 'ArrowDown') {
-      // When no index is set or at the last index, focus to the first, otherwise increment focus index
-      if (focusedItemIndex === null || focusedItemIndex === filteredSelections.length - 1) {
-        indexToFocus = 0;
-      } else {
-        indexToFocus = focusedItemIndex + 1;
-      }
-
-      // Skip disabled options
-      while (filteredSelections[indexToFocus].isDisabled) {
-        indexToFocus++;
-        if (indexToFocus === filteredSelections.length) {
-          indexToFocus = 0;
-        }
-      }
+      const nextNavIndex =
+        currentNavIndex === -1 || currentNavIndex === navigableItems.length - 1
+          ? 0
+          : currentNavIndex + 1;
+      indexToFocus = visibleMenuItems.findIndex(
+        (option) => option.value === navigableItems[nextNavIndex].value,
+      );
     }
 
     setActiveAndFocusedItem(indexToFocus);
   };
 
   const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    const focusedItem = focusedItemIndex !== null ? filteredSelections[focusedItemIndex] : null;
+    const focusedItem = focusedItemIndex !== null ? visibleMenuItems[focusedItemIndex] : null;
 
     switch (event.key) {
       case 'Enter':
@@ -426,6 +478,11 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
           focusedItem.value !== NO_RESULTS &&
           !focusedItem.isAriaDisabled
         ) {
+          if (isGroupToggleValue(focusedItem.value)) {
+            event.preventDefault();
+            toggleGroup(String(focusedItem.value).slice(GROUP_TOGGLE_VALUE_PREFIX.length));
+            break;
+          }
           selectOption(event, focusedItem);
         }
 
@@ -518,25 +575,6 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     </MenuToggle>
   );
 
-  const groupedSelections = React.useMemo(() => {
-    const group: Record<string, TypeaheadSelectOption[]> = {};
-    const noGroup: TypeaheadSelectOption[] = [];
-
-    filteredSelections.forEach((option) => {
-      if (option.group) {
-        if (option.group in group) {
-          group[option.group].push(option);
-        } else {
-          group[option.group] = [option];
-        }
-      } else {
-        noGroup.push(option);
-      }
-    });
-
-    return { group, noGroup };
-  }, [filteredSelections]);
-
   const tSelectOption = (option: TypeaheadSelectOption, index: number) => {
     const { content, value, dropdownLabel, ...optionProps } = option;
     return (
@@ -569,21 +607,13 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       .toLowerCase()
       .replace(/\s+/g, '-')
       .replace(/[()]/g, '')}`;
-
-    // When filtering, always expand so all matching results are visible
-    const isGroupCollapsed =
-      isCollapsible && !(isFiltering && filterValue) && collapsedGroups.has(group);
-
-    const groupLabel = group;
-
-    // Always advance the index by the full group size so keyboard-navigation
-    // indices remain consistent with filteredSelections even when collapsed.
-    const renderedOptions = isGroupCollapsed
-      ? []
-      : groupOptions.map((opt) => tSelectOption(opt, index++));
-    const nextIndex = optionIdx + groupOptions.length;
+    const groupCollapsed = isGroupCollapsed(group);
 
     if (isCollapsible) {
+      const toggleIndex = index++;
+      const renderedOptions = groupCollapsed
+        ? []
+        : groupOptions.map((opt) => tSelectOption(opt, index++));
       return {
         node: (
           <>
@@ -591,12 +621,13 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
               key={`${group}-toggle`}
               value={`${GROUP_TOGGLE_VALUE_PREFIX}${group}`}
               data-testid={`${testId}-toggle`}
+              isFocused={focusedItemIndex === toggleIndex}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                toggleGroup(group, e);
+                toggleGroup(group);
               }}
-              icon={isGroupCollapsed ? <AngleRightIcon /> : <AngleDownIcon />}
+              icon={groupCollapsed ? <AngleRightIcon /> : <AngleDownIcon />}
             >
               {group}
             </SelectOption>
@@ -604,20 +635,21 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
             {addDivider && <Divider />}
           </>
         ),
-        nextIndex,
+        nextIndex: index,
       };
     }
 
+    const renderedOptions = groupOptions.map((opt) => tSelectOption(opt, index++));
     return {
       node: (
         <>
-          <SelectGroup key={group} label={groupLabel} data-testid={testId}>
+          <SelectGroup key={group} label={group} data-testid={testId}>
             {renderedOptions}
           </SelectGroup>
           {addDivider && <Divider />}
         </>
       ),
-      nextIndex,
+      nextIndex: index,
     };
   };
 
@@ -675,6 +707,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
         onOpenChange={(open) => !open && closeMenu()}
         toggle={toggle}
         shouldFocusFirstItemOnOpen={false}
+        maxMenuHeight={maxMenuHeight}
         ref={innerRef}
         {...props}
       >

--- a/packages/ui-core/src/components/TypeaheadSelect.tsx
+++ b/packages/ui-core/src/components/TypeaheadSelect.tsx
@@ -336,9 +336,9 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   // Only when the field is required, not creatable and there is one option, we auto select the first option
   const isSingleOption = selectOptions.length === 1 && notAllowEmpty;
   const singleOptionValue = isSingleOption ? selectOptions[0].value : null;
-  // If there is only one option, call the onChange function
+  // If there is only one option, call the onChange function (unless already selected)
   React.useEffect(() => {
-    if (singleOptionValue && onSelect) {
+    if (singleOptionValue && onSelect && props.selected !== singleOptionValue) {
       onSelect(undefined, singleOptionValue);
     }
     // We don't want the callback function to be a dependency

--- a/packages/ui-core/src/components/TypeaheadSelect.tsx
+++ b/packages/ui-core/src/components/TypeaheadSelect.tsx
@@ -24,7 +24,7 @@ import {
   SelectGroup,
   Divider,
 } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
+import { TimesIcon, AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 import TruncatedText from './TruncatedText';
 
 export interface TypeaheadSelectOption extends Omit<SelectOptionProps, 'content' | 'isSelected'> {
@@ -100,12 +100,23 @@ export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSe
   previewDescription?: boolean;
   /** Optional icon rendered inside the text input */
   inputIcon?: React.ReactNode;
+  /**
+   * When the total number of grouped options reaches this threshold the groups
+   * become collapsible and start in a collapsed state.  Below the threshold
+   * groups are rendered as plain (non-interactive) SelectGroup headers.
+   */
+  collapsibleGroupsThreshold?: number;
 }
 
 const defaultNoOptionsFoundMessage = (filter: string) => `No results found for "${filter}"`;
 const defaultCreateOptionMessage = (newValue: string) => `Create "${newValue}"`;
 const defaultFilterFunction = (filterValue: string, options: TypeaheadSelectOption[]) =>
   options.filter((o) => String(o.content).toLowerCase().includes(filterValue.toLowerCase()));
+
+const GROUP_TOGGLE_VALUE_PREFIX = '__typeahead-group-toggle-';
+
+const isGroupToggleValue = (value: string | number): boolean =>
+  String(value).startsWith(GROUP_TOGGLE_VALUE_PREFIX);
 
 const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   innerRef,
@@ -130,6 +141,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   previewDescription = true,
   dataTestId,
   inputIcon,
+  collapsibleGroupsThreshold,
   ...props
 }: TypeaheadSelectProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -138,6 +150,44 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
   const textInputRef = React.useRef<HTMLInputElement>();
+
+  // Collapsible-group state — only active when total grouped options >= threshold
+  const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(new Set());
+  const hasAutoCollapsed = React.useRef(false);
+
+  // Auto-collapse all groups the first time the grouped option count reaches the threshold
+  React.useEffect(() => {
+    if (!hasAutoCollapsed.current && collapsibleGroupsThreshold !== undefined) {
+      const groupedCount = selectOptions.filter((o) => !!o.group).length;
+      if (groupedCount >= collapsibleGroupsThreshold) {
+        hasAutoCollapsed.current = true;
+        const groups = new Set<string>();
+        selectOptions.forEach((o) => {
+          if (o.group) {
+            groups.add(o.group);
+          }
+        });
+        setCollapsedGroups(groups);
+      }
+    }
+  }, [selectOptions, collapsibleGroupsThreshold]);
+
+  const isCollapsible =
+    collapsibleGroupsThreshold !== undefined &&
+    selectOptions.filter((o) => !!o.group).length >= collapsibleGroupsThreshold;
+
+  const toggleGroup = React.useCallback((group: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(group)) {
+        next.delete(group);
+      } else {
+        next.add(group);
+      }
+      return next;
+    });
+  }, []);
 
   const NO_RESULTS = 'no results';
 
@@ -299,7 +349,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
   ) => {
-    if (value && value !== NO_RESULTS) {
+    if (value && value !== NO_RESULTS && !isGroupToggleValue(value)) {
       const optionToSelect = selectOptions.find((option) => option.value === value);
       if (optionToSelect) {
         selectOption(_event, optionToSelect);
@@ -519,16 +569,55 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       .toLowerCase()
       .replace(/\s+/g, '-')
       .replace(/[()]/g, '')}`;
+
+    // When filtering, always expand so all matching results are visible
+    const isGroupCollapsed =
+      isCollapsible && !(isFiltering && filterValue) && collapsedGroups.has(group);
+
+    const groupLabel = group;
+
+    // Always advance the index by the full group size so keyboard-navigation
+    // indices remain consistent with filteredSelections even when collapsed.
+    const renderedOptions = isGroupCollapsed
+      ? []
+      : groupOptions.map((opt) => tSelectOption(opt, index++));
+    const nextIndex = optionIdx + groupOptions.length;
+
+    if (isCollapsible) {
+      return {
+        node: (
+          <>
+            <SelectOption
+              key={`${group}-toggle`}
+              value={`${GROUP_TOGGLE_VALUE_PREFIX}${group}`}
+              data-testid={`${testId}-toggle`}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                toggleGroup(group, e);
+              }}
+              icon={isGroupCollapsed ? <AngleRightIcon /> : <AngleDownIcon />}
+            >
+              {group}
+            </SelectOption>
+            {renderedOptions}
+            {addDivider && <Divider />}
+          </>
+        ),
+        nextIndex,
+      };
+    }
+
     return {
       node: (
         <>
-          <SelectGroup key={group} label={group} data-testid={testId}>
-            {groupOptions.map((opt) => tSelectOption(opt, index++))}
+          <SelectGroup key={group} label={groupLabel} data-testid={testId}>
+            {renderedOptions}
           </SelectGroup>
           {addDivider && <Divider />}
         </>
       ),
-      nextIndex: index,
+      nextIndex,
     };
   };
 

--- a/packages/ui-core/src/components/TypeaheadSelect.tsx
+++ b/packages/ui-core/src/components/TypeaheadSelect.tsx
@@ -39,6 +39,8 @@ export interface TypeaheadSelectOption extends Omit<SelectOptionProps, 'content'
   group?: string;
   /** Internal marker used to ensure the creatable option can be rendered first even with groups */
   isCreateOption?: boolean;
+  /** Internal marker for collapsible group header rows — not a selectable public value */
+  isGroupToggle?: boolean;
 }
 
 export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSelect'> {
@@ -113,12 +115,14 @@ const defaultCreateOptionMessage = (newValue: string) => `Create "${newValue}"`;
 const defaultFilterFunction = (filterValue: string, options: TypeaheadSelectOption[]) =>
   options.filter((o) => String(o.content).toLowerCase().includes(filterValue.toLowerCase()));
 
-const GROUP_TOGGLE_VALUE_PREFIX = '__typeahead-group-toggle-';
-
 const DEFAULT_MAX_MENU_HEIGHT = '300px';
 
-const isGroupToggleValue = (value: string | number): boolean =>
-  String(value).startsWith(GROUP_TOGGLE_VALUE_PREFIX);
+const createGroupToggleOption = (groupName: string): TypeaheadSelectOption => ({
+  // PF requires a value; selection is gated by isGroupToggle, not by this string.
+  value: `typeahead-group-toggle:${groupName}`,
+  content: groupName,
+  isGroupToggle: true,
+});
 
 const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   innerRef,
@@ -309,10 +313,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
 
     Object.entries(groupedSelections.group).forEach(([groupName, groupOptions]) => {
       if (isCollapsible) {
-        items.push({
-          value: `${GROUP_TOGGLE_VALUE_PREFIX}${groupName}`,
-          content: groupName,
-        });
+        items.push(createGroupToggleOption(groupName));
         if (!isGroupCollapsed(groupName)) {
           items.push(...groupOptions);
         }
@@ -407,7 +408,12 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
   ) => {
-    if (value && value !== NO_RESULTS && !isGroupToggleValue(value)) {
+    const menuItem = value ? visibleMenuItems.find((option) => option.value === value) : undefined;
+    if (menuItem?.isGroupToggle) {
+      return;
+    }
+
+    if (value && value !== NO_RESULTS) {
       const optionToSelect = selectOptions.find((option) => option.value === value);
       if (optionToSelect) {
         selectOption(_event, optionToSelect);
@@ -478,9 +484,9 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
           focusedItem.value !== NO_RESULTS &&
           !focusedItem.isAriaDisabled
         ) {
-          if (isGroupToggleValue(focusedItem.value)) {
+          if (focusedItem.isGroupToggle) {
             event.preventDefault();
-            toggleGroup(String(focusedItem.value).slice(GROUP_TOGGLE_VALUE_PREFIX.length));
+            toggleGroup(String(focusedItem.content));
             break;
           }
           selectOption(event, focusedItem);
@@ -611,6 +617,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
 
     if (isCollapsible) {
       const toggleIndex = index++;
+      const toggleOption = createGroupToggleOption(group);
       const renderedOptions = groupCollapsed
         ? []
         : groupOptions.map((opt) => tSelectOption(opt, index++));
@@ -619,7 +626,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
           <>
             <SelectOption
               key={`${group}-toggle`}
-              value={`${GROUP_TOGGLE_VALUE_PREFIX}${group}`}
+              value={toggleOption.value}
               data-testid={`${testId}-toggle`}
               isFocused={focusedItemIndex === toggleIndex}
               onClick={(e) => {

--- a/packages/ui-core/src/components/TypeaheadSelect.tsx
+++ b/packages/ui-core/src/components/TypeaheadSelect.tsx
@@ -115,8 +115,6 @@ const defaultCreateOptionMessage = (newValue: string) => `Create "${newValue}"`;
 const defaultFilterFunction = (filterValue: string, options: TypeaheadSelectOption[]) =>
   options.filter((o) => String(o.content).toLowerCase().includes(filterValue.toLowerCase()));
 
-const DEFAULT_MAX_MENU_HEIGHT = '300px';
-
 const createGroupToggleOption = (groupName: string): TypeaheadSelectOption => ({
   // PF requires a value; selection is gated by isGroupToggle, not by this string.
   value: `typeahead-group-toggle:${groupName}`,
@@ -148,7 +146,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   dataTestId,
   inputIcon,
   collapsibleGroupsThreshold,
-  maxMenuHeight = DEFAULT_MAX_MENU_HEIGHT,
+  maxMenuHeight,
   ...props
 }: TypeaheadSelectProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -639,7 +637,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
               {group}
             </SelectOption>
             {renderedOptions}
-            {addDivider && <Divider />}
+            {addDivider && <Divider key={`${group}-divider`} />}
           </>
         ),
         nextIndex: index,
@@ -653,7 +651,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
           <SelectGroup key={group} label={group} data-testid={testId}>
             {renderedOptions}
           </SelectGroup>
-          {addDivider && <Divider />}
+          {addDivider && <Divider key={`${group}-divider`} />}
         </>
       ),
       nextIndex: index,
@@ -681,7 +679,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
         groupIndex !== groupEntries.length - 1,
       );
       idx = nextIndex;
-      return node;
+      return <React.Fragment key={groupName}>{node}</React.Fragment>;
     });
     const selectOpts = ungroupedSelections.map((opt) => tSelectOption(opt, idx++));
 
@@ -697,9 +695,9 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     return (
       <>
         {createNode}
-        {showDividerAfterCreate ? <Divider /> : null}
+        {showDividerAfterCreate ? <Divider key="typeahead-divider-after-create" /> : null}
         {groupOpts}
-        {showDividerBeforeUngrouped ? <Divider /> : null}
+        {showDividerBeforeUngrouped ? <Divider key="typeahead-divider-before-ungrouped" /> : null}
         {selectOpts}
       </>
     );
@@ -714,7 +712,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
         onOpenChange={(open) => !open && closeMenu()}
         toggle={toggle}
         shouldFocusFirstItemOnOpen={false}
-        maxMenuHeight={maxMenuHeight}
+        {...(maxMenuHeight !== undefined ? { maxMenuHeight } : {})}
         ref={innerRef}
         {...props}
       >

--- a/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
+++ b/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TypeaheadSelect from '../TypeaheadSelect';
+
+const makeGroupedOptions = (count: number, group: string) =>
+  Array.from({ length: count }, (_, i) => ({
+    value: `${group}-${i}`,
+    content: `${group} option ${i}`,
+    group,
+  }));
+
+describe('TypeaheadSelect', () => {
+  const openMenu = () => {
+    fireEvent.click(screen.getByRole('combobox'));
+  };
+
+  describe('collapsible groups', () => {
+    it('should render plain group headers when grouped option count is below threshold', () => {
+      const options = makeGroupedOptions(5, 'NIM storage');
+      render(
+        <TypeaheadSelect
+          dataTestId="test-select"
+          selectOptions={options}
+          collapsibleGroupsThreshold={12}
+          isRequired={false}
+        />,
+      );
+
+      openMenu();
+
+      expect(screen.getByTestId('typeahead-group-nim-storage')).toBeInTheDocument();
+      expect(screen.queryByTestId('typeahead-group-nim-storage-toggle')).not.toBeInTheDocument();
+      expect(screen.getByText('NIM storage option 0')).toBeInTheDocument();
+    });
+
+    it('should render collapsible group toggles when grouped option count reaches threshold', () => {
+      const options = [
+        ...makeGroupedOptions(6, 'NIM storage'),
+        ...makeGroupedOptions(6, 'General purpose'),
+      ];
+      render(
+        <TypeaheadSelect
+          dataTestId="test-select"
+          selectOptions={options}
+          collapsibleGroupsThreshold={12}
+          isRequired={false}
+        />,
+      );
+
+      openMenu();
+
+      expect(screen.getByTestId('typeahead-group-nim-storage-toggle')).toBeInTheDocument();
+      expect(screen.getByTestId('typeahead-group-general-purpose-toggle')).toBeInTheDocument();
+      expect(screen.queryByText('NIM storage option 0')).not.toBeInTheDocument();
+      expect(screen.queryByText('General purpose option 0')).not.toBeInTheDocument();
+    });
+
+    it('should expand a collapsed group when its toggle is clicked', () => {
+      const options = [
+        ...makeGroupedOptions(6, 'NIM storage'),
+        ...makeGroupedOptions(6, 'General purpose'),
+      ];
+      render(
+        <TypeaheadSelect
+          dataTestId="test-select"
+          selectOptions={options}
+          collapsibleGroupsThreshold={12}
+          isRequired={false}
+        />,
+      );
+
+      openMenu();
+      fireEvent.click(screen.getByRole('option', { name: 'NIM storage' }));
+
+      expect(screen.getByText('NIM storage option 0')).toBeInTheDocument();
+      expect(screen.queryByText('General purpose option 0')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('single option auto-select', () => {
+    it('should not call onSelect when the only option is already selected', () => {
+      const onSelect = jest.fn();
+      render(
+        <TypeaheadSelect
+          selectOptions={[{ value: 'only', content: 'Only option' }]}
+          selected="only"
+          onSelect={onSelect}
+        />,
+      );
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('should call onSelect when there is only one required option and nothing is selected yet', () => {
+      const onSelect = jest.fn();
+      render(
+        <TypeaheadSelect
+          selectOptions={[{ value: 'only', content: 'Only option' }]}
+          onSelect={onSelect}
+        />,
+      );
+
+      expect(onSelect).toHaveBeenCalledWith(undefined, 'only');
+    });
+  });
+
+  describe('maxMenuHeight', () => {
+    it('should apply maxMenuHeight to the menu content when provided', () => {
+      const options = makeGroupedOptions(3, 'NIM storage');
+      render(
+        <TypeaheadSelect
+          dataTestId="test-select"
+          selectOptions={options}
+          maxMenuHeight="300px"
+          isRequired={false}
+        />,
+      );
+
+      openMenu();
+
+      const menuContent = document.querySelector('.pf-v6-c-menu__content');
+      expect(menuContent).toHaveStyle({ '--pf-v6-c-menu__content--MaxHeight': '300px' });
+    });
+
+    it('should not set maxMenuHeight on the menu content when omitted', () => {
+      const options = makeGroupedOptions(3, 'NIM storage');
+      render(
+        <TypeaheadSelect dataTestId="test-select" selectOptions={options} isRequired={false} />,
+      );
+
+      openMenu();
+
+      const menuContent = document.querySelector('.pf-v6-c-menu__content');
+      expect(menuContent).toBeInTheDocument();
+      expect(menuContent).not.toHaveStyle({ '--pf-v6-c-menu__content--MaxHeight': '300px' });
+    });
+  });
+});


### PR DESCRIPTION
<!-- https://issues.redhat.com/browse/RHOAIENG-65755 -->

## Description

Follow-up to #7705 (feat: add PVC caching storage field to deployment wizard).

When a user selects "Use existing cluster storage" in the NIM deployment wizard, the storage dropdown now categorizes PVCs into three labelled groups instead of showing a flat, unsorted list:

1. **NIM storage** — PVCs annotated with `dashboard.opendatahub.io/nim-pvc: "true"` (shown first)
2. **General purpose** — PVCs with no special annotations (shown second)
3. **Model serving** — PVCs annotated with `dashboard.opendatahub.io/model-path` (shown last)

Additional changes:
- **Switched from `SimpleSelect` to `TypeaheadSelect`** for the existing-PVC dropdown, enabling typeahead search and consistent UX with the non-NIM serving wizard.
- **Collapsible groups**: When the total number of grouped PVCs reaches or exceeds 12, all groups auto-collapse on open and can be individually expanded, keeping the dropdown usable in clusters with many PVCs. Groups always expand automatically when the user types to filter.
- **Visual indentation**: The PVC detail fields (name, sub-path, storage class, size) are now indented beneath the "Storage and deployment option" toggle using `pf-v6-u-pl-xl`, clearly conveying hierarchy.
- **Extracted `nimPVCUtils.ts`**: Categorization logic and annotation constants (`NIM_PVC_ANNOTATION`, `NIM_PVC_SUBPATH_ANNOTATION`) moved to a dedicated utility file for modularity and testability.
- **Extended `TypeaheadSelect` (ui-core)**: Added the `collapsibleGroupsThreshold` prop so any consumer can opt into collapsible groups.


## How Has This Been Tested?
When 12+PVCS
<img width="1421" height="364" alt="Screenshot 2026-09-01 at 4 10 57 PM" src="https://github.com/user-attachments/assets/dc27918d-f011-4378-ab7a-2c8e149002b7" />
<img width="1481" height="532" alt="Screenshot 2026-09-01 at 4 11 10 PM" src="https://github.com/user-attachments/assets/ece2bfef-77af-4b10-9f4c-b7b66f4072e6" />
<img width="1391" height="686" alt="Screenshot 2026-09-01 at 4 11 40 PM" src="https://github.com/user-attachments/assets/15483131-ad80-4e3f-9a66-e82a0e60f55b" />
When less than 12 
<img width="1000" height="477" alt="Screenshot 2026-09-01 at 2 57 45 PM" src="https://github.com/user-attachments/assets/5543d476-644b-4b86-9e01-98f03d3bfedb" />


- Manually verified on a live cluster with the `nimWizard` feature flag enabled.
- Tested with fewer than 12 PVCs (groups shown as static headers) and more than 12 PVCs (groups auto-collapse and can be expanded).
- Verified that typeahead filtering always expands collapsed groups to show matching results.
- Verified group ordering: NIM → General purpose → Model serving.
- Verified that PVCs carrying both `nim-pvc` and `model-path` annotations are classified as NIM.
- Ran the full `nim-serving` Jest suite (25 suites, 240 tests) — all pass.
- Ran ESLint for `nim-serving` and `ui-core` — 0 errors.

## Test Impact

- **Added** `packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCUtils.spec.ts` — 2 unit tests covering PVC categorization ordering and annotation-conflict resolution.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added searchable, grouped existing-storage selection to the deployment wizard.
  - Organized storage options into NIM storage, general-purpose, and model-serving categories.
  - Large option groups can be collapsed and expanded for easier browsing.
  - Searching automatically expands relevant groups so matching storage options remain visible.
  - Improved spacing around storage selection controls.
  - Excluded unnamed storage options from the selection list.
  - Improved menu sizing for long option lists.

- **Tests**
  - Added coverage for storage categorization, category ordering, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->