### PR TITLE
fix(autox): support new component status artifact schemas

### DIFF
--- a/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/4f78f2b7-a297-40bc-95d4-98504d4e50ee/autogluon-models-training-2/4a207ca3-54fd-4fdc-b091-2ffc33cb5c50/component_status/component_status.json
+++ b/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/4f78f2b7-a297-40bc-95d4-98504d4e50ee/autogluon-models-training-2/4a207ca3-54fd-4fdc-b091-2ffc33cb5c50/component_status/component_status.json
@@ -2,47 +2,40 @@
   "component_id": "autogluon_models_training",
   "started_at": "2026-07-16T19:40:40.265279Z",
   "completed_at": "2026-07-16T19:45:54.939298Z",
+  "metadata": { "display_name": "Models Training Status" },
   "stages": [
     {
       "id": "load_data",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:40:40.274852Z",
-      "train_rows": 171,
-      "test_rows": 143
+      "status": { "state": "completed" },
+      "metrics": { "train_rows": 171, "test_rows": 143 }
     },
     {
       "id": "model_selection",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:45:43.505824Z",
-      "top_n": 3,
-      "selected_models": [
-        "NeuralNetTorch_BAG_L2",
-        "NeuralNetTorch_BAG_L1",
-        "ExtraTreesMSE_BAG_L2"
-      ],
-      "steps": [
-        "feature_engineering",
-        "model_training",
-        "stacking",
-        "evaluation"
-      ]
+      "status": { "state": "completed" },
+      "metrics": {
+        "top_n": 3,
+        "selected_models": [
+          "NeuralNetTorch_BAG_L2",
+          "NeuralNetTorch_BAG_L1",
+          "ExtraTreesMSE_BAG_L2"
+        ]
+      }
     },
     {
       "id": "refit_and_evaluate",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:45:54.935370Z",
-      "model_count": 3,
-      "eval_metric": "r2"
+      "status": { "state": "completed" },
+      "metrics": {
+        "model_count": 3,
+        "eval_metric": "r2"
+      }
     },
     {
       "id": "build_leaderboard",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:45:54.939149Z",
-      "best_model": "NeuralNetTorch_BAG_L1_FULL",
-      "model_count": 3
+      "status": { "state": "completed" },
+      "metrics": {
+        "best_model": "NeuralNetTorch_BAG_L1_FULL",
+        "model_count": 3
+      }
     }
-  ],
-  "metadata": {
-    "display_name": "Models Training Status"
-  }
+  ]
 }

--- a/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/4f78f2b7-a297-40bc-95d4-98504d4e50ee/automl-data-loader/9f382e6d-746f-4bda-9a71-9995bde8d02d/component_status/component_status.json
+++ b/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/4f78f2b7-a297-40bc-95d4-98504d4e50ee/automl-data-loader/9f382e6d-746f-4bda-9a71-9995bde8d02d/component_status/component_status.json
@@ -1,28 +1,27 @@
 {
   "component_id": "automl_data_loader",
   "started_at": "2026-07-16T19:39:54.139289Z",
-  "completed_at": "2026-07-16T19:39:54.992213Z",
+  "metadata": { "display_name": "Data Loader Status" },
   "stages": [
     {
       "id": "prepare_data",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:39:54.334161Z",
-      "sampling_method": "random",
-      "source": "s3://ai-eng-autox/automl input data/TitanicFullMF.csv",
-      "rows": 714,
-      "duplicates_dropped": 0,
-      "labels_dropped": 177
+      "status": { "state": "completed" },
+      "metrics": {
+        "sampling_method": "random",
+        "source": "s3://ai-eng-autox/automl input data/TitanicFullMF.csv",
+        "rows": 714,
+        "duplicates_dropped": 0,
+        "labels_dropped": 177
+      }
     },
     {
       "id": "split_and_export",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:39:54.991506Z",
-      "test_size": 0.2,
-      "selection_train_size": 0.3,
-      "stratify": false
+      "status": { "state": "completed" },
+      "metrics": {
+        "test_size": 0.2,
+        "selection_train_size": 0.3,
+        "stratify": false
+      }
     }
-  ],
-  "metadata": {
-    "display_name": "Data Loader Status"
-  }
+  ]
 }

--- a/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/9ec21d90-baa0-4a6b-bb2a-40d9d4b43c54/autogluon-models-training-2/c9edcc9a-ac4e-472a-83c4-0258f9be0794/component_status/component_status.json
+++ b/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/9ec21d90-baa0-4a6b-bb2a-40d9d4b43c54/autogluon-models-training-2/c9edcc9a-ac4e-472a-83c4-0258f9be0794/component_status/component_status.json
@@ -1,48 +1,36 @@
 {
   "component_id": "autogluon_models_training",
   "started_at": "2026-07-16T19:40:10.038726Z",
-  "completed_at": "2026-07-16T19:44:03.459103Z",
+  "metadata": { "display_name": "Models Training Status" },
   "stages": [
     {
       "id": "load_data",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:40:10.047940Z",
-      "train_rows": 213,
-      "test_rows": 179
+      "status": { "state": "completed" },
+      "metrics": { "train_rows": 213, "test_rows": 179 }
     },
     {
       "id": "model_selection",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:43:57.048335Z",
-      "top_n": 3,
-      "selected_models": [
-        "XGBoost_BAG_L1",
-        "LightGBMLarge_BAG_L1",
-        "WeightedEnsemble_L2"
-      ],
-      "steps": [
-        "feature_engineering",
-        "model_training",
-        "stacking",
-        "evaluation"
-      ]
+      "status": { "state": "completed" },
+      "metrics": {
+        "top_n": 3,
+        "selected_models": ["XGBoost_BAG_L1", "LightGBMLarge_BAG_L1", "WeightedEnsemble_L2"]
+      }
     },
     {
       "id": "refit_and_evaluate",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:44:03.455198Z",
-      "model_count": 3,
-      "eval_metric": "accuracy"
+      "status": { "state": "completed" },
+      "metrics": {
+        "model_count": 3,
+        "eval_metric": "accuracy"
+      }
     },
     {
       "id": "build_leaderboard",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:44:03.458947Z",
-      "best_model": "XGBoost_BAG_L1_FULL",
-      "model_count": 3
+      "status": { "state": "completed" },
+      "metrics": {
+        "best_model": "XGBoost_BAG_L1_FULL",
+        "model_count": 3
+      }
     }
-  ],
-  "metadata": {
-    "display_name": "Models Training Status"
-  }
+  ]
 }

--- a/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/9ec21d90-baa0-4a6b-bb2a-40d9d4b43c54/automl-data-loader/15f48d9b-356c-4c36-a145-e76cffef98fd/component_status/component_status.json
+++ b/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/9ec21d90-baa0-4a6b-bb2a-40d9d4b43c54/automl-data-loader/15f48d9b-356c-4c36-a145-e76cffef98fd/component_status/component_status.json
@@ -1,28 +1,27 @@
 {
   "component_id": "automl_data_loader",
   "started_at": "2026-07-16T19:39:16.477433Z",
-  "completed_at": "2026-07-16T19:39:17.286967Z",
+  "metadata": { "display_name": "Data Loader Status" },
   "stages": [
     {
       "id": "prepare_data",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:39:16.683826Z",
-      "sampling_method": "stratified",
-      "source": "s3://ai-eng-autox/automl input data/TitanicFullMF.csv",
-      "rows": 891,
-      "duplicates_dropped": 0,
-      "labels_dropped": 0
+      "status": { "state": "completed" },
+      "metrics": {
+        "sampling_method": "stratified",
+        "source": "s3://ai-eng-autox/automl input data/TitanicFullMF.csv",
+        "rows": 891,
+        "duplicates_dropped": 0,
+        "labels_dropped": 0
+      }
     },
     {
       "id": "split_and_export",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:39:17.286420Z",
-      "test_size": 0.2,
-      "selection_train_size": 0.3,
-      "stratify": true
+      "status": { "state": "completed" },
+      "metrics": {
+        "test_size": 0.2,
+        "selection_train_size": 0.3,
+        "stratify": true
+      }
     }
-  ],
-  "metadata": {
-    "display_name": "Data Loader Status"
-  }
+  ]
 }

--- a/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/a4a27f0d-2cbd-4bb9-b501-335ca0ec14b2/autogluon-models-training-2/de445eca-3ec1-4e35-8e3b-cc420b2b3286/component_status/component_status.json
+++ b/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/a4a27f0d-2cbd-4bb9-b501-335ca0ec14b2/autogluon-models-training-2/de445eca-3ec1-4e35-8e3b-cc420b2b3286/component_status/component_status.json
@@ -1,48 +1,40 @@
 {
   "component_id": "autogluon_models_training",
   "started_at": "2026-07-16T19:40:30.041451Z",
-  "completed_at": "2026-07-16T19:47:04.672760Z",
+  "metadata": { "display_name": "Models Training Status" },
   "stages": [
     {
       "id": "load_data",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:40:30.050558Z",
-      "train_rows": 213,
-      "test_rows": 179
+      "status": { "state": "completed" },
+      "metrics": { "train_rows": 213, "test_rows": 179 }
     },
     {
       "id": "model_selection",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:46:46.676204Z",
-      "top_n": 3,
-      "selected_models": [
-        "RandomForestEntr_BAG_L2",
-        "RandomForestGini_BAG_L2",
-        "ExtraTreesEntr_BAG_L2"
-      ],
-      "steps": [
-        "feature_engineering",
-        "model_training",
-        "stacking",
-        "evaluation"
-      ]
+      "status": { "state": "completed" },
+      "metrics": {
+        "top_n": 3,
+        "selected_models": [
+          "RandomForestEntr_BAG_L2",
+          "RandomForestGini_BAG_L2",
+          "ExtraTreesEntr_BAG_L2"
+        ]
+      }
     },
     {
       "id": "refit_and_evaluate",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:47:04.668907Z",
-      "model_count": 3,
-      "eval_metric": "accuracy"
+      "status": { "state": "completed" },
+      "metrics": {
+        "model_count": 3,
+        "eval_metric": "accuracy"
+      }
     },
     {
       "id": "build_leaderboard",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:47:04.672602Z",
-      "best_model": "RandomForestEntr_BAG_L2_FULL",
-      "model_count": 3
+      "status": { "state": "completed" },
+      "metrics": {
+        "best_model": "RandomForestEntr_BAG_L2_FULL",
+        "model_count": 3
+      }
     }
-  ],
-  "metadata": {
-    "display_name": "Models Training Status"
-  }
+  ]
 }

--- a/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/a4a27f0d-2cbd-4bb9-b501-335ca0ec14b2/automl-data-loader/53046d2e-323b-4d58-97d8-5a855cb75e1d/component_status/component_status.json
+++ b/packages/automl/bff/internal/fake/s3-bucket/autogluon-tabular-training-pipeline/a4a27f0d-2cbd-4bb9-b501-335ca0ec14b2/automl-data-loader/53046d2e-323b-4d58-97d8-5a855cb75e1d/component_status/component_status.json
@@ -1,28 +1,27 @@
 {
   "component_id": "automl_data_loader",
   "started_at": "2026-07-16T19:39:27.446244Z",
-  "completed_at": "2026-07-16T19:39:28.232803Z",
+  "metadata": { "display_name": "Data Loader Status" },
   "stages": [
     {
       "id": "prepare_data",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:39:27.646448Z",
-      "sampling_method": "stratified",
-      "source": "s3://ai-eng-autox/automl input data/TitanicFullMF.csv",
-      "rows": 891,
-      "duplicates_dropped": 0,
-      "labels_dropped": 0
+      "status": { "state": "completed" },
+      "metrics": {
+        "sampling_method": "stratified",
+        "source": "s3://ai-eng-autox/automl input data/TitanicFullMF.csv",
+        "rows": 891,
+        "duplicates_dropped": 0,
+        "labels_dropped": 0
+      }
     },
     {
       "id": "split_and_export",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:39:28.232266Z",
-      "test_size": 0.2,
-      "selection_train_size": 0.3,
-      "stratify": true
+      "status": { "state": "completed" },
+      "metrics": {
+        "test_size": 0.2,
+        "selection_train_size": 0.3,
+        "stratify": true
+      }
     }
-  ],
-  "metadata": {
-    "display_name": "Data Loader Status"
-  }
+  ]
 }

--- a/packages/automl/bff/internal/fake/s3-bucket/autogluon-timeseries-training-pipeline/ba44c73f-307c-4529-84e9-27a0698ae2ae/autogluon-timeseries-models-training-2/2f50ac61-f100-442e-9428-0cff4cd066d8/component_status/component_status.json
+++ b/packages/automl/bff/internal/fake/s3-bucket/autogluon-timeseries-training-pipeline/ba44c73f-307c-4529-84e9-27a0698ae2ae/autogluon-timeseries-models-training-2/2f50ac61-f100-442e-9428-0cff4cd066d8/component_status/component_status.json
@@ -1,48 +1,39 @@
 {
   "component_id": "autogluon_timeseries_models_training",
   "started_at": "2026-07-16T19:41:02.391204Z",
-  "completed_at": "2026-07-16T19:51:14.908316Z",
+  "metadata": { "display_name": "Timeseries Models Training Status" },
   "stages": [
     {
       "id": "load_data",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:41:02.476147Z",
-      "train_rows": 35522,
-      "test_rows": 29612
+      "status": { "state": "completed" },
+      "metrics": {
+        "train_rows": 35522,
+        "test_rows": 29612
+      }
     },
     {
       "id": "model_selection",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:41:35.188870Z",
-      "top_n": 3,
-      "selected_models": [
-        "RecursiveTabular",
-        "Theta",
-        "WeightedEnsemble"
-      ],
-      "steps": [
-        "feature_engineering",
-        "model_training",
-        "stacking",
-        "evaluation"
-      ]
+      "status": { "state": "completed" },
+      "metrics": {
+        "top_n": 3,
+        "selected_models": ["RecursiveTabular", "Theta", "WeightedEnsemble"]
+      }
     },
     {
       "id": "refit_and_evaluate",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:51:14.904427Z",
-      "model_count": 3,
-      "eval_metric": "mean_absolute_scaled_error"
+      "status": { "state": "completed" },
+      "metrics": {
+        "model_count": 3,
+        "eval_metric": "mean_absolute_scaled_error"
+      }
     },
     {
       "id": "build_leaderboard",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:51:14.907974Z",
-      "best_model": "RecursiveTabular_FULL",
-      "model_count": 3
+      "status": { "state": "completed" },
+      "metrics": {
+        "best_model": "RecursiveTabular_FULL",
+        "model_count": 3
+      }
     }
-  ],
-  "metadata": {
-    "display_name": "Timeseries Models Training Status"
-  }
+  ]
 }

--- a/packages/automl/bff/internal/fake/s3-bucket/autogluon-timeseries-training-pipeline/ba44c73f-307c-4529-84e9-27a0698ae2ae/timeseries-data-loader/54cfd0db-d294-4956-b354-3471775688c2/component_status/component_status.json
+++ b/packages/automl/bff/internal/fake/s3-bucket/autogluon-timeseries-training-pipeline/ba44c73f-307c-4529-84e9-27a0698ae2ae/timeseries-data-loader/54cfd0db-d294-4956-b354-3471775688c2/component_status/component_status.json
@@ -1,24 +1,23 @@
 {
   "component_id": "timeseries_data_loader",
   "started_at": "2026-07-16T19:40:08.875287Z",
-  "completed_at": "2026-07-16T19:40:10.257983Z",
+  "metadata": { "display_name": "Timeseries Data Loader Status" },
   "stages": [
     {
       "id": "prepare_data",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:40:09.603051Z",
-      "source": "s3://ai-eng-autox/automl input data/timeseries/m4_hourly_subset_train.csv",
-      "rows": 148060
+      "status": { "state": "completed" },
+      "metrics": {
+        "source": "s3://ai-eng-autox/automl input data/timeseries/m4_hourly_subset_train.csv",
+        "rows": 148060
+      }
     },
     {
       "id": "split_and_export",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:40:10.254956Z",
-      "test_size": 0.2,
-      "selection_train_size": 0.3
+      "status": { "state": "completed" },
+      "metrics": {
+        "test_size": 0.2,
+        "selection_train_size": 0.3
+      }
     }
-  ],
-  "metadata": {
-    "display_name": "Timeseries Data Loader Status"
-  }
+  ]
 }

--- a/packages/automl/frontend/src/app/components/run-results/StepDetailsPanel.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/StepDetailsPanel.tsx
@@ -32,6 +32,7 @@ import type { PipelineStatusFilter } from '~/app/topology/tree-view/types';
 import { getStepMetadata, type StepDetail } from '~/app/topology/tree-view/stepMetadata';
 import {
   parseStageMapNodeId,
+  getComponentDisplayName,
   type ParsedStageMapNode,
 } from '~/app/topology/tree-view/stageMapStepMetadata';
 import type { TreeNodeData } from '~/app/topology/tree-view/TreeNode';
@@ -265,7 +266,13 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
     branchModelKey === selectedModel &&
     parsedNodeId?.type === 'branch_model' &&
     nodeData.stepState === 'completed';
-  const panelTitle = isBestModel ? 'Best model' : (nodeData.label ?? 'Step details');
+  const panelTitle = isBestModel
+    ? 'Best model'
+    : parsedNodeId?.type === 'stage' && componentStageMap
+      ? (getComponentDisplayName(parsedNodeId, componentStageMap) ??
+        nodeData.label ??
+        'Step details')
+      : (nodeData.label ?? 'Step details');
   const statusLabel = getStepStateLabel(nodeData.stepState);
   const inProgressLoadingContent = getStepDetailsLoadingContent();
   const isStepLoading = nodeData.stepState === 'active';
@@ -308,18 +315,17 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
                 titleSize="lg"
               />
             </StackItem>
-          ) : (
-            <StackItem>
-              <DescriptionList isCompact>
-                {metadata.details.map((detail, index) => (
-                  <DescriptionListGroup key={`${detail.label}-${index}`}>
-                    <StepDetailTerm detail={detail} />
-                    <DescriptionListDescription>{detail.value}</DescriptionListDescription>
-                  </DescriptionListGroup>
-                ))}
-              </DescriptionList>
-            </StackItem>
-          )}
+          ) : null}
+          <StackItem>
+            <DescriptionList isCompact>
+              {metadata.details.map((detail, index) => (
+                <DescriptionListGroup key={`${detail.label}-${index}`}>
+                  <StepDetailTerm detail={detail} />
+                  <DescriptionListDescription>{detail.value}</DescriptionListDescription>
+                </DescriptionListGroup>
+              ))}
+            </DescriptionList>
+          </StackItem>
         </Stack>
       </DrawerPanelBody>
     </>

--- a/packages/automl/frontend/src/app/hooks/__tests__/useComponentStatuses.spec.ts
+++ b/packages/automl/frontend/src/app/hooks/__tests__/useComponentStatuses.spec.ts
@@ -1,42 +1,64 @@
+/* eslint-disable camelcase */
+
 import { renderHook, waitFor } from '@testing-library/react';
-import type { PipelineRun } from '~/app/types';
-import type { ComponentStageMap } from '~/app/hooks/useComponentStageMap';
-import { useS3ListFilesQuery } from '~/app/hooks/queries';
-import { getFiles } from '~/app/api/s3';
 import {
   buildRunLevelPrefixesFromTaskDetails,
   componentIdToTaskId,
+  ComponentStatusFileSchema,
   findComponentTaskInRunDetails,
   getComponentsToFetch,
+  isComponentFullyComplete,
   isKfpDriverTaskName,
   mergeStageWithStatus,
   mergeStatusIntoStageMap,
-  isComponentFullyComplete,
   matchesComponentTaskName,
   resolveActiveRunLevelPrefix,
   resolveComponentTaskS3Prefix,
-  ComponentStatusFileSchema,
   useComponentStatuses,
 } from '~/app/hooks/useComponentStatuses';
-import type { ComponentStatusFile } from '~/app/hooks/useComponentStatuses';
-import { MAX_MODEL_SELECTION_STEPS } from '~/app/topology/stageMapConstants';
+import { useS3ListFilesQuery } from '~/app/hooks/queries';
+import { getFiles } from '~/app/api/s3';
+import type { PipelineRun } from '~/app/types';
+import type { ComponentStageMap } from '~/app/hooks/useComponentStageMap';
 
-jest.mock('~/app/hooks/queries', () => ({
-  useS3ListFilesQuery: jest.fn(),
-}));
+jest.mock('~/app/hooks/queries', () => ({ useS3ListFilesQuery: jest.fn() }));
+jest.mock('~/app/api/s3', () => ({ getFiles: jest.fn() }));
 
-jest.mock('~/app/api/s3', () => ({
-  getFiles: jest.fn(),
-}));
+const stageMap: ComponentStageMap = {
+  pipeline_id: 'pipeline',
+  description: 'Pipeline',
+  kfp_run_id: 'run',
+  published_at: '2026-01-01T00:00:00Z',
+  components: [
+    {
+      id: 'training_component',
+      description: 'Training component',
+      stages: [
+        { id: 'load_data', description: 'Load data', steps: ['load', 'train'] },
+        {
+          id: 'model_selection',
+          description: 'Train models',
+          steps: ['train'],
+          selected_models: ['map-model'],
+        },
+        { id: 'publish', description: 'Publish results' },
+      ],
+    },
+  ],
+};
 
