### PR TITLE
Fix NIM image field with unavailable account

### DIFF
--- a/packages/nim-serving/src/api/accounts/__tests__/hooks.spec.ts
+++ b/packages/nim-serving/src/api/accounts/__tests__/hooks.spec.ts
@@ -14,6 +14,19 @@ describe('useNIMAccountStatus', () => {
     jest.clearAllMocks();
   });
 
+  it('should expose Account list errors without marking the request loaded', async () => {
+    const error = new Error('Forbidden');
+    mockListNIMAccounts.mockRejectedValue(error);
+
+    const renderResult = testHook(useNIMAccountStatus)('test-ns');
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current.loaded).toBe(false);
+    expect(renderResult.result.current.loadError).toBe(error);
+    expect(renderResult.result.current.nimAccount).toBeNull();
+    expect(renderResult.result.current.status).toBe(NIMAccountStatus.LOADING);
+  });
+
   it('should return NOT_FOUND when no account exists', async () => {
     mockListNIMAccounts.mockResolvedValue([]);
 

--- a/packages/nim-serving/src/api/accounts/hooks.ts
+++ b/packages/nim-serving/src/api/accounts/hooks.ts
@@ -16,6 +16,7 @@ type NIMAccountStatusResult = {
   nimAccount: NIMAccountKind | null;
   errorMessages: string[];
   loaded: boolean;
+  loadError?: Error;
   refresh: () => Promise<NIMAccountKind | null | undefined>;
   startRevalidation: () => void;
 };
@@ -40,6 +41,7 @@ const useNIMAccountStatus = (namespace?: string): NIMAccountStatusResult => {
   const {
     data: nimAccount,
     loaded,
+    error: loadError,
     refresh,
   } = useFetch(fetchCallback, null, {
     refreshRate: pollRate,
@@ -89,6 +91,7 @@ const useNIMAccountStatus = (namespace?: string): NIMAccountStatusResult => {
     nimAccount,
     errorMessages: effectiveErrors,
     loaded,
+    loadError,
     refresh,
     startRevalidation,
   };

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -27,17 +27,20 @@ export const isNIMImageFieldExternalData = (data: unknown): data is NIMImageFiel
 export type NIMImageFieldExternalData = {
   nimImages: NIMImagesData;
   accountStatus: NIMAccountStatus;
+  nimImagesLoaded?: boolean;
   nimTemplate?: TemplateKind;
 };
 
 export const useNIMImageFieldExternalData = (dependencies?: {
   project?: { projectName?: string };
+  isEditing?: boolean;
 }): {
   data: NIMImageFieldExternalData;
   loaded: boolean;
   loadError?: Error;
 } => {
   const projectName = dependencies?.project?.projectName;
+  const isEditing = dependencies?.isEditing ?? false;
   const {
     status: accountStatus,
     nimAccount,
@@ -70,22 +73,33 @@ export const useNIMImageFieldExternalData = (dependencies?: {
   // Account failures and terminal Account states must settle the field. Dependent image/template
   // requests cannot load without an Account, and edits must not remain blocked by those requests.
   const loaded =
+    isEditing ||
     !projectName ||
     accountTerminal ||
     ((imagesLoaded || !!loadError) && accountLoaded && (nimTemplateLoaded || !!nimTemplateError));
 
   return React.useMemo(
     () => ({
-      data: { nimImages, accountStatus, nimTemplate },
+      data: { nimImages, accountStatus, nimImagesLoaded: imagesLoaded, nimTemplate },
       loaded,
       loadError: accountLoadError ?? loadError ?? nimTemplateError,
     }),
-    [nimImages, accountStatus, nimTemplate, loaded, accountLoadError, loadError, nimTemplateError],
+    [
+      nimImages,
+      accountStatus,
+      imagesLoaded,
+      nimTemplate,
+      loaded,
+      accountLoadError,
+      loadError,
+      nimTemplateError,
+    ],
   );
 };
 
 export type NIMImageDependencies = {
   project: ProjectSectionType;
+  isEditing: boolean;
 };
 
 export type NIMImageFieldValue = {
@@ -206,7 +220,8 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
   const isReselectionUnlocked = reselectionUnlockedRef.current;
 
   const selectedKey = value?.repository && value.tag ? getImageOptionKey(value) : undefined;
-  const catalogLoadedWithImages = Boolean(externalData?.loaded && images.length > 0);
+  const catalogLoadedWithImages = Boolean(externalData?.data.nimImagesLoaded && images.length > 0);
+  const isImageCatalogLoaded = externalData?.data.nimImagesLoaded ?? externalData?.loaded ?? false;
   const isImageSelectionLocked = isNIMImageSelectionLocked(
     isEditing,
     value,
@@ -308,7 +323,7 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
           </HelperTextItem>
         </HelperText>
       )}
-      {existingOptionNotFound && !externalData.loadError && (
+      {existingOptionNotFound && isImageCatalogLoaded && !externalData.loadError && (
         <HelperText>
           <HelperTextItem variant="warning" data-testid="nim-image-not-found-warning">
             The existing NIM image was not found. The deployment may not work as expected.
@@ -336,7 +351,10 @@ export const NIMImageFieldWizardField: NIMImageFieldType = {
     getInitialFieldData: (existingFieldData?: NIMImageFieldValue): NIMImageFieldValue =>
       existingFieldData ?? { repository: '', tag: '' },
     validationSchema: nimImageFieldSchema,
-    resolveDependencies: (formData) => ({ project: formData.project }),
+    resolveDependencies: (formData, initialData) => ({
+      project: formData.project,
+      isEditing: initialData?.isEditing ?? false,
+    }),
     getFieldOverrides: getNIMHardwareProfileFieldOverrides,
   },
   component: NIMImageFieldComponent,

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -220,8 +220,16 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
   const isReselectionUnlocked = reselectionUnlockedRef.current;
 
   const selectedKey = value?.repository && value.tag ? getImageOptionKey(value) : undefined;
-  const catalogLoadedWithImages = Boolean(externalData?.data.nimImagesLoaded && images.length > 0);
+  const accountStatus = externalData?.data.accountStatus ?? NIMAccountStatus.LOADING;
+  const catalogLoadedWithImages = Boolean(
+    externalData?.data.nimImagesLoaded &&
+      images.length > 0 &&
+      accountStatus === NIMAccountStatus.READY,
+  );
   const isImageCatalogLoaded = externalData?.data.nimImagesLoaded ?? externalData?.loaded ?? false;
+  const canConfirmImageIsMissing = isImageCatalogLoaded && accountStatus === NIMAccountStatus.READY;
+  const shouldShowImagePreservedMessage =
+    isEditing && (Boolean(externalData?.loadError) || accountStatus !== NIMAccountStatus.READY);
   const isImageSelectionLocked = isNIMImageSelectionLocked(
     isEditing,
     value,
@@ -242,8 +250,6 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
     },
     [options, onChange, isImageSelectionLocked],
   );
-
-  const accountStatus = externalData?.data.accountStatus ?? NIMAccountStatus.LOADING;
 
   if (!externalData || !externalData.loaded) {
     return (
@@ -314,16 +320,22 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
           }
         }}
       />
-      {externalData.loadError && (
+      {shouldShowImagePreservedMessage && (
         <HelperText>
           <HelperTextItem variant="error">
-            {isEditing
-              ? 'NVIDIA NIM account information could not be loaded. The deployed image is preserved but cannot be changed.'
-              : 'There was a problem fetching the NIM models. Please try again later.'}
+            NVIDIA NIM account information could not be loaded. The deployed image is preserved but
+            cannot be changed.
           </HelperTextItem>
         </HelperText>
       )}
-      {existingOptionNotFound && isImageCatalogLoaded && !externalData.loadError && (
+      {!isEditing && externalData.loadError && (
+        <HelperText>
+          <HelperTextItem variant="error">
+            There was a problem fetching the NIM models. Please try again later.
+          </HelperTextItem>
+        </HelperText>
+      )}
+      {existingOptionNotFound && canConfirmImageIsMissing && !externalData.loadError && (
         <HelperText>
           <HelperTextItem variant="warning" data-testid="nim-image-not-found-warning">
             The existing NIM image was not found. The deployment may not work as expected.

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -228,8 +228,10 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
   );
   const isImageCatalogLoaded = externalData?.data.nimImagesLoaded ?? externalData?.loaded ?? false;
   const canConfirmImageIsMissing = isImageCatalogLoaded && accountStatus === NIMAccountStatus.READY;
+  const accountRequestSettled =
+    accountStatus !== NIMAccountStatus.LOADING || Boolean(externalData?.loadError);
   const shouldShowImagePreservedMessage =
-    isEditing && (Boolean(externalData?.loadError) || accountStatus !== NIMAccountStatus.READY);
+    isEditing && accountRequestSettled && accountStatus !== NIMAccountStatus.READY;
   const isImageSelectionLocked = isNIMImageSelectionLocked(
     isEditing,
     value,

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -30,7 +30,7 @@ export type NIMImageFieldExternalData = {
   nimTemplate?: TemplateKind;
 };
 
-const useNIMImageFieldExternalData = (dependencies?: {
+export const useNIMImageFieldExternalData = (dependencies?: {
   project?: { projectName?: string };
 }): {
   data: NIMImageFieldExternalData;
@@ -42,6 +42,7 @@ const useNIMImageFieldExternalData = (dependencies?: {
     status: accountStatus,
     nimAccount,
     loaded: accountLoaded,
+    loadError: accountLoadError,
   } = useNIMAccountStatus(projectName);
 
   const {
@@ -61,18 +62,25 @@ const useNIMImageFieldExternalData = (dependencies?: {
     loaded: nimTemplateLoaded,
   } = useFetchNIMTemplate(nimAccount);
 
-  // Show as loaded if there is an error, otherwise loaded is false (for example existing deployments don't care)
+  const accountTerminal =
+    !!accountLoadError ||
+    accountStatus === NIMAccountStatus.NOT_FOUND ||
+    accountStatus === NIMAccountStatus.ERROR;
+
+  // Account failures and terminal Account states must settle the field. Dependent image/template
+  // requests cannot load without an Account, and edits must not remain blocked by those requests.
   const loaded =
     !projectName ||
+    accountTerminal ||
     ((imagesLoaded || !!loadError) && accountLoaded && (nimTemplateLoaded || !!nimTemplateError));
 
   return React.useMemo(
     () => ({
       data: { nimImages, accountStatus, nimTemplate },
       loaded,
-      loadError: loadError ?? nimTemplateError,
+      loadError: accountLoadError ?? loadError ?? nimTemplateError,
     }),
-    [nimImages, accountStatus, nimTemplate, loaded, loadError, nimTemplateError],
+    [nimImages, accountStatus, nimTemplate, loaded, accountLoadError, loadError, nimTemplateError],
   );
 };
 
@@ -238,7 +246,20 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
     );
   }
 
+  const isAccountLoadFailed =
+    accountStatus === NIMAccountStatus.LOADING && Boolean(externalData.loadError);
+
+  if (!isEditing && isAccountLoadFailed) {
+    return (
+      <Alert variant="danger" isInline title="Unable to load NVIDIA NIM account">
+        NVIDIA NIM account information could not be loaded for this project. Ask your project
+        administrator to verify that you have permission to view NIM accounts, then try again.
+      </Alert>
+    );
+  }
+
   const isNIMUnconfigured =
+    !isEditing &&
     (accountStatus === NIMAccountStatus.NOT_FOUND || accountStatus === NIMAccountStatus.ERROR) &&
     images.length === 0;
 
@@ -281,7 +302,9 @@ const NIMImageFieldComponent: React.FC<NIMImageFieldComponentProps> = ({
       {externalData.loadError && (
         <HelperText>
           <HelperTextItem variant="error">
-            There was a problem fetching the NIM models. Please try again later.
+            {isEditing
+              ? 'NVIDIA NIM account information could not be loaded. The deployed image is preserved but cannot be changed.'
+              : 'There was a problem fetching the NIM models. Please try again later.'}
           </HelperTextItem>
         </HelperText>
       )}

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
@@ -200,9 +200,11 @@ describe('NIMImageFieldComponent', () => {
       value: { repository: 'nvcr.io/nim/test/legacy-model', tag: '9.9.9' },
       externalData: {
         data: {
+          // The image hook resolves an empty list once the Account list has completed, even
+          // though no Account exists. This must not be treated as a catalog lookup.
           nimImages: { images: [], projectName: 'test-project' },
           accountStatus: NIMAccountStatus.NOT_FOUND,
-          nimImagesLoaded: false,
+          nimImagesLoaded: true,
         },
         loaded: true,
       },
@@ -212,6 +214,31 @@ describe('NIMImageFieldComponent', () => {
     expect(screen.getByRole('combobox')).toHaveValue('nvcr.io/nim/test/legacy-model:9.9.9');
     expect(screen.queryByRole('button', { name: 'Clear input value' })).not.toBeInTheDocument();
     expect(screen.queryByText('No NVIDIA NIM key', { exact: false })).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/NVIDIA NIM account information could not be loaded/),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('nim-image-not-found-warning')).not.toBeInTheDocument();
+  });
+
+  it('should preserve and lock the raw image while editing with a pending Account', () => {
+    renderComponent({
+      isEditing: true,
+      value: { repository: 'nvcr.io/nim/test/legacy-model', tag: '9.9.9' },
+      externalData: {
+        data: {
+          nimImages: { images: [], projectName: 'test-project' },
+          accountStatus: NIMAccountStatus.PENDING,
+          nimImagesLoaded: true,
+        },
+        loaded: true,
+      },
+    });
+
+    expect(screen.getByRole('combobox')).toHaveValue('nvcr.io/nim/test/legacy-model:9.9.9');
+    expect(
+      screen.getByText(/NVIDIA NIM account information could not be loaded/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Clear input value' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('nim-image-not-found-warning')).not.toBeInTheDocument();
   });
 

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
@@ -194,6 +194,26 @@ describe('NIMImageFieldComponent', () => {
     expect(screen.queryByTestId('nim-image-select')).not.toBeInTheDocument();
   });
 
+  it('should not show the preserved-image message while the Account request is loading', () => {
+    renderComponent({
+      isEditing: true,
+      value: { repository: 'nvcr.io/nim/test/legacy-model', tag: '9.9.9' },
+      externalData: {
+        data: {
+          nimImages: { images: [], projectName: 'test-project' },
+          accountStatus: NIMAccountStatus.LOADING,
+          nimImagesLoaded: false,
+        },
+        loaded: true,
+      },
+    });
+
+    expect(screen.getByRole('combobox')).toHaveValue('nvcr.io/nim/test/legacy-model:9.9.9');
+    expect(
+      screen.queryByText(/NVIDIA NIM account information could not be loaded/),
+    ).not.toBeInTheDocument();
+  });
+
   it('should preserve and lock the raw image while editing without an Account', () => {
     renderComponent({
       isEditing: true,

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
@@ -177,6 +177,63 @@ describe('NIMImageFieldComponent', () => {
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
+  it('should show an actionable error when the Account request fails during creation', () => {
+    renderComponent({
+      externalData: {
+        data: {
+          nimImages: { images: [], projectName: 'test-project' },
+          accountStatus: NIMAccountStatus.LOADING,
+        },
+        loaded: true,
+        loadError: new Error('Forbidden'),
+      },
+    });
+
+    expect(screen.getByText('Unable to load NVIDIA NIM account')).toBeInTheDocument();
+    expect(screen.getByText(/permission to view NIM accounts/)).toBeInTheDocument();
+    expect(screen.queryByTestId('nim-image-select')).not.toBeInTheDocument();
+  });
+
+  it('should preserve and lock the raw image while editing without an Account', () => {
+    renderComponent({
+      isEditing: true,
+      value: { repository: 'nvcr.io/nim/test/legacy-model', tag: '9.9.9' },
+      externalData: {
+        data: {
+          nimImages: { images: [], projectName: 'test-project' },
+          accountStatus: NIMAccountStatus.NOT_FOUND,
+        },
+        loaded: true,
+      },
+    });
+
+    expect(screen.getByTestId('nim-image-select')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveValue('nvcr.io/nim/test/legacy-model:9.9.9');
+    expect(screen.queryByRole('button', { name: 'Clear input value' })).not.toBeInTheDocument();
+    expect(screen.queryByText('No NVIDIA NIM key', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('should preserve and lock the raw image while editing after an Account request failure', () => {
+    renderComponent({
+      isEditing: true,
+      value: { repository: 'nvcr.io/nim/test/legacy-model', tag: '9.9.9' },
+      externalData: {
+        data: {
+          nimImages: { images: [], projectName: 'test-project' },
+          accountStatus: NIMAccountStatus.LOADING,
+        },
+        loaded: true,
+        loadError: new Error('Forbidden'),
+      },
+    });
+
+    expect(screen.getByRole('combobox')).toHaveValue('nvcr.io/nim/test/legacy-model:9.9.9');
+    expect(
+      screen.getByText(/deployed image is preserved but cannot be changed/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Clear input value' })).not.toBeInTheDocument();
+  });
+
   it('should show skeleton while account status and images are loading', () => {
     renderComponent({
       externalData: {

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
@@ -202,6 +202,7 @@ describe('NIMImageFieldComponent', () => {
         data: {
           nimImages: { images: [], projectName: 'test-project' },
           accountStatus: NIMAccountStatus.NOT_FOUND,
+          nimImagesLoaded: false,
         },
         loaded: true,
       },
@@ -211,6 +212,7 @@ describe('NIMImageFieldComponent', () => {
     expect(screen.getByRole('combobox')).toHaveValue('nvcr.io/nim/test/legacy-model:9.9.9');
     expect(screen.queryByRole('button', { name: 'Clear input value' })).not.toBeInTheDocument();
     expect(screen.queryByText('No NVIDIA NIM key', { exact: false })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('nim-image-not-found-warning')).not.toBeInTheDocument();
   });
 
   it('should preserve and lock the raw image while editing after an Account request failure', () => {
@@ -265,6 +267,7 @@ describe('NIMImageFieldComponent', () => {
         projectName: 'test-project',
       },
       accountStatus: NIMAccountStatus.READY,
+      nimImagesLoaded: true,
     },
     loaded: true,
   };

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageFieldExternalData.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageFieldExternalData.spec.ts
@@ -1,0 +1,87 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import useNIMAccountStatus, { NIMAccountStatus } from '../../../../api/accounts/hooks';
+import { useNIMImages } from '../../../../api/images/hooks';
+import { useFetchNIMTemplate } from '../../../../api/servingruntime/useFetchNIMTemplate';
+import { useNIMImageFieldExternalData } from '../NIMImageField';
+
+jest.mock('../../../../api/accounts/hooks', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  NIMAccountStatus: {
+    LOADING: 'LOADING',
+    NOT_FOUND: 'NOT_FOUND',
+    PENDING: 'PENDING',
+    ERROR: 'ERROR',
+    READY: 'READY',
+  },
+}));
+
+jest.mock('../../../../api/images/hooks', () => ({
+  useNIMImages: jest.fn(),
+}));
+
+jest.mock('../../../../api/servingruntime/useFetchNIMTemplate', () => ({
+  useFetchNIMTemplate: jest.fn(),
+}));
+
+const mockUseNIMAccountStatus = jest.mocked(useNIMAccountStatus);
+const mockUseNIMImages = jest.mocked(useNIMImages);
+const mockUseFetchNIMTemplate = jest.mocked(useFetchNIMTemplate);
+
+const NOT_READY_IMAGES = {
+  data: { images: [], projectName: 'test-project' },
+  loaded: false,
+};
+
+const NOT_READY_TEMPLATE = {
+  data: undefined,
+  loaded: false,
+  error: undefined,
+  refresh: jest.fn(),
+};
+
+describe('useNIMImageFieldExternalData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNIMImages.mockReturnValue(NOT_READY_IMAGES);
+    mockUseFetchNIMTemplate.mockReturnValue(NOT_READY_TEMPLATE);
+  });
+
+  it('should not block editing while the NIM Account is pending', () => {
+    mockUseNIMAccountStatus.mockReturnValue({
+      status: NIMAccountStatus.PENDING,
+      nimAccount: null,
+      errorMessages: [],
+      loaded: true,
+      refresh: jest.fn(),
+      startRevalidation: jest.fn(),
+    });
+
+    const result = testHook(useNIMImageFieldExternalData)({
+      project: { projectName: 'test-project' },
+      isEditing: true,
+    });
+
+    expect(result.result.current.loaded).toBe(true);
+    expect(result.result.current.data.nimImagesLoaded).toBe(false);
+  });
+
+  it('should not mark a missing Account catalog as loaded', () => {
+    mockUseNIMAccountStatus.mockReturnValue({
+      status: NIMAccountStatus.NOT_FOUND,
+      nimAccount: null,
+      errorMessages: [],
+      loaded: true,
+      refresh: jest.fn(),
+      startRevalidation: jest.fn(),
+    });
+
+    const result = testHook(useNIMImageFieldExternalData)({
+      project: { projectName: 'test-project' },
+      isEditing: true,
+    });
+
+    expect(result.result.current.loaded).toBe(true);
+    expect(result.result.current.data.nimImagesLoaded).toBe(false);
+  });
+});

--- a/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
@@ -5,6 +5,7 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
+  Alert,
   Button,
   HelperText,
   HelperTextItem,
@@ -41,7 +42,8 @@ type NIMSettingsCardProps = {
 };
 
 const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
-  const { status, errorMessages, refresh, startRevalidation } = useNIMAccountStatus(namespace);
+  const { status, errorMessages, loadError, refresh, startRevalidation } =
+    useNIMAccountStatus(namespace);
 
   const { loaded: accessReviewLoaded, allowed } = useNIMSettingsAccessAllowed(namespace);
 
@@ -95,8 +97,17 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
   }, [namespace, refresh, stopPollingDeleteStatus]);
 
   const renderFooterContent = () => {
-    if (!accessReviewLoaded || status === NIMAccountStatus.LOADING) {
+    if (!accessReviewLoaded || (status === NIMAccountStatus.LOADING && !loadError)) {
       return <Skeleton data-testid="nim-permissions-loading" height="35px" width="250px" />;
+    }
+
+    if (loadError) {
+      return (
+        <Alert variant="danger" isInline title="Unable to load NVIDIA NIM account">
+          NVIDIA NIM account information could not be loaded for this project. Ask your project
+          administrator to verify that you have permission to view NIM accounts, then try again.
+        </Alert>
+      );
     }
 
     const enableButton = (

--- a/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
@@ -73,6 +73,22 @@ describe('NIMSettingsCard', () => {
     expect(screen.queryByTestId('nim-enable-button')).not.toBeInTheDocument();
   });
 
+  it('should show an actionable error when the NIM Account request fails', () => {
+    mockUseNIMSettingsAccessAllowed.mockReturnValue({ loaded: true, allowed: false });
+    mockUseNIMAccountStatus.mockReturnValue({
+      ...defaultAccountStatus,
+      status: NIMAccountStatus.LOADING,
+      loaded: false,
+      loadError: new Error('Forbidden'),
+    });
+
+    render(<NIMSettingsCard namespace="test-ns" />);
+
+    expect(screen.getByText('Unable to load NVIDIA NIM account')).toBeInTheDocument();
+    expect(screen.getByText(/permission to view NIM accounts/)).toBeInTheDocument();
+    expect(screen.queryByTestId('nim-permissions-loading')).not.toBeInTheDocument();
+  });
+
   it('should show skeleton regardless of account status while RBAC loads', () => {
     mockUseNIMSettingsAccessAllowed.mockReturnValue({ loaded: false, allowed: undefined });
     mockUseNIMAccountStatus.mockReturnValue({


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-66492

## Description

Fix NIM image-field behavior when NIM Account data is unavailable, so users receive an actionable state instead of an indefinite loading skeleton.

- Propagate NIM Account-list request errors to the deployment field external-data hook.
- Keep **new NIM deployments** blocked with actionable Account configuration/access messaging when the Account is missing, invalid, or cannot be read.
- Allow **existing NIM deployment edits**, including legacy KServe NIM deployments created before `nimWizard`, to proceed regardless of Account status.
- Preserve the deployed image as a locked raw `repository:tag` value whenever the Account is not ready, missing, or inaccessible.
- Show a non-blocking explanation when the image is preserved but cannot be changed because Account data cannot be used.
- Only show the existing “NIM image was not found” warning after an Account is ready and a catalog lookup has successfully completed.
- Show an explicit Account-access error in Project settings when the Account-list request fails, instead of leaving the card on a loading skeleton.

## How Has This Been Tested?

Automated validation:

- `npm run test-unit --workspace=@odh-dashboard/nim-serving` — passed.
- `npm run type-check --workspace=@odh-dashboard/nim-serving` — passed.
- `npm run lint --workspace=@odh-dashboard/nim-serving` — passed with one existing restricted-import warning in `NIMSettingsLink.tsx`.
- `npm run type-check` — passed.
- `npm run lint` — passed with existing repository warnings only.
- `git diff --check` — passed.

### Manual verification matrix

For the **Account-list permission denied** row, use a namespace-scoped Role based on the default project edit permissions role, but remove all permissions for `accounts.nim.opendatahub.io`. Confirm through impersonation that the user can still edit and deploy normal project resources but cannot get, list, or watch NIM Account resources.

| NIM Account scenario | Create deployment | Edit NIM deployment (both legacy and non-legacy) | View NIM key in Project settings |
| --- | --- | --- | --- |
| No Account | Blocked; directs user to add a key (screenshot A). | Preserves and locks raw `repository:tag`; other fields remain editable (screenshot D). | Shows **Add personal API key** when permitted (screenshot G). |
| Invalid Account | Blocked with the invalid-key message (screenshot B). | Preserves and locks raw `repository:tag`; other fields remain editable (screenshot D). | Shows validation failure and key-management actions (screenshot H). |
| Pending Account | Shows the NIM image loading skeleton while validation is pending; image selection becomes available only after validation succeeds. | Preserves and locks raw `repository:tag`; other fields remain editable (screenshot D). | Shows pending-validation status and key-management actions (screenshot I). |
| Valid Account | Catalog loads and image selection is available. | Image remains locked if it is present in the catalog (screenshot E), or shows the missing-image warning and allows the user to select a different image (screenshot F). | Confirms saved key and offers Replace key / Remove (screenshot J). |
| Account list forbidden | Blocked with Account access/configuration guidance (screenshot C). | Preserves and locks raw `repository:tag`; other fields remain editable (screenshot D). | Shows the explicit Account-access error rather than an indefinite skeleton (screenshot K). |

### Screenshots

A: New NIM deployment blocked when no Account exists

<img width="1145" height="540" alt="Screenshot 2026-09-02 at 3 10 24 PM" src="https://github.com/user-attachments/assets/404e4fef-b3e7-4c68-b158-68dc70be375a" />

B: New NIM deployment blocked when Account has an invalid key

<img width="1191" height="546" alt="Screenshot 2026-09-02 at 3 16 24 PM" src="https://github.com/user-attachments/assets/c2881330-7852-4f92-86f8-bfd67b980494" />

C: New NIM deployment blocked when Account listing is forbidden

<img width="1108" height="571" alt="Screenshot 2026-09-01 at 4 58 03 PM" src="https://github.com/user-attachments/assets/14a17777-fcb0-4cf6-92a2-c19f43fe6c3c" />

D: Existing NIM deployment edit with issues fetching the Account, a missing Account or pending/invalid key on the Account

<img width="1109" height="537" alt="Screenshot 2026-09-01 at 5 05 45 PM" src="https://github.com/user-attachments/assets/c62ea44e-9e7c-41e9-9ec9-b49ef4cd8578" />

E: NIM deployment edit with a valid Account

<img width="1090" height="519" alt="Screenshot 2026-09-02 at 2 07 57 PM" src="https://github.com/user-attachments/assets/bbabc010-558b-4e4c-9fca-981aab4e56a7" />

F: NIM deployment edit with a valid Account and missing image

<img width="938" height="542" alt="Screenshot 2026-09-02 at 1 40 06 PM" src="https://github.com/user-attachments/assets/4b5748a7-35c3-481a-814c-fd47420cdb93" />

G: Normal settings tile with no Account

<img width="701" height="275" alt="Screenshot 2026-09-02 at 3 15 15 PM" src="https://github.com/user-attachments/assets/b53d053e-8e7a-44c1-9903-4550779eed7b" />

H: Settings tile with invalid key

<img width="699" height="362" alt="Screenshot 2026-09-02 at 3 18 20 PM" src="https://github.com/user-attachments/assets/0b327327-2753-4d85-a93a-3c5afd412205" />

I: Settings tile while validating key

<img width="696" height="369" alt="Screenshot 2026-09-02 at 3 22 32 PM" src="https://github.com/user-attachments/assets/093d65a6-0a66-4e3e-83eb-1507722921e5" />

J: Settings tile with valid key

<img width="691" height="299" alt="Screenshot 2026-09-02 at 3 34 34 PM" src="https://github.com/user-attachments/assets/1efb6764-6caf-4133-8d99-13d1593a79bd" />

K: Settings tile with account fetch error

<img width="704" height="342" alt="Screenshot 2026-09-02 at 3 36 31 PM" src="https://github.com/user-attachments/assets/8ad217ea-e9e9-4895-9978-55ab977c6d51" />


## Test Impact

Added/updated Jest coverage for:

- rejected NIM Account-list requests, including the Project settings error state;
- external-data readiness while editing with pending or missing Accounts;
- suppression of the preserved-image error while a normal Account request is still loading;
- creating a deployment when Account lookup fails;
- editing with no Account, a pending Account, or Account access denied;
- locked raw-image fallback and suppression of an unverified missing-image warning.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
