### PR TITLE
fix(feature-store): prevent breadcrumb link from blocking clicks below

### DIFF
--- a/packages/feature-store/src/screens/components/FeatureStoreBreadcrumb.scss
+++ b/packages/feature-store/src/screens/components/FeatureStoreBreadcrumb.scss
@@ -3,7 +3,11 @@
 // FIXME: Upstream still open — https://github.com/patternfly/patternfly/issues/7554 (breadcrumb icon underline). Re-check after PF ships fix (e.g. patternfly/patternfly#8184).
 .fs-link-button-with-icon {
   position: relative;
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
   text-decoration: none;
+  overflow: hidden;
 
   &::after {
     content: "\00A0";
@@ -15,5 +19,6 @@
     top: 3px;
     letter-spacing: 1000px;
     overflow: hidden;
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
## Description

The Feature Store breadcrumb link (`fs-link-button-with-icon`) uses a `::after` pseudo-element hack to render an underline under the icon. On dataset details pages, that decorative overlay could extend over the **Feature service** link in the details list and block clicks.

Verified running locally 

https://github.com/user-attachments/assets/a04ed709-a7c9-4d7b-a47f-a367396813b2


Cypress failure (reproduced locally on `main` with a fresh `public-cypress` build):

```
cy.click() failed because ... test-feature-service ... is being covered by another element:
<a class="fs-link-button-with-icon" href=".../feature-store/datasets">
```

This fix:
- Constrains the breadcrumb link to its content (`inline-flex`, `fit-content`)
- Clips the pseudo-element (`overflow: hidden`)
- Sets `pointer-events: none` on the decorative `::after` so it cannot intercept clicks

## How Has This Been Tested?

- `npm install` from repo root (clean `main` workspace)
- Fresh `frontend/public-cypress` build via `npm run cypress:server:build`
- Cypress mock test: `packages/cypress/cypress/tests/mocked/featureStore/featureDataSet.cy.ts` — **15/15 passing** (including `should navigate to feature service details when clicking feature service link`)

## Test Impact

Existing Cypress mock coverage in `featureDataSet.cy.ts` exercises the fixed click path; no new tests added.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved breadcrumb link behavior by preventing decorative underline elements from blocking clicks.
  - Updated breadcrumb link sizing and overflow handling for more consistent display of long labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->