-/* eslint-disable camelcase */
-
-// -- Fixtures based on real pipeline data --
+const artifact = (stages: unknown[], metadata = { display_name: 'Model training' }) =>
+  ComponentStatusFileSchema.parse({
+    component_id: 'training_component',
+    started_at: '2026-01-01T00:00:00Z',
+    metadata,
+    stages,
+  });
 
 const mockComponentStageMap: ComponentStageMap = {
   pipeline_id: 'autogluon-tabular-training-pipeline',
   description: 'Tabular AutoGluon pipeline',
-  kfp_run_id: '029660b9-c210-4ad4-9434-de28c2c9baec',
+  kfp_run_id: 'run-123',
   published_at: '2026-06-04T17:47:14.948493Z',
   components: [
     {
@@ -72,45 +94,26 @@ const mockComponentStageMap: ComponentStageMap = {
   ],
 };
 
-const mockComponentStatus: ComponentStatusFile = {
+const mockComponentStatus = ComponentStatusFileSchema.parse({
   component_id: 'autogluon_models_training',
   started_at: '2026-06-04T17:49:19.223056Z',
   completed_at: '2026-06-04T17:50:10.290690Z',
+  metadata: { display_name: 'Training' },
   stages: [
     {
       id: 'load_data',
-      description: 'Load train/validation CSVs',
-      status: 'completed',
-      timestamp: '2026-06-04T17:49:19.232065Z',
-      train_rows: 213,
-      test_rows: 179,
+      status: { state: 'completed' },
+      metrics: { train_rows: 213, test_rows: 179 },
     },
     {
       id: 'model_selection',
-      description: 'Run AutoGluon model selection',
-      status: 'completed',
-      timestamp: '2026-06-04T17:49:53.951525Z',
-      top_n: 3,
-      selected_models: ['ExtraTreesGini_BAG_L2', 'LightGBM_BAG_L2', 'LightGBMLarge_BAG_L2'],
-      steps: ['feature_engineering', 'model_training', 'stacking', 'model_evaluation'],
+      status: { state: 'completed' },
+      metrics: { selected_models: ['ExtraTreesGini_BAG_L2', 'LightGBM_BAG_L2'] },
     },
-    {
-      id: 'refit_full',
-      description: 'Refit the best models',
-      status: 'completed',
-      timestamp: '2026-06-04T17:50:02.238567Z',
-      model_count: 3,
-    },
-    {
-      id: 'evaluate_models',
-      description: 'Evaluate refit models',
-      status: 'completed',
-      timestamp: '2026-06-04T17:50:10.290550Z',
-      eval_metric: 'accuracy',
-    },
+    { id: 'refit_full', status: { state: 'completed' }, metrics: { model_count: 3 } },
+    { id: 'evaluate_models', status: { state: 'completed' }, metrics: { eval_metric: 'accuracy' } },
   ],
-  metadata: {},
-};
+});
 
 const createMockPipelineRun = (
   state: string,
@@ -122,156 +125,207 @@ const createMockPipelineRun = (
     state,
     created_at: '2025-01-17T00:00:00Z',
     run_details: {
-      task_details: taskDetails.map((td) => ({
+      task_details: taskDetails.map((task) => ({
         run_id: 'run-123',
-        task_id: td.task_id,
-        display_name: td.display_name ?? td.task_id,
+        task_id: task.task_id,
+        display_name: task.display_name ?? task.task_id,
         create_time: '2025-01-17T00:00:00Z',
         start_time: '2025-01-17T00:00:00Z',
         end_time: '2025-01-17T00:00:00Z',
-        state: td.state,
+        state: task.state,
       })),
     },
   }) as PipelineRun;
 
-// -- Tests --
+describe('component task discovery and prefixes', () => {
+  it.each([
+    ['autogluon_models_training', 'autogluon-models-training'],
+    ['leaderboard', 'leaderboard'],
+    ['', ''],
+    ['a__b___c', 'a--b---c'],
+  ])('converts component id %s', (id, expected) => expect(componentIdToTaskId(id)).toBe(expected));
 
-describe('componentIdToTaskId', () => {
-  it('should convert underscores to hyphens', () => {
-    expect(componentIdToTaskId('autogluon_models_training')).toBe('autogluon-models-training');
+  it('filters components by run and task state', () => {
+    expect(getComponentsToFetch(undefined, createMockPipelineRun('RUNNING'), new Set())).toEqual(
+      [],
+    );
+    expect(getComponentsToFetch(mockComponentStageMap, undefined, new Set())).toEqual([]);
+    expect(
+      getComponentsToFetch(mockComponentStageMap, createMockPipelineRun('SUCCEEDED'), new Set()),
+    ).toEqual(['automl_data_loader', 'autogluon_models_training', 'leaderboard_evaluation']);
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('running', [
+          { task_id: 'automl-data-loader', state: ' Succeeded ' },
+          { task_id: 'autogluon-models-training', state: 'running' },
+          { task_id: 'leaderboard-evaluation', state: 'pending' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['automl_data_loader', 'autogluon_models_training']);
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('FAILED', [
+          { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
+          { task_id: 'autogluon-models-training-2', state: 'FAILED' },
+        ]),
+        new Set(['automl_data_loader']),
+      ),
+    ).toEqual(['autogluon_models_training']);
   });
 
-  it('should handle ids with no underscores', () => {
-    expect(componentIdToTaskId('leaderboard')).toBe('leaderboard');
+  it('matches display names and branch suffixes, but not arbitrary suffixes', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('RUNNING', [
+          { task_id: 'internal', display_name: 'automl-data-loader', state: 'SUCCEEDED' },
+          { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['automl_data_loader', 'autogluon_models_training']);
+    expect(matchesComponentTaskName('autogluon-models-training', 'autogluon_models_training')).toBe(
+      true,
+    );
+    expect(
+      matchesComponentTaskName('autogluon-models-training-2', 'autogluon_models_training'),
+    ).toBe(true);
+    expect(
+      matchesComponentTaskName('autogluon-models-training-backup', 'autogluon_models_training'),
+    ).toBe(false);
   });
 
-  it('should handle empty string', () => {
-    expect(componentIdToTaskId('')).toBe('');
+  it('skips driver tasks when resolving executor details', () => {
+    const details = [
+      { task_id: 'autogluon-models-training-2-driver', state: 'SUCCEEDED' },
+      { task_id: 'autogluon-models-training-2', state: 'FAILED' },
+    ];
+    expect(findComponentTaskInRunDetails(details, 'autogluon_models_training')).toEqual(details[1]);
+    expect(isKfpDriverTaskName(details[0].task_id)).toBe(true);
+    expect(isKfpDriverTaskName(details[1].task_id)).toBe(false);
   });
 
-  it('should handle multiple consecutive underscores', () => {
-    expect(componentIdToTaskId('a__b___c')).toBe('a--b---c');
+  it('discovers branch prefixes and falls back safely', () => {
+    const run = createMockPipelineRun('RUNNING', [
+      { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
+    ]);
+    const prefixes = buildRunLevelPrefixesFromTaskDetails('root', 'run-123', [
+      { task_id: 'autogluon-models-training-2-driver' },
+      { task_id: 'autogluon-models-training-2' },
+      { task_id: 'automl-data-loader' },
+    ]);
+    expect(prefixes).toEqual([
+      { prefix: 'root/run-123/autogluon-models-training-2/' },
+      { prefix: 'root/run-123/automl-data-loader/' },
+    ]);
+    expect(resolveActiveRunLevelPrefix('root', 'run-123', mockComponentStageMap, run)).toBe(
+      'root/run-123/autogluon-models-training-2',
+    );
+    expect(
+      resolveComponentTaskS3Prefix('root', 'run-123', 'autogluon_models_training', prefixes),
+    ).toBe('root/run-123/autogluon-models-training-2');
+    expect(resolveComponentTaskS3Prefix('root', 'run-123', 'automl_data_loader')).toBe(
+      'root/run-123/automl-data-loader',
+    );
+    expect(
+      resolveComponentTaskS3Prefix('root', 'run-123', 'autogluon_models_training', []),
+    ).toBeUndefined();
+    expect(
+      resolveComponentTaskS3Prefix('root', 'run-123', 'autogluon_models_training', [
+        { prefix: 'root/run-123/autogluon-models-training-backup/' },
+      ]),
+    ).toBe('root/run-123/autogluon-models-training');
   });
-});
 
-describe('getComponentsToFetch', () => {
-  it('should return empty array when componentStageMap is undefined', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', []);
-    expect(getComponentsToFetch(undefined, pipelineRun, new Set())).toEqual([]);
+  it('returns all component ids when the run is succeeded', () => {
+    expect(
+      getComponentsToFetch(mockComponentStageMap, createMockPipelineRun('SUCCEEDED'), new Set()),
+    ).toEqual(['automl_data_loader', 'autogluon_models_training', 'leaderboard_evaluation']);
   });
 
-  it('should return empty array when pipelineRun is undefined', () => {
+  it('normalizes run and task state casing and whitespace', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun(' succeeded ', [
+          { task_id: 'automl-data-loader', state: ' succeeded ' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['automl_data_loader', 'autogluon_models_training', 'leaderboard_evaluation']);
+  });
+
+  it('skips components already completed', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('SUCCEEDED'),
+        new Set(['autogluon_models_training']),
+      ),
+    ).toEqual(['automl_data_loader', 'leaderboard_evaluation']);
+  });
+
+  it('includes failed tasks when the run has not succeeded', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('FAILED', [
+          { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
+          { task_id: 'autogluon-models-training-2', state: 'FAILED' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['automl_data_loader', 'autogluon_models_training']);
+  });
+
+  it('returns no components when no tasks match', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('RUNNING', [{ task_id: 'unrelated-task', state: 'SUCCEEDED' }]),
+        new Set(),
+      ),
+    ).toEqual([]);
+  });
+
+  it('returns no components when the stage map is undefined', () => {
+    expect(getComponentsToFetch(undefined, createMockPipelineRun('RUNNING'), new Set())).toEqual(
+      [],
+    );
+  });
+
+  it('returns no components when the pipeline run is undefined', () => {
     expect(getComponentsToFetch(mockComponentStageMap, undefined, new Set())).toEqual([]);
   });
 
-  it('should return all component ids when run is SUCCEEDED', () => {
-    const pipelineRun = createMockPipelineRun('SUCCEEDED', []);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual([
-      'automl_data_loader',
-      'autogluon_models_training',
-      'leaderboard_evaluation',
-    ]);
+  it('matches tasks by display name', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('RUNNING', [
+          { task_id: 'some-internal-id', display_name: 'automl-data-loader', state: 'SUCCEEDED' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['automl_data_loader']);
   });
 
-  it('should normalize run and task state casing and whitespace', () => {
-    const pipelineRun = createMockPipelineRun(' succeeded ', [
-      { task_id: 'automl-data-loader', state: ' succeeded ' },
-    ]);
-    expect(getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set())).toEqual([
-      'automl_data_loader',
-      'autogluon_models_training',
-      'leaderboard_evaluation',
-    ]);
-
-    const runningRun = createMockPipelineRun('running', [
-      { task_id: 'automl-data-loader', state: ' Succeeded ' },
-      { task_id: 'autogluon-models-training', state: 'running' },
-      { task_id: 'leaderboard-evaluation', state: 'pending' },
-    ]);
-    expect(getComponentsToFetch(mockComponentStageMap, runningRun, new Set())).toEqual([
-      'automl_data_loader',
-      'autogluon_models_training',
-    ]);
+  it('matches suffixed task directories from branches', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('RUNNING', [
+          { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['autogluon_models_training']);
   });
 
-  it('should skip components already in completedComponentIds', () => {
-    const pipelineRun = createMockPipelineRun('SUCCEEDED', []);
-    const completed = new Set(['autogluon_models_training']);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, completed);
-
-    expect(result).toEqual(['automl_data_loader', 'leaderboard_evaluation']);
-  });
-
-  it('should return RUNNING, SUCCEEDED, or FAILED tasks when run is not SUCCEEDED', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
-      { task_id: 'autogluon-models-training', state: 'RUNNING' },
-      { task_id: 'leaderboard-evaluation', state: 'PENDING' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['automl_data_loader', 'autogluon_models_training']);
-  });
-
-  it('should include FAILED tasks when the run has not succeeded', () => {
-    const pipelineRun = createMockPipelineRun('FAILED', [
-      { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
-      { task_id: 'autogluon-models-training-2', state: 'FAILED' },
-      { task_id: 'leaderboard-evaluation', state: 'PENDING' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['automl_data_loader', 'autogluon_models_training']);
-  });
-
-  it('should include CANCELED tasks when the run is terminal but not SUCCEEDED', () => {
-    const pipelineRun = createMockPipelineRun('CANCELED', [
-      { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
-      { task_id: 'autogluon-models-training', state: 'CANCELED' },
-      { task_id: 'leaderboard-evaluation', state: 'PENDING' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['automl_data_loader', 'autogluon_models_training']);
-  });
-
-  it('should match tasks by display_name as well', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      {
-        task_id: 'some-internal-id',
-        display_name: 'automl-data-loader',
-        state: 'SUCCEEDED',
-      },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['automl_data_loader']);
-  });
-
-  it('should return empty array when no tasks match', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'unrelated-task', state: 'SUCCEEDED' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual([]);
-  });
-
-  it('should match suffixed task directory names from condition branches', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
-      { task_id: 'leaderboard-evaluation-2', state: 'PENDING' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['autogluon_models_training']);
-  });
-});
-
-describe('matchesComponentTaskName', () => {
-  it('should match exact and branch-suffixed task names', () => {
+  it('matches exact and branch-suffixed task names', () => {
     expect(matchesComponentTaskName('autogluon-models-training', 'autogluon_models_training')).toBe(
       true,
     );
@@ -281,766 +335,684 @@ describe('matchesComponentTaskName', () => {
     expect(matchesComponentTaskName('other-task', 'autogluon_models_training')).toBe(false);
   });
 
-  it('should reject non-branch suffixes', () => {
-    expect(
-      matchesComponentTaskName('autogluon-models-training-backup', 'autogluon_models_training'),
-    ).toBe(false);
-  });
-});
-
-describe('isKfpDriverTaskName', () => {
-  it('should identify KFP driver tasks', () => {
-    expect(isKfpDriverTaskName('autogluon-models-training-2-driver')).toBe(true);
+  it('identifies KFP driver tasks', () => {
     expect(isKfpDriverTaskName('automl-data-loader-driver')).toBe(true);
     expect(isKfpDriverTaskName('autogluon-models-training-2')).toBe(false);
   });
-});
 
-describe('findComponentTaskInRunDetails', () => {
-  it('should skip driver tasks and return the executor task status', () => {
-    const taskDetails = [
-      { task_id: 'autogluon-models-training-2-driver', state: 'SUCCEEDED' },
-      { task_id: 'autogluon-models-training-2', state: 'FAILED' },
-    ];
-
-    expect(findComponentTaskInRunDetails(taskDetails, 'autogluon_models_training')).toEqual({
-      task_id: 'autogluon-models-training-2',
-      state: 'FAILED',
-    });
-  });
-
-  it('should resolve data loader status from the executor task when driver succeeded first', () => {
-    const taskDetails = [
+  it('resolves the executor when the driver appears first', () => {
+    const details = [
       { task_id: 'automl-data-loader-driver', state: 'SUCCEEDED' },
       { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
     ];
-
-    expect(findComponentTaskInRunDetails(taskDetails, 'automl_data_loader')).toEqual({
-      task_id: 'automl-data-loader',
-      state: 'SUCCEEDED',
-    });
+    expect(findComponentTaskInRunDetails(details, 'automl_data_loader')).toEqual(details[1]);
   });
-});
 
-describe('buildRunLevelPrefixesFromTaskDetails', () => {
-  it('should build branch-suffixed prefixes from executor task names and skip drivers', () => {
-    const prefixes = buildRunLevelPrefixesFromTaskDetails(
-      'autogluon-tabular-training-pipeline',
-      'run-123',
-      [
-        { task_id: 'autogluon-models-training-2-driver', state: 'SUCCEEDED' },
-        { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
-        { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
-      ],
-    );
-
-    expect(prefixes).toEqual([
-      { prefix: 'autogluon-tabular-training-pipeline/run-123/autogluon-models-training-2/' },
-      { prefix: 'autogluon-tabular-training-pipeline/run-123/automl-data-loader/' },
+  it('builds branch prefixes from executor names and skips drivers', () => {
+    expect(
+      buildRunLevelPrefixesFromTaskDetails('root', 'run-123', [
+        { task_id: 'autogluon-models-training-2-driver' },
+        { task_id: 'autogluon-models-training-2' },
+        { task_id: 'automl-data-loader' },
+      ]),
+    ).toEqual([
+      { prefix: 'root/run-123/autogluon-models-training-2/' },
+      { prefix: 'root/run-123/automl-data-loader/' },
     ]);
   });
-});
 
-describe('resolveActiveRunLevelPrefix', () => {
-  it('should resolve the executor task directory for an active branch-suffixed component', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
-    ]);
-
+  it('resolves the active executor task directory', () => {
     expect(
       resolveActiveRunLevelPrefix(
-        'autogluon-tabular-training-pipeline',
+        'root',
         'run-123',
         mockComponentStageMap,
-        pipelineRun,
+        createMockPipelineRun('RUNNING', [
+          { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
+        ]),
       ),
-    ).toBe('autogluon-tabular-training-pipeline/run-123/autogluon-models-training-2');
+    ).toBe('root/run-123/autogluon-models-training-2');
   });
 
-  it('should resolve suffixed task directories through run-level prefix discovery', () => {
-    const prefixes = buildRunLevelPrefixesFromTaskDetails(
-      'autogluon-tabular-training-pipeline',
-      'run-123',
-      [{ task_id: 'autogluon-models-training-2', state: 'RUNNING' }],
+  it('falls back to the base task path without a matching prefix', () => {
+    expect(resolveComponentTaskS3Prefix('root', 'run-123', 'automl_data_loader')).toBe(
+      'root/run-123/automl-data-loader',
     );
-
     expect(
-      resolveComponentTaskS3Prefix(
-        'autogluon-tabular-training-pipeline',
-        'run-123',
-        'autogluon_models_training',
-        prefixes,
-      ),
-    ).toBe('autogluon-tabular-training-pipeline/run-123/autogluon-models-training-2');
+      resolveComponentTaskS3Prefix('root', 'run-123', 'autogluon_models_training', [
+        { prefix: 'root/run-123/autogluon-models-training-backup/' },
+      ]),
+    ).toBe('root/run-123/autogluon-models-training');
   });
 });
 
-describe('resolveComponentTaskS3Prefix', () => {
-  it('should resolve suffixed task directories from run-level prefixes', () => {
-    const prefixes = [
-      { prefix: 'autogluon-tabular-training-pipeline/run-123/automl-data-loader/' },
-      { prefix: 'autogluon-tabular-training-pipeline/run-123/autogluon-models-training-2/' },
-    ];
-
-    expect(
-      resolveComponentTaskS3Prefix(
-        'autogluon-tabular-training-pipeline',
-        'run-123',
-        'autogluon_models_training',
-        prefixes,
-      ),
-    ).toBe('autogluon-tabular-training-pipeline/run-123/autogluon-models-training-2');
-  });
-
-  it('should fall back to the base task path when no run-level prefix matches', () => {
-    expect(
-      resolveComponentTaskS3Prefix(
-        'autogluon-tabular-training-pipeline',
-        'run-123',
-        'automl_data_loader',
-      ),
-    ).toBe('autogluon-tabular-training-pipeline/run-123/automl-data-loader');
-  });
-
-  it('should return undefined when run-level discovery succeeded with no prefixes', () => {
-    expect(
-      resolveComponentTaskS3Prefix(
-        'autogluon-tabular-training-pipeline',
-        'run-123',
-        'autogluon_models_training',
-        [],
-      ),
-    ).toBeUndefined();
-  });
-
-  it('should ignore non-numeric sibling prefixes and fall back to the base task path', () => {
-    const prefixes = [
-      { prefix: 'autogluon-tabular-training-pipeline/run-123/autogluon-models-training-backup/' },
-    ];
-
-    expect(
-      resolveComponentTaskS3Prefix(
-        'autogluon-tabular-training-pipeline',
-        'run-123',
-        'autogluon_models_training',
-        prefixes,
-      ),
-    ).toBe('autogluon-tabular-training-pipeline/run-123/autogluon-models-training');
-  });
-});
-
-describe('mergeStatusIntoStageMap', () => {
-  it('should return stageMap unchanged when no status files match', () => {
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, new Map());
-    expect(result).toEqual(mockComponentStageMap);
-  });
-
-  it('should merge status data into matching component stages', () => {
-    const statusFiles = new Map([['autogluon_models_training', mockComponentStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const mergedComponent = result.components.find((c) => c.id === 'autogluon_models_training')!;
-    expect(mergedComponent.started_at).toBe('2026-06-04T17:49:19.223056Z');
-    expect(mergedComponent.completed_at).toBe('2026-06-04T17:50:10.290690Z');
-    expect(mergedComponent.metadata).toEqual({});
-  });
-
-  it('should preserve original stage descriptions after merge', () => {
-    const statusFiles = new Map([['autogluon_models_training', mockComponentStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const mergedComponent = result.components.find((c) => c.id === 'autogluon_models_training')!;
-    expect(mergedComponent.stages[0].description).toBe('Load train/validation CSVs');
-  });
-
-  it('should add status fields to merged stages', () => {
-    const statusFiles = new Map([['autogluon_models_training', mockComponentStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const mergedComponent = result.components.find((c) => c.id === 'autogluon_models_training')!;
-    const loadDataStage = mergedComponent.stages.find((s) => s.id === 'load_data')!;
-
-    expect(loadDataStage.status).toBe('completed');
-    expect(loadDataStage.timestamp).toBe('2026-06-04T17:49:19.232065Z');
-    expect(loadDataStage.train_rows).toBe(213);
-    expect(loadDataStage.test_rows).toBe(179);
-  });
-
-  it('should flatten nested stage metadata onto merged stages', () => {
-    const statusWithNestedMetadata: ComponentStatusFile = {
-      component_id: 'autogluon_models_training',
-      stages: [
-        {
-          id: 'load_data',
-          description: 'Load train/validation CSVs',
-          status: 'completed',
-          timestamp: '2026-06-04T17:49:19.232065Z',
-          metadata: {
-            train_rows: 500,
-            test_rows: 125,
-          },
-        },
-      ],
-    };
-    const statusFiles = new Map([['autogluon_models_training', statusWithNestedMetadata]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const loadDataStage = result.components
-      .find((component) => component.id === 'autogluon_models_training')!
-      .stages.find((stage) => stage.id === 'load_data')!;
-
-    expect(loadDataStage.train_rows).toBe(500);
-    expect(loadDataStage.test_rows).toBe(125);
-    expect(loadDataStage.metadata).toBeUndefined();
-  });
-
-  it('should merge nested stage metadata via mergeStageWithStatus', () => {
-    const merged = mergeStageWithStatus(
-      { id: 'load_data', description: 'Load train/validation CSVs' },
-      {
-        id: 'load_data',
-        description: 'ignored',
-        status: 'completed',
-        metadata: { train_rows: 42 },
-      },
+describe('legacy merge and completion coverage with canonical status files', () => {
+  it('merges matching components, preserves descriptions, and leaves unmatched data alone', () => {
+    const result = mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['autogluon_models_training', mockComponentStatus]]),
     );
-
-    expect(merged.description).toBe('Load train/validation CSVs');
-    expect(merged.status).toBe('completed');
-    expect(merged.train_rows).toBe(42);
-    expect(merged.metadata).toBeUndefined();
+    const component = result.components[1];
+    expect(component.started_at).toBe('2026-06-04T17:49:19.223056Z');
+    expect(component.completed_at).toBe('2026-06-04T17:50:10.290690Z');
+    expect(component.metadata).toEqual({ display_name: 'Training' });
+    expect(component.stages[0].description).toBe('Load train/validation CSVs');
+    expect(component.stages[0].metrics).toEqual({ train_rows: 213, test_rows: 179 });
+    expect(result.components[0]).toEqual(mockComponentStageMap.components[0]);
   });
 
-  it('should not let nested metadata overwrite top-level status and timestamp', () => {
-    const statusWithCollidingMetadata: ComponentStatusFile = {
+  it('keeps missing stages pending and does not mutate the map', () => {
+    const original = JSON.stringify(mockComponentStageMap);
+    const partial = ComponentStatusFileSchema.parse({
       component_id: 'autogluon_models_training',
-      stages: [
-        {
-          id: 'load_data',
-          description: 'Load train/validation CSVs',
-          status: 'completed',
-          timestamp: '2026-06-04T17:49:19.232065Z',
-          metadata: {
-            status: 'pending',
-            timestamp: '2026-01-01T00:00:00.000000Z',
-            train_rows: 500,
-            test_rows: 125,
-          },
-        },
-      ],
-    };
-    const statusFiles = new Map([['autogluon_models_training', statusWithCollidingMetadata]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const loadDataStage = result.components
-      .find((component) => component.id === 'autogluon_models_training')!
-      .stages.find((stage) => stage.id === 'load_data')!;
-
-    expect(loadDataStage.status).toBe('completed');
-    expect(loadDataStage.timestamp).toBe('2026-06-04T17:49:19.232065Z');
-    expect(loadDataStage.train_rows).toBe(500);
-    expect(loadDataStage.test_rows).toBe(125);
-    expect(loadDataStage.metadata).toBeUndefined();
-
-    const merged = mergeStageWithStatus(
-      { id: 'load_data', description: 'Load train/validation CSVs' },
-      statusWithCollidingMetadata.stages[0],
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Training' },
+      stages: [{ id: 'load_data', status: { state: 'completed' } }],
+    });
+    const result = mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['autogluon_models_training', partial]]),
     );
-
-    expect(merged.status).toBe('completed');
-    expect(merged.timestamp).toBe('2026-06-04T17:49:19.232065Z');
-    expect(merged.train_rows).toBe(500);
-    expect(merged.test_rows).toBe(125);
-    expect(merged.metadata).toBeUndefined();
+    expect(result.components[1].stages[2].status).toBeUndefined();
+    expect(JSON.stringify(mockComponentStageMap)).toBe(original);
   });
 
-  it('should reject unsafe and protected keys when flattening nested stage fields', () => {
-    const maliciousMetadata = {
-      steps: ['evil_step'],
-      selected_models: ['EvilModel'],
-      train_rows: 500,
-      constructor: { polluted: true },
-      prototype: { polluted: true },
-      ...JSON.parse('{"__proto__":{"polluted":true}}'),
-    };
-
-    const merged = mergeStageWithStatus(
-      {
-        id: 'model_selection',
-        description: 'Run AutoGluon model selection',
-        steps: ['feature_engineering', 'model_training'],
-      },
-      {
-        id: 'model_selection',
-        description: 'ignored',
-        status: 'completed',
-        timestamp: '2026-06-04T17:49:53.951525Z',
-        selected_models: ['LightGBM_BAG_L2'],
-        metadata: maliciousMetadata,
-      },
-    );
-
-    expect(merged.status).toBe('completed');
-    expect(merged.timestamp).toBe('2026-06-04T17:49:53.951525Z');
-    expect(merged.steps).toEqual(['feature_engineering', 'model_training']);
-    expect(merged.selected_models).toEqual(['LightGBM_BAG_L2']);
-    expect(merged.train_rows).toBe(500);
-    expect(merged.metadata).toBeUndefined();
-
-    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
-    expect(Object.hasOwn(merged, 'constructor')).toBe(false);
-    expect(Object.hasOwn(merged, 'prototype')).toBe(false);
-    expect(Object.hasOwn(merged, '__proto__')).toBe(false);
-    expect(merged).not.toHaveProperty('polluted');
-    expect(Object.prototype).toEqual(expect.not.objectContaining({ polluted: true }));
-  });
-
-  it('should leave unmatched components untouched', () => {
-    const statusFiles = new Map([['autogluon_models_training', mockComponentStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const dataLoader = result.components.find((c) => c.id === 'automl_data_loader')!;
-    expect(dataLoader).toEqual(mockComponentStageMap.components[0]);
-  });
-
-  it('should leave unmatched stages within a merged component untouched', () => {
-    const partialStatus: ComponentStatusFile = {
-      component_id: 'autogluon_models_training',
-      stages: [
-        {
-          id: 'load_data',
-          description: 'Load train/validation CSVs',
-          status: 'completed',
-          timestamp: '2026-06-04T17:49:19Z',
-        },
-      ],
-    };
-    const statusFiles = new Map([['autogluon_models_training', partialStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const mergedComponent = result.components.find((c) => c.id === 'autogluon_models_training')!;
-    const refitStage = mergedComponent.stages.find((s) => s.id === 'refit_full')!;
-    expect(refitStage.status).toBeUndefined();
-  });
-
-  it('should not mutate the original stageMap', () => {
-    const originalJson = JSON.stringify(mockComponentStageMap);
-    const statusFiles = new Map([['autogluon_models_training', mockComponentStatus]]);
-    mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    expect(JSON.stringify(mockComponentStageMap)).toBe(originalJson);
-  });
-
-  it('should merge leaderboard best_model when status stage omits description', () => {
-    const leaderboardStatus: ComponentStatusFile = {
+  it('merges leaderboard metrics without replacing map descriptions', () => {
+    const status = ComponentStatusFileSchema.parse({
       component_id: 'leaderboard_evaluation',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Leaderboard' },
       stages: [
         {
           id: 'build_leaderboard',
-          status: 'completed',
-          timestamp: '2026-06-04T17:50:15.000000Z',
-          best_model: 'LightGBM_BAG_L2',
+          status: { state: 'completed' },
+          metrics: { best_model: 'LightGBM_BAG_L2' },
         },
       ],
-    };
-
-    expect(() => ComponentStatusFileSchema.parse(leaderboardStatus)).not.toThrow();
-
-    const result = mergeStatusIntoStageMap(
+    });
+    const stage = mergeStatusIntoStageMap(
       mockComponentStageMap,
-      new Map([['leaderboard_evaluation', leaderboardStatus]]),
-    );
-
-    const buildLeaderboard = result.components
-      .find((component) => component.id === 'leaderboard_evaluation')!
-      .stages.find((stage) => stage.id === 'build_leaderboard')!;
-
-    expect(buildLeaderboard.description).toBe('Aggregate model metrics');
-    expect(buildLeaderboard.best_model).toBe('LightGBM_BAG_L2');
+      new Map([['leaderboard_evaluation', status]]),
+    ).components[2].stages[0];
+    expect(stage.description).toBe('Aggregate model metrics');
+    expect(stage.metrics).toEqual({ best_model: 'LightGBM_BAG_L2' });
   });
 
-  it('should truncate oversized model_selection steps during status parsing', () => {
-    const oversizedSteps = Array.from(
-      { length: MAX_MODEL_SELECTION_STEPS + 5 },
-      (_, index) => `step_${index}`,
-    );
-    const parsed = ComponentStatusFileSchema.parse({
-      component_id: 'autogluon_models_training',
+  it('reports completion only for non-empty all-completed canonical stages', () => {
+    expect(isComponentFullyComplete(mockComponentStatus)).toBe(true);
+    const partial = ComponentStatusFileSchema.parse({
+      component_id: 'test',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Test' },
       stages: [
-        {
-          id: 'model_selection',
-          steps: oversizedSteps,
-        },
+        { id: 'a', status: { state: 'completed' } },
+        { id: 'b', status: { state: 'started' } },
       ],
     });
-
-    expect(parsed.stages[0].steps).toHaveLength(MAX_MODEL_SELECTION_STEPS);
-    expect(parsed.stages[0].steps).toEqual(oversizedSteps.slice(0, MAX_MODEL_SELECTION_STEPS));
-  });
-
-  it('should dedupe repeated model_selection steps before applying the cap', () => {
-    const repeatedSteps = [
-      ...Array.from({ length: MAX_MODEL_SELECTION_STEPS }, () => 'feature_engineering'),
-      'model_training',
-      'stacking',
-    ];
-    const parsed = ComponentStatusFileSchema.parse({
-      component_id: 'autogluon_models_training',
-      stages: [
-        {
-          id: 'model_selection',
-          steps: repeatedSteps,
-        },
-      ],
+    expect(isComponentFullyComplete(partial)).toBe(false);
+    const empty = ComponentStatusFileSchema.parse({
+      component_id: 'test',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Test' },
+      stages: [],
     });
-
-    expect(parsed.stages[0].steps).toEqual(['feature_engineering', 'model_training', 'stacking']);
-
-    const merged = mergeStageWithStatus(
-      {
-        id: 'model_selection',
-        description: 'Train candidate models',
-        steps: repeatedSteps,
-      },
-      parsed.stages[0],
-    );
-
-    expect(merged.steps).toEqual(['feature_engineering', 'model_training', 'stacking']);
-  });
-
-  it('should reject malformed selected_models during status parsing', () => {
-    const objectParsed = ComponentStatusFileSchema.parse({
-      component_id: 'autogluon_models_training',
-      stages: [
-        {
-          id: 'model_selection',
-          selected_models: { model_a: 'ExtraTreesGini_BAG_L2' },
-        },
-      ],
-    });
-    expect(objectParsed.stages[0].selected_models).toBeUndefined();
-
-    const mixedParsed = ComponentStatusFileSchema.parse({
-      component_id: 'autogluon_models_training',
-      stages: [
-        {
-          id: 'model_selection',
-          selected_models: ['LightGBM_BAG_L2', 42, null],
-        },
-      ],
-    });
-    expect(mixedParsed.stages[0].selected_models).toEqual(['LightGBM_BAG_L2']);
-
-    const emptyParsed = ComponentStatusFileSchema.parse({
-      component_id: 'autogluon_models_training',
-      stages: [
-        {
-          id: 'model_selection',
-          selected_models: [],
-        },
-      ],
-    });
-    expect(emptyParsed.stages[0].selected_models).toEqual([]);
-  });
-
-  it('should normalize documented stage statuses and drop unsupported ones during parsing', () => {
-    const parsed = ComponentStatusFileSchema.parse({
-      component_id: 'autogluon_models_training',
-      stages: [
-        { id: 'load_data', status: ' Completed ' },
-        { id: 'model_selection', status: 'STARTED' },
-        { id: 'refit_full', status: 'running' },
-        { id: 'build_leaderboard', status: 'pending' },
-      ],
-    });
-
-    expect(parsed.stages[0].status).toBe('completed');
-    expect(parsed.stages[1].status).toBe('started');
-    expect(parsed.stages[2].status).toBeUndefined();
-    expect(parsed.stages[3].status).toBeUndefined();
-  });
-
-  it('should not let unsupported status overwrite completed or failed canonical stages', () => {
-    const completedPreserved = mergeStageWithStatus(
-      { id: 'load_data', description: 'Load data', status: 'completed' },
-      {
-        id: 'load_data',
-        status: 'running',
-        timestamp: '2026-06-04T17:49:19.232065Z',
-      } as unknown as ComponentStatusFile['stages'][number],
-    );
-    expect(completedPreserved.status).toBe('completed');
-    expect(completedPreserved.timestamp).toBe('2026-06-04T17:49:19.232065Z');
-
-    const failedPreserved = mergeStageWithStatus(
-      { id: 'load_data', description: 'Load data', status: 'failed' },
-      {
-        id: 'load_data',
-        status: 'pending',
-      } as unknown as ComponentStatusFile['stages'][number],
-    );
-    expect(failedPreserved.status).toBe('failed');
-
-    const progressed = mergeStageWithStatus(
-      { id: 'load_data', description: 'Load data', status: 'started' },
-      { id: 'load_data', status: 'completed' },
-    );
-    expect(progressed.status).toBe('completed');
-  });
-
-  it('should clear canonical selected_models when status provides an empty array', () => {
-    const merged = mergeStageWithStatus(
-      {
-        id: 'model_selection',
-        description: 'Run AutoGluon model selection',
-        selected_models: ['ExistingModel'],
-      },
-      {
-        id: 'model_selection',
-        status: 'completed',
-        selected_models: [],
-      },
-    );
-
-    expect(merged.selected_models).toEqual([]);
-    expect(merged.status).toBe('completed');
-  });
-
-  it('should not clear canonical selected_models when a non-empty array has no valid strings', () => {
-    const nonStringParsed = ComponentStatusFileSchema.parse({
-      component_id: 'autogluon_models_training',
-      stages: [
-        {
-          id: 'model_selection',
-          selected_models: [42, null],
-        },
-      ],
-    });
-    expect(nonStringParsed.stages[0].selected_models).toBeUndefined();
-
-    const merged = mergeStageWithStatus(
-      {
-        id: 'model_selection',
-        description: 'Run AutoGluon model selection',
-        selected_models: ['ExistingModel'],
-      },
-      {
-        id: 'model_selection',
-        status: 'completed',
-        selected_models: [42, null],
-      } as unknown as ComponentStatusFile['stages'][number],
-    );
-
-    expect(merged.selected_models).toEqual(['ExistingModel']);
-    expect(merged.status).toBe('completed');
-  });
-
-  it('should not merge malformed selected_models into branch metadata', () => {
-    const merged = mergeStageWithStatus(
-      {
-        id: 'model_selection',
-        description: 'Run AutoGluon model selection',
-        selected_models: ['ExistingModel'],
-      },
-      {
-        id: 'model_selection',
-        status: 'completed',
-        selected_models: { bad: 'value' },
-      } as unknown as ComponentStatusFile['stages'][number],
-    );
-
-    expect(merged.selected_models).toEqual(['ExistingModel']);
-    expect(merged.status).toBe('completed');
+    expect(isComponentFullyComplete(empty)).toBe(false);
   });
 });
 
 describe('useComponentStatuses', () => {
-  const useS3ListFilesQueryMock = jest.mocked(useS3ListFilesQuery);
-  const getFilesMock = jest.mocked(getFiles);
-  const dataUpdatedAt = 1_700_000_000_000;
-
+  const queryMock = jest.mocked(useS3ListFilesQuery);
+  const filesMock = jest.mocked(getFiles);
+  const updatedAt = 1_700_000_000_000;
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-    useS3ListFilesQueryMock.mockReturnValue({
+    queryMock.mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: false,
       error: null,
     } as ReturnType<typeof useS3ListFilesQuery>);
   });
+  afterEach(() => jest.restoreAllMocks());
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('should populate errors when all component status fetches fail', async () => {
+  it('reports errors and settles loading when status fetches fail', async () => {
+    filesMock.mockRejectedValue(new Error('S3 unavailable'));
     const pipelineRun = createMockPipelineRun('RUNNING', [
       { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
       { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
     ]);
-
-    getFilesMock.mockRejectedValue(new Error('S3 unavailable'));
-
     const { result } = renderHook(() =>
       useComponentStatuses(
         'run-123',
         'test-namespace',
         pipelineRun,
         mockComponentStageMap,
-        dataUpdatedAt,
+        updatedAt,
       ),
     );
-
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([
-        { componentId: 'automl_data_loader', message: 'S3 unavailable' },
-        { componentId: 'autogluon_models_training', message: 'S3 unavailable' },
-      ]);
-    });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
+    await waitFor(() => expect(result.current.errors).toHaveLength(2));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.mergedStageMap).toEqual(mockComponentStageMap);
   });
 
-  it('should clear stale errors when a later fetch returns missing status', async () => {
+  it('clears stale errors when a later fetch finds no status', async () => {
+    filesMock.mockRejectedValueOnce(new Error('S3 unavailable')).mockResolvedValue({
+      contents: [],
+      common_prefixes: [],
+      is_truncated: false,
+      key_count: 0,
+      max_keys: 1000,
+    });
     const pipelineRun = createMockPipelineRun('RUNNING', [
       { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
-      { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
     ]);
-
-    getFilesMock.mockRejectedValue(new Error('S3 unavailable'));
-
     const { result, rerender } = renderHook(
-      ({ updatedAt }) =>
+      ({ stamp }) =>
         useComponentStatuses(
           'run-123',
           'test-namespace',
           pipelineRun,
           mockComponentStageMap,
-          updatedAt,
+          stamp,
         ),
-      { initialProps: { updatedAt: dataUpdatedAt } },
+      { initialProps: { stamp: updatedAt } },
     );
-
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([
-        { componentId: 'automl_data_loader', message: 'S3 unavailable' },
-        { componentId: 'autogluon_models_training', message: 'S3 unavailable' },
-      ]);
-    });
-
-    getFilesMock.mockResolvedValue({
-      contents: [],
-      common_prefixes: [],
-      is_truncated: false,
-      key_count: 0,
-      max_keys: 1000,
-    });
-
-    rerender({ updatedAt: dataUpdatedAt + 1 });
-
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([]);
-    });
-    expect(result.current.mergedStageMap).toEqual(mockComponentStageMap);
+    await waitFor(() => expect(result.current.errors).toHaveLength(1));
+    rerender({ stamp: updatedAt + 1 });
+    await waitFor(() => expect(result.current.errors).toEqual([]));
   });
 
-  it('should settle loading when namespace is unavailable', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
-      { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
-    ]);
-
+  it('settles without fetching when namespace is unavailable', () => {
     const { result } = renderHook(() =>
-      useComponentStatuses('run-123', undefined, pipelineRun, mockComponentStageMap, dataUpdatedAt),
+      useComponentStatuses(
+        'run-123',
+        undefined,
+        createMockPipelineRun('RUNNING'),
+        mockComponentStageMap,
+        updatedAt,
+      ),
     );
-
     expect(result.current.isLoading).toBe(false);
     expect(result.current.mergedStageMap).toEqual(mockComponentStageMap);
-    expect(getFilesMock).not.toHaveBeenCalled();
+    expect(filesMock).not.toHaveBeenCalled();
   });
 
-  it('should reset status caches when namespace changes for the same runId', async () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
-      { task_id: 'autogluon-models-training-2', state: 'RUNNING' },
-    ]);
-
-    getFilesMock.mockRejectedValue(new Error('S3 unavailable'));
-
-    const { result, rerender } = renderHook(
-      ({ namespace }) =>
-        useComponentStatuses(
-          'run-123',
-          namespace,
-          pipelineRun,
-          mockComponentStageMap,
-          dataUpdatedAt,
-        ),
-      { initialProps: { namespace: 'project-a' } },
-    );
-
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([
-        { componentId: 'automl_data_loader', message: 'S3 unavailable' },
-        { componentId: 'autogluon_models_training', message: 'S3 unavailable' },
-      ]);
-    });
-
-    getFilesMock.mockResolvedValue({
+  it('resets errors when the namespace changes for the same run', async () => {
+    filesMock.mockRejectedValueOnce(new Error('S3 unavailable')).mockResolvedValue({
       contents: [],
       common_prefixes: [],
       is_truncated: false,
       key_count: 0,
       max_keys: 1000,
     });
-
+    const pipelineRun = createMockPipelineRun('RUNNING', [
+      { task_id: 'automl-data-loader', state: 'SUCCEEDED' },
+    ]);
+    const { result, rerender } = renderHook(
+      ({ namespace }) =>
+        useComponentStatuses('run-123', namespace, pipelineRun, mockComponentStageMap, updatedAt),
+      { initialProps: { namespace: 'project-a' } },
+    );
+    await waitFor(() => expect(result.current.errors).toHaveLength(1));
     rerender({ namespace: 'project-b' });
+    await waitFor(() => expect(result.current.errors).toEqual([]));
+  });
+});
 
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([]);
+describe('ComponentStatusFileSchema', () => {
+  it('should reject the legacy flat stage and string status shape', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'training_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'Training' },
+        stages: [{ id: 'load_data', status: 'completed', row_count: 10 }],
+      }),
+    ).toThrow();
+  });
+
+  it('should require the canonical envelope and stage fields', () => {
+    expect(() => ComponentStatusFileSchema.parse({ component_id: 'training_component' })).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'training_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: {},
+        stages: [],
+      }),
+    ).toThrow();
+  });
+
+  it('should parse running metrics, message, and status step', () => {
+    const parsed = artifact([
+      {
+        id: 'load_data',
+        status: {
+          state: 'running',
+          step: 'load',
+          message: { level: 'info', text: 'Loading data' },
+          running_at: '2026-01-01T00:01:00Z',
+        },
+        metrics: { completed_units: 3, total_units: 8, batches: [1, 2] },
+      },
+    ]);
+
+    expect(parsed.stages[0]).toMatchObject({
+      id: 'load_data',
+      status: {
+        state: 'running',
+        step: 'load',
+        message: { text: 'Loading data' },
+      },
+      metrics: { completed_units: 3, total_units: 8 },
     });
-    expect(result.current.mergedStageMap).toEqual(mockComponentStageMap);
+  });
+
+  it('should accept an error only on a failed stage', () => {
+    const failedStage = artifact([
+      { id: 'model_selection', status: { state: 'failed' }, error: 'TRAIN_FAILED' },
+    ]).stages[0];
+    expect('error' in failedStage ? failedStage.error : undefined).toBe('TRAIN_FAILED');
+    expect(() =>
+      artifact([{ id: 'model_selection', status: { state: 'running' }, error: 'stale error' }]),
+    ).toThrow();
+  });
+
+  it('should reject a missing envelope or required metadata', () => {
+    expect(() => ComponentStatusFileSchema.parse({ component_id: 'training_component' })).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'training_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: {},
+        stages: [],
+      }),
+    ).toThrow();
+  });
+
+  it('should parse canonical running status, message, and metrics', () => {
+    const parsed = artifact([
+      {
+        id: 'load_data',
+        status: {
+          state: 'running',
+          step: 'load',
+          message: { level: 'info', text: 'Loading data' },
+          running_at: '2026-01-01T00:01:00Z',
+        },
+        metrics: { completed_units: 3, total_units: 8, batches: [1, 2] },
+      },
+    ]);
+    expect(parsed.stages[0].status).toMatchObject({ state: 'running', step: 'load' });
+    expect(parsed.stages[0].metrics).toEqual({
+      completed_units: 3,
+      total_units: 8,
+      batches: [1, 2],
+    });
+  });
+
+  it('should enforce canonical identifiers, timestamps, messages, errors, and metric values', () => {
+    const valid = {
+      component_id: 'training_component',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Training', extra: { retained: true } },
+      stages: [
+        {
+          id: 'load_data',
+          status: { state: 'running', running_at: '2026-01-01T00:01:00Z' },
+          metrics: {
+            string: 'value',
+            number: 1.5,
+            integer: 1,
+            boolean: true,
+            empty: null,
+            values: ['value', 1, false],
+          },
+        },
+      ],
+    };
+    expect(ComponentStatusFileSchema.parse(valid)).toEqual(valid);
+    for (const [field, value] of [
+      ['component_id', 'Training'],
+      ['started_at', '2026-01-01T00:00:00+00:00'],
+    ] as const) {
+      expect(() => ComponentStatusFileSchema.parse({ ...valid, [field]: value })).toThrow();
+    }
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        completed_at: 'not-a-timestamp',
+        stages: [{ ...valid.stages[0], id: 'load-data' }],
+      }),
+    ).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        stages: [
+          { ...valid.stages[0], status: { state: 'running', running_at: 'not-a-timestamp' } },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        stages: [
+          {
+            ...valid.stages[0],
+            status: { state: 'running', message: { level: 'info', text: '' } },
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        stages: [{ ...valid.stages[0], metrics: { object: {} } }],
+      }),
+    ).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        stages: [{ ...valid.stages[0], metrics: { values: ['value', null] } }],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('mergeStatusIntoStageMap', () => {
+  it('should preserve stage descriptions and the complete map step catalog', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'training_component',
+          artifact([
+            {
+              id: 'load_data',
+              status: { state: 'running', step: 'not-in-map' },
+              metrics: { completed_units: 2, total_units: 4 },
+            },
+          ]),
+        ],
+      ]),
+    );
+    const stage = merged.components[0].stages[0];
+    expect(stage.description).toBe('Load data');
+    expect(stage.steps).toEqual(['load', 'train']);
+    expect(stage.status).toEqual({ state: 'running', step: undefined });
+    expect(stage.metrics).toEqual({ completed_units: 2, total_units: 4 });
+  });
+
+  it('should use the component display name and retain failed error details', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'training_component',
+          artifact([{ id: 'model_selection', status: { state: 'failed' }, error: 'Failed' }]),
+        ],
+      ]),
+    );
+    expect(merged.components[0].metadata).toEqual({ display_name: 'Model training' });
+    expect(merged.components[0].stages[1].error).toBe('Failed');
+  });
+
+  it('should leave unrecorded stages pending in a partial artifact', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        ['training_component', artifact([{ id: 'load_data', status: { state: 'completed' } }])],
+      ]),
+    );
+    expect(merged.components[0].stages).toHaveLength(3);
+    expect(merged.components[0].stages[2].status).toBeUndefined();
+  });
+
+  it('should merge canonical stage data without flattening it', () => {
+    const merged = mergeStageWithStatus(
+      stageMap.components[0].stages[0],
+      artifact([{ id: 'load_data', status: { state: 'running' }, metrics: { total_units: 2 } }])
+        .stages[0],
+    );
+    expect(merged.metrics).toEqual({ total_units: 2 });
+    expect(merged.total_units).toBeUndefined();
+  });
+
+  it('should promote canonical model selection metrics and preserve map selections when absent', () => {
+    const selected = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'training_component',
+          artifact([
+            {
+              id: 'model_selection',
+              status: { state: 'completed' },
+              metrics: { selected_models: ['model-a', 'model-b'] },
+            },
+          ]),
+        ],
+      ]),
+    );
+    expect(selected.components[0].stages[1].selected_models).toEqual(['model-a', 'model-b']);
+
+    const preserved = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'training_component',
+          artifact([{ id: 'model_selection', status: { state: 'completed' } }]),
+        ],
+      ]),
+    );
+    expect(preserved.components[0].stages[1].selected_models).toEqual(['map-model']);
+  });
+
+  it('should ignore malformed model selection metrics', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'training_component',
+          artifact([
+            {
+              id: 'model_selection',
+              status: { state: 'completed' },
+              metrics: { selected_models: ['model-a', 1] },
+            },
+          ]),
+        ],
+      ]),
+    );
+    expect(merged.components[0].stages[1].selected_models).toEqual(['map-model']);
+  });
+
+  it('should return the map unchanged when no status files match', () => {
+    expect(mergeStatusIntoStageMap(mockComponentStageMap, new Map())).toEqual(
+      mockComponentStageMap,
+    );
+  });
+
+  it('should leave unmatched stages untouched', () => {
+    const result = mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([
+        [
+          'autogluon_models_training',
+          artifact([{ id: 'load_data', status: { state: 'completed' } }]),
+        ],
+      ]),
+    );
+    expect(
+      result.components[1].stages.find((stage) => stage.id === 'refit_full')?.status,
+    ).toBeUndefined();
+  });
+
+  it('should not mutate the original stage map', () => {
+    const original = JSON.stringify(mockComponentStageMap);
+    mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['autogluon_models_training', mockComponentStatus]]),
+    );
+    expect(JSON.stringify(mockComponentStageMap)).toBe(original);
+  });
+
+  it('should merge leaderboard metrics when the status omits its description', () => {
+    const status = ComponentStatusFileSchema.parse({
+      component_id: 'leaderboard_evaluation',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Leaderboard' },
+      stages: [
+        {
+          id: 'build_leaderboard',
+          status: { state: 'completed' },
+          metrics: { best_model: 'model-a' },
+        },
+      ],
+    });
+    const stage = mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['leaderboard_evaluation', status]]),
+    ).components[2].stages[0];
+    expect(stage.description).toBe('Aggregate model metrics');
+    expect(stage.metrics).toEqual({ best_model: 'model-a' });
+  });
+
+  it('should add canonical status and metrics to merged stages', () => {
+    const merged = mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['autogluon_models_training', mockComponentStatus]]),
+    );
+    expect(merged.components[1].stages[0].status).toEqual({ state: 'completed', step: undefined });
+    expect(merged.components[1].stages[0].metrics).toEqual({ train_rows: 213, test_rows: 179 });
+  });
+
+  it('should preserve stage descriptions and the complete map catalog', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'training_component',
+          artifact([{ id: 'load_data', status: { state: 'running', step: 'unknown' } }]),
+        ],
+      ]),
+    );
+    expect(merged.components[0].stages[0].description).toBe('Load data');
+    expect(merged.components[0].stages[0].steps).toEqual(['load', 'train']);
+    expect(merged.components[0].stages).toHaveLength(3);
+    expect(merged.components[0].stages[0].status).toEqual({ state: 'running', step: undefined });
+  });
+
+  it('should retain component metadata and failed error details', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'training_component',
+          artifact([{ id: 'model_selection', status: { state: 'failed' }, error: 'Failed' }]),
+        ],
+      ]),
+    );
+    expect(merged.components[0].metadata).toEqual({ display_name: 'Model training' });
+    expect(merged.components[0].stages[1].error).toBe('Failed');
+  });
+
+  it('should preserve completed and failed stages against unsupported canonical states', () => {
+    const completed = mergeStageWithStatus(
+      { id: 'load_data', description: 'Load data', status: 'completed' },
+      { id: 'load_data', status: { state: 'running' } },
+    );
+    const failed = mergeStageWithStatus(
+      { id: 'load_data', description: 'Load data', status: 'failed' },
+      { id: 'load_data', status: { state: 'started' } },
+    );
+    expect(completed.status).toEqual({ state: 'running', step: undefined });
+    expect(failed.status).toEqual({ state: 'started', step: undefined });
+  });
+
+  it('should clear canonical selected models when metrics provides an empty array', () => {
+    const merged = mergeStageWithStatus(
+      { id: 'model_selection', description: 'Run models', selected_models: ['ExistingModel'] },
+      { id: 'model_selection', status: { state: 'completed' }, metrics: { selected_models: [] } },
+    );
+    expect(merged.selected_models).toEqual([]);
+  });
+
+  it('should preserve selected models when metrics has no valid strings', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...mockComponentStatus,
+        stages: [
+          {
+            id: 'model_selection',
+            status: { state: 'completed' },
+            metrics: { selected_models: [42, null] },
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it('should reject legacy flat status fields instead of flattening them', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'training_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'Training' },
+        stages: [{ id: 'load_data', status: 'completed', metadata: { train_rows: 1 } }],
+      }),
+    ).toThrow();
+  });
+
+  it('should reject legacy nested stage metadata', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'training_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'Training' },
+        stages: [{ id: 'load_data', status: 'completed', metadata: { train_rows: 500 } }],
+      }),
+    ).toThrow();
+  });
+
+  it('should reject unsafe legacy flattening payloads', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'training_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'Training' },
+        stages: [{ id: 'model_selection', status: 'completed', __proto__: { polluted: true } }],
+      }),
+    ).toThrow();
   });
 });
 
 describe('isComponentFullyComplete', () => {
-  it('should return true when all stages are completed', () => {
+  it('should return true when every canonical stage is completed', () => {
     expect(isComponentFullyComplete(mockComponentStatus)).toBe(true);
   });
 
-  it('should return false when some stages are not completed', () => {
-    const partial: ComponentStatusFile = {
+  it('should return false when a stage has no status', () => {
+    const partial = ComponentStatusFileSchema.parse({
       component_id: 'test',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Test' },
       stages: [
-        { id: 'a', status: 'completed', description: 'A' },
-        { id: 'b', status: 'started', description: 'B' },
+        { id: 'a', status: { state: 'completed' } },
+        { id: 'b', status: { state: 'started' } },
       ],
-    };
+    });
     expect(isComponentFullyComplete(partial)).toBe(false);
   });
 
-  it('should return false when stages array is empty', () => {
-    const empty: ComponentStatusFile = {
+  it('should return false for an empty canonical stages array', () => {
+    const empty = ComponentStatusFileSchema.parse({
       component_id: 'test',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Test' },
       stages: [],
-    };
+    });
     expect(isComponentFullyComplete(empty)).toBe(false);
   });
-
-  it('should return false when a stage has no status', () => {
-    const noStatus: ComponentStatusFile = {
-      component_id: 'test',
-      stages: [
-        { id: 'a', status: 'completed', description: 'A' },
-        { id: 'b', description: 'B' },
-      ],
-    };
-    expect(isComponentFullyComplete(noStatus)).toBe(false);
-  });
 });
-
-/* eslint-enable camelcase */

--- a/packages/automl/frontend/src/app/hooks/useComponentStageMap.ts
+++ b/packages/automl/frontend/src/app/hooks/useComponentStageMap.ts
@@ -10,7 +10,19 @@ const ComponentStageMapStageSchema = z
     id: z.string(),
     description: z.string(),
     steps: z.array(z.string()).optional(),
-    status: z.string().optional(),
+    status: z
+      .union([
+        z.string(),
+        z.object({
+          state: z.enum(['started', 'running', 'completed', 'failed']),
+          step: z.string().optional(),
+          message: z
+            .object({ level: z.enum(['info', 'warning', 'error']), text: z.string() })
+            .optional(),
+          running_at: z.string().optional(),
+        }),
+      ])
+      .optional(),
     timestamp: z.string().optional(),
   })
   .catchall(z.unknown());

--- a/packages/automl/frontend/src/app/hooks/useComponentStatuses.ts
+++ b/packages/automl/frontend/src/app/hooks/useComponentStatuses.ts
@@ -10,11 +10,6 @@ import type {
 import type { PipelineRun, PipelineRunError, S3ListObjectsResponse } from '~/app/types';
 import { getFiles as getS3Files } from '~/app/api/s3';
 import {
-  isAllowedFlattenKey,
-  NESTED_STAGE_FIELD_KEYS,
-  capModelSelectionSteps,
-} from '~/app/topology/stageMapConstants';
-import {
   findTrainingTaskPrefix,
   isRunCompleted,
   isRunInTerminalState,
@@ -31,20 +26,37 @@ type ComponentTaskDetail = {
   error?: PipelineRunError;
 };
 
-function parseSelectedModels(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  if (value.length === 0) {
-    return [];
-  }
-  const models = value.filter((item): item is string => typeof item === 'string');
-  return models.length > 0 ? models : undefined;
-}
-
 /** Documented inline stage statuses (aligned with translateStageStatus). */
 export const COMPONENT_STAGE_STATUSES = ['completed', 'started', 'failed', 'skipped'] as const;
 export type ComponentStageStatus = (typeof COMPONENT_STAGE_STATUSES)[number];
+
+const MetricValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(z.union([z.string(), z.number(), z.boolean()])),
+]);
+const TimestampSchema = z.string().datetime({ offset: false });
+const IdentifierSchema = z.string().regex(/^[a-z][a-z0-9_]*$/);
+
+const ComponentStatusMessageSchema = z
+  .object({
+    level: z.enum(['info', 'warning', 'error']),
+    text: z.string().min(1),
+  })
+  .strict();
+
+/* eslint-disable camelcase */
+const ComponentStatusStateSchema = z
+  .object({
+    state: z.enum(['started', 'running', 'completed', 'failed']),
+    step: z.string().optional(),
+    message: ComponentStatusMessageSchema.optional(),
+    running_at: TimestampSchema.optional(),
+  })
+  .strict();
+/* eslint-enable camelcase */
 
 /** Normalize and accept only documented stage statuses; unsupported values become undefined. */
 export function normalizeComponentStageStatus(value: unknown): ComponentStageStatus | undefined {
@@ -61,36 +73,35 @@ export function normalizeComponentStageStatus(value: unknown): ComponentStageSta
 }
 
 /* eslint-disable camelcase */
-const ComponentStatusStageSchema = z
-  .object({
-    id: z.string(),
-    description: z.string().optional(),
-    steps: z.preprocess(
-      (val) => (Array.isArray(val) ? capModelSelectionSteps(val) : val),
-      z.array(z.string()).optional(),
-    ),
-    selected_models: z.preprocess(parseSelectedModels, z.array(z.string()).optional()),
-    status: z.preprocess(
-      normalizeComponentStageStatus,
-      z.enum(COMPONENT_STAGE_STATUSES).optional(),
-    ),
-    timestamp: z.string().optional(),
-    metadata: z.record(z.string(), z.unknown()).optional(),
-    metrics: z.record(z.string(), z.unknown()).optional(),
-    outputs: z.record(z.string(), z.unknown()).optional(),
-    details: z.record(z.string(), z.unknown()).optional(),
-  })
-  .catchall(z.unknown());
+const ComponentStatusStageSchema = z.union([
+  z
+    .object({
+      id: IdentifierSchema,
+      status: ComponentStatusStateSchema.extend({ state: z.literal('failed') }),
+      metrics: z.record(z.string(), MetricValueSchema).optional(),
+      error: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      id: IdentifierSchema,
+      status: ComponentStatusStateSchema.extend({
+        state: z.enum(['started', 'running', 'completed']),
+      }),
+      metrics: z.record(z.string(), MetricValueSchema).optional(),
+    })
+    .strict(),
+]);
 
 export const ComponentStatusFileSchema = z
   .object({
-    component_id: z.string(),
-    started_at: z.string().optional(),
-    completed_at: z.string().optional(),
+    component_id: IdentifierSchema,
+    started_at: TimestampSchema,
+    completed_at: TimestampSchema.optional(),
     stages: z.array(ComponentStatusStageSchema),
-    metadata: z.record(z.string(), z.unknown()).optional(),
+    metadata: z.object({ display_name: z.string().min(1) }).catchall(z.unknown()),
   })
-  .catchall(z.unknown());
+  .strict();
 
 export type ComponentStatusFile = z.infer<typeof ComponentStatusFileSchema>;
 export type ComponentStatusStage = z.infer<typeof ComponentStatusStageSchema>;
@@ -235,13 +246,21 @@ const MERGED_FIELD_EXCLUDED = new Set([
   'name',
   'component_id',
   'id',
-  'steps',
   'selected_models',
   'status',
 ]);
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+function getSelectedModels(metrics: ComponentStatusStage['metrics']): string[] | undefined {
+  const selectedModels = metrics?.selected_models;
+  return Array.isArray(selectedModels) && selectedModels.every((model) => typeof model === 'string')
+    ? selectedModels
+    : undefined;
+}
+
+export function getComponentStageStatus(
+  status: ComponentStatusStage['status'] | ComponentStageMapStage['status'],
+): ComponentStageStatus | 'running' | undefined {
+  return typeof status === 'object' ? status.state : normalizeComponentStageStatus(status);
 }
 
 export function mergeStageWithStatus(
@@ -254,21 +273,6 @@ export function mergeStageWithStatus(
     description: stage.description,
   };
 
-  for (const nestedKey of NESTED_STAGE_FIELD_KEYS) {
-    const nested = statusStage[nestedKey];
-    if (isPlainObject(nested)) {
-      for (const [key, value] of Object.entries(nested)) {
-        if (isAllowedFlattenKey(key)) {
-          merged[key] = value;
-        }
-      }
-    }
-  }
-
-  for (const nestedKey of NESTED_STAGE_FIELD_KEYS) {
-    delete merged[nestedKey];
-  }
-
   for (const excludedKey of MERGED_FIELD_EXCLUDED) {
     delete merged[excludedKey];
   }
@@ -278,22 +282,20 @@ export function mergeStageWithStatus(
     id: stage.id,
     description: stage.description,
   };
-  if (stage.steps !== undefined) {
-    result.steps = capModelSelectionSteps(stage.steps);
+  if (statusStage.status.state !== 'failed') {
+    delete result.error;
   }
-  // Prefer a validated payload status; otherwise keep a validated canonical status so
-  // unsupported values cannot clear or overwrite completed/failed (or any prior) status.
-  const normalizedStatus =
-    normalizeComponentStageStatus(statusStage.status) ??
-    normalizeComponentStageStatus(stage.status);
-  if (normalizedStatus !== undefined) {
-    result.status = normalizedStatus;
+  if (stage.id === 'model_selection') {
+    // Branch topology consumes this selection from the stage map.
+    // eslint-disable-next-line camelcase
+    result.selected_models = getSelectedModels(statusStage.metrics) ?? stage.selected_models;
   }
-  const selectedModels =
-    parseSelectedModels(statusStage.selected_models) ?? parseSelectedModels(stage.selected_models);
-  if (selectedModels !== undefined) {
-    result.selected_models = selectedModels; // eslint-disable-line camelcase
-  }
+  result.status = {
+    ...statusStage.status,
+    ...(statusStage.status.step && stage.steps?.includes(statusStage.status.step)
+      ? { step: statusStage.status.step }
+      : { step: undefined }),
+  };
   return result;
 }
 
@@ -321,22 +323,21 @@ export function mergeStatusIntoStageMap(
         ...component,
         stages: mergedStages,
       };
-      if (status.started_at != null) {
-        merged.started_at = status.started_at; // eslint-disable-line camelcase
-      }
+      merged.started_at = status.started_at; // eslint-disable-line camelcase
       if (status.completed_at != null) {
         merged.completed_at = status.completed_at; // eslint-disable-line camelcase
       }
-      if (status.metadata != null) {
-        merged.metadata = status.metadata;
-      }
+      merged.metadata = status.metadata;
       return merged;
     }),
   };
 }
 
 export function isComponentFullyComplete(status: ComponentStatusFile): boolean {
-  return status.stages.length > 0 && status.stages.every((s) => s.status === 'completed');
+  return (
+    status.stages.length > 0 &&
+    status.stages.every((s) => getComponentStageStatus(s.status) === 'completed')
+  );
 }
 
 async function discoverStatusJsonPath(

--- a/packages/automl/frontend/src/app/topology/__tests__/stageMapStatus.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/stageMapStatus.spec.ts
@@ -229,6 +229,20 @@ describe('resolveStageRunStatus', () => {
 });
 
 describe('resolveSequentialStageRunStatuses', () => {
+  it('should keep stages after the canonical active frontier pending', () => {
+    const statuses = resolveSequentialStageRunStatuses(
+      [
+        { id: 'load_data', description: 'Load', status: { state: 'completed' } },
+        { id: 'model_selection', description: 'Select', status: { state: 'completed' } },
+        { id: 'refit_full', description: 'Refit' },
+      ],
+      RunStatus.InProgress,
+      'RUNNING',
+    );
+    expect(statuses.get('load_data')).toBe(RunStatus.Succeeded);
+    expect(statuses.get('model_selection')).toBe(RunStatus.Succeeded);
+    expect(statuses.get('refit_full')).toBe(RunStatus.Pending);
+  });
   const stages = [
     { id: 'validate_inputs', description: 'Validate pipeline inputs' },
     { id: 'load_data', description: 'Load data' },
@@ -356,7 +370,7 @@ describe('resolveSequentialStageRunStatuses', () => {
     expect(statuses.get('split_data')).toBe(RunStatus.InProgress);
   });
 
-  it('should keep later stages in progress when an earlier stage is already started', () => {
+  it('should preserve legacy inline string status behavior when an earlier stage is already started', () => {
     const statuses = resolveSequentialStageRunStatuses(
       [
         { id: 'load_data', description: 'Load data', status: 'started' },

--- a/packages/automl/frontend/src/app/topology/stageMapStatus.ts
+++ b/packages/automl/frontend/src/app/topology/stageMapStatus.ts
@@ -7,7 +7,10 @@ import type { RunDetailsKF } from '~/app/types/pipeline';
 import type { PipelineNodeModelExpanded } from '~/app/types/topology';
 import { isRunInTerminalState, normalizePipelineRunState } from '~/app/utilities/utils';
 import { MAX_TOP_N_TABULAR, MAX_TOP_N_TIMESERIES, MIN_TOP_N } from '~/app/utilities/const';
-import { findComponentTaskInRunDetails } from '~/app/hooks/useComponentStatuses';
+import {
+  findComponentTaskInRunDetails,
+  getComponentStageStatus,
+} from '~/app/hooks/useComponentStatuses';
 import { dedupePreservingOrder } from './stageMapConstants';
 import { translateStatusForNode } from './parseUtils';
 
@@ -27,6 +30,7 @@ export const translateStageStatus = (status?: string): RunStatus | undefined => 
     case 'completed':
       return RunStatus.Succeeded;
     case 'started':
+    case 'running':
       return RunStatus.InProgress;
     case 'failed':
       return RunStatus.Failed;
@@ -115,7 +119,7 @@ export const resolveStageRunStatus = (
   hasExplicitFailureInPipeline = false,
 ): RunStatus | undefined => {
   const terminalRunFailure = getTerminalRunFailureStatus(runState, hasExplicitFailureInPipeline);
-  const inlineStatus = translateStageStatus(stage.status);
+  const inlineStatus = translateStageStatus(getComponentStageStatus(stage.status));
   if (inlineStatus != null) {
     if (terminalRunFailure != null && inlineStatus === RunStatus.InProgress) {
       return terminalRunFailure;
@@ -151,11 +155,12 @@ export const isStageTerminalFailure = (status: RunStatus | undefined): boolean =
 
 /** True when the backend reported this stage failed (not inferred from component-level status). */
 export const isInlineStageFailure = (stage?: ComponentStageMapStage): boolean =>
-  translateStageStatus(stage?.status) === RunStatus.Failed;
+  translateStageStatus(stage ? getComponentStageStatus(stage.status) : undefined) ===
+  RunStatus.Failed;
 
 /** True when the stage map marks a stage skipped (never ran due to upstream barrier). */
 export const isInlineStageSkipped = (stage?: ComponentStageMapStage): boolean =>
-  stage?.status?.trim().toLowerCase() === 'skipped';
+  getComponentStageStatus(stage?.status) === 'skipped';
 
 /** True when a pre-branch stage (before model_selection) failed inline. */
 export const hasPreBranchInlineFailure = (preBranchStages: ComponentStageMapStage[]): boolean =>
@@ -173,14 +178,23 @@ export const isStageFinished = (status: RunStatus | undefined): boolean =>
   status === RunStatus.Succeeded || status === RunStatus.Skipped;
 
 const hasAnyInlineStageStatus = (stages: ComponentStageMapStage[]): boolean =>
-  stages.some((stage) => translateStageStatus(stage.status) != null);
+  stages.some((stage) => translateStageStatus(getComponentStageStatus(stage.status)) != null);
+
+const hasCanonicalStageStatus = (stages: ComponentStageMapStage[]): boolean =>
+  stages.some((stage) => stage.status != null && typeof stage.status === 'object');
+
+const isAfterCanonicalFrontier = (
+  stages: ComponentStageMapStage[],
+  stageIndex: number,
+  latestActivityIndex: number,
+): boolean => hasCanonicalStageStatus(stages) && stageIndex > latestActivityIndex;
 
 /** True when model selection published selected models via a status merge. */
 const hasBranchingStatusEvidence = (stage: ComponentStageMapStage): boolean =>
   stage.id === BRANCHING_STAGE_ID &&
   Array.isArray(stage.selected_models) &&
   stage.selected_models.length > 0 &&
-  translateStageStatus(stage.status) != null;
+  translateStageStatus(getComponentStageStatus(stage.status)) != null;
 
 /**
  * Index of the latest stage that published inline progress. Used to backfill earlier
@@ -189,7 +203,7 @@ const hasBranchingStatusEvidence = (stage: ComponentStageMapStage): boolean =>
 export const findLatestInlineActivityIndex = (stages: ComponentStageMapStage[]): number => {
   let latest = -1;
   stages.forEach((stage, index) => {
-    if (translateStageStatus(stage.status) != null) {
+    if (translateStageStatus(getComponentStageStatus(stage.status)) != null) {
       latest = index;
       return;
     }
@@ -284,7 +298,7 @@ export const resolveSequentialStageRunStatuses = (
 
   for (let stageIndex = 0; stageIndex < stages.length; stageIndex++) {
     const stage = stages[stageIndex];
-    const inlineStatus = translateStageStatus(stage.status);
+    const inlineStatus = translateStageStatus(getComponentStageStatus(stage.status));
 
     if (inlineStatus != null) {
       let resolved = applyEarlierStageBackfill(
@@ -336,6 +350,10 @@ export const resolveSequentialStageRunStatuses = (
         continue;
       }
       if (componentStatus === RunStatus.InProgress) {
+        if (hasCanonicalStageStatus(stages) && stageIndex > latestActivityIndex) {
+          statusById.set(stage.id, RunStatus.Pending);
+          continue;
+        }
         const resolved = applyEarlierStageBackfill(
           stageIndex,
           latestActivityIndex,
@@ -398,6 +416,10 @@ export const resolveSequentialStageRunStatuses = (
         } else {
           statusById.set(stage.id, RunStatus.InProgress);
         }
+        continue;
+      }
+      if (isAfterCanonicalFrontier(stages, stageIndex, latestActivityIndex)) {
+        statusById.set(stage.id, RunStatus.Pending);
         continue;
       }
       const resolved = applyEarlierStageBackfill(
@@ -628,7 +650,9 @@ export const promoteWaitingFrontierToInProgress = (
 /** True when every stage has a recognized inline status (no unresolved gaps). */
 const hasCompleteInlineStageStatus = (component: ComponentStageMapComponent): boolean =>
   component.stages.length > 0 &&
-  component.stages.every((stage) => translateStageStatus(stage.status) != null);
+  component.stages.every(
+    (stage) => translateStageStatus(getComponentStageStatus(stage.status)) != null,
+  );
 
 /** True when any mapped component has explicit task or inline stage failure evidence. */
 export const hasExplicitComponentFailureEvidence = (

--- a/packages/automl/frontend/src/app/topology/tree-view/stageMapStepMetadata.ts
+++ b/packages/automl/frontend/src/app/topology/tree-view/stageMapStepMetadata.ts
@@ -3,7 +3,10 @@ import type {
   ComponentStageMapComponent,
   ComponentStageMapStage,
 } from '~/app/hooks/useComponentStageMap';
-import { findComponentTaskInRunDetails } from '~/app/hooks/useComponentStatuses';
+import {
+  findComponentTaskInRunDetails,
+  getComponentStageStatus,
+} from '~/app/hooks/useComponentStatuses';
 import type { PipelineRun } from '~/app/types';
 import {
   isAllowedFlattenKey,
@@ -47,6 +50,8 @@ const STAGE_FIELD_LABELS: Record<string, string> = {
   export_path: 'Export path',
   output_path: 'Output path',
   best_model: 'Best model',
+  completed_units: 'Completed units',
+  total_units: 'Total units',
 };
 
 /** Fields to show with "—" when pending/failed/unreached and values are not yet on the stage record. */
@@ -222,6 +227,9 @@ function flattenStageRecord(stage: ComponentStageMapStage): Record<string, unkno
 
   for (const [key, value] of Object.entries(stage)) {
     if (NESTED_STAGE_FIELD_KEY_SET.has(key)) {
+      if (key === 'metrics') {
+        continue;
+      }
       if (isPlainObject(value)) {
         for (const [nestedKey, nestedValue] of Object.entries(value)) {
           if (isAllowedFlattenKey(nestedKey) && nestedValue != null) {
@@ -287,9 +295,10 @@ const hasStageExecutionEvidence = (
   stepState?: StepExecutionState,
 ): boolean =>
   stage.timestamp != null ||
-  stage.status === 'started' ||
-  stage.status === 'completed' ||
-  stage.status === 'failed' ||
+  getComponentStageStatus(stage.status) === 'started' ||
+  getComponentStageStatus(stage.status) === 'running' ||
+  getComponentStageStatus(stage.status) === 'completed' ||
+  getComponentStageStatus(stage.status) === 'failed' ||
   stepState === 'failed' ||
   stepState === 'active' ||
   stepState === 'completed';
@@ -316,8 +325,8 @@ const isTerminalStageState = (
   stage: ComponentStageMapStage,
   stepState?: StepExecutionState,
 ): boolean =>
-  stage.status === 'completed' ||
-  stage.status === 'failed' ||
+  getComponentStageStatus(stage.status) === 'completed' ||
+  getComponentStageStatus(stage.status) === 'failed' ||
   stepState === 'completed' ||
   stepState === 'failed';
 
@@ -325,9 +334,10 @@ const shouldUseTaskEndTime = (
   stage: ComponentStageMapStage,
   stepState?: StepExecutionState,
 ): boolean =>
-  stage.status === 'failed' ||
-  stage.status === 'started' ||
-  stage.status === 'completed' ||
+  getComponentStageStatus(stage.status) === 'failed' ||
+  getComponentStageStatus(stage.status) === 'started' ||
+  getComponentStageStatus(stage.status) === 'running' ||
+  getComponentStageStatus(stage.status) === 'completed' ||
   stepState === 'failed' ||
   stepState === 'active' ||
   stepState === 'completed';
@@ -341,9 +351,10 @@ const resolveStageStartTime = (
     return stage.timestamp;
   }
   if (
-    stage.status === 'started' ||
-    stage.status === 'failed' ||
-    stage.status === 'completed' ||
+    getComponentStageStatus(stage.status) === 'started' ||
+    getComponentStageStatus(stage.status) === 'running' ||
+    getComponentStageStatus(stage.status) === 'failed' ||
+    getComponentStageStatus(stage.status) === 'completed' ||
     stepState === 'active' ||
     stepState === 'failed' ||
     stepState === 'completed'
@@ -422,7 +433,27 @@ function buildDetailsFromStageRecord(
 ): StepDetail[] {
   const details: StepDetail[] = [{ label: 'Duration', value: duration ?? '—' }];
 
+  if (isPlainObject(stage.status)) {
+    details.push({ label: 'State', value: stage.status.state });
+    if (isPlainObject(stage.status.message) && typeof stage.status.message.text === 'string') {
+      details.push({ label: 'Message', value: stage.status.message.text });
+    }
+    if (typeof stage.status.running_at === 'string') {
+      details.push({ label: 'Running at', value: stage.status.running_at });
+    }
+    if (stage.status.state === 'failed' && isPlainObject(stage.error)) {
+      details.push({ label: 'Error', value: formatStageFieldValue('error', stage.error) });
+    }
+  }
+
   const flattened = flattenStageRecord(stage);
+  if (isPlainObject(stage.metrics)) {
+    for (const [key, value] of Object.entries(stage.metrics)) {
+      if (value != null) {
+        flattened[key] = value;
+      }
+    }
+  }
   const orderedKeys = resolveDetailFieldKeys(flattened, stepState, stageId);
 
   for (const key of orderedKeys) {
@@ -556,4 +587,16 @@ export function getStageDescriptionFromMap(
     return undefined;
   }
   return findStage(component, parsed.stageId)?.description;
+}
+
+export function getComponentDisplayName(
+  parsed: ParsedStageMapNode,
+  componentStageMap: ComponentStageMap,
+): string | undefined {
+  const component = findComponent(componentStageMap, parsed.componentId);
+  if (!component) {
+    return undefined;
+  }
+  const displayName = component.metadata?.display_name;
+  return typeof displayName === 'string' ? displayName : component.description;
 }

--- a/packages/automl/frontend/tsconfig.json
+++ b/packages/automl/frontend/tsconfig.json
@@ -8,6 +8,7 @@
       "es2021",
       "dom",
       "ES2022.Object",
+      "ES2022.Array",
       "ES2023.Array"
     ],
     "sourceMap": true,

--- a/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/documents-discovery/1ce843c7-5786-4b07-ba55-1f3cf8cb42fb/component_status/component_status.json
+++ b/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/documents-discovery/1ce843c7-5786-4b07-ba55-1f3cf8cb42fb/component_status/component_status.json
@@ -1,15 +1,12 @@
 {
   "component_id": "documents_discovery",
   "started_at": "2026-07-16T19:38:59.102358Z",
-  "completed_at": "2026-07-16T19:38:59.505595Z",
+  "metadata": { "display_name": "Documents Discovery Status" },
   "stages": [
     {
       "id": "discover_documents",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:38:59.505465Z"
+      "status": { "state": "completed" },
+      "metrics": {}
     }
-  ],
-  "metadata": {
-    "display_name": "Documents Discovery Status"
-  }
+  ]
 }

--- a/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/rag-templates-optimization/e9920e43-b0cc-497a-ac3a-c7ee794a7787/component_status/component_status.json
+++ b/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/rag-templates-optimization/e9920e43-b0cc-497a-ac3a-c7ee794a7787/component_status/component_status.json
@@ -1,38 +1,29 @@
 {
   "component_id": "rag_templates_optimization",
   "started_at": "2026-07-16T19:41:20.878188Z",
-  "completed_at": "2026-07-16T19:42:11.972431Z",
+  "metadata": { "display_name": "RAG Templates Optimization Status" },
   "stages": [
     {
       "id": "optimize_templates",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:42:11.970929Z",
-      "steps": [
-        "chunking",
-        "embedding",
-        "retrieval",
-        "generation",
-        "evaluation"
-      ],
-      "max_rag_patterns": 8,
-      "selected_patterns": [
-        "Pattern1",
-        "Pattern2",
-        "Pattern3",
-        "Pattern4",
-        "Pattern5",
-        "Pattern6",
-        "Pattern7",
-        "Pattern8"
-      ]
+      "status": { "state": "completed" },
+      "metrics": {
+        "max_rag_patterns": 8,
+        "selected_patterns": [
+          "Pattern1",
+          "Pattern2",
+          "Pattern3",
+          "Pattern4",
+          "Pattern5",
+          "Pattern6",
+          "Pattern7",
+          "Pattern8"
+        ]
+      }
     },
     {
       "id": "build_leaderboard",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:42:11.972316Z"
+      "status": { "state": "completed" },
+      "metrics": {}
     }
-  ],
-  "metadata": {
-    "display_name": "RAG Templates Optimization Status"
-  }
+  ]
 }

--- a/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/search-space-preparation/ee664683-45e6-4f3d-bd7e-bb270a4f8936/component_status/component_status.json
+++ b/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/search-space-preparation/ee664683-45e6-4f3d-bd7e-bb270a4f8936/component_status/component_status.json
@@ -1,15 +1,12 @@
 {
   "component_id": "search_space_preparation",
   "started_at": "2026-07-16T19:40:38.742205Z",
-  "completed_at": "2026-07-16T19:40:41.837230Z",
+  "metadata": { "display_name": "Search Space Preparation Status" },
   "stages": [
     {
       "id": "prepare_search_space",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:40:41.837070Z"
+      "status": { "state": "completed" },
+      "metrics": {}
     }
-  ],
-  "metadata": {
-    "display_name": "Search Space Preparation Status"
-  }
+  ]
 }

--- a/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/test-data-loader/b8c693d4-2fd8-4e91-b6fb-624dac343817/component_status/component_status.json
+++ b/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/test-data-loader/b8c693d4-2fd8-4e91-b6fb-624dac343817/component_status/component_status.json
@@ -1,15 +1,12 @@
 {
   "component_id": "test_data_loader",
   "started_at": "2026-07-16T19:38:28.234904Z",
-  "completed_at": "2026-07-16T19:38:28.694903Z",
+  "metadata": { "display_name": "Test Data Loader Status" },
   "stages": [
     {
       "id": "load_benchmark",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:38:28.694725Z"
+      "status": { "state": "completed" },
+      "metrics": {}
     }
-  ],
-  "metadata": {
-    "display_name": "Test Data Loader Status"
-  }
+  ]
 }

--- a/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/text-extraction/f669f5ae-9947-494e-ae17-bc9ad3d8fdf0/component_status/component_status.json
+++ b/packages/autorag/bff/internal/fake/s3-bucket/documents-rag-optimization-pipeline/e78c5f2a-5726-4e1c-bcb6-60434e77e453/text-extraction/f669f5ae-9947-494e-ae17-bc9ad3d8fdf0/component_status/component_status.json
@@ -1,15 +1,12 @@
 {
   "component_id": "text_extraction",
   "started_at": "2026-07-16T19:39:34.286719Z",
-  "completed_at": "2026-07-16T19:40:03.455104Z",
+  "metadata": { "display_name": "Text Extraction Status" },
   "stages": [
     {
       "id": "extract_documents",
-      "status": "completed",
-      "timestamp": "2026-07-16T19:40:03.454906Z"
+      "status": { "state": "completed" },
+      "metrics": {}
     }
-  ],
-  "metadata": {
-    "display_name": "Text Extraction Status"
-  }
+  ]
 }

--- a/packages/autorag/frontend/src/app/components/run-results/StepDetailsPanel.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/StepDetailsPanel.tsx
@@ -33,6 +33,7 @@ import type { PipelineStatusFilter } from '~/app/topology/tree-view/types';
 import { getStepMetadata, type StepDetail } from '~/app/topology/tree-view/stepMetadata';
 import {
   parseStageMapNodeId,
+  getComponentDisplayName,
   type ParsedStageMapNode,
 } from '~/app/topology/tree-view/stageMapStepMetadata';
 import type { TreeNodeData } from '~/app/topology/tree-view/TreeNode';
@@ -269,7 +270,13 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
     branchPatternKey === selectedPattern &&
     parsedNodeId?.type === 'branch_pattern' &&
     nodeData.stepState === 'completed';
-  const panelTitle = isBestPattern ? 'Best pattern' : (nodeData.label ?? 'Step details');
+  const panelTitle = isBestPattern
+    ? 'Best pattern'
+    : parsedNodeId?.type === 'stage' && componentStageMap
+      ? (getComponentDisplayName(parsedNodeId, componentStageMap) ??
+        nodeData.label ??
+        'Step details')
+      : (nodeData.label ?? 'Step details');
   const statusLabel = getStepStateLabel(nodeData.stepState);
   const inProgressLoadingContent = getStepDetailsLoadingContent();
   const isStepLoading = nodeData.stepState === 'active';
@@ -312,18 +319,17 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
                 titleSize="lg"
               />
             </StackItem>
-          ) : (
-            <StackItem>
-              <DescriptionList isCompact>
-                {metadata.details.map((detail, index) => (
-                  <DescriptionListGroup key={`${detail.label}-${index}`}>
-                    <StepDetailTerm detail={detail} />
-                    <DescriptionListDescription>{detail.value}</DescriptionListDescription>
-                  </DescriptionListGroup>
-                ))}
-              </DescriptionList>
-            </StackItem>
-          )}
+          ) : null}
+          <StackItem>
+            <DescriptionList isCompact>
+              {metadata.details.map((detail, index) => (
+                <DescriptionListGroup key={`${detail.label}-${index}`}>
+                  <StepDetailTerm detail={detail} />
+                  <DescriptionListDescription>{detail.value}</DescriptionListDescription>
+                </DescriptionListGroup>
+              ))}
+            </DescriptionList>
+          </StackItem>
         </Stack>
       </DrawerPanelBody>
     </>

--- a/packages/autorag/frontend/src/app/hooks/__tests__/useComponentStatuses.spec.ts
+++ b/packages/autorag/frontend/src/app/hooks/__tests__/useComponentStatuses.spec.ts
@@ -1,42 +1,64 @@
+/* eslint-disable camelcase */
+
 import { renderHook, waitFor } from '@testing-library/react';
-import type { PipelineRun } from '~/app/types';
-import type { ComponentStageMap } from '~/app/hooks/useComponentStageMap';
-import { useS3ListFilesQuery } from '~/app/hooks/queries';
-import { getFiles } from '~/app/api/s3';
 import {
   buildRunLevelPrefixesFromTaskDetails,
   componentIdToTaskId,
+  ComponentStatusFileSchema,
   findComponentTaskInRunDetails,
   getComponentsToFetch,
+  isComponentFullyComplete,
   isKfpDriverTaskName,
   mergeStageWithStatus,
   mergeStatusIntoStageMap,
-  isComponentFullyComplete,
   matchesComponentTaskName,
   resolveActiveRunLevelPrefix,
   resolveComponentTaskS3Prefix,
-  ComponentStatusFileSchema,
   useComponentStatuses,
 } from '~/app/hooks/useComponentStatuses';
-import type { ComponentStatusFile } from '~/app/hooks/useComponentStatuses';
-import { MAX_PATTERN_SELECTION_STEPS } from '~/app/topology/stageMapConstants';
+import { useS3ListFilesQuery } from '~/app/hooks/queries';
+import { getFiles } from '~/app/api/s3';
+import type { PipelineRun } from '~/app/types';
+import type { ComponentStageMap } from '~/app/hooks/useComponentStageMap';
 
-jest.mock('~/app/hooks/queries', () => ({
-  useS3ListFilesQuery: jest.fn(),
-}));
+jest.mock('~/app/hooks/queries', () => ({ useS3ListFilesQuery: jest.fn() }));
+jest.mock('~/app/api/s3', () => ({ getFiles: jest.fn() }));
 
-jest.mock('~/app/api/s3', () => ({
-  getFiles: jest.fn(),
-}));
+const stageMap: ComponentStageMap = {
+  pipeline_id: 'pipeline',
+  description: 'Pipeline',
+  kfp_run_id: 'run',
+  published_at: '2026-01-01T00:00:00Z',
+  components: [
+    {
+      id: 'rag_component',
+      description: 'RAG component',
+      stages: [
+        { id: 'prepare', description: 'Prepare data', steps: ['chunk', 'embed'] },
+        {
+          id: 'optimize_templates',
+          description: 'Optimize patterns',
+          steps: ['retrieve'],
+          selected_patterns: ['map-pattern'],
+        },
+        { id: 'publish', description: 'Publish results' },
+      ],
+    },
+  ],
+};
 
-/* eslint-disable camelcase */
-
-// -- Fixtures based on real pipeline data --
+const artifact = (stages: unknown[], metadata = { display_name: 'RAG optimization' }) =>
+  ComponentStatusFileSchema.parse({
+    component_id: 'rag_component',
+    started_at: '2026-01-01T00:00:00Z',
+    metadata,
+    stages,
+  });
 
 const mockComponentStageMap: ComponentStageMap = {
   pipeline_id: 'documents-rag-optimization-pipeline',
   description: 'AutoRAG pipeline',
-  kfp_run_id: '029660b9-c210-4ad4-9434-de28c2c9baec',
+  kfp_run_id: 'run-123',
   published_at: '2026-06-04T17:47:14.948493Z',
   components: [
     {
@@ -71,44 +93,30 @@ const mockComponentStageMap: ComponentStageMap = {
   ],
 };
 
-const mockComponentStatus: ComponentStatusFile = {
+const mockComponentStatus = ComponentStatusFileSchema.parse({
   component_id: 'rag_optimization',
   started_at: '2026-06-04T17:49:19.223056Z',
   completed_at: '2026-06-04T17:50:10.290690Z',
+  metadata: { display_name: 'Optimization' },
   stages: [
     {
       id: 'prepare_search_space',
-      description: 'Prepare the search space',
-      status: 'completed',
-      timestamp: '2026-06-04T17:49:19.232065Z',
-      document_count: 213,
+      status: { state: 'completed' },
+      metrics: { document_count: 213 },
     },
     {
       id: 'optimize_templates',
-      description: 'Evaluate candidate RAG pattern configurations',
-      status: 'completed',
-      timestamp: '2026-06-04T17:49:53.951525Z',
-      pattern_count: 3,
-      selected_patterns: ['pattern_a', 'pattern_b', 'pattern_c'],
-      steps: ['chunking', 'embedding', 'retrieval', 'generation'],
+      status: { state: 'completed' },
+      metrics: { selected_patterns: ['pattern_a', 'pattern_b'] },
     },
-    {
-      id: 'run_optimization',
-      description: 'Run the top patterns',
-      status: 'completed',
-      timestamp: '2026-06-04T17:50:02.238567Z',
-      pattern_count: 3,
-    },
+    { id: 'run_optimization', status: { state: 'completed' }, metrics: { pattern_count: 3 } },
     {
       id: 'write_patterns',
-      description: 'Write evaluated patterns',
-      status: 'completed',
-      timestamp: '2026-06-04T17:50:10.290550Z',
-      eval_metric: 'faithfulness',
+      status: { state: 'completed' },
+      metrics: { eval_metric: 'faithfulness' },
     },
   ],
-  metadata: {},
-};
+});
 
 const createMockPipelineRun = (
   state: string,
@@ -120,928 +128,892 @@ const createMockPipelineRun = (
     state,
     created_at: '2025-01-17T00:00:00Z',
     run_details: {
-      task_details: taskDetails.map((td) => ({
+      task_details: taskDetails.map((task) => ({
         run_id: 'run-123',
-        task_id: td.task_id,
-        display_name: td.display_name ?? td.task_id,
+        task_id: task.task_id,
+        display_name: task.display_name ?? task.task_id,
         create_time: '2025-01-17T00:00:00Z',
         start_time: '2025-01-17T00:00:00Z',
         end_time: '2025-01-17T00:00:00Z',
-        state: td.state,
+        state: task.state,
       })),
     },
   }) as PipelineRun;
 
-// -- Tests --
-
-describe('componentIdToTaskId', () => {
-  it('should convert underscores to hyphens', () => {
-    expect(componentIdToTaskId('rag_optimization')).toBe('rag-optimization');
-  });
-
-  it('should handle ids with no underscores', () => {
-    expect(componentIdToTaskId('leaderboard')).toBe('leaderboard');
-  });
-
-  it('should handle empty string', () => {
-    expect(componentIdToTaskId('')).toBe('');
-  });
-
-  it('should handle multiple consecutive underscores', () => {
-    expect(componentIdToTaskId('a__b___c')).toBe('a--b---c');
-  });
-});
-
-describe('getComponentsToFetch', () => {
-  it('should return empty array when componentStageMap is undefined', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', []);
-    expect(getComponentsToFetch(undefined, pipelineRun, new Set())).toEqual([]);
-  });
-
-  it('should return empty array when pipelineRun is undefined', () => {
+describe('component task discovery and prefixes', () => {
+  it.each([
+    ['rag_optimization', 'rag-optimization'],
+    ['leaderboard', 'leaderboard'],
+    ['', ''],
+    ['a__b___c', 'a--b---c'],
+  ])('converts component id %s', (id, expected) => expect(componentIdToTaskId(id)).toBe(expected));
+  it('filters by run and task state, including terminal failures and cancellations', () => {
+    expect(getComponentsToFetch(undefined, createMockPipelineRun('RUNNING'), new Set())).toEqual(
+      [],
+    );
     expect(getComponentsToFetch(mockComponentStageMap, undefined, new Set())).toEqual([]);
+    expect(
+      getComponentsToFetch(mockComponentStageMap, createMockPipelineRun('SUCCEEDED'), new Set()),
+    ).toEqual(['data_ingestion', 'rag_optimization', 'leaderboard_evaluation']);
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('running', [
+          { task_id: 'data-ingestion', state: ' Succeeded ' },
+          { task_id: 'rag-optimization', state: 'running' },
+          { task_id: 'leaderboard-evaluation', state: 'pending' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['data_ingestion', 'rag_optimization']);
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('CANCELED', [
+          { task_id: 'data-ingestion', state: 'SUCCEEDED' },
+          { task_id: 'rag-optimization', state: 'CANCELED' },
+        ]),
+        new Set(['data_ingestion']),
+      ),
+    ).toEqual(['rag_optimization']);
   });
-
-  it('should return all component ids when run is SUCCEEDED', () => {
-    const pipelineRun = createMockPipelineRun('SUCCEEDED', []);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['data_ingestion', 'rag_optimization', 'leaderboard_evaluation']);
-  });
-
-  it('should normalize run and task state casing and whitespace', () => {
-    const pipelineRun = createMockPipelineRun(' succeeded ', [
-      { task_id: 'data-ingestion', state: ' succeeded ' },
-    ]);
-    expect(getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set())).toEqual([
-      'data_ingestion',
-      'rag_optimization',
-      'leaderboard_evaluation',
-    ]);
-
-    const runningRun = createMockPipelineRun('running', [
-      { task_id: 'data-ingestion', state: ' Succeeded ' },
-      { task_id: 'rag-optimization', state: 'running' },
-      { task_id: 'leaderboard-evaluation', state: 'pending' },
-    ]);
-    expect(getComponentsToFetch(mockComponentStageMap, runningRun, new Set())).toEqual([
-      'data_ingestion',
-      'rag_optimization',
-    ]);
-  });
-
-  it('should skip components already in completedComponentIds', () => {
-    const pipelineRun = createMockPipelineRun('SUCCEEDED', []);
-    const completed = new Set(['rag_optimization']);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, completed);
-
-    expect(result).toEqual(['data_ingestion', 'leaderboard_evaluation']);
-  });
-
-  it('should return RUNNING, SUCCEEDED, or FAILED tasks when run is not SUCCEEDED', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'data-ingestion', state: 'SUCCEEDED' },
-      { task_id: 'rag-optimization', state: 'RUNNING' },
-      { task_id: 'leaderboard-evaluation', state: 'PENDING' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['data_ingestion', 'rag_optimization']);
-  });
-
-  it('should include FAILED tasks when the run has not succeeded', () => {
-    const pipelineRun = createMockPipelineRun('FAILED', [
-      { task_id: 'data-ingestion', state: 'SUCCEEDED' },
-      { task_id: 'rag-optimization-2', state: 'FAILED' },
-      { task_id: 'leaderboard-evaluation', state: 'PENDING' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['data_ingestion', 'rag_optimization']);
-  });
-
-  it('should include CANCELED tasks when the run is terminal but not SUCCEEDED', () => {
-    const pipelineRun = createMockPipelineRun('CANCELED', [
-      { task_id: 'data-ingestion', state: 'SUCCEEDED' },
-      { task_id: 'rag-optimization', state: 'CANCELED' },
-      { task_id: 'leaderboard-evaluation', state: 'PENDING' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['data_ingestion', 'rag_optimization']);
-  });
-
-  it('should match tasks by display_name as well', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      {
-        task_id: 'some-internal-id',
-        display_name: 'data-ingestion',
-        state: 'SUCCEEDED',
-      },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['data_ingestion']);
-  });
-
-  it('should return empty array when no tasks match', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'unrelated-task', state: 'SUCCEEDED' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual([]);
-  });
-
-  it('should match suffixed task directory names from condition branches', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'rag-optimization-2', state: 'RUNNING' },
-      { task_id: 'leaderboard-evaluation-2', state: 'PENDING' },
-    ]);
-    const result = getComponentsToFetch(mockComponentStageMap, pipelineRun, new Set());
-
-    expect(result).toEqual(['rag_optimization']);
-  });
-});
-
-describe('matchesComponentTaskName', () => {
-  it('should match exact and branch-suffixed task names', () => {
-    expect(matchesComponentTaskName('rag-optimization', 'rag_optimization')).toBe(true);
+  it('matches display names and only numeric branch suffixes', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('RUNNING', [
+          { task_id: 'internal', display_name: 'data-ingestion', state: 'SUCCEEDED' },
+          { task_id: 'rag-optimization-2', state: 'RUNNING' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['data_ingestion', 'rag_optimization']);
     expect(matchesComponentTaskName('rag-optimization-2', 'rag_optimization')).toBe(true);
-    expect(matchesComponentTaskName('other-task', 'rag_optimization')).toBe(false);
-  });
-
-  it('should reject non-branch suffixes', () => {
     expect(matchesComponentTaskName('rag-optimization-backup', 'rag_optimization')).toBe(false);
   });
-});
-
-describe('isKfpDriverTaskName', () => {
-  it('should identify KFP driver tasks', () => {
-    expect(isKfpDriverTaskName('rag-optimization-2-driver')).toBe(true);
-    expect(isKfpDriverTaskName('data-ingestion-driver')).toBe(true);
-    expect(isKfpDriverTaskName('rag-optimization-2')).toBe(false);
-  });
-});
-
-describe('findComponentTaskInRunDetails', () => {
-  it('should skip driver tasks and return the executor task status', () => {
-    const taskDetails = [
+  it('skips driver tasks and discovers branch prefixes', () => {
+    const details = [
       { task_id: 'rag-optimization-2-driver', state: 'SUCCEEDED' },
       { task_id: 'rag-optimization-2', state: 'FAILED' },
     ];
-
-    expect(findComponentTaskInRunDetails(taskDetails, 'rag_optimization')).toEqual({
-      task_id: 'rag-optimization-2',
-      state: 'FAILED',
-    });
+    expect(findComponentTaskInRunDetails(details, 'rag_optimization')).toEqual(details[1]);
+    expect(isKfpDriverTaskName(details[0].task_id)).toBe(true);
+    const prefixes = buildRunLevelPrefixesFromTaskDetails('root', 'run-123', [
+      ...details,
+      { task_id: 'data-ingestion' },
+    ]);
+    expect(prefixes).toEqual([
+      { prefix: 'root/run-123/rag-optimization-2/' },
+      { prefix: 'root/run-123/data-ingestion/' },
+    ]);
+    expect(
+      resolveActiveRunLevelPrefix(
+        'root',
+        'run-123',
+        mockComponentStageMap,
+        createMockPipelineRun('RUNNING', [{ task_id: 'rag-optimization-2', state: 'RUNNING' }]),
+      ),
+    ).toBe('root/run-123/rag-optimization-2');
+    expect(resolveComponentTaskS3Prefix('root', 'run-123', 'rag_optimization', prefixes)).toBe(
+      'root/run-123/rag-optimization-2',
+    );
+    expect(resolveComponentTaskS3Prefix('root', 'run-123', 'data_ingestion')).toBe(
+      'root/run-123/data-ingestion',
+    );
+    expect(resolveComponentTaskS3Prefix('root', 'run-123', 'rag_optimization', [])).toBeUndefined();
   });
 
-  it('should resolve data ingestion status from the executor task when driver succeeded first', () => {
-    const taskDetails = [
+  it('returns all component ids when the run is succeeded', () => {
+    expect(
+      getComponentsToFetch(mockComponentStageMap, createMockPipelineRun('SUCCEEDED'), new Set()),
+    ).toEqual(['data_ingestion', 'rag_optimization', 'leaderboard_evaluation']);
+  });
+
+  it('normalizes run and task state casing and whitespace', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun(' succeeded ', [{ task_id: 'data-ingestion', state: ' succeeded ' }]),
+        new Set(),
+      ),
+    ).toEqual(['data_ingestion', 'rag_optimization', 'leaderboard_evaluation']);
+  });
+
+  it('skips components already completed', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('SUCCEEDED'),
+        new Set(['rag_optimization']),
+      ),
+    ).toEqual(['data_ingestion', 'leaderboard_evaluation']);
+  });
+
+  it('includes failed and canceled tasks when the run is not succeeded', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('CANCELED', [
+          { task_id: 'data-ingestion', state: 'SUCCEEDED' },
+          { task_id: 'rag-optimization', state: 'CANCELED' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['data_ingestion', 'rag_optimization']);
+  });
+
+  it('returns no components when no tasks match', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('RUNNING', [{ task_id: 'unrelated-task', state: 'SUCCEEDED' }]),
+        new Set(),
+      ),
+    ).toEqual([]);
+  });
+
+  it('returns no components when inputs are unavailable', () => {
+    expect(getComponentsToFetch(undefined, createMockPipelineRun('RUNNING'), new Set())).toEqual(
+      [],
+    );
+    expect(getComponentsToFetch(mockComponentStageMap, undefined, new Set())).toEqual([]);
+  });
+
+  it('matches tasks by display name and branch suffix', () => {
+    expect(
+      getComponentsToFetch(
+        mockComponentStageMap,
+        createMockPipelineRun('RUNNING', [
+          { task_id: 'internal', display_name: 'data-ingestion', state: 'SUCCEEDED' },
+          { task_id: 'rag-optimization-2', state: 'RUNNING' },
+        ]),
+        new Set(),
+      ),
+    ).toEqual(['data_ingestion', 'rag_optimization']);
+  });
+
+  it('matches exact task names and identifies drivers', () => {
+    expect(matchesComponentTaskName('rag-optimization', 'rag_optimization')).toBe(true);
+    expect(matchesComponentTaskName('rag-optimization-2', 'rag_optimization')).toBe(true);
+    expect(matchesComponentTaskName('other-task', 'rag_optimization')).toBe(false);
+    expect(isKfpDriverTaskName('data-ingestion-driver')).toBe(true);
+    expect(isKfpDriverTaskName('rag-optimization-2')).toBe(false);
+  });
+
+  it('resolves the executor when the driver appears first', () => {
+    const details = [
       { task_id: 'data-ingestion-driver', state: 'SUCCEEDED' },
       { task_id: 'data-ingestion', state: 'SUCCEEDED' },
     ];
+    expect(findComponentTaskInRunDetails(details, 'data_ingestion')).toEqual(details[1]);
+  });
 
-    expect(findComponentTaskInRunDetails(taskDetails, 'data_ingestion')).toEqual({
-      task_id: 'data-ingestion',
-      state: 'SUCCEEDED',
+  it('falls back to the base path when discovery has no matching prefix', () => {
+    expect(resolveComponentTaskS3Prefix('root', 'run-123', 'data_ingestion')).toBe(
+      'root/run-123/data-ingestion',
+    );
+    expect(resolveComponentTaskS3Prefix('root', 'run-123', 'rag_optimization', [])).toBeUndefined();
+    expect(
+      resolveComponentTaskS3Prefix('root', 'run-123', 'rag_optimization', [
+        { prefix: 'root/run-123/rag-optimization-backup/' },
+      ]),
+    ).toBe('root/run-123/rag-optimization');
+  });
+});
+
+describe('legacy merge and completion coverage with canonical status files', () => {
+  it('merges matching components and preserves map descriptions and unmatched components', () => {
+    const result = mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['rag_optimization', mockComponentStatus]]),
+    );
+    expect(result.components[1].started_at).toBe('2026-06-04T17:49:19.223056Z');
+    expect(result.components[1].metadata).toEqual({ display_name: 'Optimization' });
+    expect(result.components[1].stages[0].description).toBe('Prepare the search space');
+    expect(result.components[1].stages[0].metrics).toEqual({ document_count: 213 });
+    expect(result.components[0]).toEqual(mockComponentStageMap.components[0]);
+  });
+  it('keeps unrecorded stages pending and does not mutate the source map', () => {
+    const original = JSON.stringify(mockComponentStageMap);
+    const partial = ComponentStatusFileSchema.parse({
+      component_id: 'rag_optimization',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Optimization' },
+      stages: [{ id: 'prepare_search_space', status: { state: 'completed' } }],
     });
-  });
-});
-
-describe('buildRunLevelPrefixesFromTaskDetails', () => {
-  it('should build branch-suffixed prefixes from executor task names and skip drivers', () => {
-    const prefixes = buildRunLevelPrefixesFromTaskDetails(
-      'documents-rag-optimization-pipeline',
-      'run-123',
-      [
-        { task_id: 'rag-optimization-2-driver', state: 'SUCCEEDED' },
-        { task_id: 'rag-optimization-2', state: 'RUNNING' },
-        { task_id: 'data-ingestion', state: 'SUCCEEDED' },
-      ],
-    );
-
-    expect(prefixes).toEqual([
-      { prefix: 'documents-rag-optimization-pipeline/run-123/rag-optimization-2/' },
-      { prefix: 'documents-rag-optimization-pipeline/run-123/data-ingestion/' },
-    ]);
-  });
-});
-
-describe('resolveActiveRunLevelPrefix', () => {
-  it('should resolve the executor task directory for an active branch-suffixed component', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'rag-optimization-2', state: 'RUNNING' },
-    ]);
-
     expect(
-      resolveActiveRunLevelPrefix(
-        'documents-rag-optimization-pipeline',
-        'run-123',
-        mockComponentStageMap,
-        pipelineRun,
-      ),
-    ).toBe('documents-rag-optimization-pipeline/run-123/rag-optimization-2');
-  });
-
-  it('should resolve suffixed task directories through run-level prefix discovery', () => {
-    const prefixes = buildRunLevelPrefixesFromTaskDetails(
-      'documents-rag-optimization-pipeline',
-      'run-123',
-      [{ task_id: 'rag-optimization-2', state: 'RUNNING' }],
-    );
-
-    expect(
-      resolveComponentTaskS3Prefix(
-        'documents-rag-optimization-pipeline',
-        'run-123',
-        'rag_optimization',
-        prefixes,
-      ),
-    ).toBe('documents-rag-optimization-pipeline/run-123/rag-optimization-2');
-  });
-});
-
-describe('resolveComponentTaskS3Prefix', () => {
-  it('should resolve suffixed task directories from run-level prefixes', () => {
-    const prefixes = [
-      { prefix: 'documents-rag-optimization-pipeline/run-123/data-ingestion/' },
-      { prefix: 'documents-rag-optimization-pipeline/run-123/rag-optimization-2/' },
-    ];
-
-    expect(
-      resolveComponentTaskS3Prefix(
-        'documents-rag-optimization-pipeline',
-        'run-123',
-        'rag_optimization',
-        prefixes,
-      ),
-    ).toBe('documents-rag-optimization-pipeline/run-123/rag-optimization-2');
-  });
-
-  it('should fall back to the base task path when no run-level prefix matches', () => {
-    expect(
-      resolveComponentTaskS3Prefix(
-        'documents-rag-optimization-pipeline',
-        'run-123',
-        'data_ingestion',
-      ),
-    ).toBe('documents-rag-optimization-pipeline/run-123/data-ingestion');
-  });
-
-  it('should return undefined when run-level discovery succeeded with no prefixes', () => {
-    expect(
-      resolveComponentTaskS3Prefix(
-        'documents-rag-optimization-pipeline',
-        'run-123',
-        'rag_optimization',
-        [],
-      ),
+      mergeStatusIntoStageMap(mockComponentStageMap, new Map([['rag_optimization', partial]]))
+        .components[1].stages[2].status,
     ).toBeUndefined();
+    expect(JSON.stringify(mockComponentStageMap)).toBe(original);
   });
-
-  it('should ignore non-numeric sibling prefixes and fall back to the base task path', () => {
-    const prefixes = [
-      { prefix: 'documents-rag-optimization-pipeline/run-123/rag-optimization-backup/' },
-    ];
-
-    expect(
-      resolveComponentTaskS3Prefix(
-        'documents-rag-optimization-pipeline',
-        'run-123',
-        'rag_optimization',
-        prefixes,
-      ),
-    ).toBe('documents-rag-optimization-pipeline/run-123/rag-optimization');
-  });
-});
-
-describe('mergeStatusIntoStageMap', () => {
-  it('should return stageMap unchanged when no status files match', () => {
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, new Map());
-    expect(result).toEqual(mockComponentStageMap);
-  });
-
-  it('should merge status data into matching component stages', () => {
-    const statusFiles = new Map([['rag_optimization', mockComponentStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const mergedComponent = result.components.find((c) => c.id === 'rag_optimization')!;
-    expect(mergedComponent.started_at).toBe('2026-06-04T17:49:19.223056Z');
-    expect(mergedComponent.completed_at).toBe('2026-06-04T17:50:10.290690Z');
-    expect(mergedComponent.metadata).toEqual({});
-  });
-
-  it('should preserve original stage descriptions after merge', () => {
-    const statusFiles = new Map([['rag_optimization', mockComponentStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const mergedComponent = result.components.find((c) => c.id === 'rag_optimization')!;
-    expect(mergedComponent.stages[0].description).toBe('Prepare the search space');
-  });
-
-  it('should add status fields to merged stages', () => {
-    const statusFiles = new Map([['rag_optimization', mockComponentStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const mergedComponent = result.components.find((c) => c.id === 'rag_optimization')!;
-    const stage = mergedComponent.stages.find((s) => s.id === 'prepare_search_space')!;
-
-    expect(stage.status).toBe('completed');
-    expect(stage.timestamp).toBe('2026-06-04T17:49:19.232065Z');
-    expect(stage.document_count).toBe(213);
-  });
-
-  it('should flatten nested stage metadata onto merged stages', () => {
-    const statusWithNestedMetadata: ComponentStatusFile = {
-      component_id: 'rag_optimization',
-      stages: [
-        {
-          id: 'prepare_search_space',
-          description: 'Prepare the search space',
-          status: 'completed',
-          timestamp: '2026-06-04T17:49:19.232065Z',
-          metadata: {
-            document_count: 500,
-            row_count: 125,
-          },
-        },
-      ],
-    };
-    const statusFiles = new Map([['rag_optimization', statusWithNestedMetadata]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const stage = result.components
-      .find((component) => component.id === 'rag_optimization')!
-      .stages.find((s) => s.id === 'prepare_search_space')!;
-
-    expect(stage.document_count).toBe(500);
-    expect(stage.row_count).toBe(125);
-    expect(stage.metadata).toBeUndefined();
-  });
-
-  it('should merge nested stage metadata via mergeStageWithStatus', () => {
-    const merged = mergeStageWithStatus(
-      { id: 'prepare_search_space', description: 'Prepare the search space' },
-      {
-        id: 'prepare_search_space',
-        description: 'ignored',
-        status: 'completed',
-        metadata: { document_count: 42 },
-      },
-    );
-
-    expect(merged.description).toBe('Prepare the search space');
-    expect(merged.status).toBe('completed');
-    expect(merged.document_count).toBe(42);
-    expect(merged.metadata).toBeUndefined();
-  });
-
-  it('should recover selected_patterns nested under status metadata', () => {
-    const merged = mergeStageWithStatus(
-      { id: 'optimize_templates', description: 'Optimize templates' },
-      {
-        id: 'optimize_templates',
-        status: 'completed',
-        metadata: { selected_patterns: ['PatternA', 'PatternB'] },
-      },
-    );
-
-    expect(merged.selected_patterns).toEqual(['PatternA', 'PatternB']);
-    expect(merged.metadata).toBeUndefined();
-  });
-
-  it('should not let nested metadata overwrite top-level status and timestamp', () => {
-    const statusWithCollidingMetadata: ComponentStatusFile = {
-      component_id: 'rag_optimization',
-      stages: [
-        {
-          id: 'prepare_search_space',
-          description: 'Prepare the search space',
-          status: 'completed',
-          timestamp: '2026-06-04T17:49:19.232065Z',
-          metadata: {
-            status: 'pending',
-            timestamp: '2026-01-01T00:00:00.000000Z',
-            document_count: 500,
-            row_count: 125,
-          },
-        },
-      ],
-    };
-    const statusFiles = new Map([['rag_optimization', statusWithCollidingMetadata]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const stage = result.components
-      .find((component) => component.id === 'rag_optimization')!
-      .stages.find((s) => s.id === 'prepare_search_space')!;
-
-    expect(stage.status).toBe('completed');
-    expect(stage.timestamp).toBe('2026-06-04T17:49:19.232065Z');
-    expect(stage.document_count).toBe(500);
-    expect(stage.row_count).toBe(125);
-    expect(stage.metadata).toBeUndefined();
-
-    const merged = mergeStageWithStatus(
-      { id: 'prepare_search_space', description: 'Prepare the search space' },
-      statusWithCollidingMetadata.stages[0],
-    );
-
-    expect(merged.status).toBe('completed');
-    expect(merged.timestamp).toBe('2026-06-04T17:49:19.232065Z');
-    expect(merged.document_count).toBe(500);
-    expect(merged.row_count).toBe(125);
-    expect(merged.metadata).toBeUndefined();
-  });
-
-  it('should reject unsafe and protected keys when flattening nested stage fields', () => {
-    const maliciousMetadata = {
-      steps: ['evil_step'],
-      selected_patterns: ['EvilPattern'],
-      document_count: 500,
-      constructor: { polluted: true },
-      prototype: { polluted: true },
-      ...JSON.parse('{"__proto__":{"polluted":true}}'),
-    };
-
-    const merged = mergeStageWithStatus(
-      {
-        id: 'optimize_templates',
-        description: 'Evaluate candidate RAG pattern configurations',
-        steps: ['chunking', 'embedding'],
-      },
-      {
-        id: 'optimize_templates',
-        description: 'ignored',
-        status: 'completed',
-        timestamp: '2026-06-04T17:49:53.951525Z',
-        selected_patterns: ['pattern_b'],
-        metadata: maliciousMetadata,
-      },
-    );
-
-    expect(merged.status).toBe('completed');
-    expect(merged.timestamp).toBe('2026-06-04T17:49:53.951525Z');
-    expect(merged.steps).toEqual(['chunking', 'embedding']);
-    expect(merged.selected_patterns).toEqual(['pattern_b']);
-    expect(merged.document_count).toBe(500);
-    expect(merged.metadata).toBeUndefined();
-
-    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
-    expect(Object.hasOwn(merged, 'constructor')).toBe(false);
-    expect(Object.hasOwn(merged, 'prototype')).toBe(false);
-    expect(Object.hasOwn(merged, '__proto__')).toBe(false);
-    expect(merged).not.toHaveProperty('polluted');
-    expect(Object.prototype).toEqual(expect.not.objectContaining({ polluted: true }));
-  });
-
-  it('should leave unmatched components untouched', () => {
-    const statusFiles = new Map([['rag_optimization', mockComponentStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const dataIngestion = result.components.find((c) => c.id === 'data_ingestion')!;
-    expect(dataIngestion).toEqual(mockComponentStageMap.components[0]);
-  });
-
-  it('should leave unmatched stages within a merged component untouched', () => {
-    const partialStatus: ComponentStatusFile = {
-      component_id: 'rag_optimization',
-      stages: [
-        {
-          id: 'prepare_search_space',
-          description: 'Prepare the search space',
-          status: 'completed',
-          timestamp: '2026-06-04T17:49:19Z',
-        },
-      ],
-    };
-    const statusFiles = new Map([['rag_optimization', partialStatus]]);
-    const result = mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    const mergedComponent = result.components.find((c) => c.id === 'rag_optimization')!;
-    const runOptimizationStage = mergedComponent.stages.find((s) => s.id === 'run_optimization')!;
-    expect(runOptimizationStage.status).toBeUndefined();
-  });
-
-  it('should not mutate the original stageMap', () => {
-    const originalJson = JSON.stringify(mockComponentStageMap);
-    const statusFiles = new Map([['rag_optimization', mockComponentStatus]]);
-    mergeStatusIntoStageMap(mockComponentStageMap, statusFiles);
-
-    expect(JSON.stringify(mockComponentStageMap)).toBe(originalJson);
-  });
-
-  it('should merge leaderboard best_pattern when status stage omits description', () => {
-    const leaderboardStatus: ComponentStatusFile = {
+  it('merges leaderboard metrics without replacing descriptions', () => {
+    const status = ComponentStatusFileSchema.parse({
       component_id: 'leaderboard_evaluation',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Leaderboard' },
       stages: [
         {
           id: 'build_leaderboard',
-          status: 'completed',
-          timestamp: '2026-06-04T17:50:15.000000Z',
-          best_pattern: 'pattern_b',
+          status: { state: 'completed' },
+          metrics: { best_pattern: 'pattern_b' },
         },
       ],
-    };
-
-    expect(() => ComponentStatusFileSchema.parse(leaderboardStatus)).not.toThrow();
-
-    const result = mergeStatusIntoStageMap(
+    });
+    const stage = mergeStatusIntoStageMap(
       mockComponentStageMap,
-      new Map([['leaderboard_evaluation', leaderboardStatus]]),
-    );
-
-    const buildLeaderboard = result.components
-      .find((component) => component.id === 'leaderboard_evaluation')!
-      .stages.find((stage) => stage.id === 'build_leaderboard')!;
-
-    expect(buildLeaderboard.description).toBe('Aggregate pattern metrics');
-    expect(buildLeaderboard.best_pattern).toBe('pattern_b');
+      new Map([['leaderboard_evaluation', status]]),
+    ).components[2].stages[0];
+    expect(stage.description).toBe('Aggregate pattern metrics');
+    expect(stage.metrics).toEqual({ best_pattern: 'pattern_b' });
   });
-
-  it('should truncate oversized optimize_templates steps during status parsing', () => {
-    const oversizedSteps = Array.from(
-      { length: MAX_PATTERN_SELECTION_STEPS + 5 },
-      (_, index) => `step_${index}`,
-    );
-    const parsed = ComponentStatusFileSchema.parse({
-      component_id: 'rag_optimization',
+  it('recognizes only complete non-empty canonical status files', () => {
+    expect(isComponentFullyComplete(mockComponentStatus)).toBe(true);
+    const partial = ComponentStatusFileSchema.parse({
+      component_id: 'test',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Test' },
       stages: [
-        {
-          id: 'optimize_templates',
-          steps: oversizedSteps,
-        },
+        { id: 'a', status: { state: 'completed' } },
+        { id: 'b', status: { state: 'started' } },
       ],
     });
-
-    expect(parsed.stages[0].steps).toHaveLength(MAX_PATTERN_SELECTION_STEPS);
-    expect(parsed.stages[0].steps).toEqual(oversizedSteps.slice(0, MAX_PATTERN_SELECTION_STEPS));
-  });
-
-  it('should dedupe repeated optimize_templates steps before applying the cap', () => {
-    const repeatedSteps = [
-      ...Array.from({ length: MAX_PATTERN_SELECTION_STEPS }, () => 'chunking'),
-      'embedding',
-      'retrieval',
-    ];
-    const parsed = ComponentStatusFileSchema.parse({
-      component_id: 'rag_optimization',
-      stages: [
-        {
-          id: 'optimize_templates',
-          steps: repeatedSteps,
-        },
-      ],
-    });
-
-    expect(parsed.stages[0].steps).toEqual(['chunking', 'embedding', 'retrieval']);
-
-    const merged = mergeStageWithStatus(
-      {
-        id: 'optimize_templates',
-        description: 'Evaluate candidate RAG pattern configurations',
-        steps: repeatedSteps,
-      },
-      parsed.stages[0],
-    );
-
-    expect(merged.steps).toEqual(['chunking', 'embedding', 'retrieval']);
-  });
-
-  it('should reject malformed selected_patterns during status parsing', () => {
-    const objectParsed = ComponentStatusFileSchema.parse({
-      component_id: 'rag_optimization',
-      stages: [
-        {
-          id: 'optimize_templates',
-          selected_patterns: { pattern_a: 'pattern_a' },
-        },
-      ],
-    });
-    expect(objectParsed.stages[0].selected_patterns).toBeUndefined();
-
-    const mixedParsed = ComponentStatusFileSchema.parse({
-      component_id: 'rag_optimization',
-      stages: [
-        {
-          id: 'optimize_templates',
-          selected_patterns: ['pattern_b', 42, null],
-        },
-      ],
-    });
-    expect(mixedParsed.stages[0].selected_patterns).toEqual(['pattern_b']);
-
-    const emptyParsed = ComponentStatusFileSchema.parse({
-      component_id: 'rag_optimization',
-      stages: [
-        {
-          id: 'optimize_templates',
-          selected_patterns: [],
-        },
-      ],
-    });
-    expect(emptyParsed.stages[0].selected_patterns).toEqual([]);
-  });
-
-  it('should normalize documented stage statuses and drop unsupported ones during parsing', () => {
-    const parsed = ComponentStatusFileSchema.parse({
-      component_id: 'rag_optimization',
-      stages: [
-        { id: 'load_benchmark', status: ' Completed ' },
-        { id: 'optimize_templates', status: 'STARTED' },
-        { id: 'evaluate_patterns', status: 'running' },
-        { id: 'build_leaderboard', status: 'pending' },
-      ],
-    });
-
-    expect(parsed.stages[0].status).toBe('completed');
-    expect(parsed.stages[1].status).toBe('started');
-    expect(parsed.stages[2].status).toBeUndefined();
-    expect(parsed.stages[3].status).toBeUndefined();
-  });
-
-  it('should not let unsupported status overwrite completed or failed canonical stages', () => {
-    const completedPreserved = mergeStageWithStatus(
-      { id: 'load_benchmark', description: 'Load benchmark', status: 'completed' },
-      {
-        id: 'load_benchmark',
-        status: 'running',
-        timestamp: '2026-06-04T17:49:19.232065Z',
-      } as unknown as ComponentStatusFile['stages'][number],
-    );
-    expect(completedPreserved.status).toBe('completed');
-    expect(completedPreserved.timestamp).toBe('2026-06-04T17:49:19.232065Z');
-
-    const failedPreserved = mergeStageWithStatus(
-      { id: 'load_benchmark', description: 'Load benchmark', status: 'failed' },
-      {
-        id: 'load_benchmark',
-        status: 'pending',
-      } as unknown as ComponentStatusFile['stages'][number],
-    );
-    expect(failedPreserved.status).toBe('failed');
-
-    const progressed = mergeStageWithStatus(
-      { id: 'load_benchmark', description: 'Load benchmark', status: 'started' },
-      { id: 'load_benchmark', status: 'completed' },
-    );
-    expect(progressed.status).toBe('completed');
-  });
-
-  it('should clear canonical selected_patterns when status provides an empty array', () => {
-    const merged = mergeStageWithStatus(
-      {
-        id: 'optimize_templates',
-        description: 'Evaluate candidate RAG pattern configurations',
-        selected_patterns: ['ExistingPattern'],
-      },
-      {
-        id: 'optimize_templates',
-        status: 'completed',
-        selected_patterns: [],
-      },
-    );
-
-    expect(merged.selected_patterns).toEqual([]);
-    expect(merged.status).toBe('completed');
-  });
-
-  it('should not clear canonical selected_patterns when a non-empty array has no valid strings', () => {
-    const nonStringParsed = ComponentStatusFileSchema.parse({
-      component_id: 'rag_optimization',
-      stages: [
-        {
-          id: 'optimize_templates',
-          selected_patterns: [42, null],
-        },
-      ],
-    });
-    expect(nonStringParsed.stages[0].selected_patterns).toBeUndefined();
-
-    const merged = mergeStageWithStatus(
-      {
-        id: 'optimize_templates',
-        description: 'Evaluate candidate RAG pattern configurations',
-        selected_patterns: ['ExistingPattern'],
-      },
-      {
-        id: 'optimize_templates',
-        status: 'completed',
-        selected_patterns: [42, null],
-      } as unknown as ComponentStatusFile['stages'][number],
-    );
-
-    expect(merged.selected_patterns).toEqual(['ExistingPattern']);
-    expect(merged.status).toBe('completed');
-  });
-
-  it('should not merge malformed selected_patterns into branch metadata', () => {
-    const merged = mergeStageWithStatus(
-      {
-        id: 'optimize_templates',
-        description: 'Evaluate candidate RAG pattern configurations',
-        selected_patterns: ['ExistingPattern'],
-      },
-      {
-        id: 'optimize_templates',
-        status: 'completed',
-        selected_patterns: { bad: 'value' },
-      } as unknown as ComponentStatusFile['stages'][number],
-    );
-
-    expect(merged.selected_patterns).toEqual(['ExistingPattern']);
-    expect(merged.status).toBe('completed');
+    expect(isComponentFullyComplete(partial)).toBe(false);
+    expect(
+      isComponentFullyComplete(
+        ComponentStatusFileSchema.parse({
+          component_id: 'test',
+          started_at: '2026-01-01T00:00:00Z',
+          metadata: { display_name: 'Test' },
+          stages: [],
+        }),
+      ),
+    ).toBe(false);
   });
 });
 
 describe('useComponentStatuses', () => {
-  const useS3ListFilesQueryMock = jest.mocked(useS3ListFilesQuery);
-  const getFilesMock = jest.mocked(getFiles);
-  const dataUpdatedAt = 1_700_000_000_000;
-
+  const queryMock = jest.mocked(useS3ListFilesQuery);
+  const filesMock = jest.mocked(getFiles);
+  const updatedAt = 1_700_000_000_000;
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-    useS3ListFilesQueryMock.mockReturnValue({
+    queryMock.mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: false,
       error: null,
     } as ReturnType<typeof useS3ListFilesQuery>);
   });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('should populate errors when all component status fetches fail', async () => {
+  afterEach(() => jest.restoreAllMocks());
+  it('reports fetch errors and settles loading', async () => {
+    filesMock.mockRejectedValue(new Error('S3 unavailable'));
     const pipelineRun = createMockPipelineRun('RUNNING', [
       { task_id: 'data-ingestion', state: 'SUCCEEDED' },
       { task_id: 'rag-optimization-2', state: 'RUNNING' },
     ]);
-
-    getFilesMock.mockRejectedValue(new Error('S3 unavailable'));
-
     const { result } = renderHook(() =>
       useComponentStatuses(
         'run-123',
         'test-namespace',
         pipelineRun,
         mockComponentStageMap,
-        dataUpdatedAt,
+        updatedAt,
       ),
     );
-
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([
-        { componentId: 'data_ingestion', message: 'S3 unavailable' },
-        { componentId: 'rag_optimization', message: 'S3 unavailable' },
-      ]);
-    });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
+    await waitFor(() => expect(result.current.errors).toHaveLength(2));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.mergedStageMap).toEqual(mockComponentStageMap);
   });
-
-  it('should clear stale errors when a later fetch returns missing status', async () => {
+  it('clears stale errors after a later missing status response', async () => {
+    filesMock.mockRejectedValueOnce(new Error('S3 unavailable')).mockResolvedValue({
+      contents: [],
+      common_prefixes: [],
+      is_truncated: false,
+      key_count: 0,
+      max_keys: 1000,
+    });
     const pipelineRun = createMockPipelineRun('RUNNING', [
       { task_id: 'data-ingestion', state: 'SUCCEEDED' },
-      { task_id: 'rag-optimization-2', state: 'RUNNING' },
     ]);
-
-    getFilesMock.mockRejectedValue(new Error('S3 unavailable'));
-
     const { result, rerender } = renderHook(
-      ({ updatedAt }) =>
+      ({ stamp }) =>
         useComponentStatuses(
           'run-123',
           'test-namespace',
           pipelineRun,
           mockComponentStageMap,
-          updatedAt,
+          stamp,
         ),
-      { initialProps: { updatedAt: dataUpdatedAt } },
+      { initialProps: { stamp: updatedAt } },
     );
-
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([
-        { componentId: 'data_ingestion', message: 'S3 unavailable' },
-        { componentId: 'rag_optimization', message: 'S3 unavailable' },
-      ]);
-    });
-
-    getFilesMock.mockResolvedValue({
-      contents: [],
-      common_prefixes: [],
-      is_truncated: false,
-      key_count: 0,
-      max_keys: 1000,
-    });
-
-    rerender({ updatedAt: dataUpdatedAt + 1 });
-
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([]);
-    });
-    expect(result.current.mergedStageMap).toEqual(mockComponentStageMap);
+    await waitFor(() => expect(result.current.errors).toHaveLength(1));
+    rerender({ stamp: updatedAt + 1 });
+    await waitFor(() => expect(result.current.errors).toEqual([]));
   });
-
-  it('should settle loading when namespace is unavailable', () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'data-ingestion', state: 'SUCCEEDED' },
-      { task_id: 'rag-optimization-2', state: 'RUNNING' },
-    ]);
-
+  it('settles without fetching when namespace is unavailable', () => {
     const { result } = renderHook(() =>
-      useComponentStatuses('run-123', undefined, pipelineRun, mockComponentStageMap, dataUpdatedAt),
+      useComponentStatuses(
+        'run-123',
+        undefined,
+        createMockPipelineRun('RUNNING'),
+        mockComponentStageMap,
+        updatedAt,
+      ),
     );
-
     expect(result.current.isLoading).toBe(false);
     expect(result.current.mergedStageMap).toEqual(mockComponentStageMap);
-    expect(getFilesMock).not.toHaveBeenCalled();
+    expect(filesMock).not.toHaveBeenCalled();
   });
-
-  it('should reset status caches when namespace changes for the same runId', async () => {
-    const pipelineRun = createMockPipelineRun('RUNNING', [
-      { task_id: 'data-ingestion', state: 'SUCCEEDED' },
-      { task_id: 'rag-optimization-2', state: 'RUNNING' },
-    ]);
-
-    getFilesMock.mockRejectedValue(new Error('S3 unavailable'));
-
-    const { result, rerender } = renderHook(
-      ({ namespace }) =>
-        useComponentStatuses(
-          'run-123',
-          namespace,
-          pipelineRun,
-          mockComponentStageMap,
-          dataUpdatedAt,
-        ),
-      { initialProps: { namespace: 'project-a' } },
-    );
-
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([
-        { componentId: 'data_ingestion', message: 'S3 unavailable' },
-        { componentId: 'rag_optimization', message: 'S3 unavailable' },
-      ]);
-    });
-
-    getFilesMock.mockResolvedValue({
+  it('resets status state when namespace changes for the same run', async () => {
+    filesMock.mockRejectedValueOnce(new Error('S3 unavailable')).mockResolvedValue({
       contents: [],
       common_prefixes: [],
       is_truncated: false,
       key_count: 0,
       max_keys: 1000,
     });
-
+    const pipelineRun = createMockPipelineRun('RUNNING', [
+      { task_id: 'data-ingestion', state: 'SUCCEEDED' },
+    ]);
+    const { result, rerender } = renderHook(
+      ({ namespace }) =>
+        useComponentStatuses('run-123', namespace, pipelineRun, mockComponentStageMap, updatedAt),
+      { initialProps: { namespace: 'project-a' } },
+    );
+    await waitFor(() => expect(result.current.errors).toHaveLength(1));
     rerender({ namespace: 'project-b' });
+    await waitFor(() => expect(result.current.errors).toEqual([]));
+  });
+});
 
-    await waitFor(() => {
-      expect(result.current.errors).toEqual([]);
+describe('ComponentStatusFileSchema', () => {
+  it('should reject the legacy flat stage and string status shape', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'RAG' },
+        stages: [{ id: 'prepare', status: 'completed', row_count: 10 }],
+      }),
+    ).toThrow();
+  });
+
+  it('should require the canonical envelope and stage fields', () => {
+    expect(() => ComponentStatusFileSchema.parse({ component_id: 'rag_component' })).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: {},
+        stages: [],
+      }),
+    ).toThrow();
+  });
+
+  it('should parse running metrics, message, and status step', () => {
+    const parsed = artifact([
+      {
+        id: 'prepare',
+        status: {
+          state: 'running',
+          step: 'chunk',
+          message: { level: 'warning', text: 'Chunking documents' },
+          running_at: '2026-01-01T00:01:00Z',
+        },
+        metrics: { completed_units: 3, total_units: 8, batches: [1, 2] },
+      },
+    ]);
+    expect(parsed.stages[0]).toMatchObject({ status: { state: 'running', step: 'chunk' } });
+    expect(parsed.stages[0].metrics).toEqual({
+      completed_units: 3,
+      total_units: 8,
+      batches: [1, 2],
     });
-    expect(result.current.mergedStageMap).toEqual(mockComponentStageMap);
+  });
+
+  it('should accept an error only on a failed stage', () => {
+    const failedStage = artifact([
+      { id: 'optimize_templates', status: { state: 'failed' }, error: 'OPTIMIZE_FAILED' },
+    ]).stages[0];
+    expect('error' in failedStage ? failedStage.error : undefined).toBe('OPTIMIZE_FAILED');
+    expect(() =>
+      artifact([{ id: 'optimize_templates', status: { state: 'running' }, error: 'stale error' }]),
+    ).toThrow();
+  });
+
+  it('should reject a missing envelope or required metadata', () => {
+    expect(() => ComponentStatusFileSchema.parse({ component_id: 'rag_component' })).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: {},
+        stages: [],
+      }),
+    ).toThrow();
+  });
+
+  it('should parse canonical running status, message, and metrics', () => {
+    const parsed = artifact([
+      {
+        id: 'prepare',
+        status: {
+          state: 'running',
+          step: 'chunk',
+          message: { level: 'warning', text: 'Chunking documents' },
+          running_at: '2026-01-01T00:01:00Z',
+        },
+        metrics: { completed_units: 3, total_units: 8, batches: [1, 2] },
+      },
+    ]);
+    expect(parsed.stages[0].status).toMatchObject({ state: 'running', step: 'chunk' });
+    expect(parsed.stages[0].metrics).toEqual({
+      completed_units: 3,
+      total_units: 8,
+      batches: [1, 2],
+    });
+  });
+
+  it('should enforce canonical identifiers, timestamps, messages, errors, and metric values', () => {
+    const valid = {
+      component_id: 'rag_component',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'RAG', extra: { retained: true } },
+      stages: [
+        {
+          id: 'prepare',
+          status: { state: 'running', running_at: '2026-01-01T00:01:00Z' },
+          metrics: {
+            string: 'value',
+            number: 1.5,
+            integer: 1,
+            boolean: true,
+            empty: null,
+            values: ['value', 1, false],
+          },
+        },
+      ],
+    };
+    expect(ComponentStatusFileSchema.parse(valid)).toEqual(valid);
+    for (const [field, value] of [
+      ['component_id', 'RAG'],
+      ['started_at', '2026-01-01T00:00:00+00:00'],
+    ] as const) {
+      expect(() => ComponentStatusFileSchema.parse({ ...valid, [field]: value })).toThrow();
+    }
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        completed_at: 'not-a-timestamp',
+        stages: [{ ...valid.stages[0], id: 'prepare-data' }],
+      }),
+    ).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        stages: [
+          { ...valid.stages[0], status: { state: 'running', running_at: 'not-a-timestamp' } },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        stages: [
+          {
+            ...valid.stages[0],
+            status: { state: 'running', message: { level: 'info', text: '' } },
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        stages: [{ ...valid.stages[0], metrics: { object: {} } }],
+      }),
+    ).toThrow();
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...valid,
+        stages: [{ ...valid.stages[0], metrics: { values: ['value', null] } }],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('mergeStatusIntoStageMap', () => {
+  it('should preserve descriptions, order, and the complete map step catalog', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'rag_component',
+          artifact([{ id: 'prepare', status: { state: 'running', step: 'unknown' } }]),
+        ],
+      ]),
+    );
+    expect(merged.components[0].stages.map((stage) => stage.id)).toEqual([
+      'prepare',
+      'optimize_templates',
+      'publish',
+    ]);
+    expect(merged.components[0].stages[0].description).toBe('Prepare data');
+    expect(merged.components[0].stages[0].steps).toEqual(['chunk', 'embed']);
+    expect(merged.components[0].stages[0].status).toEqual({ state: 'running', step: undefined });
+  });
+
+  it('should use the component display name and retain failed error details', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'rag_component',
+          artifact([{ id: 'optimize_templates', status: { state: 'failed' }, error: 'Failed' }]),
+        ],
+      ]),
+    );
+    expect(merged.components[0].metadata).toEqual({ display_name: 'RAG optimization' });
+    expect(merged.components[0].stages[1].error).toBe('Failed');
+  });
+
+  it('should leave unrecorded stages pending in a partial artifact', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([['rag_component', artifact([{ id: 'prepare', status: { state: 'completed' } }])]]),
+    );
+    expect(merged.components[0].stages[2].status).toBeUndefined();
+  });
+
+  it('should merge canonical stage data without flattening it', () => {
+    const merged = mergeStageWithStatus(
+      stageMap.components[0].stages[0],
+      artifact([{ id: 'prepare', status: { state: 'running' }, metrics: { total_units: 2 } }])
+        .stages[0],
+    );
+    expect(merged.metrics).toEqual({ total_units: 2 });
+    expect(merged.total_units).toBeUndefined();
+  });
+
+  it('should promote canonical pattern selection metrics and preserve map selections when absent', () => {
+    const selected = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'rag_component',
+          artifact([
+            {
+              id: 'optimize_templates',
+              status: { state: 'completed' },
+              metrics: { selected_patterns: ['pattern-a', 'pattern-b'] },
+            },
+          ]),
+        ],
+      ]),
+    );
+    expect(selected.components[0].stages[1].selected_patterns).toEqual(['pattern-a', 'pattern-b']);
+
+    const preserved = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        ['rag_component', artifact([{ id: 'optimize_templates', status: { state: 'completed' } }])],
+      ]),
+    );
+    expect(preserved.components[0].stages[1].selected_patterns).toEqual(['map-pattern']);
+  });
+
+  it('should ignore malformed pattern selection metrics', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'rag_component',
+          artifact([
+            {
+              id: 'optimize_templates',
+              status: { state: 'completed' },
+              metrics: { selected_patterns: ['pattern-a', 1] },
+            },
+          ]),
+        ],
+      ]),
+    );
+    expect(merged.components[0].stages[1].selected_patterns).toEqual(['map-pattern']);
+  });
+
+  it('should return the map unchanged when no status files match', () => {
+    expect(mergeStatusIntoStageMap(mockComponentStageMap, new Map())).toEqual(
+      mockComponentStageMap,
+    );
+  });
+
+  it('should leave unmatched stages untouched', () => {
+    const result = mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['rag_component', artifact([{ id: 'prepare', status: { state: 'completed' } }])]]),
+    );
+    expect(
+      result.components[0].stages.find((stage) => stage.id === 'publish')?.status,
+    ).toBeUndefined();
+  });
+
+  it('should not mutate the original stage map', () => {
+    const original = JSON.stringify(mockComponentStageMap);
+    mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['rag_optimization', mockComponentStatus]]),
+    );
+    expect(JSON.stringify(mockComponentStageMap)).toBe(original);
+  });
+
+  it('should merge leaderboard metrics when the status omits its description', () => {
+    const status = ComponentStatusFileSchema.parse({
+      component_id: 'leaderboard_evaluation',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Leaderboard' },
+      stages: [
+        {
+          id: 'build_leaderboard',
+          status: { state: 'completed' },
+          metrics: { best_pattern: 'pattern-b' },
+        },
+      ],
+    });
+    const stage = mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['leaderboard_evaluation', status]]),
+    ).components[2].stages[0];
+    expect(stage.description).toBe('Aggregate pattern metrics');
+    expect(stage.metrics).toEqual({ best_pattern: 'pattern-b' });
+  });
+
+  it('should add canonical status and metrics to merged stages', () => {
+    const merged = mergeStatusIntoStageMap(
+      mockComponentStageMap,
+      new Map([['rag_optimization', mockComponentStatus]]),
+    );
+    expect(merged.components[1].stages[0].status).toEqual({ state: 'completed', step: undefined });
+    expect(merged.components[1].stages[0].metrics).toEqual({ document_count: 213 });
+  });
+
+  it('should preserve descriptions, order, and the complete map catalog', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'rag_component',
+          artifact([{ id: 'prepare', status: { state: 'running', step: 'unknown' } }]),
+        ],
+      ]),
+    );
+    expect(merged.components[0].stages.map((stage) => stage.id)).toEqual([
+      'prepare',
+      'optimize_templates',
+      'publish',
+    ]);
+    expect(merged.components[0].stages[0].description).toBe('Prepare data');
+    expect(merged.components[0].stages[0].steps).toEqual(['chunk', 'embed']);
+    expect(merged.components[0].stages[0].status).toEqual({ state: 'running', step: undefined });
+  });
+
+  it('should retain component metadata and failed error details', () => {
+    const merged = mergeStatusIntoStageMap(
+      stageMap,
+      new Map([
+        [
+          'rag_component',
+          artifact([{ id: 'optimize_templates', status: { state: 'failed' }, error: 'Failed' }]),
+        ],
+      ]),
+    );
+    expect(merged.components[0].metadata).toEqual({ display_name: 'RAG optimization' });
+    expect(merged.components[0].stages[1].error).toBe('Failed');
+  });
+
+  it('should preserve selected patterns when metrics has no valid strings', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        ...mockComponentStatus,
+        stages: [
+          {
+            id: 'optimize_templates',
+            status: { state: 'completed' },
+            metrics: { selected_patterns: [42, null] },
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it('should clear canonical selected patterns when metrics provides an empty array', () => {
+    const merged = mergeStageWithStatus(
+      {
+        id: 'optimize_templates',
+        description: 'Optimize templates',
+        selected_patterns: ['ExistingPattern'],
+      },
+      {
+        id: 'optimize_templates',
+        status: { state: 'completed' },
+        metrics: { selected_patterns: [] },
+      },
+    );
+    expect(merged.selected_patterns).toEqual([]);
+  });
+
+  it('should reject legacy flat status fields instead of flattening them', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'RAG' },
+        stages: [{ id: 'prepare', status: 'completed', metadata: { document_count: 1 } }],
+      }),
+    ).toThrow();
+  });
+
+  it('should reject legacy nested stage metadata', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'RAG' },
+        stages: [{ id: 'prepare', status: 'completed', metadata: { document_count: 500 } }],
+      }),
+    ).toThrow();
+  });
+
+  it('should reject legacy metadata selection recovery', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'RAG' },
+        stages: [
+          {
+            id: 'optimize_templates',
+            status: 'completed',
+            metadata: { selected_patterns: ['PatternA'] },
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it('should reject unsafe legacy flattening payloads', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'RAG' },
+        stages: [{ id: 'optimize_templates', status: 'completed', __proto__: { polluted: true } }],
+      }),
+    ).toThrow();
+  });
+
+  it('should reject unsupported flat status values', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'RAG' },
+        stages: [{ id: 'prepare', status: 'pending' }],
+      }),
+    ).toThrow();
+  });
+
+  it('should reject unsupported nested status values', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'RAG' },
+        stages: [{ id: 'prepare', status: { state: 'pending' } }],
+      }),
+    ).toThrow();
+  });
+
+  it('should retain canonical metrics under their envelope', () => {
+    const stage = artifact([
+      { id: 'prepare', status: { state: 'completed' }, metrics: { document_count: 42 } },
+    ]).stages[0];
+    expect(stage.metrics).toEqual({ document_count: 42 });
+    expect('document_count' in stage).toBe(false);
+  });
+
+  it('should reject canonical stages with unknown top-level fields', () => {
+    expect(() =>
+      ComponentStatusFileSchema.parse({
+        component_id: 'rag_component',
+        started_at: '2026-01-01T00:00:00Z',
+        metadata: { display_name: 'RAG' },
+        stages: [{ id: 'prepare', status: { state: 'completed' }, timestamp: 'legacy' }],
+      }),
+    ).toThrow();
+  });
+
+  it('should preserve the selected pattern map value when metrics are absent', () => {
+    const merged = mergeStageWithStatus(
+      {
+        id: 'optimize_templates',
+        description: 'Optimize templates',
+        selected_patterns: ['map-pattern'],
+      },
+      { id: 'optimize_templates', status: { state: 'completed' } },
+    );
+    expect(merged.selected_patterns).toEqual(['map-pattern']);
+  });
+
+  it('should preserve failed errors only for failed canonical stages', () => {
+    const merged = mergeStageWithStatus({ id: 'prepare', description: 'Prepare data' }, {
+      id: 'prepare',
+      status: { state: 'completed' },
+      error: 'stale',
+    } as never);
+    expect(merged.error).toBeUndefined();
+  });
+
+  it('should return false when canonical stages are incomplete', () => {
+    const partial = ComponentStatusFileSchema.parse({
+      component_id: 'test',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Test' },
+      stages: [
+        { id: 'a', status: { state: 'completed' } },
+        { id: 'b', status: { state: 'running' } },
+      ],
+    });
+    expect(isComponentFullyComplete(partial)).toBe(false);
+  });
+
+  it('should return false when canonical stages are empty', () => {
+    const empty = ComponentStatusFileSchema.parse({
+      component_id: 'test',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Test' },
+      stages: [],
+    });
+    expect(isComponentFullyComplete(empty)).toBe(false);
+  });
+
+  it('should return true when canonical stages are all completed', () => {
+    expect(isComponentFullyComplete(mockComponentStatus)).toBe(true);
   });
 });
 
 describe('isComponentFullyComplete', () => {
-  it('should return true when all stages are completed', () => {
-    expect(isComponentFullyComplete(mockComponentStatus)).toBe(true);
-  });
-
-  it('should return false when some stages are not completed', () => {
-    const partial: ComponentStatusFile = {
+  it('should return false when a stage has no status', () => {
+    const partial = ComponentStatusFileSchema.parse({
       component_id: 'test',
+      started_at: '2026-01-01T00:00:00Z',
+      metadata: { display_name: 'Test' },
       stages: [
-        { id: 'a', status: 'completed', description: 'A' },
-        { id: 'b', status: 'started', description: 'B' },
+        { id: 'a', status: { state: 'completed' } },
+        { id: 'b', status: { state: 'started' } },
       ],
-    };
+    });
     expect(isComponentFullyComplete(partial)).toBe(false);
   });
-
-  it('should return false when stages array is empty', () => {
-    const empty: ComponentStatusFile = {
-      component_id: 'test',
-      stages: [],
-    };
-    expect(isComponentFullyComplete(empty)).toBe(false);
-  });
-
-  it('should return false when a stage has no status', () => {
-    const noStatus: ComponentStatusFile = {
-      component_id: 'test',
-      stages: [
-        { id: 'a', status: 'completed', description: 'A' },
-        { id: 'b', description: 'B' },
-      ],
-    };
-    expect(isComponentFullyComplete(noStatus)).toBe(false);
-  });
 });
-
-/* eslint-enable camelcase */

--- a/packages/autorag/frontend/src/app/hooks/useComponentStageMap.ts
+++ b/packages/autorag/frontend/src/app/hooks/useComponentStageMap.ts
@@ -10,7 +10,19 @@ const ComponentStageMapStageSchema = z
     id: z.string(),
     description: z.string(),
     steps: z.array(z.string()).optional(),
-    status: z.string().optional(),
+    status: z
+      .union([
+        z.string(),
+        z.object({
+          state: z.enum(['started', 'running', 'completed', 'failed']),
+          step: z.string().optional(),
+          message: z
+            .object({ level: z.enum(['info', 'warning', 'error']), text: z.string() })
+            .optional(),
+          running_at: z.string().optional(),
+        }),
+      ])
+      .optional(),
     timestamp: z.string().optional(),
   })
   .catchall(z.unknown());

--- a/packages/autorag/frontend/src/app/hooks/useComponentStatuses.ts
+++ b/packages/autorag/frontend/src/app/hooks/useComponentStatuses.ts
@@ -10,31 +10,43 @@ import type {
 import type { PipelineRun, PipelineRunTaskDetail, S3ListObjectsResponse } from '~/app/types';
 import { getFiles as getS3Files } from '~/app/api/s3';
 import {
-  isAllowedFlattenKey,
-  NESTED_STAGE_FIELD_KEYS,
-  capPatternSelectionSteps,
-} from '~/app/topology/stageMapConstants';
-import {
   findComponentTaskPrefix,
   isRunCompleted,
   isRunInTerminalState,
   normalizePipelineRunState,
 } from '~/app/utilities/utils';
 
-function parseSelectedPatterns(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  if (value.length === 0) {
-    return [];
-  }
-  const patterns = value.filter((item): item is string => typeof item === 'string');
-  return patterns.length > 0 ? patterns : undefined;
-}
-
 /** Documented inline stage statuses (aligned with translateStageStatus). */
 export const COMPONENT_STAGE_STATUSES = ['completed', 'started', 'failed', 'skipped'] as const;
 export type ComponentStageStatus = (typeof COMPONENT_STAGE_STATUSES)[number];
+
+const MetricValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(z.union([z.string(), z.number(), z.boolean()])),
+]);
+const TimestampSchema = z.string().datetime({ offset: false });
+const IdentifierSchema = z.string().regex(/^[a-z][a-z0-9_]*$/);
+
+const ComponentStatusMessageSchema = z
+  .object({
+    level: z.enum(['info', 'warning', 'error']),
+    text: z.string().min(1),
+  })
+  .strict();
+
+/* eslint-disable camelcase */
+const ComponentStatusStateSchema = z
+  .object({
+    state: z.enum(['started', 'running', 'completed', 'failed']),
+    step: z.string().optional(),
+    message: ComponentStatusMessageSchema.optional(),
+    running_at: TimestampSchema.optional(),
+  })
+  .strict();
+/* eslint-enable camelcase */
 
 /** Normalize and accept only documented stage statuses; unsupported values become undefined. */
 export function normalizeComponentStageStatus(value: unknown): ComponentStageStatus | undefined {
@@ -50,66 +62,36 @@ export function normalizeComponentStageStatus(value: unknown): ComponentStageSta
   return undefined;
 }
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function readSelectedPatternsFromRecord(
-  source: Record<string, unknown> | undefined,
-): string[] | undefined {
-  if (!source) {
-    return undefined;
-  }
-
-  const topLevel = parseSelectedPatterns(source.selected_patterns);
-  if (topLevel !== undefined) {
-    return topLevel;
-  }
-
-  for (const nestedKey of NESTED_STAGE_FIELD_KEYS) {
-    const nested = source[nestedKey];
-    if (isPlainObject(nested)) {
-      const fromNested = parseSelectedPatterns(nested.selected_patterns);
-      if (fromNested !== undefined) {
-        return fromNested;
-      }
-    }
-  }
-
-  return undefined;
-}
-
 /* eslint-disable camelcase */
-const ComponentStatusStageSchema = z
-  .object({
-    id: z.string(),
-    description: z.string().optional(),
-    steps: z.preprocess(
-      (val) => (Array.isArray(val) ? capPatternSelectionSteps(val) : val),
-      z.array(z.string()).optional(),
-    ),
-    selected_patterns: z.preprocess(parseSelectedPatterns, z.array(z.string()).optional()),
-    status: z.preprocess(
-      normalizeComponentStageStatus,
-      z.enum(COMPONENT_STAGE_STATUSES).optional(),
-    ),
-    timestamp: z.string().optional(),
-    metadata: z.record(z.string(), z.unknown()).optional(),
-    metrics: z.record(z.string(), z.unknown()).optional(),
-    outputs: z.record(z.string(), z.unknown()).optional(),
-    details: z.record(z.string(), z.unknown()).optional(),
-  })
-  .catchall(z.unknown());
+const ComponentStatusStageSchema = z.union([
+  z
+    .object({
+      id: IdentifierSchema,
+      status: ComponentStatusStateSchema.extend({ state: z.literal('failed') }),
+      metrics: z.record(z.string(), MetricValueSchema).optional(),
+      error: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      id: IdentifierSchema,
+      status: ComponentStatusStateSchema.extend({
+        state: z.enum(['started', 'running', 'completed']),
+      }),
+      metrics: z.record(z.string(), MetricValueSchema).optional(),
+    })
+    .strict(),
+]);
 
 export const ComponentStatusFileSchema = z
   .object({
-    component_id: z.string(),
-    started_at: z.string().optional(),
-    completed_at: z.string().optional(),
+    component_id: IdentifierSchema,
+    started_at: TimestampSchema,
+    completed_at: TimestampSchema.optional(),
     stages: z.array(ComponentStatusStageSchema),
-    metadata: z.record(z.string(), z.unknown()).optional(),
+    metadata: z.object({ display_name: z.string().min(1) }).catchall(z.unknown()),
   })
-  .catchall(z.unknown());
+  .strict();
 
 export type ComponentStatusFile = z.infer<typeof ComponentStatusFileSchema>;
 export type ComponentStatusStage = z.infer<typeof ComponentStatusStageSchema>;
@@ -254,10 +236,23 @@ const MERGED_FIELD_EXCLUDED = new Set([
   'name',
   'component_id',
   'id',
-  'steps',
   'selected_patterns',
   'status',
 ]);
+
+function getSelectedPatterns(metrics: ComponentStatusStage['metrics']): string[] | undefined {
+  const selectedPatterns = metrics?.selected_patterns;
+  return Array.isArray(selectedPatterns) &&
+    selectedPatterns.every((pattern) => typeof pattern === 'string')
+    ? selectedPatterns
+    : undefined;
+}
+
+export function getComponentStageStatus(
+  status: ComponentStatusStage['status'] | ComponentStageMapStage['status'],
+): ComponentStageStatus | 'running' | undefined {
+  return typeof status === 'object' ? status.state : normalizeComponentStageStatus(status);
+}
 
 export function mergeStageWithStatus(
   stage: ComponentStageMapStage,
@@ -269,21 +264,6 @@ export function mergeStageWithStatus(
     description: stage.description,
   };
 
-  for (const nestedKey of NESTED_STAGE_FIELD_KEYS) {
-    const nested = statusStage[nestedKey];
-    if (isPlainObject(nested)) {
-      for (const [key, value] of Object.entries(nested)) {
-        if (isAllowedFlattenKey(key)) {
-          merged[key] = value;
-        }
-      }
-    }
-  }
-
-  for (const nestedKey of NESTED_STAGE_FIELD_KEYS) {
-    delete merged[nestedKey];
-  }
-
   for (const excludedKey of MERGED_FIELD_EXCLUDED) {
     delete merged[excludedKey];
   }
@@ -293,23 +273,20 @@ export function mergeStageWithStatus(
     id: stage.id,
     description: stage.description,
   };
-  if (stage.steps !== undefined) {
-    result.steps = capPatternSelectionSteps(stage.steps);
+  if (statusStage.status.state !== 'failed') {
+    delete result.error;
   }
-  // Prefer a validated payload status; otherwise keep a validated canonical status so
-  // unsupported values cannot clear or overwrite completed/failed (or any prior) status.
-  const normalizedStatus =
-    normalizeComponentStageStatus(statusStage.status) ??
-    normalizeComponentStageStatus(stage.status);
-  if (normalizedStatus !== undefined) {
-    result.status = normalizedStatus;
+  if (stage.id === 'optimize_templates') {
+    // Branch topology consumes this selection from the stage map.
+    // eslint-disable-next-line camelcase
+    result.selected_patterns = getSelectedPatterns(statusStage.metrics) ?? stage.selected_patterns;
   }
-  const selectedPatterns =
-    readSelectedPatternsFromRecord({ ...statusStage }) ??
-    readSelectedPatternsFromRecord({ ...stage });
-  if (selectedPatterns !== undefined) {
-    result.selected_patterns = selectedPatterns; // eslint-disable-line camelcase
-  }
+  result.status = {
+    ...statusStage.status,
+    ...(statusStage.status.step && stage.steps?.includes(statusStage.status.step)
+      ? { step: statusStage.status.step }
+      : { step: undefined }),
+  };
   return result;
 }
 
@@ -337,22 +314,21 @@ export function mergeStatusIntoStageMap(
         ...component,
         stages: mergedStages,
       };
-      if (status.started_at != null) {
-        merged.started_at = status.started_at; // eslint-disable-line camelcase
-      }
+      merged.started_at = status.started_at; // eslint-disable-line camelcase
       if (status.completed_at != null) {
         merged.completed_at = status.completed_at; // eslint-disable-line camelcase
       }
-      if (status.metadata != null) {
-        merged.metadata = status.metadata;
-      }
+      merged.metadata = status.metadata;
       return merged;
     }),
   };
 }
 
 export function isComponentFullyComplete(status: ComponentStatusFile): boolean {
-  return status.stages.length > 0 && status.stages.every((s) => s.status === 'completed');
+  return (
+    status.stages.length > 0 &&
+    status.stages.every((s) => getComponentStageStatus(s.status) === 'completed')
+  );
 }
 
 async function discoverStatusJsonPath(

--- a/packages/autorag/frontend/src/app/topology/__tests__/stageMapStatus.spec.ts
+++ b/packages/autorag/frontend/src/app/topology/__tests__/stageMapStatus.spec.ts
@@ -253,6 +253,20 @@ describe('resolveStageRunStatus', () => {
 });
 
 describe('resolveSequentialStageRunStatuses', () => {
+  it('should keep stages after the canonical active frontier pending', () => {
+    const statuses = resolveSequentialStageRunStatuses(
+      [
+        { id: 'prepare', description: 'Prepare', status: { state: 'completed' } },
+        { id: 'optimize', description: 'Optimize', status: { state: 'completed' } },
+        { id: 'publish', description: 'Publish' },
+      ],
+      RunStatus.InProgress,
+      'RUNNING',
+    );
+    expect(statuses.get('prepare')).toBe(RunStatus.Succeeded);
+    expect(statuses.get('optimize')).toBe(RunStatus.Succeeded);
+    expect(statuses.get('publish')).toBe(RunStatus.Pending);
+  });
   const stages = [
     { id: 'validate_inputs', description: 'Validate pipeline inputs' },
     { id: 'download_and_sample', description: 'Download and sample' },

--- a/packages/autorag/frontend/src/app/topology/stageMapStatus.ts
+++ b/packages/autorag/frontend/src/app/topology/stageMapStatus.ts
@@ -7,7 +7,7 @@ import type { RunDetailsKF } from '~/app/types/pipeline';
 import type { PipelineNodeModelExpanded } from '~/app/types/topology';
 import { isRunInTerminalState, normalizePipelineRunState } from '~/app/utilities/utils';
 import { MAX_RAG_PATTERNS, MIN_RAG_PATTERNS } from '~/app/utilities/const';
-import { componentIdToTaskId } from '~/app/hooks/useComponentStatuses';
+import { componentIdToTaskId, getComponentStageStatus } from '~/app/hooks/useComponentStatuses';
 import { dedupePreservingOrder } from './stageMapConstants';
 import { parseRuntimeInfoFromRunDetails, translateStatusForNode } from './parseUtils';
 
@@ -26,6 +26,7 @@ export const translateStageStatus = (status?: string): RunStatus | undefined => 
     case 'completed':
       return RunStatus.Succeeded;
     case 'started':
+    case 'running':
       return RunStatus.InProgress;
     case 'failed':
       return RunStatus.Failed;
@@ -119,7 +120,7 @@ export const resolveStageRunStatus = (
   hasExplicitFailureInPipeline = false,
 ): RunStatus | undefined => {
   const terminalRunFailure = getTerminalRunFailureStatus(runState, hasExplicitFailureInPipeline);
-  const inlineStatus = translateStageStatus(stage.status);
+  const inlineStatus = translateStageStatus(getComponentStageStatus(stage.status));
   if (inlineStatus != null) {
     if (terminalRunFailure != null && inlineStatus === RunStatus.InProgress) {
       return terminalRunFailure;
@@ -155,7 +156,8 @@ export const isStageTerminalFailure = (status: RunStatus | undefined): boolean =
 
 /** True when the backend reported this stage failed (not inferred from component-level status). */
 export const isInlineStageFailure = (stage?: ComponentStageMapStage): boolean =>
-  translateStageStatus(stage?.status) === RunStatus.Failed;
+  translateStageStatus(stage ? getComponentStageStatus(stage.status) : undefined) ===
+  RunStatus.Failed;
 
 /** True when a pre-branch stage (before optimize_templates) failed inline. */
 export const hasPreBranchInlineFailure = (preBranchStages: ComponentStageMapStage[]): boolean =>
@@ -181,12 +183,17 @@ export const resolveSequentialStageRunStatuses = (
   let blockSubsequent = false;
   let blockedByInlineFailure = false;
   let propagatedTerminal: RunStatus | undefined;
+  const hasInlineStatuses = stages.some((stage) => typeof stage.status === 'object');
+  const latestActivityIndex = stages.reduce(
+    (latest, stage, index) => (typeof stage.status === 'object' ? index : latest),
+    -1,
+  );
 
   const resolveUnresolved = (stage: ComponentStageMapStage): RunStatus | undefined =>
     resolveStageRunStatus(stage, componentStatus, runState, hasExplicitFailureInPipeline);
 
-  for (const stage of stages) {
-    const inlineStatus = translateStageStatus(stage.status);
+  for (const [stageIndex, stage] of stages.entries()) {
+    const inlineStatus = translateStageStatus(getComponentStageStatus(stage.status));
 
     if (inlineStatus != null) {
       const resolved = resolveUnresolved(stage);
@@ -219,6 +226,10 @@ export const resolveSequentialStageRunStatuses = (
         continue;
       }
       if (componentStatus === RunStatus.InProgress) {
+        if (hasInlineStatuses && stageIndex > latestActivityIndex) {
+          statusById.set(stage.id, RunStatus.Pending);
+          continue;
+        }
         const resolved = resolveUnresolved(stage);
         if (isStageFinished(resolved)) {
           statusById.set(stage.id, resolved);
@@ -245,6 +256,10 @@ export const resolveSequentialStageRunStatuses = (
     }
 
     if (componentStatus === RunStatus.InProgress) {
+      if (hasInlineStatuses && stageIndex > latestActivityIndex) {
+        statusById.set(stage.id, RunStatus.Pending);
+        continue;
+      }
       const resolved = resolveUnresolved(stage);
       if (isStageFinished(resolved)) {
         statusById.set(stage.id, resolved);
@@ -441,7 +456,9 @@ export const resolvePromotedNodeActiveIconVariant = (
 /** True when every stage has a recognized inline status (no unresolved gaps). */
 const hasCompleteInlineStageStatus = (component: ComponentStageMapComponent): boolean =>
   component.stages.length > 0 &&
-  component.stages.every((stage) => translateStageStatus(stage.status) != null);
+  component.stages.every(
+    (stage) => translateStageStatus(getComponentStageStatus(stage.status)) != null,
+  );
 
 /** True when any mapped component has explicit task or inline stage failure evidence. */
 export const hasExplicitComponentFailureEvidence = (

--- a/packages/autorag/frontend/src/app/topology/tree-view/stageMapStepMetadata.ts
+++ b/packages/autorag/frontend/src/app/topology/tree-view/stageMapStepMetadata.ts
@@ -3,7 +3,10 @@ import type {
   ComponentStageMapComponent,
   ComponentStageMapStage,
 } from '~/app/hooks/useComponentStageMap';
-import { findComponentTaskInRunDetails } from '~/app/hooks/useComponentStatuses';
+import {
+  findComponentTaskInRunDetails,
+  getComponentStageStatus,
+} from '~/app/hooks/useComponentStatuses';
 import type { PipelineRun } from '~/app/types';
 import {
   isAllowedFlattenKey,
@@ -38,6 +41,8 @@ const STAGE_FIELD_LABELS: Record<string, string> = {
   export_path: 'Export path',
   output_path: 'Output path',
   best_pattern: 'Best pattern',
+  completed_units: 'Completed units',
+  total_units: 'Total units',
 };
 
 /** Fields to show with "—" when pending/failed/unreached and values are not yet on the stage record. */
@@ -204,6 +209,9 @@ function flattenStageRecord(stage: ComponentStageMapStage): Record<string, unkno
 
   for (const [key, value] of Object.entries(stage)) {
     if (NESTED_STAGE_FIELD_KEY_SET.has(key)) {
+      if (key === 'metrics') {
+        continue;
+      }
       if (isPlainObject(value)) {
         for (const [nestedKey, nestedValue] of Object.entries(value)) {
           if (isAllowedFlattenKey(nestedKey) && nestedValue != null) {
@@ -288,9 +296,10 @@ const hasStageExecutionEvidence = (
   stepState?: StepExecutionState,
 ): boolean =>
   stage.timestamp != null ||
-  stage.status === 'started' ||
-  stage.status === 'completed' ||
-  stage.status === 'failed' ||
+  getComponentStageStatus(stage.status) === 'started' ||
+  getComponentStageStatus(stage.status) === 'running' ||
+  getComponentStageStatus(stage.status) === 'completed' ||
+  getComponentStageStatus(stage.status) === 'failed' ||
   stepState === 'failed' ||
   stepState === 'active' ||
   stepState === 'completed';
@@ -317,8 +326,8 @@ const isTerminalStageState = (
   stage: ComponentStageMapStage,
   stepState?: StepExecutionState,
 ): boolean =>
-  stage.status === 'completed' ||
-  stage.status === 'failed' ||
+  getComponentStageStatus(stage.status) === 'completed' ||
+  getComponentStageStatus(stage.status) === 'failed' ||
   stepState === 'completed' ||
   stepState === 'failed';
 
@@ -326,9 +335,10 @@ const shouldUseTaskEndTime = (
   stage: ComponentStageMapStage,
   stepState?: StepExecutionState,
 ): boolean =>
-  stage.status === 'failed' ||
-  stage.status === 'started' ||
-  stage.status === 'completed' ||
+  getComponentStageStatus(stage.status) === 'failed' ||
+  getComponentStageStatus(stage.status) === 'started' ||
+  getComponentStageStatus(stage.status) === 'running' ||
+  getComponentStageStatus(stage.status) === 'completed' ||
   stepState === 'failed' ||
   stepState === 'active' ||
   stepState === 'completed';
@@ -348,9 +358,10 @@ const resolveStageStartTime = (
     return previousStage.timestamp;
   }
   if (
-    stage?.status === 'started' ||
-    stage?.status === 'failed' ||
-    stage?.status === 'completed' ||
+    getComponentStageStatus(stage?.status) === 'started' ||
+    getComponentStageStatus(stage?.status) === 'running' ||
+    getComponentStageStatus(stage?.status) === 'failed' ||
+    getComponentStageStatus(stage?.status) === 'completed' ||
     stepState === 'active' ||
     stepState === 'failed' ||
     stepState === 'completed' ||
@@ -436,7 +447,27 @@ function buildDetailsFromStageRecord(
 ): StepDetail[] {
   const details: StepDetail[] = [{ label: 'Duration', value: duration ?? '—' }];
 
+  if (isPlainObject(stage.status)) {
+    details.push({ label: 'State', value: stage.status.state });
+    if (isPlainObject(stage.status.message) && typeof stage.status.message.text === 'string') {
+      details.push({ label: 'Message', value: stage.status.message.text });
+    }
+    if (typeof stage.status.running_at === 'string') {
+      details.push({ label: 'Running at', value: stage.status.running_at });
+    }
+    if (stage.status.state === 'failed' && isPlainObject(stage.error)) {
+      details.push({ label: 'Error', value: formatStageFieldValue('error', stage.error) });
+    }
+  }
+
   const flattened = flattenStageRecord(stage);
+  if (isPlainObject(stage.metrics)) {
+    for (const [key, value] of Object.entries(stage.metrics)) {
+      if (value != null) {
+        flattened[key] = value;
+      }
+    }
+  }
   const orderedKeys = resolveDetailFieldKeys(flattened, stepState, stageId);
 
   for (const key of orderedKeys) {
@@ -584,4 +615,16 @@ export function getStageDescriptionFromMap(
     return undefined;
   }
   return findStage(component, parsed.stageId)?.description;
+}
+
+export function getComponentDisplayName(
+  parsed: ParsedStageMapNode,
+  componentStageMap: ComponentStageMap,
+): string | undefined {
+  const component = findComponent(componentStageMap, parsed.componentId);
+  if (!component) {
+    return undefined;
+  }
+  const displayName = component.metadata?.display_name;
+  return typeof displayName === 'string' ? displayName : component.description;
 }

--- a/packages/autorag/frontend/tsconfig.json
+++ b/packages/autorag/frontend/tsconfig.json
@@ -8,6 +8,7 @@
       "es2021",
       "dom",
       "ES2022.Object",
+      "ES2022.Array",
       "ES2023.Array"
     ],
     "sourceMap": true,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-90241
https://redhat.atlassian.net/browse/RHOAIENG-90242

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
