### PR TITLE
 add cluster queue workload rows data layer

### DIFF
--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -10,6 +10,23 @@ export const NON_KUEUE_PROJECTS_MODAL_DESCRIPTION =
   'Data from the following projects is not displayed on the Infrastructure page because they do not use Kueue for workload admission.';
 export const NON_KUEUE_PROJECT_STATUS_LABEL = 'not Kueue-managed';
 
+export const CLUSTER_QUEUE_WORKLOADS_TABLE_DESCRIPTION =
+  'Workloads admitted or waiting in this cluster queue.';
+export const CLUSTER_QUEUE_WORKLOADS_EMPTY_TITLE = 'No workloads';
+export const CLUSTER_QUEUE_WORKLOADS_EMPTY_BODY = 'Admitted or waiting workloads will appear here.';
+export const CLUSTER_QUEUE_WORKLOADS_TYPE_HELP =
+  'Workload type: Workbench, Training, Model serving, Ray cluster, or Unknown (e.g. pipeline workloads without a dedicated integration).';
+
+export enum ClusterQueueWorkloadsToolbarFilterOptions {
+  name = 'name',
+  status = 'status',
+}
+
+export const clusterQueueWorkloadsFilterOptions: Record<string, string> = {
+  [ClusterQueueWorkloadsToolbarFilterOptions.name]: 'Name',
+  [ClusterQueueWorkloadsToolbarFilterOptions.status]: 'Status',
+};
+
 export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
 
 export const TREND_REFRESH_INTERVAL = 5 * 60 * 1000;

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -15,7 +15,7 @@ export const CLUSTER_QUEUE_WORKLOADS_TABLE_DESCRIPTION =
 export const CLUSTER_QUEUE_WORKLOADS_EMPTY_TITLE = 'No workloads';
 export const CLUSTER_QUEUE_WORKLOADS_EMPTY_BODY = 'Admitted or waiting workloads will appear here.';
 export const CLUSTER_QUEUE_WORKLOADS_TYPE_HELP =
-  'Workload type: Workbench, Training, Model serving, Ray cluster, or Unknown (e.g. pipeline workloads without a dedicated integration).';
+  'Workload type: Workbench, Training, Ray job, Model serving, Ray cluster, or Unknown (e.g. pipeline workloads without a dedicated integration).';
 
 export enum ClusterQueueWorkloadsToolbarFilterOptions {
   name = 'name',

--- a/packages/gpuaas/src/hooks/__tests__/useClusterQueueWorkloads.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useClusterQueueWorkloads.spec.ts
@@ -1,0 +1,65 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { QuotaUsageWorkloadStatuses, QuotaUsageWorkloadTypes } from '../../types';
+import useClusterQueueWorkloads from '../useClusterQueueWorkloads';
+import useWorkloadRows from '../useWorkloadRows';
+
+jest.mock('../useWorkloadRows', () => jest.fn());
+
+const useWorkloadRowsMock = jest.mocked(useWorkloadRows);
+
+describe('useClusterQueueWorkloads', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches workloads for the selected cluster queue only', () => {
+    const workloads = [
+      {
+        name: 'wl-1',
+        namespace: 'dsp-1',
+        project: 'dsp-1',
+        clusterQueue: 'gpu-cq',
+        type: QuotaUsageWorkloadTypes.Workbench,
+        status: QuotaUsageWorkloadStatuses.Queued,
+        localQueue: 'user-queue',
+        accelerators: 1,
+        queuePosition: 2,
+      },
+    ];
+
+    useWorkloadRowsMock.mockReturnValue({
+      data: {
+        mode: 'clusterQueues',
+        workloadsByClusterQueue: new Map([['gpu-cq', workloads]]),
+      },
+      loaded: true,
+      error: undefined,
+      refresh: jest.fn(),
+    });
+
+    const renderResult = testHook(useClusterQueueWorkloads)('gpu-cq');
+    expect(useWorkloadRowsMock).toHaveBeenCalledWith(
+      { mode: 'clusterQueues', clusterQueueNames: ['gpu-cq'] },
+      {},
+    );
+    expect(renderResult.result.current.workloads).toEqual(workloads);
+    expect(renderResult.result.current.isEmpty).toBe(false);
+  });
+
+  it('skips fetch when clusterQueueName is undefined', () => {
+    useWorkloadRowsMock.mockReturnValue({
+      data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
+      loaded: true,
+      error: undefined,
+      refresh: jest.fn(),
+    });
+
+    const renderResult = testHook(useClusterQueueWorkloads)(undefined);
+    expect(useWorkloadRowsMock).toHaveBeenCalledWith(
+      { mode: 'clusterQueues', clusterQueueNames: [] },
+      {},
+    );
+    expect(renderResult.result.current.workloads).toEqual([]);
+    expect(renderResult.result.current.isEmpty).toBe(true);
+  });
+});

--- a/packages/gpuaas/src/hooks/__tests__/useClusterQueueWorkloadsData.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useClusterQueueWorkloadsData.spec.ts
@@ -1,0 +1,118 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
+import useFetch from '@odh-dashboard/ui-core/hooks/useFetch';
+import { QuotaUsageWorkloadStatuses, QuotaUsageWorkloadTypes } from '../../types';
+import useClusterQueueWorkloadsData from '../useClusterQueueWorkloadsData';
+import { fetchWorkloadsForClusterQueues } from '../../utils/clusterQueueWorkloads';
+
+jest.mock('@odh-dashboard/internal/api/k8s/projects', () => ({
+  useProjects: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/ui-core/hooks/useFetch', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  NotReadyError: class NotReadyError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'NotReadyError';
+    }
+  },
+}));
+
+jest.mock('../../utils/clusterQueueWorkloads', () => ({
+  ...jest.requireActual('../../utils/clusterQueueWorkloads'),
+  fetchWorkloadsForClusterQueues: jest.fn(),
+}));
+
+const useProjectsMock = jest.mocked(useProjects);
+const useFetchMock = jest.mocked(useFetch);
+const fetchWorkloadsForClusterQueuesMock = jest.mocked(fetchWorkloadsForClusterQueues);
+
+const kueueProject = mockProjectK8sResource({ k8sName: 'dsp-1', enableKueue: true });
+
+describe('useClusterQueueWorkloadsData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useProjectsMock.mockReturnValue([[kueueProject], true, undefined]);
+    useFetchMock.mockImplementation((callback) => {
+      void callback({ signal: new AbortController().signal });
+      return {
+        data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      };
+    });
+  });
+
+  it('returns loading until projects and workloads are loaded', () => {
+    useProjectsMock.mockReturnValue([[], false, undefined]);
+    useFetchMock.mockReturnValue({
+      data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
+      loaded: false,
+      error: undefined,
+      refresh: jest.fn(),
+    });
+
+    const renderResult = testHook(useClusterQueueWorkloadsData)(['gpu-cq']);
+    expect(renderResult.result.current.loaded).toBe(false);
+  });
+
+  it('fetches workloads once for all cluster queues', () => {
+    const workloadsByClusterQueue = new Map([
+      [
+        'gpu-cq',
+        [
+          {
+            name: 'wl-1',
+            namespace: 'dsp-1',
+            project: 'dsp-1',
+            clusterQueue: 'gpu-cq',
+            type: QuotaUsageWorkloadTypes.Workbench,
+            status: QuotaUsageWorkloadStatuses.Queued,
+            localQueue: 'user-queue',
+            accelerators: 1,
+            queuePosition: 2,
+          },
+        ],
+      ],
+    ]);
+
+    fetchWorkloadsForClusterQueuesMock.mockResolvedValue(workloadsByClusterQueue);
+    useFetchMock.mockImplementation((callback) => {
+      void callback({ signal: new AbortController().signal });
+      return {
+        data: { mode: 'clusterQueues', workloadsByClusterQueue },
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      };
+    });
+
+    const renderResult = testHook(useClusterQueueWorkloadsData)(['gpu-cq', 'other-cq']);
+    expect(fetchWorkloadsForClusterQueuesMock).toHaveBeenCalledWith(
+      ['gpu-cq', 'other-cq'],
+      ['dsp-1'],
+      expect.any(Map),
+      false,
+    );
+    expect(renderResult.result.current.workloadsByClusterQueue.get('gpu-cq')).toHaveLength(1);
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('returns empty map when no cluster queues are provided', () => {
+    const renderResult = testHook(useClusterQueueWorkloadsData)([]);
+    expect(renderResult.result.current.workloadsByClusterQueue.size).toBe(0);
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('surfaces project watch errors', () => {
+    const error = new Error('projects failed');
+    useProjectsMock.mockReturnValue([[], true, error]);
+
+    const renderResult = testHook(useClusterQueueWorkloadsData)(['gpu-cq']);
+    expect(renderResult.result.current.error).toBe(error);
+  });
+});

--- a/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
@@ -158,4 +158,35 @@ describe('useWorkloadRows', () => {
     });
     expect(renderResult.result.current.loaded).toBe(false);
   });
+
+  it('returns loaded empty result for clusterQueues scope with no cluster queues', async () => {
+    useFetchMock.mockImplementation(() => {
+      return {
+        data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      };
+    });
+    useProjectsMock.mockReturnValue([[], false, new Error('projects failed')]);
+
+    testHook(useWorkloadRows)({ mode: 'clusterQueues', clusterQueueNames: [] });
+
+    const fetchCallback = useFetchMock.mock.calls[0][0];
+    await expect(fetchCallback({ signal: new AbortController().signal })).resolves.toEqual({
+      mode: 'clusterQueues',
+      workloadsByClusterQueue: new Map(),
+    });
+    expect(fetchWorkloadsForClusterQueuesMock).not.toHaveBeenCalled();
+  });
+
+  it('passes initialPromisePurity to useFetch', () => {
+    testHook(useWorkloadRows)({ mode: 'clusterQueues', clusterQueueNames: ['gpu-cq'] });
+
+    expect(useFetchMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.anything(),
+      expect.objectContaining({ initialPromisePurity: true }),
+    );
+  });
 });

--- a/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
@@ -1,0 +1,161 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
+import useFetch from '@odh-dashboard/ui-core/hooks/useFetch';
+import { QuotaUsageWorkloadStatuses, QuotaUsageWorkloadTypes } from '../../types';
+import useWorkloadRows from '../useWorkloadRows';
+import {
+  fetchNamespaceWorkloads,
+  fetchWorkloadsForClusterQueues,
+} from '../../utils/clusterQueueWorkloads';
+
+jest.mock('@odh-dashboard/internal/api/k8s/projects', () => ({
+  useProjects: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/ui-core/hooks/useFetch', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  NotReadyError: class NotReadyError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'NotReadyError';
+    }
+  },
+}));
+
+jest.mock('../../utils/clusterQueueWorkloads', () => ({
+  ...jest.requireActual('../../utils/clusterQueueWorkloads'),
+  fetchWorkloadsForClusterQueues: jest.fn(),
+  fetchNamespaceWorkloads: jest.fn(),
+}));
+
+const useProjectsMock = jest.mocked(useProjects);
+const useFetchMock = jest.mocked(useFetch);
+const fetchWorkloadsForClusterQueuesMock = jest.mocked(fetchWorkloadsForClusterQueues);
+const fetchNamespaceWorkloadsMock = jest.mocked(fetchNamespaceWorkloads);
+
+const kueueProject = mockProjectK8sResource({ k8sName: 'dsp-1', enableKueue: true });
+
+describe('useWorkloadRows', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useProjectsMock.mockReturnValue([[kueueProject], true, undefined]);
+    useFetchMock.mockImplementation((callback) => {
+      void callback({ signal: new AbortController().signal });
+      return {
+        data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      };
+    });
+  });
+
+  it('fetches workloads for all cluster queues in clusterQueues scope', () => {
+    const workloadsByClusterQueue = new Map([
+      [
+        'gpu-cq',
+        [
+          {
+            name: 'wl-1',
+            namespace: 'dsp-1',
+            project: 'dsp-1',
+            clusterQueue: 'gpu-cq',
+            type: QuotaUsageWorkloadTypes.Workbench,
+            status: QuotaUsageWorkloadStatuses.Queued,
+            localQueue: 'user-queue',
+            accelerators: 1,
+            queuePosition: 2,
+          },
+        ],
+      ],
+    ]);
+
+    fetchWorkloadsForClusterQueuesMock.mockResolvedValue(workloadsByClusterQueue);
+    useFetchMock.mockImplementation((callback) => {
+      void callback({ signal: new AbortController().signal });
+      return {
+        data: { mode: 'clusterQueues', workloadsByClusterQueue },
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      };
+    });
+
+    const renderResult = testHook(useWorkloadRows)({
+      mode: 'clusterQueues',
+      clusterQueueNames: ['gpu-cq', 'other-cq'],
+    });
+
+    expect(fetchWorkloadsForClusterQueuesMock).toHaveBeenCalledWith(
+      ['gpu-cq', 'other-cq'],
+      ['dsp-1'],
+      expect.any(Map),
+      false,
+    );
+    expect(renderResult.result.current.data.mode).toBe('clusterQueues');
+    if (renderResult.result.current.data.mode === 'clusterQueues') {
+      expect(renderResult.result.current.data.workloadsByClusterQueue.get('gpu-cq')).toHaveLength(
+        1,
+      );
+    }
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('fetches all workloads for a namespace scope', () => {
+    const workloads = [
+      {
+        name: 'wl-1',
+        namespace: 'dsp-1',
+        project: 'DSP 1',
+        clusterQueue: 'gpu-cq',
+        type: QuotaUsageWorkloadTypes.Serve,
+        status: QuotaUsageWorkloadStatuses.Admitted,
+        localQueue: 'user-queue',
+        accelerators: 1,
+        queuePosition: undefined,
+      },
+    ];
+
+    fetchNamespaceWorkloadsMock.mockResolvedValue(workloads);
+    useFetchMock.mockImplementation((callback) => {
+      void callback({ signal: new AbortController().signal });
+      return {
+        data: { mode: 'namespace', workloads },
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      };
+    });
+
+    const renderResult = testHook(useWorkloadRows)({
+      mode: 'namespace',
+      namespace: 'dsp-1',
+      projectDisplayName: 'DSP 1',
+    });
+
+    expect(fetchNamespaceWorkloadsMock).toHaveBeenCalledWith('dsp-1', 'DSP 1', false);
+    expect(renderResult.result.current.data.mode).toBe('namespace');
+    if (renderResult.result.current.data.mode === 'namespace') {
+      expect(renderResult.result.current.data.workloads).toHaveLength(1);
+    }
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('waits for projects in clusterQueues scope', () => {
+    useProjectsMock.mockReturnValue([[], false, undefined]);
+    useFetchMock.mockReturnValue({
+      data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
+      loaded: false,
+      error: undefined,
+      refresh: jest.fn(),
+    });
+
+    const renderResult = testHook(useWorkloadRows)({
+      mode: 'clusterQueues',
+      clusterQueueNames: ['gpu-cq'],
+    });
+    expect(renderResult.result.current.loaded).toBe(false);
+  });
+});

--- a/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
@@ -170,7 +170,10 @@ describe('useWorkloadRows', () => {
     });
     useProjectsMock.mockReturnValue([[], false, new Error('projects failed')]);
 
-    testHook(useWorkloadRows)({ mode: 'clusterQueues', clusterQueueNames: [] });
+    const renderResult = testHook(useWorkloadRows)({
+      mode: 'clusterQueues',
+      clusterQueueNames: [],
+    });
 
     const fetchCallback = useFetchMock.mock.calls[0][0];
     await expect(fetchCallback({ signal: new AbortController().signal })).resolves.toEqual({
@@ -178,6 +181,8 @@ describe('useWorkloadRows', () => {
       workloadsByClusterQueue: new Map(),
     });
     expect(fetchWorkloadsForClusterQueuesMock).not.toHaveBeenCalled();
+    expect(renderResult.result.current.loaded).toBe(true);
+    expect(renderResult.result.current.error).toBeUndefined();
   });
 
   it('passes initialPromisePurity to useFetch', () => {

--- a/packages/gpuaas/src/hooks/useClusterQueueWorkloads.ts
+++ b/packages/gpuaas/src/hooks/useClusterQueueWorkloads.ts
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import useWorkloadRows, { type UseWorkloadRowsOptions } from './useWorkloadRows';
+import type { ClusterQueueWorkloadRow, WorkloadRowsScope } from '../types';
+
+export type UseClusterQueueWorkloadsResult = {
+  workloads: ClusterQueueWorkloadRow[];
+  loaded: boolean;
+  error: Error | undefined;
+  isEmpty: boolean;
+  refresh: ReturnType<typeof useWorkloadRows>['refresh'];
+};
+
+/**
+ * Fetches workloads for one cluster queue — for drawer/panel UX when user selects a CQ.
+ * Pass undefined to skip fetch (drawer closed).
+ */
+const useClusterQueueWorkloads = (
+  clusterQueueName: string | undefined,
+  options: UseWorkloadRowsOptions = {},
+): UseClusterQueueWorkloadsResult => {
+  const scope = React.useMemo(
+    (): WorkloadRowsScope => ({
+      mode: 'clusterQueues',
+      clusterQueueNames: clusterQueueName ? [clusterQueueName] : [],
+    }),
+    [clusterQueueName],
+  );
+
+  const { data, loaded, error, refresh } = useWorkloadRows(scope, options);
+
+  const workloads = React.useMemo(() => {
+    if (!clusterQueueName || data.mode !== 'clusterQueues') {
+      return [];
+    }
+    return data.workloadsByClusterQueue.get(clusterQueueName) ?? [];
+  }, [clusterQueueName, data]);
+
+  return {
+    workloads,
+    loaded,
+    error,
+    isEmpty: loaded && !error && workloads.length === 0,
+    refresh,
+  };
+};
+
+export default useClusterQueueWorkloads;

--- a/packages/gpuaas/src/hooks/useClusterQueueWorkloadsData.ts
+++ b/packages/gpuaas/src/hooks/useClusterQueueWorkloadsData.ts
@@ -1,0 +1,34 @@
+import useWorkloadRows, { type UseWorkloadRowsOptions } from './useWorkloadRows';
+import type { ClusterQueueWorkloadRow } from '../types';
+
+export type UseClusterQueueWorkloadsDataOptions = UseWorkloadRowsOptions;
+
+export type UseClusterQueueWorkloadsDataResult = {
+  workloadsByClusterQueue: Map<string, ClusterQueueWorkloadRow[]>;
+  loaded: boolean;
+  error: Error | undefined;
+  refresh: ReturnType<typeof useWorkloadRows>['refresh'];
+};
+
+/** Batch fetch for multiple cluster queues. Drawer UX should use useClusterQueueWorkloads instead. */
+const useClusterQueueWorkloadsData = (
+  clusterQueueNames: string[],
+  options: UseClusterQueueWorkloadsDataOptions = {},
+): UseClusterQueueWorkloadsDataResult => {
+  const { data, loaded, error, refresh } = useWorkloadRows(
+    { mode: 'clusterQueues', clusterQueueNames },
+    options,
+  );
+
+  const workloadsByClusterQueue =
+    data.mode === 'clusterQueues' ? data.workloadsByClusterQueue : new Map();
+
+  return {
+    workloadsByClusterQueue,
+    loaded,
+    error,
+    refresh,
+  };
+};
+
+export default useClusterQueueWorkloadsData;

--- a/packages/gpuaas/src/hooks/useNamespaceWorkloads.ts
+++ b/packages/gpuaas/src/hooks/useNamespaceWorkloads.ts
@@ -17,20 +17,20 @@ const useNamespaceWorkloads = (
   projectDisplayName: string | undefined,
   options: UseNamespaceWorkloadsOptions = {},
 ): UseNamespaceWorkloadsResult => {
-  const scope =
-    namespace && projectDisplayName
-      ? { mode: 'namespace' as const, namespace, projectDisplayName }
-      : { mode: 'namespace' as const, namespace: '', projectDisplayName: '' };
+  const scope = namespace
+    ? { mode: 'namespace' as const, namespace, projectDisplayName: projectDisplayName ?? '' }
+    : { mode: 'namespace' as const, namespace: '', projectDisplayName: '' };
 
   const { data, loaded, error, refresh } = useWorkloadRows(scope, options);
 
-  const workloads = data.mode === 'namespace' ? data.workloads : [];
+  const workloads = namespace && data.mode === 'namespace' ? data.workloads : [];
+  const effectiveLoaded = namespace ? loaded : true;
 
   return {
-    workloads: namespace ? workloads : [],
-    loaded: namespace ? loaded : true,
+    workloads,
+    loaded: effectiveLoaded,
     error,
-    isEmpty: loaded && !error && workloads.length === 0,
+    isEmpty: effectiveLoaded && !error && workloads.length === 0,
     refresh,
   };
 };

--- a/packages/gpuaas/src/hooks/useNamespaceWorkloads.ts
+++ b/packages/gpuaas/src/hooks/useNamespaceWorkloads.ts
@@ -1,0 +1,38 @@
+import useWorkloadRows, { type UseWorkloadRowsOptions } from './useWorkloadRows';
+import type { ClusterQueueWorkloadRow } from '../types';
+
+export type UseNamespaceWorkloadsOptions = UseWorkloadRowsOptions;
+
+export type UseNamespaceWorkloadsResult = {
+  workloads: ClusterQueueWorkloadRow[];
+  loaded: boolean;
+  error: Error | undefined;
+  isEmpty: boolean;
+  refresh: ReturnType<typeof useWorkloadRows>['refresh'];
+};
+
+/** Future namespace tab: all workloads in one namespace, any cluster queue. */
+const useNamespaceWorkloads = (
+  namespace: string | undefined,
+  projectDisplayName: string | undefined,
+  options: UseNamespaceWorkloadsOptions = {},
+): UseNamespaceWorkloadsResult => {
+  const scope =
+    namespace && projectDisplayName
+      ? { mode: 'namespace' as const, namespace, projectDisplayName }
+      : { mode: 'namespace' as const, namespace: '', projectDisplayName: '' };
+
+  const { data, loaded, error, refresh } = useWorkloadRows(scope, options);
+
+  const workloads = data.mode === 'namespace' ? data.workloads : [];
+
+  return {
+    workloads: namespace ? workloads : [],
+    loaded: namespace ? loaded : true,
+    error,
+    isEmpty: loaded && !error && workloads.length === 0,
+    refresh,
+  };
+};
+
+export default useNamespaceWorkloads;

--- a/packages/gpuaas/src/hooks/useWorkloadRows.ts
+++ b/packages/gpuaas/src/hooks/useWorkloadRows.ts
@@ -129,12 +129,12 @@ const useWorkloadRows = (
         return { mode: 'namespace', workloads };
       }
 
-      if (!projectsLoaded) {
-        throw new NotReadyError('Projects not loaded');
-      }
-
       if (currentScope.clusterQueueNames.length === 0) {
         return { mode: 'clusterQueues', workloadsByClusterQueue: new Map() };
+      }
+
+      if (!projectsLoaded) {
+        throw new NotReadyError('Projects not loaded');
       }
 
       const workloadsByClusterQueue = await fetchWorkloadsForClusterQueues(
@@ -149,7 +149,7 @@ const useWorkloadRows = (
       // eslint-disable-next-line react-hooks/exhaustive-deps -- keys trigger refetch when inputs change
     }, [scopeKey, namespacesKey, projectDisplayNamesKey, includeTerminal, projectsLoaded]),
     initialFetchResult,
-    { refreshRate },
+    { refreshRate, initialPromisePurity: true },
   );
 
   const loaded = scope.mode === 'namespace' ? workloadsLoaded : projectsLoaded && workloadsLoaded;

--- a/packages/gpuaas/src/hooks/useWorkloadRows.ts
+++ b/packages/gpuaas/src/hooks/useWorkloadRows.ts
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import type { ProjectKind } from '@odh-dashboard/k8s-core';
+import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
+import useFetch, {
+  NotReadyError,
+  type FetchStateObject,
+} from '@odh-dashboard/ui-core/hooks/useFetch';
+import type { WorkloadRowsFetchResult, WorkloadRowsScope } from '../types';
+import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../const';
+import {
+  fetchNamespaceWorkloads,
+  fetchWorkloadsForClusterQueues,
+  getProjectDisplayName,
+} from '../utils/clusterQueueWorkloads';
+import { getKueueManagedDataScienceProjects } from '../utils/kueueProjects';
+
+export type UseWorkloadRowsOptions = {
+  /** When true, includes Complete and Failed workloads. Defaults to active-only. */
+  includeTerminal?: boolean;
+  refreshRate?: number;
+};
+
+export type UseWorkloadRowsResult = {
+  data: WorkloadRowsFetchResult;
+  loaded: boolean;
+  error: Error | undefined;
+  refresh: FetchStateObject<WorkloadRowsFetchResult>['refresh'];
+};
+
+const buildProjectDisplayNames = (projects: ProjectKind[]): Map<string, string> =>
+  new Map(
+    projects.flatMap((project) => {
+      const namespace = project.metadata.name;
+      return namespace ? [[namespace, getProjectDisplayName(project)] as const] : [];
+    }),
+  );
+
+const buildNamespacesKey = (namespaces: string[]): string =>
+  namespaces.toSorted((a, b) => a.localeCompare(b)).join('\0');
+
+const buildProjectDisplayNamesKey = (projectDisplayNames: Map<string, string>): string =>
+  [...projectDisplayNames.entries()]
+    .toSorted(([a], [b]) => a.localeCompare(b))
+    .map(([namespace, displayName]) => `${namespace}\0${displayName}`)
+    .join('\n');
+
+const buildClusterQueueNamesKey = (clusterQueueNames: string[]): string =>
+  clusterQueueNames.toSorted((a, b) => a.localeCompare(b)).join('\0');
+
+const buildNamespaceScopeKey = (namespace: string, projectDisplayName: string): string =>
+  `${namespace}\0${projectDisplayName}`;
+
+const getInitialFetchResult = (scope: WorkloadRowsScope): WorkloadRowsFetchResult =>
+  scope.mode === 'namespace'
+    ? { mode: 'namespace', workloads: [] }
+    : { mode: 'clusterQueues', workloadsByClusterQueue: new Map() };
+
+const buildScopeKey = (scope: WorkloadRowsScope): string => {
+  if (scope.mode === 'namespace') {
+    return buildNamespaceScopeKey(scope.namespace, scope.projectDisplayName);
+  }
+  return buildClusterQueueNamesKey(scope.clusterQueueNames);
+};
+
+/**
+ * Core workload rows hook. Scope selects admin cluster-queue view or single-namespace view.
+ */
+const useWorkloadRows = (
+  scope: WorkloadRowsScope,
+  options: UseWorkloadRowsOptions = {},
+): UseWorkloadRowsResult => {
+  const { includeTerminal = false, refreshRate = INFRASTRUCTURE_REFRESH_INTERVAL } = options;
+  const [allProjects, projectsLoaded, projectsError] = useProjects();
+
+  const kueueProjects = React.useMemo(
+    () => getKueueManagedDataScienceProjects(allProjects),
+    [allProjects],
+  );
+
+  const projectDisplayNames = React.useMemo(
+    () => buildProjectDisplayNames(kueueProjects),
+    [kueueProjects],
+  );
+
+  const namespaces = React.useMemo(
+    () =>
+      kueueProjects.flatMap((project) => {
+        const namespace = project.metadata.name;
+        return namespace ? [namespace] : [];
+      }),
+    [kueueProjects],
+  );
+
+  const namespacesKey = React.useMemo(() => buildNamespacesKey(namespaces), [namespaces]);
+  const projectDisplayNamesKey = React.useMemo(
+    () => buildProjectDisplayNamesKey(projectDisplayNames),
+    [projectDisplayNames],
+  );
+  const scopeKey = React.useMemo(() => buildScopeKey(scope), [scope]);
+
+  const scopeRef = React.useRef(scope);
+  scopeRef.current = scope;
+  const namespacesRef = React.useRef(namespaces);
+  namespacesRef.current = namespaces;
+  const projectDisplayNamesRef = React.useRef(projectDisplayNames);
+  projectDisplayNamesRef.current = projectDisplayNames;
+
+  const initialFetchResult = React.useMemo(() => getInitialFetchResult(scope), [scope]);
+
+  const {
+    data,
+    loaded: workloadsLoaded,
+    error: workloadsError,
+    refresh,
+  } = useFetch<WorkloadRowsFetchResult>(
+    React.useCallback(async () => {
+      const currentScope = scopeRef.current;
+
+      if (currentScope.mode === 'namespace') {
+        if (!currentScope.namespace) {
+          return { mode: 'namespace', workloads: [] };
+        }
+
+        const workloads = await fetchNamespaceWorkloads(
+          currentScope.namespace,
+          currentScope.projectDisplayName,
+          includeTerminal,
+        );
+        return { mode: 'namespace', workloads };
+      }
+
+      if (!projectsLoaded) {
+        throw new NotReadyError('Projects not loaded');
+      }
+
+      if (currentScope.clusterQueueNames.length === 0) {
+        return { mode: 'clusterQueues', workloadsByClusterQueue: new Map() };
+      }
+
+      const workloadsByClusterQueue = await fetchWorkloadsForClusterQueues(
+        currentScope.clusterQueueNames,
+        namespacesRef.current,
+        projectDisplayNamesRef.current,
+        includeTerminal,
+      );
+
+      return { mode: 'clusterQueues', workloadsByClusterQueue };
+      // scopeKey / namespacesKey / projectDisplayNamesKey are content fingerprints.
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- keys trigger refetch when inputs change
+    }, [scopeKey, namespacesKey, projectDisplayNamesKey, includeTerminal, projectsLoaded]),
+    initialFetchResult,
+    { refreshRate },
+  );
+
+  const loaded = scope.mode === 'namespace' ? workloadsLoaded : projectsLoaded && workloadsLoaded;
+  const error = scope.mode === 'namespace' ? workloadsError : projectsError ?? workloadsError;
+
+  return {
+    data,
+    loaded,
+    error,
+    refresh,
+  };
+};
+
+export default useWorkloadRows;

--- a/packages/gpuaas/src/hooks/useWorkloadRows.ts
+++ b/packages/gpuaas/src/hooks/useWorkloadRows.ts
@@ -152,8 +152,17 @@ const useWorkloadRows = (
     { refreshRate, initialPromisePurity: true },
   );
 
-  const loaded = scope.mode === 'namespace' ? workloadsLoaded : projectsLoaded && workloadsLoaded;
-  const error = scope.mode === 'namespace' ? workloadsError : projectsError ?? workloadsError;
+  const isSkippedClusterQueueScope =
+    scope.mode === 'clusterQueues' && scope.clusterQueueNames.length === 0;
+
+  const loaded =
+    scope.mode === 'namespace' || isSkippedClusterQueueScope
+      ? workloadsLoaded
+      : projectsLoaded && workloadsLoaded;
+  const error =
+    scope.mode === 'namespace' || isSkippedClusterQueueScope
+      ? workloadsError
+      : projectsError ?? workloadsError;
 
   return {
     data,

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -29,3 +29,69 @@ export type CQDcgmResult = {
 export type KueueProject = {
   name: string;
 };
+
+/** UXD Quota usage workloads table — Type column values (ODH + Kueue workload taxonomy). */
+export const QuotaUsageWorkloadTypes = {
+  Workbench: 'Workbench',
+  Train: 'Train',
+  Serve: 'Serve',
+  RayCluster: 'Ray cluster',
+  Unknown: 'Unknown',
+} as const;
+
+export type QuotaUsageWorkloadType =
+  (typeof QuotaUsageWorkloadTypes)[keyof typeof QuotaUsageWorkloadTypes];
+
+/**
+ * UXD Quota usage workloads table — Status column values.
+ * Mapped from Kueue workload conditions via mapKueueStatusToQuotaUsageStatus.
+ */
+export const QuotaUsageWorkloadStatuses = {
+  Pending: 'Pending',
+  Queued: 'Queued',
+  Admitted: 'Admitted',
+} as const;
+
+export type QuotaUsageWorkloadStatus =
+  (typeof QuotaUsageWorkloadStatuses)[keyof typeof QuotaUsageWorkloadStatuses];
+
+/** Row model for the Quota usage tab workloads table (RHOAIENG-88168). */
+export type ClusterQueueWorkloadRow = {
+  name: string;
+  namespace: string;
+  project: string;
+  /** Admitted cluster queue, or pending local queue's target cluster queue. */
+  clusterQueue: string;
+  type: QuotaUsageWorkloadType;
+  status: QuotaUsageWorkloadStatus;
+  localQueue: string;
+  accelerators: number;
+  /** 1-indexed position in the local queue; undefined when admitted or unavailable. */
+  queuePosition: number | undefined;
+  /** Formatted from spec.priorityClassRef and spec.priority, e.g. "on-demand (100)". */
+  priority?: string;
+  /** GPU product from admitted ResourceFlavor assignment, e.g. "NVIDIA-L40S". */
+  hardwareProfile?: string;
+};
+
+/** Fetch scope for shared workload table data layer. */
+export type WorkloadRowsScope =
+  | {
+      mode: 'clusterQueues';
+      clusterQueueNames: string[];
+    }
+  | {
+      mode: 'namespace';
+      namespace: string;
+      projectDisplayName: string;
+    };
+
+export type WorkloadRowsFetchResult =
+  | {
+      mode: 'clusterQueues';
+      workloadsByClusterQueue: Map<string, ClusterQueueWorkloadRow[]>;
+    }
+  | {
+      mode: 'namespace';
+      workloads: ClusterQueueWorkloadRow[];
+    };

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -34,6 +34,7 @@ export type KueueProject = {
 export const QuotaUsageWorkloadTypes = {
   Workbench: 'Workbench',
   Train: 'Train',
+  RayJob: 'Ray job',
   Serve: 'Serve',
   RayCluster: 'Ray cluster',
   Unknown: 'Unknown',
@@ -44,16 +45,37 @@ export type QuotaUsageWorkloadType =
 
 /**
  * UXD Quota usage workloads table — Status column values.
- * Mapped from Kueue workload conditions via mapKueueStatusToQuotaUsageStatus.
+ * All Kueue workload statuses; mapped 1:1 from KueueWorkloadStatus via mapKueueStatusToQuotaUsageStatus.
  */
 export const QuotaUsageWorkloadStatuses = {
-  Pending: 'Pending',
   Queued: 'Queued',
+  Failed: 'Failed',
+  Preempted: 'Preempted',
+  Evicted: 'Evicted',
+  Requeued: 'Requeued',
+  Inadmissible: 'Inadmissible',
+  AdmissionCheck: 'Admission check',
+  BlockedOnPreemptionGates: 'Blocked',
+  Running: 'Running',
   Admitted: 'Admitted',
+  Complete: 'Complete',
 } as const;
 
 export type QuotaUsageWorkloadStatus =
   (typeof QuotaUsageWorkloadStatuses)[keyof typeof QuotaUsageWorkloadStatuses];
+
+/** Statuses for which queue position is fetched via the Kueue Visibility API. */
+export const QUOTA_USAGE_STATUSES_WITH_QUEUE_POSITION: QuotaUsageWorkloadStatus[] = [
+  QuotaUsageWorkloadStatuses.Queued,
+  QuotaUsageWorkloadStatuses.Inadmissible,
+];
+
+/** Statuses indicating the workload has passed Kueue admission. */
+export const QUOTA_USAGE_STATUSES_PAST_ADMISSION: QuotaUsageWorkloadStatus[] = [
+  QuotaUsageWorkloadStatuses.Admitted,
+  QuotaUsageWorkloadStatuses.Running,
+  QuotaUsageWorkloadStatuses.Complete,
+];
 
 /** Row model for the Quota usage tab workloads table (RHOAIENG-88168). */
 export type ClusterQueueWorkloadRow = {

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
@@ -1,0 +1,699 @@
+import type {
+  LocalQueueKind,
+  PodKind,
+  ResourceFlavorKind,
+  WorkloadCondition,
+  WorkloadKind,
+} from '@odh-dashboard/k8s-core';
+import { WorkloadOwnerType } from '@odh-dashboard/k8s-core';
+import { getPendingWorkloads } from '@odh-dashboard/internal/api/k8s/pendingWorkloads';
+import { KueueWorkloadStatus } from '@odh-dashboard/internal/concepts/kueue/types';
+import { QuotaUsageWorkloadStatuses, QuotaUsageWorkloadTypes } from '../../types';
+import {
+  applyQueuePositions,
+  buildLocalQueueByName,
+  fetchQueuePositions,
+  filterAndMapClusterQueueWorkloads,
+  filterAndMapNamespaceWorkloads,
+  formatWorkloadPriority,
+  isActiveWorkload,
+  isKueueManagedWorkload,
+  isRayClusterWorkload,
+  isServingWorkload,
+  isTrainingJobWorkload,
+  isWorkbenchWorkload,
+  mapKueueStatusToQuotaUsageStatus,
+  mapWorkloadToRow,
+  resolveWorkloadClusterQueue,
+  resolveWorkloadType,
+  workloadMatchesClusterQueue,
+} from '../clusterQueueWorkloads';
+
+jest.mock('@odh-dashboard/internal/api/k8s/pendingWorkloads', () => ({
+  getPendingWorkloads: jest.fn(),
+}));
+
+const getPendingWorkloadsMock = jest.mocked(getPendingWorkloads);
+
+const NS = 'dsp-1';
+const CQ = 'gpu-cq';
+const LQ = 'user-queue';
+const emptyResourceFlavors = new Map<string, ResourceFlavorKind>();
+
+const baseWorkload = (overrides: Partial<WorkloadKind> = {}): WorkloadKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
+  kind: 'Workload',
+  metadata: {
+    name: 'wl-1',
+    namespace: NS,
+    ...(overrides.metadata ?? {}),
+  },
+  spec: {
+    active: true,
+    podSets: [
+      {
+        count: 1,
+        name: 'main',
+        template: {
+          metadata: {},
+          spec: {
+            containers: [
+              {
+                name: 'main',
+                image: 'test-image',
+                env: [],
+                resources: { requests: { 'nvidia.com/gpu': '2' } },
+              },
+            ],
+          },
+        },
+      },
+    ],
+    queueName: LQ,
+    ...(overrides.spec ?? {}),
+  },
+  ...(overrides.status ? { status: overrides.status } : {}),
+});
+
+const localQueue = (name: string, clusterQueue: string): LocalQueueKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
+  kind: 'LocalQueue',
+  metadata: { name, namespace: NS },
+  spec: { clusterQueue },
+});
+
+const admittedConditions: WorkloadCondition[] = [
+  {
+    type: 'QuotaReserved',
+    status: 'True',
+    reason: 'QuotaReserved',
+    message: 'Quota reserved',
+    lastTransitionTime: '2026-01-01T00:00:00Z',
+  },
+  {
+    type: 'Admitted',
+    status: 'True',
+    reason: 'Admitted',
+    message: 'Admitted',
+    lastTransitionTime: '2026-01-01T00:00:00Z',
+  },
+];
+
+const queuedConditions: WorkloadCondition[] = [
+  {
+    type: 'QuotaReserved',
+    status: 'False',
+    reason: 'Pending',
+    message: 'Waiting',
+    lastTransitionTime: '2026-01-01T00:00:00Z',
+  },
+];
+
+const completeConditions: WorkloadCondition[] = [
+  ...admittedConditions,
+  {
+    type: 'Finished',
+    status: 'True',
+    reason: 'Succeeded',
+    message: 'Succeeded',
+    lastTransitionTime: '2026-01-02T00:00:00Z',
+  },
+];
+
+const makePod = (uid: string, labels: Record<string, string>): PodKind =>
+  ({
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: `pod-${uid}`, namespace: NS, uid, labels },
+    spec: {},
+    status: { phase: 'Running' },
+  } as PodKind);
+
+describe('clusterQueueWorkloads', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('workloadMatchesClusterQueue', () => {
+    const localQueueByName = buildLocalQueueByName([localQueue(LQ, CQ)]);
+
+    it('matches admitted workloads on the cluster queue', () => {
+      const workload = baseWorkload({
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      expect(workloadMatchesClusterQueue(workload, CQ, localQueueByName)).toBe(true);
+    });
+
+    it('matches pending workloads targeting the cluster queue via local queue', () => {
+      const workload = baseWorkload({ status: { conditions: queuedConditions } });
+      expect(workloadMatchesClusterQueue(workload, CQ, localQueueByName)).toBe(true);
+    });
+
+    it('excludes workloads on a different cluster queue', () => {
+      const workload = baseWorkload({
+        status: {
+          admission: { clusterQueue: 'other-cq', podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      expect(workloadMatchesClusterQueue(workload, CQ, localQueueByName)).toBe(false);
+    });
+  });
+
+  describe('isActiveWorkload', () => {
+    it('excludes complete workloads by default scope', () => {
+      expect(isActiveWorkload(baseWorkload({ status: { conditions: completeConditions } }))).toBe(
+        false,
+      );
+    });
+
+    it('includes admitted active workloads', () => {
+      expect(
+        isActiveWorkload(
+          baseWorkload({
+            status: {
+              admission: { clusterQueue: CQ, podSetAssignments: [] },
+              conditions: admittedConditions,
+            },
+          }),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('resolveWorkloadType', () => {
+    it('resolves workbench workloads from job-name label and owner refs', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'nb-wl',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-name': 'my-nb' },
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'my-nb', uid: 'job-uid' }],
+        },
+      });
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Workbench);
+      expect(isWorkbenchWorkload(workload)).toBe(true);
+    });
+
+    it('resolves workbench workloads from StatefulSet owner', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'wb-wl',
+          namespace: NS,
+          ownerReferences: [
+            { apiVersion: 'v1', kind: WorkloadOwnerType.StatefulSet, name: 'my-nb', uid: 'ss-uid' },
+          ],
+        },
+      });
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Workbench);
+      expect(isWorkbenchWorkload(workload)).toBe(true);
+    });
+
+    it('resolves ray cluster workloads from RayCluster owner', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'ray-wl',
+          namespace: NS,
+          ownerReferences: [
+            { apiVersion: 'v1', kind: WorkloadOwnerType.RayCluster, name: 'ray', uid: 'ray-uid' },
+          ],
+        },
+      });
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.RayCluster);
+      expect(isRayClusterWorkload(workload)).toBe(true);
+    });
+
+    it('resolves training workloads from Job owner when not a workbench', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'train-wl',
+          namespace: NS,
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'train-job', uid: 'job-uid' }],
+        },
+      });
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Train);
+      expect(isTrainingJobWorkload(workload)).toBe(true);
+    });
+
+    it('resolves serving workloads from Pod owner single-hop labels', () => {
+      const podUid = 'serving-pod';
+      const workload = baseWorkload({
+        metadata: {
+          name: 'serving-wl',
+          namespace: NS,
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Pod', name: 'pod', uid: podUid }],
+        },
+      });
+      const pods = [makePod(podUid, { 'serving.kserve.io/inferenceservice': 'my-model' })];
+      expect(resolveWorkloadType(workload, pods)).toBe(QuotaUsageWorkloadTypes.Serve);
+      expect(isServingWorkload(workload, pods)).toBe(true);
+    });
+
+    it('resolves serving workloads from ReplicaSet owner', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'rs-serving-wl',
+          namespace: NS,
+          ownerReferences: [
+            { apiVersion: 'v1', kind: WorkloadOwnerType.ReplicaSet, name: 'rs', uid: 'rs-uid' },
+          ],
+        },
+      });
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Serve);
+    });
+
+    it('resolves serving workloads from LeaderWorkerSet owner', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'lws-serving-wl',
+          namespace: NS,
+          ownerReferences: [
+            {
+              apiVersion: 'v1',
+              kind: WorkloadOwnerType.LeaderWorkerSet,
+              name: 'lws',
+              uid: 'lws-uid',
+            },
+          ],
+        },
+      });
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Serve);
+    });
+
+    it('falls back to unknown for unclassified pod workloads', () => {
+      const podUid = 'infra-pod';
+      const workload = baseWorkload({
+        metadata: {
+          name: 'unknown-wl',
+          namespace: NS,
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Pod', name: 'pod', uid: podUid }],
+        },
+      });
+      const pods = [makePod(podUid, { component: 'data-science-pipelines' })];
+      expect(resolveWorkloadType(workload, pods)).toBe(QuotaUsageWorkloadTypes.Unknown);
+    });
+  });
+
+  describe('mapKueueStatusToQuotaUsageStatus', () => {
+    it.each([
+      [KueueWorkloadStatus.Queued, QuotaUsageWorkloadStatuses.Queued],
+      [KueueWorkloadStatus.Admitted, QuotaUsageWorkloadStatuses.Admitted],
+      [KueueWorkloadStatus.Running, QuotaUsageWorkloadStatuses.Admitted],
+      [KueueWorkloadStatus.Inadmissible, QuotaUsageWorkloadStatuses.Pending],
+      [KueueWorkloadStatus.AdmissionCheck, QuotaUsageWorkloadStatuses.Pending],
+      [KueueWorkloadStatus.BlockedOnPreemptionGates, QuotaUsageWorkloadStatuses.Pending],
+      [KueueWorkloadStatus.Evicted, QuotaUsageWorkloadStatuses.Pending],
+      [KueueWorkloadStatus.Requeued, QuotaUsageWorkloadStatuses.Pending],
+      [KueueWorkloadStatus.Preempted, QuotaUsageWorkloadStatuses.Pending],
+    ])('maps %s to %s', (kueueStatus, expected) => {
+      expect(mapKueueStatusToQuotaUsageStatus(kueueStatus)).toBe(expected);
+    });
+  });
+
+  describe('filterAndMapClusterQueueWorkloads', () => {
+    const projectDisplayNames = new Map([[NS, 'DSP One']]);
+
+    it('maps rows with accelerators and excludes terminal workloads by default', () => {
+      const admitted = baseWorkload({
+        metadata: {
+          name: 'admitted-wl',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-name': 'nb-admitted' },
+          ownerReferences: [
+            { apiVersion: 'v1', kind: 'Job', name: 'nb-admitted', uid: 'job-admitted' },
+          ],
+        },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      const queued = baseWorkload({
+        metadata: {
+          name: 'queued-wl',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-name': 'nb' },
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'nb', uid: 'job' }],
+        },
+        status: { conditions: queuedConditions },
+      });
+      const complete = baseWorkload({
+        metadata: { name: 'complete-wl', namespace: NS },
+        status: { conditions: completeConditions },
+      });
+
+      const rows = filterAndMapClusterQueueWorkloads(
+        CQ,
+        [
+          {
+            namespace: NS,
+            workloads: [admitted, queued, complete],
+            localQueues: [localQueue(LQ, CQ)],
+            pods: [],
+          },
+        ],
+        projectDisplayNames,
+        emptyResourceFlavors,
+      );
+
+      expect(rows).toHaveLength(2);
+      expect(rows.find((row) => row.name === 'admitted-wl')).toMatchObject({
+        project: 'DSP One',
+        clusterQueue: CQ,
+        status: QuotaUsageWorkloadStatuses.Admitted,
+        localQueue: LQ,
+        accelerators: 2,
+        queuePosition: undefined,
+      });
+      expect(rows.find((row) => row.name === 'queued-wl')).toMatchObject({
+        type: QuotaUsageWorkloadTypes.Workbench,
+        status: QuotaUsageWorkloadStatuses.Queued,
+      });
+      expect(rows.some((row) => row.name === 'complete-wl')).toBe(false);
+    });
+
+    it('excludes workloads not actively managed by Kueue', () => {
+      const admitted = baseWorkload({
+        metadata: {
+          name: 'admitted-wl',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-name': 'nb-admitted' },
+          ownerReferences: [
+            { apiVersion: 'v1', kind: 'Job', name: 'nb-admitted', uid: 'job-admitted' },
+          ],
+        },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      const autoCreatedNotebook = baseWorkload({
+        metadata: {
+          name: 'auto-notebook-wl',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-name': 'nb' },
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'nb', uid: 'job' }],
+        },
+        spec: { queueName: undefined, active: true, podSets: baseWorkload().spec.podSets },
+        status: { conditions: queuedConditions },
+      });
+      const servingWithoutQueueLabel = baseWorkload({
+        metadata: {
+          name: 'serving-wl',
+          namespace: NS,
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Pod', name: 'pod-1', uid: 'pod-uid' }],
+        },
+        status: { conditions: queuedConditions },
+      });
+      const servingPod = makePod('pod-uid', { 'serving.kserve.io/inferenceservice': 'is-1' });
+      const servingWithQueueLabel = baseWorkload({
+        metadata: {
+          name: 'serving-kueue-wl',
+          namespace: NS,
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Pod', name: 'pod-2', uid: 'pod-uid-2' }],
+        },
+        status: { conditions: queuedConditions },
+      });
+      const servingPodWithQueue = makePod('pod-uid-2', {
+        'serving.kserve.io/inferenceservice': 'is-2',
+        'kueue.x-k8s.io/queue-name': LQ,
+      });
+
+      const rows = filterAndMapClusterQueueWorkloads(
+        CQ,
+        [
+          {
+            namespace: NS,
+            workloads: [
+              admitted,
+              autoCreatedNotebook,
+              servingWithoutQueueLabel,
+              servingWithQueueLabel,
+            ],
+            localQueues: [localQueue(LQ, CQ)],
+            pods: [servingPod, servingPodWithQueue],
+          },
+        ],
+        projectDisplayNames,
+        emptyResourceFlavors,
+      );
+
+      expect(rows.map((row) => row.name)).toEqual(['admitted-wl', 'serving-kueue-wl']);
+    });
+
+    it('includes admitted infrastructure workloads with unknown type', () => {
+      const infraWorkload = baseWorkload({
+        metadata: {
+          name: 'pod-bin-packing-scheduler-6b7f99547f-kmzgx-a8631',
+          namespace: NS,
+          ownerReferences: [
+            {
+              apiVersion: 'v1',
+              kind: 'Pod',
+              name: 'bin-packing-scheduler-6b7f99547f-kmzgx',
+              uid: 'pod-uid',
+            },
+          ],
+        },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      const infraPod = makePod('pod-uid', {
+        component: 'bin-packing-scheduler',
+        'kueue.x-k8s.io/queue-name': LQ,
+      });
+
+      const rows = filterAndMapClusterQueueWorkloads(
+        CQ,
+        [
+          {
+            namespace: NS,
+            workloads: [infraWorkload],
+            localQueues: [localQueue(LQ, CQ)],
+            pods: [infraPod],
+          },
+        ],
+        projectDisplayNames,
+        emptyResourceFlavors,
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        name: 'pod-bin-packing-scheduler-6b7f99547f-kmzgx-a8631',
+        type: QuotaUsageWorkloadTypes.Unknown,
+      });
+    });
+  });
+
+  describe('isKueueManagedWorkload', () => {
+    const localQueueByName = buildLocalQueueByName([localQueue(LQ, CQ)]);
+
+    it('returns false when workload has no queue assignment and is not admitted', () => {
+      const workload = baseWorkload({
+        spec: { queueName: undefined, active: true, podSets: baseWorkload().spec.podSets },
+      });
+      expect(isKueueManagedWorkload(workload, [], localQueueByName)).toBe(false);
+    });
+
+    it('returns false for serving workloads when correlated pod lacks queue-name label', () => {
+      const workload = baseWorkload({
+        metadata: {
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Pod', name: 'pod-1', uid: 'pod-uid' }],
+        },
+      });
+      const pod = makePod('pod-uid', { 'serving.kserve.io/inferenceservice': 'is-1' });
+      expect(isKueueManagedWorkload(workload, [pod], localQueueByName)).toBe(false);
+    });
+  });
+
+  describe('fetchQueuePositions', () => {
+    it('returns 1-indexed positions for queued workloads', async () => {
+      getPendingWorkloadsMock.mockResolvedValue({
+        items: [
+          {
+            metadata: { name: 'queued-wl', namespace: NS },
+            priority: 100,
+            localQueueName: LQ,
+            positionInClusterQueue: 0,
+            positionInLocalQueue: 2,
+          },
+        ],
+      });
+
+      const positions = await fetchQueuePositions([
+        {
+          name: 'queued-wl',
+          namespace: NS,
+          project: 'DSP One',
+          clusterQueue: CQ,
+          type: QuotaUsageWorkloadTypes.Workbench,
+          status: QuotaUsageWorkloadStatuses.Queued,
+          localQueue: LQ,
+          accelerators: 1,
+          queuePosition: undefined,
+        },
+      ]);
+
+      expect(getPendingWorkloadsMock).toHaveBeenCalledWith(NS, LQ);
+      expect(positions.get(`${NS}/queued-wl`)).toBe(3);
+    });
+
+    it('does not fetch positions for admitted workloads', async () => {
+      await fetchQueuePositions([
+        {
+          name: 'admitted-wl',
+          namespace: NS,
+          project: 'DSP One',
+          clusterQueue: CQ,
+          type: QuotaUsageWorkloadTypes.Train,
+          status: QuotaUsageWorkloadStatuses.Admitted,
+          localQueue: LQ,
+          accelerators: 1,
+          queuePosition: undefined,
+        },
+      ]);
+
+      expect(getPendingWorkloadsMock).not.toHaveBeenCalled();
+    });
+
+    it('handles Visibility API 403 gracefully', async () => {
+      getPendingWorkloadsMock.mockRejectedValue({ status: 403 });
+
+      const rows = [
+        {
+          name: 'queued-wl',
+          namespace: NS,
+          project: 'DSP One',
+          clusterQueue: CQ,
+          type: QuotaUsageWorkloadTypes.Workbench,
+          status: QuotaUsageWorkloadStatuses.Queued,
+          localQueue: LQ,
+          accelerators: 1,
+          queuePosition: undefined,
+        },
+      ];
+
+      const positions = await fetchQueuePositions(rows);
+      expect(positions.size).toBe(0);
+      expect(applyQueuePositions(rows, positions)[0].queuePosition).toBeUndefined();
+    });
+  });
+
+  describe('mapWorkloadToRow', () => {
+    it('maps priority and hardware profile from workload spec and admission', () => {
+      const resourceFlavor: ResourceFlavorKind = {
+        apiVersion: 'kueue.x-k8s.io/v1beta2',
+        kind: 'ResourceFlavor',
+        metadata: { name: 'gpu-l40s' },
+        spec: { nodeLabels: { 'nvidia.com/gpu.product': 'NVIDIA-L40S' } },
+      };
+      const workload = baseWorkload({
+        spec: {
+          queueName: LQ,
+          active: true,
+          podSets: baseWorkload().spec.podSets,
+          priority: 100,
+          priorityClassRef: {
+            group: 'kueue.x-k8s.io',
+            kind: 'WorkloadPriorityClass',
+            name: 'on-demand',
+          },
+        },
+        status: {
+          admission: {
+            clusterQueue: CQ,
+            podSetAssignments: [{ name: 'main', flavors: { 'nvidia.com/gpu': 'gpu-l40s' } }],
+          },
+          conditions: admittedConditions,
+        },
+      });
+
+      const row = mapWorkloadToRow(
+        workload,
+        NS,
+        'DSP One',
+        [],
+        buildLocalQueueByName([localQueue(LQ, CQ)]),
+        new Map([['gpu-l40s', resourceFlavor]]),
+        CQ,
+      );
+
+      expect(row).toMatchObject({
+        clusterQueue: CQ,
+        priority: 'on-demand (100)',
+        hardwareProfile: 'NVIDIA-L40S',
+      });
+    });
+  });
+
+  describe('formatWorkloadPriority', () => {
+    it('formats priority class name and numeric value together', () => {
+      expect(
+        formatWorkloadPriority(
+          baseWorkload({
+            spec: {
+              queueName: LQ,
+              active: true,
+              podSets: baseWorkload().spec.podSets,
+              priority: 100,
+              priorityClassRef: {
+                group: 'kueue.x-k8s.io',
+                kind: 'WorkloadPriorityClass',
+                name: 'on-demand',
+              },
+            },
+          }),
+        ),
+      ).toBe('on-demand (100)');
+    });
+  });
+
+  describe('resolveWorkloadClusterQueue', () => {
+    it('resolves pending workloads via local queue target cluster queue', () => {
+      const workload = baseWorkload({
+        status: { conditions: queuedConditions },
+      });
+      const localQueueByName = buildLocalQueueByName([localQueue(LQ, CQ)]);
+
+      expect(resolveWorkloadClusterQueue(workload, localQueueByName)).toBe(CQ);
+    });
+  });
+
+  describe('filterAndMapNamespaceWorkloads', () => {
+    it('maps all active workloads in a namespace regardless of cluster queue', () => {
+      const admitted = baseWorkload({
+        metadata: { name: 'admitted-wl', namespace: NS },
+        status: { conditions: admittedConditions },
+      });
+      const queued = baseWorkload({
+        metadata: { name: 'queued-wl', namespace: NS },
+        status: { conditions: queuedConditions },
+      });
+      const complete = baseWorkload({
+        metadata: { name: 'complete-wl', namespace: NS },
+        status: { conditions: completeConditions },
+      });
+
+      const rows = filterAndMapNamespaceWorkloads(
+        {
+          namespace: NS,
+          workloads: [admitted, queued, complete],
+          localQueues: [localQueue(LQ, CQ)],
+          pods: [],
+        },
+        'DSP One',
+        emptyResourceFlavors,
+      );
+
+      expect(rows).toHaveLength(2);
+      expect(rows.map((row) => row.name)).toEqual(
+        expect.arrayContaining(['admitted-wl', 'queued-wl']),
+      );
+    });
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
@@ -7,7 +7,7 @@ import type {
 } from '@odh-dashboard/k8s-core';
 import { WorkloadOwnerType } from '@odh-dashboard/k8s-core';
 import { getPendingWorkloads } from '@odh-dashboard/internal/api/k8s/pendingWorkloads';
-import { KueueWorkloadStatus } from '@odh-dashboard/internal/concepts/kueue/types';
+import { KueueWorkloadStatus } from '@odh-dashboard/k8s-core/kueue/types';
 import { QuotaUsageWorkloadStatuses, QuotaUsageWorkloadTypes } from '../../types';
 import {
   applyQueuePositions,
@@ -488,6 +488,61 @@ describe('clusterQueueWorkloads', () => {
         type: QuotaUsageWorkloadTypes.Unknown,
       });
     });
+
+    it('includes admitted ReplicaSet-owned serving workloads with Kueue-labeled descendant pods', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'rs-serving-wl',
+          namespace: NS,
+          ownerReferences: [
+            { apiVersion: 'v1', kind: WorkloadOwnerType.ReplicaSet, name: 'rs', uid: 'rs-uid' },
+          ],
+        },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      const servingPod = {
+        ...makePod('pod-uid', {
+          'serving.kserve.io/inferenceservice': 'is-1',
+          'kueue.x-k8s.io/queue-name': LQ,
+        }),
+        metadata: {
+          name: 'serving-pod',
+          namespace: NS,
+          uid: 'pod-uid',
+          labels: {
+            'serving.kserve.io/inferenceservice': 'is-1',
+            'kueue.x-k8s.io/queue-name': LQ,
+          },
+          ownerReferences: [
+            { apiVersion: 'v1', kind: WorkloadOwnerType.ReplicaSet, name: 'rs', uid: 'rs-uid' },
+          ],
+        },
+      } as PodKind;
+
+      const rows = filterAndMapClusterQueueWorkloads(
+        CQ,
+        [
+          {
+            namespace: NS,
+            workloads: [workload],
+            localQueues: [localQueue(LQ, CQ)],
+            pods: [servingPod],
+          },
+        ],
+        projectDisplayNames,
+        emptyResourceFlavors,
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        name: 'rs-serving-wl',
+        type: QuotaUsageWorkloadTypes.Serve,
+        status: QuotaUsageWorkloadStatuses.Admitted,
+      });
+    });
   });
 
   describe('isKueueManagedWorkload', () => {
@@ -508,6 +563,42 @@ describe('clusterQueueWorkloads', () => {
       });
       const pod = makePod('pod-uid', { 'serving.kserve.io/inferenceservice': 'is-1' });
       expect(isKueueManagedWorkload(workload, [pod], localQueueByName)).toBe(false);
+    });
+
+    it('returns true for ReplicaSet-owned serving workloads with Kueue-labeled descendant pods', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'rs-serving-wl',
+          namespace: NS,
+          ownerReferences: [
+            { apiVersion: 'v1', kind: WorkloadOwnerType.ReplicaSet, name: 'rs', uid: 'rs-uid' },
+          ],
+        },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      const servingPod = {
+        ...makePod('pod-uid', {
+          'serving.kserve.io/inferenceservice': 'is-1',
+          'kueue.x-k8s.io/queue-name': LQ,
+        }),
+        metadata: {
+          name: 'serving-pod',
+          namespace: NS,
+          uid: 'pod-uid',
+          labels: {
+            'serving.kserve.io/inferenceservice': 'is-1',
+            'kueue.x-k8s.io/queue-name': LQ,
+          },
+          ownerReferences: [
+            { apiVersion: 'v1', kind: WorkloadOwnerType.ReplicaSet, name: 'rs', uid: 'rs-uid' },
+          ],
+        },
+      } as PodKind;
+
+      expect(isKueueManagedWorkload(workload, [servingPod], localQueueByName)).toBe(true);
     });
   });
 

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
@@ -17,6 +17,7 @@ import {
   filterAndMapNamespaceWorkloads,
   formatWorkloadPriority,
   isActiveWorkload,
+  isGpuAwareWorkload,
   isKueueManagedWorkload,
   isRayClusterWorkload,
   isRayJobWorkload,
@@ -386,6 +387,41 @@ describe('clusterQueueWorkloads', () => {
     });
   });
 
+  describe('isGpuAwareWorkload', () => {
+    it('returns true when workload requests accelerator resources', () => {
+      expect(isGpuAwareWorkload(baseWorkload())).toBe(true);
+    });
+
+    it('returns false for CPU-only resource requests', () => {
+      const cpuOnly = baseWorkload({
+        spec: {
+          active: true,
+          queueName: LQ,
+          podSets: [
+            {
+              count: 1,
+              name: 'main',
+              template: {
+                metadata: {},
+                spec: {
+                  containers: [
+                    {
+                      name: 'main',
+                      image: 'test-image',
+                      env: [],
+                      resources: { requests: { cpu: '1', memory: '1Gi' } },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      });
+      expect(isGpuAwareWorkload(cpuOnly)).toBe(false);
+    });
+  });
+
   describe('filterAndMapClusterQueueWorkloads', () => {
     const projectDisplayNames = new Map([[NS, 'DSP One']]);
 
@@ -517,6 +553,61 @@ describe('clusterQueueWorkloads', () => {
       );
 
       expect(rows.map((row) => row.name)).toEqual(['admitted-wl', 'serving-kueue-wl']);
+    });
+
+    it('excludes Kueue-managed workloads without accelerator requests', () => {
+      const cpuOnly = baseWorkload({
+        metadata: {
+          name: 'cpu-only-wl',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-name': 'nb-cpu' },
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'nb-cpu', uid: 'job-cpu' }],
+        },
+        spec: {
+          active: true,
+          queueName: LQ,
+          podSets: [
+            {
+              count: 1,
+              name: 'main',
+              template: {
+                metadata: {},
+                spec: {
+                  containers: [
+                    {
+                      name: 'main',
+                      image: 'test-image',
+                      env: [],
+                      resources: { requests: { cpu: '1', memory: '1Gi' } },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+
+      const rows = filterAndMapClusterQueueWorkloads(
+        CQ,
+        [
+          {
+            namespace: NS,
+            workloads: [cpuOnly],
+            localQueues: [localQueue(LQ, CQ)],
+            pods: [],
+            jobKindByUid: new Map(),
+          },
+        ],
+        projectDisplayNames,
+        emptyResourceFlavors,
+      );
+
+      expect(rows).toHaveLength(0);
     });
 
     it('includes admitted infrastructure workloads with unknown type', () => {

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
@@ -18,6 +18,7 @@ import {
   formatWorkloadPriority,
   isActiveWorkload,
   isGpuAwareWorkload,
+  getWorkloadAcceleratorCount,
   isKueueManagedWorkload,
   isRayClusterWorkload,
   isRayJobWorkload,
@@ -420,6 +421,66 @@ describe('clusterQueueWorkloads', () => {
       });
       expect(isGpuAwareWorkload(cpuOnly)).toBe(false);
     });
+
+    it('returns true when accelerators are declared in limits only', () => {
+      const limitOnlyGpu = baseWorkload({
+        spec: {
+          active: true,
+          queueName: LQ,
+          podSets: [
+            {
+              count: 1,
+              name: 'main',
+              template: {
+                metadata: {},
+                spec: {
+                  containers: [
+                    {
+                      name: 'main',
+                      image: 'test-image',
+                      env: [],
+                      resources: { limits: { 'nvidia.com/gpu': '2' } },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      });
+      expect(isGpuAwareWorkload(limitOnlyGpu)).toBe(true);
+      expect(getWorkloadAcceleratorCount(limitOnlyGpu)).toBe(2);
+    });
+
+    it('parses kubernetes quantity strings for accelerator resources', () => {
+      const milliGpu = baseWorkload({
+        spec: {
+          active: true,
+          queueName: LQ,
+          podSets: [
+            {
+              count: 1,
+              name: 'main',
+              template: {
+                metadata: {},
+                spec: {
+                  containers: [
+                    {
+                      name: 'main',
+                      image: 'test-image',
+                      env: [],
+                      resources: { requests: { 'nvidia.com/gpu': '3000m' } },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      });
+      expect(isGpuAwareWorkload(milliGpu)).toBe(true);
+      expect(getWorkloadAcceleratorCount(milliGpu)).toBe(3);
+    });
   });
 
   describe('filterAndMapClusterQueueWorkloads', () => {
@@ -731,6 +792,17 @@ describe('clusterQueueWorkloads', () => {
       });
       const pod = makePod('pod-uid', { 'serving.kserve.io/inferenceservice': 'is-1' });
       expect(isKueueManagedWorkload(workload, [pod], localQueueByName)).toBe(false);
+    });
+
+    it('returns false for serving workloads when no correlated pods are available', () => {
+      const workload = baseWorkload({
+        metadata: {
+          ownerReferences: [
+            { apiVersion: 'v1', kind: WorkloadOwnerType.ReplicaSet, name: 'rs', uid: 'rs-uid' },
+          ],
+        },
+      });
+      expect(isKueueManagedWorkload(workload, [], localQueueByName)).toBe(false);
     });
 
     it('returns true for ReplicaSet-owned serving workloads with Kueue-labeled descendant pods', () => {

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
@@ -19,6 +19,9 @@ import {
   isActiveWorkload,
   isKueueManagedWorkload,
   isRayClusterWorkload,
+  isRayJobWorkload,
+  isTrainJobWorkload,
+  getWorkloadJobKind,
   isServingWorkload,
   isTrainingJobWorkload,
   isWorkbenchWorkload,
@@ -226,16 +229,81 @@ describe('clusterQueueWorkloads', () => {
       expect(isRayClusterWorkload(workload)).toBe(true);
     });
 
-    it('resolves training workloads from Job owner when not a workbench', () => {
+    it('resolves ray job workloads from RayJob owner', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'rayjob-wl',
+          namespace: NS,
+          ownerReferences: [
+            { apiVersion: 'ray.io/v1', kind: 'RayJob', name: 'ray-job', uid: 'rayjob-uid' },
+          ],
+        },
+      });
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.RayJob);
+      expect(isRayJobWorkload(workload)).toBe(true);
+    });
+
+    it('resolves ray job workloads from job-uid label matching a RayJob CR', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'rayjob-wl',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-uid': 'rayjob-cr-uid' },
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'ray-job', uid: 'job-uid' }],
+        },
+      });
+      const jobKindByUid = new Map([['rayjob-cr-uid', 'RayJob' as const]]);
+      expect(resolveWorkloadType(workload, [], jobKindByUid)).toBe(QuotaUsageWorkloadTypes.RayJob);
+      expect(isRayJobWorkload(workload, jobKindByUid)).toBe(true);
+      expect(getWorkloadJobKind(workload, jobKindByUid)).toBe('RayJob');
+    });
+
+    it('resolves train workloads from TrainJob owner', () => {
       const workload = baseWorkload({
         metadata: {
           name: 'train-wl',
           namespace: NS,
-          ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'train-job', uid: 'job-uid' }],
+          ownerReferences: [
+            {
+              apiVersion: 'trainer.kubeflow.org/v1alpha1',
+              kind: 'TrainJob',
+              name: 'train-job',
+              uid: 'trainjob-uid',
+            },
+          ],
         },
       });
       expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Train);
+      expect(isTrainJobWorkload(workload)).toBe(true);
+      expect(getWorkloadJobKind(workload)).toBe('TrainJob');
+    });
+
+    it('resolves train workloads from job-uid label matching a TrainJob CR', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'train-wl',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-uid': 'trainjob-cr-uid' },
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'train-job', uid: 'job-uid' }],
+        },
+      });
+      const jobKindByUid = new Map([['trainjob-cr-uid', 'TrainJob' as const]]);
+      expect(resolveWorkloadType(workload, [], jobKindByUid)).toBe(QuotaUsageWorkloadTypes.Train);
+      expect(isTrainJobWorkload(workload, jobKindByUid)).toBe(true);
+      expect(getWorkloadJobKind(workload, jobKindByUid)).toBe('TrainJob');
+    });
+
+    it('classifies generic Job-owned workloads as unknown when not a TrainJob or RayJob', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'batch-wl',
+          namespace: NS,
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'batch-job', uid: 'job-uid' }],
+        },
+      });
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Unknown);
       expect(isTrainingJobWorkload(workload)).toBe(true);
+      expect(getWorkloadJobKind(workload)).toBeUndefined();
     });
 
     it('resolves serving workloads from Pod owner single-hop labels', () => {
@@ -300,14 +368,19 @@ describe('clusterQueueWorkloads', () => {
   describe('mapKueueStatusToQuotaUsageStatus', () => {
     it.each([
       [KueueWorkloadStatus.Queued, QuotaUsageWorkloadStatuses.Queued],
+      [KueueWorkloadStatus.Failed, QuotaUsageWorkloadStatuses.Failed],
+      [KueueWorkloadStatus.Preempted, QuotaUsageWorkloadStatuses.Preempted],
+      [KueueWorkloadStatus.Evicted, QuotaUsageWorkloadStatuses.Evicted],
+      [KueueWorkloadStatus.Requeued, QuotaUsageWorkloadStatuses.Requeued],
+      [KueueWorkloadStatus.Inadmissible, QuotaUsageWorkloadStatuses.Inadmissible],
+      [KueueWorkloadStatus.AdmissionCheck, QuotaUsageWorkloadStatuses.AdmissionCheck],
+      [
+        KueueWorkloadStatus.BlockedOnPreemptionGates,
+        QuotaUsageWorkloadStatuses.BlockedOnPreemptionGates,
+      ],
+      [KueueWorkloadStatus.Running, QuotaUsageWorkloadStatuses.Running],
       [KueueWorkloadStatus.Admitted, QuotaUsageWorkloadStatuses.Admitted],
-      [KueueWorkloadStatus.Running, QuotaUsageWorkloadStatuses.Admitted],
-      [KueueWorkloadStatus.Inadmissible, QuotaUsageWorkloadStatuses.Pending],
-      [KueueWorkloadStatus.AdmissionCheck, QuotaUsageWorkloadStatuses.Pending],
-      [KueueWorkloadStatus.BlockedOnPreemptionGates, QuotaUsageWorkloadStatuses.Pending],
-      [KueueWorkloadStatus.Evicted, QuotaUsageWorkloadStatuses.Pending],
-      [KueueWorkloadStatus.Requeued, QuotaUsageWorkloadStatuses.Pending],
-      [KueueWorkloadStatus.Preempted, QuotaUsageWorkloadStatuses.Pending],
+      [KueueWorkloadStatus.Complete, QuotaUsageWorkloadStatuses.Complete],
     ])('maps %s to %s', (kueueStatus, expected) => {
       expect(mapKueueStatusToQuotaUsageStatus(kueueStatus)).toBe(expected);
     });
@@ -353,6 +426,7 @@ describe('clusterQueueWorkloads', () => {
             workloads: [admitted, queued, complete],
             localQueues: [localQueue(LQ, CQ)],
             pods: [],
+            jobKindByUid: new Map(),
           },
         ],
         projectDisplayNames,
@@ -435,6 +509,7 @@ describe('clusterQueueWorkloads', () => {
             ],
             localQueues: [localQueue(LQ, CQ)],
             pods: [servingPod, servingPodWithQueue],
+            jobKindByUid: new Map(),
           },
         ],
         projectDisplayNames,
@@ -476,6 +551,7 @@ describe('clusterQueueWorkloads', () => {
             workloads: [infraWorkload],
             localQueues: [localQueue(LQ, CQ)],
             pods: [infraPod],
+            jobKindByUid: new Map(),
           },
         ],
         projectDisplayNames,
@@ -530,6 +606,7 @@ describe('clusterQueueWorkloads', () => {
             workloads: [workload],
             localQueues: [localQueue(LQ, CQ)],
             pods: [servingPod],
+            jobKindByUid: new Map(),
           },
         ],
         projectDisplayNames,
@@ -711,6 +788,7 @@ describe('clusterQueueWorkloads', () => {
         [],
         buildLocalQueueByName([localQueue(LQ, CQ)]),
         new Map([['gpu-l40s', resourceFlavor]]),
+        new Map(),
         CQ,
       );
 
@@ -776,6 +854,7 @@ describe('clusterQueueWorkloads', () => {
           workloads: [admitted, queued, complete],
           localQueues: [localQueue(LQ, CQ)],
           pods: [],
+          jobKindByUid: new Map(),
         },
         'DSP One',
         emptyResourceFlavors,

--- a/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
@@ -1,5 +1,10 @@
-import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/k8s-core';
-import { resolveHardwareModels, resolvePerModelGpuCounts } from '../hardwareModels';
+import { ClusterQueueKind, ResourceFlavorKind, type WorkloadKind } from '@odh-dashboard/k8s-core';
+import {
+  buildResourceFlavorByName,
+  resolveHardwareModels,
+  resolvePerModelGpuCounts,
+  resolveWorkloadHardwareProfile,
+} from '../hardwareModels';
 
 const makeGpuCQ = (
   name: string,
@@ -212,5 +217,27 @@ describe('resolvePerModelGpuCounts', () => {
     expect(result.get('cq-2')).toEqual([
       { model: 'NVIDIA H100', nominal: 4, used: 4, borrowed: 2 },
     ]);
+  });
+});
+
+describe('resolveWorkloadHardwareProfile', () => {
+  it('maps admitted resource flavor assignments to GPU product labels', () => {
+    const resourceFlavor = makeRF('gpu-l40s', 'NVIDIA-L40S');
+    const workload: WorkloadKind = {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'Workload',
+      metadata: { name: 'wl-test', namespace: 'test-ns' },
+      spec: { podSets: [] },
+      status: {
+        admission: {
+          clusterQueue: 'gpu-cq',
+          podSetAssignments: [{ name: 'main', flavors: { 'nvidia.com/gpu': 'gpu-l40s' } }],
+        },
+      },
+    };
+
+    expect(
+      resolveWorkloadHardwareProfile(workload, buildResourceFlavorByName([resourceFlavor])),
+    ).toBe('NVIDIA-L40S');
   });
 });

--- a/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
@@ -240,4 +240,63 @@ describe('resolveWorkloadHardwareProfile', () => {
       resolveWorkloadHardwareProfile(workload, buildResourceFlavorByName([resourceFlavor])),
     ).toBe('NVIDIA-L40S');
   });
+
+  it('returns undefined when no flavor matches', () => {
+    const workload: WorkloadKind = {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'Workload',
+      metadata: { name: 'wl-test', namespace: 'test-ns' },
+      spec: { podSets: [] },
+      status: {
+        admission: {
+          clusterQueue: 'gpu-cq',
+          podSetAssignments: [{ name: 'main', flavors: { 'nvidia.com/gpu': 'missing-flavor' } }],
+        },
+      },
+    };
+
+    expect(
+      resolveWorkloadHardwareProfile(workload, buildResourceFlavorByName([makeRF('gpu-l40s')])),
+    ).toBeUndefined();
+  });
+
+  it('deduplicates, sorts, and joins multiple GPU product labels', () => {
+    const l40sFlavor: ResourceFlavorKind = {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'ResourceFlavor',
+      metadata: { name: 'gpu-l40s' },
+      spec: { nodeLabels: { 'nvidia.com/gpu.product': 'NVIDIA-L40S' } },
+    };
+    const h100Flavor: ResourceFlavorKind = {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'ResourceFlavor',
+      metadata: { name: 'gpu-h100' },
+      spec: { nodeLabels: { 'nvidia.com/gpu.product': 'NVIDIA-H100' } },
+    };
+    const workload: WorkloadKind = {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'Workload',
+      metadata: { name: 'wl-multi', namespace: 'test-ns' },
+      spec: { podSets: [] },
+      status: {
+        admission: {
+          clusterQueue: 'gpu-cq',
+          podSetAssignments: [
+            {
+              name: 'main',
+              flavors: {
+                'nvidia.com/gpu': 'gpu-l40s',
+                'amd.com/gpu': 'gpu-h100',
+                'intel.com/gpu': 'gpu-l40s',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    expect(
+      resolveWorkloadHardwareProfile(workload, buildResourceFlavorByName([l40sFlavor, h100Flavor])),
+    ).toBe('NVIDIA-H100, NVIDIA-L40S');
+  });
 });

--- a/packages/gpuaas/src/utils/__tests__/kueueProjects.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/kueueProjects.spec.ts
@@ -1,7 +1,9 @@
 import { KnownLabels } from '@odh-dashboard/k8s-core';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import {
+  getKueueManagedDataScienceProjects,
   getNonKueueManagedDataScienceProjects,
+  isKueueManagedDataScienceProject,
   isNonKueueManagedDataScienceProject,
 } from '../kueueProjects';
 
@@ -42,6 +44,28 @@ describe('kueueProjects', () => {
       };
 
       expect(isNonKueueManagedDataScienceProject(project)).toBe(true);
+    });
+  });
+
+  describe('isKueueManagedDataScienceProject', () => {
+    it('should return true for Kueue-managed data science projects', () => {
+      expect(isKueueManagedDataScienceProject(kueueManagedProject)).toBe(true);
+    });
+
+    it('should return false for non-Kueue-managed data science projects', () => {
+      expect(isKueueManagedDataScienceProject(nonKueueDsProject)).toBe(false);
+    });
+  });
+
+  describe('getKueueManagedDataScienceProjects', () => {
+    it('should return only Kueue-managed data science projects', () => {
+      expect(
+        getKueueManagedDataScienceProjects([
+          kueueManagedProject,
+          nonKueueDsProject,
+          nonDsProject,
+        ]).map((project) => project.metadata.name),
+      ).toEqual(['kueue-project']);
     });
   });
 

--- a/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
+++ b/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
@@ -15,8 +15,8 @@ import { PodModel } from '@odh-dashboard/internal/api/models';
 import {
   getKueueWorkloadStatusWithMessage,
   KUEUE_QUEUE_LABEL,
-} from '@odh-dashboard/internal/concepts/kueue/index';
-import { KueueWorkloadStatus } from '@odh-dashboard/internal/concepts/kueue/types';
+} from '@odh-dashboard/k8s-core/kueue/workloadStatus';
+import { KueueWorkloadStatus } from '@odh-dashboard/k8s-core/kueue/types';
 import { buildResourceFlavorByName, resolveWorkloadHardwareProfile } from './hardwareModels';
 import {
   type ClusterQueueWorkloadRow,
@@ -113,11 +113,8 @@ export const isKueueManagedWorkload = (
   }
 
   if (isServingWorkload(workload, pods)) {
-    const podRef = workload.metadata?.ownerReferences?.find(
-      (ownerRef) => ownerRef.kind.toLowerCase() === 'pod',
-    );
-    const pod = pods.find((candidate) => candidate.metadata.uid === podRef?.uid);
-    return Boolean(pod?.metadata.labels?.[KUEUE_QUEUE_LABEL]);
+    const servingPods = findServingWorkloadPods(workload, pods);
+    return servingPods.some((pod) => Boolean(pod.metadata.labels?.[KUEUE_QUEUE_LABEL]));
   }
 
   return true;
@@ -179,6 +176,37 @@ const isServingPod = (pod: PodKind): boolean => {
 
 const hasOwnerKind = (workload: WorkloadKind, kind: WorkloadOwnerType): boolean =>
   (workload.metadata?.ownerReferences ?? []).some((ownerRef) => ownerRef.kind === kind);
+
+const findOwnerRefByKind = (workload: WorkloadKind, kind: string) =>
+  (workload.metadata?.ownerReferences ?? []).find(
+    (ownerRef) => ownerRef.kind.toLowerCase() === kind.toLowerCase(),
+  );
+
+const findPodsOwnedBy = (pods: PodKind[], ownerUid: string): PodKind[] =>
+  pods.filter((pod) =>
+    (pod.metadata.ownerReferences ?? []).some((ownerRef) => ownerRef.uid === ownerUid),
+  );
+
+/** Resolves serving Pods via direct Pod owner or descendant Pods for RS/LWS owners. */
+const findServingWorkloadPods = (workload: WorkloadKind, pods: PodKind[]): PodKind[] => {
+  const replicaSetRef = findOwnerRefByKind(workload, WorkloadOwnerType.ReplicaSet);
+  if (replicaSetRef?.uid) {
+    return findPodsOwnedBy(pods, replicaSetRef.uid);
+  }
+
+  const leaderWorkerSetRef = findOwnerRefByKind(workload, WorkloadOwnerType.LeaderWorkerSet);
+  if (leaderWorkerSetRef?.uid) {
+    return findPodsOwnedBy(pods, leaderWorkerSetRef.uid);
+  }
+
+  const podRef = findOwnerRefByKind(workload, 'pod');
+  if (!podRef?.uid) {
+    return [];
+  }
+
+  const pod = pods.find((candidate) => candidate.metadata.uid === podRef.uid);
+  return pod ? [pod] : [];
+};
 
 /**
  * Model serving workloads: InferenceService / LLMInferenceService pods, ReplicaSet, or
@@ -454,10 +482,21 @@ export const fetchWorkloadsForClusterQueues = async (
     return new Map();
   }
 
-  const [namespaceData, resourceFlavors] = await Promise.all([
-    Promise.all(namespaces.map(fetchNamespaceWorkloadData)),
+  const [namespaceResults, resourceFlavors] = await Promise.all([
+    Promise.all(
+      namespaces.map(async (namespace) => {
+        try {
+          return await fetchNamespaceWorkloadData(namespace);
+        } catch {
+          return undefined;
+        }
+      }),
+    ),
     listResourceFlavors(),
   ]);
+  const namespaceData = namespaceResults.filter(
+    (result): result is NamespaceWorkloadData => result != null,
+  );
   const resourceFlavorByName = buildResourceFlavorByName(resourceFlavors);
   const workloadsByClusterQueue = new Map<string, ClusterQueueWorkloadRow[]>();
 

--- a/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
+++ b/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
@@ -1,0 +1,529 @@
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import {
+  type LocalQueueKind,
+  type PodKind,
+  type ProjectKind,
+  type ResourceFlavorKind,
+  WorkloadOwnerType,
+  type WorkloadKind,
+} from '@odh-dashboard/k8s-core';
+import { listLocalQueues } from '@odh-dashboard/internal/api/k8s/localQueues';
+import { getPendingWorkloads } from '@odh-dashboard/internal/api/k8s/pendingWorkloads';
+import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
+import { listWorkloads } from '@odh-dashboard/internal/api/k8s/workloads';
+import { PodModel } from '@odh-dashboard/internal/api/models';
+import {
+  getKueueWorkloadStatusWithMessage,
+  KUEUE_QUEUE_LABEL,
+} from '@odh-dashboard/internal/concepts/kueue/index';
+import { KueueWorkloadStatus } from '@odh-dashboard/internal/concepts/kueue/types';
+import { buildResourceFlavorByName, resolveWorkloadHardwareProfile } from './hardwareModels';
+import {
+  type ClusterQueueWorkloadRow,
+  QuotaUsageWorkloadStatuses,
+  QuotaUsageWorkloadTypes,
+  type QuotaUsageWorkloadStatus,
+  type QuotaUsageWorkloadType,
+} from '../types';
+import { ACCELERATOR_RESOURCE_REGEX } from '../const';
+
+const ACCELERATOR_RE = new RegExp(ACCELERATOR_RESOURCE_REGEX);
+
+const NOTEBOOK_OWNER_KINDS = new Set(['job', 'statefulset', 'notebook', 'pod']);
+
+const KUEUE_JOB_NAME_LABEL = 'kueue.x-k8s.io/job-name';
+
+const TERMINAL_KUEUE_STATUSES = new Set([KueueWorkloadStatus.Complete, KueueWorkloadStatus.Failed]);
+
+export type NamespaceWorkloadData = {
+  namespace: string;
+  workloads: WorkloadKind[];
+  localQueues: LocalQueueKind[];
+  pods: PodKind[];
+};
+
+export const listPods = async (namespace: string): Promise<PodKind[]> =>
+  k8sListResource<PodKind>({
+    model: PodModel,
+    queryOptions: { ns: namespace },
+  }).then((response) => response.items);
+
+export const fetchNamespaceWorkloadData = async (
+  namespace: string,
+): Promise<NamespaceWorkloadData> => {
+  const [workloads, localQueues, pods] = await Promise.all([
+    listWorkloads(namespace),
+    listLocalQueues(namespace),
+    listPods(namespace),
+  ]);
+
+  return { namespace, workloads, localQueues, pods };
+};
+
+export const buildLocalQueueByName = (localQueues: LocalQueueKind[]): Map<string, LocalQueueKind> =>
+  new Map(
+    localQueues.flatMap((localQueue) => {
+      const name = localQueue.metadata?.name;
+      return name ? [[name, localQueue] as const] : [];
+    }),
+  );
+
+/**
+ * Includes admitted workloads on the cluster queue and pending workloads whose
+ * LocalQueue targets the cluster queue (no admission yet).
+ */
+export const workloadMatchesClusterQueue = (
+  workload: WorkloadKind,
+  clusterQueueName: string,
+  localQueueByName: Map<string, LocalQueueKind>,
+): boolean => {
+  const admittedClusterQueue = workload.status?.admission?.clusterQueue;
+  if (admittedClusterQueue) {
+    return admittedClusterQueue === clusterQueueName;
+  }
+
+  const localQueueName = workload.spec.queueName;
+  if (!localQueueName) {
+    return false;
+  }
+
+  return localQueueByName.get(localQueueName)?.spec.clusterQueue === clusterQueueName;
+};
+
+/**
+ * Cluster-queue workloads table: only workloads actively managed by Kueue.
+ * Auto-created Workload CRs for non-Kueue notebooks, RayClusters, or deployments
+ * lack a local queue assignment and/or the queue-name label on the serving Pod.
+ * Namespace-scoped workload tabs may use a different filter later.
+ */
+export const isKueueManagedWorkload = (
+  workload: WorkloadKind,
+  pods: PodKind[],
+  localQueueByName: Map<string, LocalQueueKind>,
+): boolean => {
+  if (workload.spec.active === false) {
+    return false;
+  }
+
+  const isAdmitted = Boolean(workload.status?.admission?.clusterQueue);
+  const queueName = workload.spec.queueName?.trim();
+
+  if (!isAdmitted && (!queueName || !localQueueByName.has(queueName))) {
+    return false;
+  }
+
+  if (isServingWorkload(workload, pods)) {
+    const podRef = workload.metadata?.ownerReferences?.find(
+      (ownerRef) => ownerRef.kind.toLowerCase() === 'pod',
+    );
+    const pod = pods.find((candidate) => candidate.metadata.uid === podRef?.uid);
+    return Boolean(pod?.metadata.labels?.[KUEUE_QUEUE_LABEL]);
+  }
+
+  return true;
+};
+
+/** Quota usage CQ table: Kueue-managed workloads only (Unknown type included — pipeline maps to Unknown until integrated). */
+export const isQuotaUsageClusterQueueWorkload = (
+  workload: WorkloadKind,
+  pods: PodKind[],
+  localQueueByName: Map<string, LocalQueueKind>,
+): boolean => isKueueManagedWorkload(workload, pods, localQueueByName);
+
+export const isActiveWorkload = (workload: WorkloadKind): boolean => {
+  const { status } = getKueueWorkloadStatusWithMessage(workload);
+  return !TERMINAL_KUEUE_STATUSES.has(status);
+};
+
+/**
+ * Notebook-style workbench workloads carry the job-name label and a supported owner ref.
+ * Mirrors workloadMatchesNotebook in frontend/src/api/k8s/workloads.ts without a target name.
+ */
+export const isNotebookWorkload = (workload: WorkloadKind): boolean => {
+  if (!workload.metadata?.labels?.[KUEUE_JOB_NAME_LABEL]) {
+    return false;
+  }
+
+  return (workload.metadata.ownerReferences ?? []).some((ownerRef) =>
+    NOTEBOOK_OWNER_KINDS.has(ownerRef.kind.toLowerCase()),
+  );
+};
+
+/** Workbench: notebook job-name pattern or StatefulSet owner (ODH workbench integration). */
+export const isWorkbenchWorkload = (workload: WorkloadKind): boolean => {
+  if (isNotebookWorkload(workload)) {
+    return true;
+  }
+
+  return (workload.metadata?.ownerReferences ?? []).some(
+    (ownerRef) => ownerRef.kind.toLowerCase() === WorkloadOwnerType.StatefulSet.toLowerCase(),
+  );
+};
+
+export const isRayClusterWorkload = (workload: WorkloadKind): boolean =>
+  (workload.metadata?.ownerReferences ?? []).some(
+    (ownerRef) => ownerRef.kind === WorkloadOwnerType.RayCluster,
+  );
+
+const isServingPod = (pod: PodKind): boolean => {
+  const labels = pod.metadata.labels ?? {};
+  if (labels['serving.kserve.io/inferenceservice']) {
+    return true;
+  }
+
+  return (
+    labels['app.kubernetes.io/component'] === 'llminferenceservice-workload' &&
+    Boolean(labels['app.kubernetes.io/name'])
+  );
+};
+
+const hasOwnerKind = (workload: WorkloadKind, kind: WorkloadOwnerType): boolean =>
+  (workload.metadata?.ownerReferences ?? []).some((ownerRef) => ownerRef.kind === kind);
+
+/**
+ * Model serving workloads: InferenceService / LLMInferenceService pods, ReplicaSet, or
+ * LeaderWorkerSet owners. Pod label check uses single-hop Workload → Pod (see
+ * buildWorkloadMapForDeployments in frontend for the full two-hop pattern).
+ */
+export const isServingWorkload = (workload: WorkloadKind, pods: PodKind[]): boolean => {
+  if (
+    hasOwnerKind(workload, WorkloadOwnerType.ReplicaSet) ||
+    hasOwnerKind(workload, WorkloadOwnerType.LeaderWorkerSet)
+  ) {
+    return true;
+  }
+
+  const podRef = (workload.metadata?.ownerReferences ?? []).find(
+    (ownerRef) => ownerRef.kind.toLowerCase() === 'pod',
+  );
+  if (!podRef?.uid) {
+    return false;
+  }
+
+  const pod = pods.find((candidate) => candidate.metadata.uid === podRef.uid);
+  if (!pod) {
+    return false;
+  }
+
+  return isServingPod(pod);
+};
+
+/** Training jobs: Job owner that is not a notebook workbench (TrainJob, RayJob, PyTorchJob, etc.). */
+export const isTrainingJobWorkload = (workload: WorkloadKind): boolean =>
+  hasOwnerKind(workload, WorkloadOwnerType.Job) && !isNotebookWorkload(workload);
+
+export const resolveWorkloadType = (
+  workload: WorkloadKind,
+  pods: PodKind[],
+): QuotaUsageWorkloadType => {
+  if (isServingWorkload(workload, pods)) {
+    return QuotaUsageWorkloadTypes.Serve;
+  }
+  if (isWorkbenchWorkload(workload)) {
+    return QuotaUsageWorkloadTypes.Workbench;
+  }
+  if (isRayClusterWorkload(workload)) {
+    return QuotaUsageWorkloadTypes.RayCluster;
+  }
+  if (isTrainingJobWorkload(workload)) {
+    return QuotaUsageWorkloadTypes.Train;
+  }
+  return QuotaUsageWorkloadTypes.Unknown;
+};
+
+/**
+ * UXD status mapping for the Quota usage workloads table.
+ * - Queued → Queued
+ * - Admitted / Running → Admitted
+ * - Inadmissible, AdmissionCheck, BlockedOnPreemptionGates, Evicted, Requeued, Preempted → Pending
+ */
+export const mapKueueStatusToQuotaUsageStatus = (
+  kueueStatus: KueueWorkloadStatus,
+): QuotaUsageWorkloadStatus => {
+  if (kueueStatus === KueueWorkloadStatus.Queued) {
+    return QuotaUsageWorkloadStatuses.Queued;
+  }
+  if (kueueStatus === KueueWorkloadStatus.Admitted || kueueStatus === KueueWorkloadStatus.Running) {
+    return QuotaUsageWorkloadStatuses.Admitted;
+  }
+  return QuotaUsageWorkloadStatuses.Pending;
+};
+
+export const getWorkloadAcceleratorCount = (workload: WorkloadKind): number =>
+  workload.spec.podSets.reduce((podSetTotal, podSet) => {
+    const perPod = podSet.template.spec.containers.reduce((containerTotal, container) => {
+      const requests = container.resources?.requests ?? {};
+      const acceleratorCount = Object.entries(requests).reduce((resourceTotal, [name, value]) => {
+        if (!ACCELERATOR_RE.test(name)) {
+          return resourceTotal;
+        }
+        const parsed = Number(value);
+        return resourceTotal + (Number.isFinite(parsed) ? parsed : 0);
+      }, 0);
+      return containerTotal + acceleratorCount;
+    }, 0);
+    return podSetTotal + perPod * podSet.count;
+  }, 0);
+
+export const getProjectDisplayName = (project: ProjectKind): string =>
+  project.metadata.annotations?.['openshift.io/display-name'] ?? project.metadata.name;
+
+export const resolveWorkloadClusterQueue = (
+  workload: WorkloadKind,
+  localQueueByName: Map<string, LocalQueueKind>,
+): string => {
+  const admittedClusterQueue = workload.status?.admission?.clusterQueue;
+  if (admittedClusterQueue) {
+    return admittedClusterQueue;
+  }
+
+  const localQueueName = workload.spec.queueName;
+  if (!localQueueName) {
+    return '';
+  }
+
+  return localQueueByName.get(localQueueName)?.spec.clusterQueue ?? '';
+};
+
+export const formatWorkloadPriority = (workload: WorkloadKind): string | undefined => {
+  const priorityClassName = workload.spec.priorityClassRef?.name;
+  const { priority } = workload.spec;
+
+  if (priorityClassName && priority != null) {
+    return `${priorityClassName} (${priority})`;
+  }
+  if (priorityClassName) {
+    return priorityClassName;
+  }
+  if (priority != null) {
+    return String(priority);
+  }
+  return undefined;
+};
+
+export const mapWorkloadToRow = (
+  workload: WorkloadKind,
+  namespace: string,
+  projectDisplayName: string,
+  pods: PodKind[],
+  localQueueByName: Map<string, LocalQueueKind>,
+  resourceFlavorByName: Map<string, ResourceFlavorKind>,
+  clusterQueueName?: string,
+): ClusterQueueWorkloadRow => {
+  const kueueStatus = getKueueWorkloadStatusWithMessage(workload);
+  const status = mapKueueStatusToQuotaUsageStatus(kueueStatus.status);
+
+  return {
+    name: workload.metadata?.name ?? 'Unnamed',
+    namespace,
+    project: projectDisplayName,
+    clusterQueue: clusterQueueName ?? resolveWorkloadClusterQueue(workload, localQueueByName),
+    type: resolveWorkloadType(workload, pods),
+    status,
+    localQueue: workload.spec.queueName ?? '',
+    accelerators: getWorkloadAcceleratorCount(workload),
+    queuePosition: undefined,
+    priority: formatWorkloadPriority(workload),
+    hardwareProfile: resolveWorkloadHardwareProfile(workload, resourceFlavorByName),
+  };
+};
+
+export const filterAndMapClusterQueueWorkloads = (
+  clusterQueueName: string,
+  namespaceData: NamespaceWorkloadData[],
+  projectDisplayNames: Map<string, string>,
+  resourceFlavorByName: Map<string, ResourceFlavorKind>,
+  includeTerminal = false,
+): ClusterQueueWorkloadRow[] =>
+  namespaceData.flatMap(({ namespace, workloads, localQueues, pods }) => {
+    const localQueueByName = buildLocalQueueByName(localQueues);
+    const projectDisplayName = projectDisplayNames.get(namespace) ?? namespace;
+
+    return workloads
+      .filter(
+        (workload) =>
+          workloadMatchesClusterQueue(workload, clusterQueueName, localQueueByName) &&
+          isQuotaUsageClusterQueueWorkload(workload, pods, localQueueByName) &&
+          (includeTerminal || isActiveWorkload(workload)),
+      )
+      .map((workload) =>
+        mapWorkloadToRow(
+          workload,
+          namespace,
+          projectDisplayName,
+          pods,
+          localQueueByName,
+          resourceFlavorByName,
+          clusterQueueName,
+        ),
+      );
+  });
+
+/** All workloads in a namespace, regardless of cluster queue. */
+export const filterAndMapNamespaceWorkloads = (
+  { namespace, workloads, localQueues, pods }: NamespaceWorkloadData,
+  projectDisplayName: string,
+  resourceFlavorByName: Map<string, ResourceFlavorKind>,
+  includeTerminal = false,
+): ClusterQueueWorkloadRow[] => {
+  const localQueueByName = buildLocalQueueByName(localQueues);
+
+  return workloads
+    .filter((workload) => includeTerminal || isActiveWorkload(workload))
+    .map((workload) =>
+      mapWorkloadToRow(
+        workload,
+        namespace,
+        projectDisplayName,
+        pods,
+        localQueueByName,
+        resourceFlavorByName,
+      ),
+    );
+};
+
+type QueuePositionKey = `${string}/${string}`;
+
+export const buildQueuePositionKey = (namespace: string, workloadName: string): QueuePositionKey =>
+  `${namespace}/${workloadName}`;
+
+/**
+ * Fetches queue positions for queued workloads via the Kueue Visibility API.
+ * Returns 1-indexed positions keyed by namespace/workload name.
+ * 403 and other errors are handled gracefully (no position, no error thrown).
+ */
+export const fetchQueuePositions = async (
+  rows: ClusterQueueWorkloadRow[],
+): Promise<Map<QueuePositionKey, number>> => {
+  const positions = new Map<QueuePositionKey, number>();
+  const workloadsByQueue = new Map<string, ClusterQueueWorkloadRow[]>();
+
+  for (const row of rows) {
+    if (row.status !== QuotaUsageWorkloadStatuses.Queued || !row.localQueue) {
+      continue;
+    }
+    const queueKey = `${row.namespace}/${row.localQueue}`;
+    const existing = workloadsByQueue.get(queueKey) ?? [];
+    existing.push(row);
+    workloadsByQueue.set(queueKey, existing);
+  }
+
+  await Promise.all(
+    Array.from(workloadsByQueue.entries()).map(async ([queueKey, queueRows]) => {
+      const [namespace, localQueueName] = queueKey.split('/');
+      try {
+        const summary = await getPendingWorkloads(namespace, localQueueName);
+        for (const row of queueRows) {
+          const pendingWorkload = summary.items.find((item) => item.metadata.name === row.name);
+          if (pendingWorkload != null) {
+            positions.set(
+              buildQueuePositionKey(namespace, row.name),
+              pendingWorkload.positionInLocalQueue + 1,
+            );
+          }
+        }
+      } catch {
+        // Visibility API RBAC denial or transient error — omit positions silently.
+      }
+    }),
+  );
+
+  return positions;
+};
+
+export const applyQueuePositions = (
+  rows: ClusterQueueWorkloadRow[],
+  positions: Map<QueuePositionKey, number>,
+): ClusterQueueWorkloadRow[] =>
+  rows.map((row) => {
+    if (row.status === QuotaUsageWorkloadStatuses.Admitted) {
+      return row;
+    }
+
+    const position = positions.get(buildQueuePositionKey(row.namespace, row.name));
+    return position == null ? row : { ...row, queuePosition: position };
+  });
+
+export const fetchWorkloadsForClusterQueues = async (
+  clusterQueueNames: string[],
+  namespaces: string[],
+  projectDisplayNames: Map<string, string>,
+  includeTerminal = false,
+): Promise<Map<string, ClusterQueueWorkloadRow[]>> => {
+  if (namespaces.length === 0 || clusterQueueNames.length === 0) {
+    return new Map();
+  }
+
+  const [namespaceData, resourceFlavors] = await Promise.all([
+    Promise.all(namespaces.map(fetchNamespaceWorkloadData)),
+    listResourceFlavors(),
+  ]);
+  const resourceFlavorByName = buildResourceFlavorByName(resourceFlavors);
+  const workloadsByClusterQueue = new Map<string, ClusterQueueWorkloadRow[]>();
+
+  for (const clusterQueueName of clusterQueueNames) {
+    workloadsByClusterQueue.set(
+      clusterQueueName,
+      filterAndMapClusterQueueWorkloads(
+        clusterQueueName,
+        namespaceData,
+        projectDisplayNames,
+        resourceFlavorByName,
+        includeTerminal,
+      ),
+    );
+  }
+
+  const allRows = [...workloadsByClusterQueue.values()].flat();
+  const positions = await fetchQueuePositions(allRows);
+
+  for (const [clusterQueueName, rows] of workloadsByClusterQueue) {
+    workloadsByClusterQueue.set(clusterQueueName, applyQueuePositions(rows, positions));
+  }
+
+  return workloadsByClusterQueue;
+};
+
+export const fetchNamespaceWorkloads = async (
+  namespace: string,
+  projectDisplayName: string,
+  includeTerminal = false,
+): Promise<ClusterQueueWorkloadRow[]> => {
+  if (!namespace) {
+    return [];
+  }
+
+  const [namespaceData, resourceFlavors] = await Promise.all([
+    fetchNamespaceWorkloadData(namespace),
+    listResourceFlavors(),
+  ]);
+  const resourceFlavorByName = buildResourceFlavorByName(resourceFlavors);
+  const rows = filterAndMapNamespaceWorkloads(
+    namespaceData,
+    projectDisplayName,
+    resourceFlavorByName,
+    includeTerminal,
+  );
+  const positions = await fetchQueuePositions(rows);
+  return applyQueuePositions(rows, positions);
+};
+
+export const fetchClusterQueueWorkloads = async (
+  clusterQueueName: string,
+  namespaces: string[],
+  projectDisplayNames: Map<string, string>,
+  includeTerminal = false,
+): Promise<ClusterQueueWorkloadRow[]> => {
+  if (!clusterQueueName || namespaces.length === 0) {
+    return [];
+  }
+
+  const workloadsByClusterQueue = await fetchWorkloadsForClusterQueues(
+    [clusterQueueName],
+    namespaces,
+    projectDisplayNames,
+    includeTerminal,
+  );
+
+  return workloadsByClusterQueue.get(clusterQueueName) ?? [];
+};

--- a/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
+++ b/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
@@ -20,6 +20,7 @@ import {
 } from '@odh-dashboard/k8s-core/kueue/workloadStatus';
 import { KueueWorkloadStatus } from '@odh-dashboard/k8s-core/kueue/types';
 import { buildResourceFlavorByName, resolveWorkloadHardwareProfile } from './hardwareModels';
+import { isAcceleratorResource } from './clusterQueueUtils';
 import {
   type ClusterQueueWorkloadRow,
   QUOTA_USAGE_STATUSES_PAST_ADMISSION,
@@ -29,9 +30,6 @@ import {
   type QuotaUsageWorkloadStatus,
   type QuotaUsageWorkloadType,
 } from '../types';
-import { ACCELERATOR_RESOURCE_REGEX } from '../const';
-
-const ACCELERATOR_RE = new RegExp(ACCELERATOR_RESOURCE_REGEX);
 
 const NOTEBOOK_OWNER_KINDS = new Set(['job', 'statefulset', 'notebook', 'pod']);
 
@@ -169,12 +167,12 @@ export const isKueueManagedWorkload = (
   return true;
 };
 
-/** Quota usage CQ table: Kueue-managed workloads only (Unknown type included — pipeline maps to Unknown until integrated). */
 export const isQuotaUsageClusterQueueWorkload = (
   workload: WorkloadKind,
   pods: PodKind[],
   localQueueByName: Map<string, LocalQueueKind>,
-): boolean => isKueueManagedWorkload(workload, pods, localQueueByName);
+): boolean =>
+  isGpuAwareWorkload(workload) && isKueueManagedWorkload(workload, pods, localQueueByName);
 
 export const isActiveWorkload = (workload: WorkloadKind): boolean => {
   const { status } = getKueueWorkloadStatusWithMessage(workload);
@@ -372,7 +370,7 @@ export const getWorkloadAcceleratorCount = (workload: WorkloadKind): number =>
     const perPod = podSet.template.spec.containers.reduce((containerTotal, container) => {
       const requests = container.resources?.requests ?? {};
       const acceleratorCount = Object.entries(requests).reduce((resourceTotal, [name, value]) => {
-        if (!ACCELERATOR_RE.test(name)) {
+        if (!isAcceleratorResource(name)) {
           return resourceTotal;
         }
         const parsed = Number(value);
@@ -382,6 +380,10 @@ export const getWorkloadAcceleratorCount = (workload: WorkloadKind): number =>
     }, 0);
     return podSetTotal + perPod * podSet.count;
   }, 0);
+
+/** True when the workload requests at least one accelerator resource in podSet container requests. */
+export const isGpuAwareWorkload = (workload: WorkloadKind): boolean =>
+  getWorkloadAcceleratorCount(workload) > 0;
 
 export const getProjectDisplayName = (project: ProjectKind): string =>
   project.metadata.annotations?.['openshift.io/display-name'] ?? project.metadata.name;

--- a/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
+++ b/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
@@ -1,5 +1,6 @@
 import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
 import {
+  type K8sResourceCommon,
   type LocalQueueKind,
   type PodKind,
   type ProjectKind,
@@ -12,6 +13,7 @@ import { getPendingWorkloads } from '@odh-dashboard/internal/api/k8s/pendingWork
 import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
 import { listWorkloads } from '@odh-dashboard/internal/api/k8s/workloads';
 import { PodModel } from '@odh-dashboard/internal/api/models';
+import { RayJobModel, TrainJobModel } from '@odh-dashboard/internal/api/models/kubeflow';
 import {
   getKueueWorkloadStatusWithMessage,
   KUEUE_QUEUE_LABEL,
@@ -20,6 +22,8 @@ import { KueueWorkloadStatus } from '@odh-dashboard/k8s-core/kueue/types';
 import { buildResourceFlavorByName, resolveWorkloadHardwareProfile } from './hardwareModels';
 import {
   type ClusterQueueWorkloadRow,
+  QUOTA_USAGE_STATUSES_PAST_ADMISSION,
+  QUOTA_USAGE_STATUSES_WITH_QUEUE_POSITION,
   QuotaUsageWorkloadStatuses,
   QuotaUsageWorkloadTypes,
   type QuotaUsageWorkloadStatus,
@@ -32,14 +36,20 @@ const ACCELERATOR_RE = new RegExp(ACCELERATOR_RESOURCE_REGEX);
 const NOTEBOOK_OWNER_KINDS = new Set(['job', 'statefulset', 'notebook', 'pod']);
 
 const KUEUE_JOB_NAME_LABEL = 'kueue.x-k8s.io/job-name';
+const KUEUE_JOB_UID_LABEL = 'kueue.x-k8s.io/job-uid';
 
 const TERMINAL_KUEUE_STATUSES = new Set([KueueWorkloadStatus.Complete, KueueWorkloadStatus.Failed]);
+
+/** Mirrors UnifiedJobKind.kind on the model training page (TrainJob | RayJob). */
+export type WorkloadJobKind = 'RayJob' | 'TrainJob';
 
 export type NamespaceWorkloadData = {
   namespace: string;
   workloads: WorkloadKind[];
   localQueues: LocalQueueKind[];
   pods: PodKind[];
+  /** job-uid label → job CR kind; used to classify Job-owned Kueue workloads as Train or Ray job. */
+  jobKindByUid: Map<string, WorkloadJobKind>;
 };
 
 export const listPods = async (namespace: string): Promise<PodKind[]> =>
@@ -48,16 +58,55 @@ export const listPods = async (namespace: string): Promise<PodKind[]> =>
     queryOptions: { ns: namespace },
   }).then((response) => response.items);
 
+const addJobKindsToMap = (
+  jobs: K8sResourceCommon[],
+  kind: WorkloadJobKind,
+  jobKindByUid: Map<string, WorkloadJobKind>,
+): void => {
+  for (const job of jobs) {
+    const uid = job.metadata?.uid;
+    if (uid) {
+      jobKindByUid.set(uid, kind);
+    }
+  }
+};
+
+const buildJobKindByUid = async (namespace: string): Promise<Map<string, WorkloadJobKind>> => {
+  const jobKindByUid = new Map<string, WorkloadJobKind>();
+
+  await Promise.all([
+    k8sListResource<K8sResourceCommon>({
+      model: RayJobModel,
+      queryOptions: { ns: namespace },
+    })
+      .then((response) => addJobKindsToMap(response.items, 'RayJob', jobKindByUid))
+      .catch(() => {
+        // RayJob CRD not installed or RBAC denied.
+      }),
+    k8sListResource<K8sResourceCommon>({
+      model: TrainJobModel,
+      queryOptions: { ns: namespace },
+    })
+      .then((response) => addJobKindsToMap(response.items, 'TrainJob', jobKindByUid))
+      .catch(() => {
+        // TrainJob CRD not installed or RBAC denied.
+      }),
+  ]);
+
+  return jobKindByUid;
+};
+
 export const fetchNamespaceWorkloadData = async (
   namespace: string,
 ): Promise<NamespaceWorkloadData> => {
-  const [workloads, localQueues, pods] = await Promise.all([
+  const [workloads, localQueues, pods, jobKindByUid] = await Promise.all([
     listWorkloads(namespace),
     listLocalQueues(namespace),
     listPods(namespace),
+    buildJobKindByUid(namespace),
   ]);
 
-  return { namespace, workloads, localQueues, pods };
+  return { namespace, workloads, localQueues, pods, jobKindByUid };
 };
 
 export const buildLocalQueueByName = (localQueues: LocalQueueKind[]): Map<string, LocalQueueKind> =>
@@ -162,6 +211,38 @@ export const isRayClusterWorkload = (workload: WorkloadKind): boolean =>
     (ownerRef) => ownerRef.kind === WorkloadOwnerType.RayCluster,
   );
 
+/**
+ * Resolves the training job CR kind for a Kueue workload — same distinction as
+ * `job.kind === 'TrainJob' | 'RayJob'` on the model training page.
+ * Checks owner ref kind first, then kueue.x-k8s.io/job-uid against listed job CRs.
+ */
+export const getWorkloadJobKind = (
+  workload: WorkloadKind,
+  jobKindByUid: ReadonlyMap<string, WorkloadJobKind> = new Map(),
+): WorkloadJobKind | undefined => {
+  for (const ownerRef of workload.metadata?.ownerReferences ?? []) {
+    if (ownerRef.kind === 'RayJob') {
+      return 'RayJob';
+    }
+    if (ownerRef.kind === 'TrainJob') {
+      return 'TrainJob';
+    }
+  }
+
+  const jobUid = workload.metadata?.labels?.[KUEUE_JOB_UID_LABEL];
+  return jobUid ? jobKindByUid.get(jobUid) : undefined;
+};
+
+export const isRayJobWorkload = (
+  workload: WorkloadKind,
+  jobKindByUid: ReadonlyMap<string, WorkloadJobKind> = new Map(),
+): boolean => getWorkloadJobKind(workload, jobKindByUid) === 'RayJob';
+
+export const isTrainJobWorkload = (
+  workload: WorkloadKind,
+  jobKindByUid: ReadonlyMap<string, WorkloadJobKind> = new Map(),
+): boolean => getWorkloadJobKind(workload, jobKindByUid) === 'TrainJob';
+
 const isServingPod = (pod: PodKind): boolean => {
   const labels = pod.metadata.labels ?? {};
   if (labels['serving.kserve.io/inferenceservice']) {
@@ -236,13 +317,14 @@ export const isServingWorkload = (workload: WorkloadKind, pods: PodKind[]): bool
   return isServingPod(pod);
 };
 
-/** Training jobs: Job owner that is not a notebook workbench (TrainJob, RayJob, PyTorchJob, etc.). */
+/** Training jobs: Job owner that is not a notebook workbench (TrainJob, PyTorchJob, etc.). */
 export const isTrainingJobWorkload = (workload: WorkloadKind): boolean =>
   hasOwnerKind(workload, WorkloadOwnerType.Job) && !isNotebookWorkload(workload);
 
 export const resolveWorkloadType = (
   workload: WorkloadKind,
   pods: PodKind[],
+  jobKindByUid: ReadonlyMap<string, WorkloadJobKind> = new Map(),
 ): QuotaUsageWorkloadType => {
   if (isServingWorkload(workload, pods)) {
     return QuotaUsageWorkloadTypes.Serve;
@@ -253,29 +335,37 @@ export const resolveWorkloadType = (
   if (isRayClusterWorkload(workload)) {
     return QuotaUsageWorkloadTypes.RayCluster;
   }
-  if (isTrainingJobWorkload(workload)) {
+
+  const jobKind = getWorkloadJobKind(workload, jobKindByUid);
+  if (jobKind === 'RayJob') {
+    return QuotaUsageWorkloadTypes.RayJob;
+  }
+  if (jobKind === 'TrainJob') {
     return QuotaUsageWorkloadTypes.Train;
   }
+
   return QuotaUsageWorkloadTypes.Unknown;
 };
 
-/**
- * UXD status mapping for the Quota usage workloads table.
- * - Queued → Queued
- * - Admitted / Running → Admitted
- * - Inadmissible, AdmissionCheck, BlockedOnPreemptionGates, Evicted, Requeued, Preempted → Pending
- */
+const KUEUE_TO_QUOTA_USAGE_STATUS: Record<KueueWorkloadStatus, QuotaUsageWorkloadStatus> = {
+  [KueueWorkloadStatus.Queued]: QuotaUsageWorkloadStatuses.Queued,
+  [KueueWorkloadStatus.Failed]: QuotaUsageWorkloadStatuses.Failed,
+  [KueueWorkloadStatus.Preempted]: QuotaUsageWorkloadStatuses.Preempted,
+  [KueueWorkloadStatus.Evicted]: QuotaUsageWorkloadStatuses.Evicted,
+  [KueueWorkloadStatus.Requeued]: QuotaUsageWorkloadStatuses.Requeued,
+  [KueueWorkloadStatus.Inadmissible]: QuotaUsageWorkloadStatuses.Inadmissible,
+  [KueueWorkloadStatus.AdmissionCheck]: QuotaUsageWorkloadStatuses.AdmissionCheck,
+  [KueueWorkloadStatus.BlockedOnPreemptionGates]:
+    QuotaUsageWorkloadStatuses.BlockedOnPreemptionGates,
+  [KueueWorkloadStatus.Running]: QuotaUsageWorkloadStatuses.Running,
+  [KueueWorkloadStatus.Admitted]: QuotaUsageWorkloadStatuses.Admitted,
+  [KueueWorkloadStatus.Complete]: QuotaUsageWorkloadStatuses.Complete,
+};
+
+/** Maps each KueueWorkloadStatus to its UXD Quota usage table status (1:1). */
 export const mapKueueStatusToQuotaUsageStatus = (
   kueueStatus: KueueWorkloadStatus,
-): QuotaUsageWorkloadStatus => {
-  if (kueueStatus === KueueWorkloadStatus.Queued) {
-    return QuotaUsageWorkloadStatuses.Queued;
-  }
-  if (kueueStatus === KueueWorkloadStatus.Admitted || kueueStatus === KueueWorkloadStatus.Running) {
-    return QuotaUsageWorkloadStatuses.Admitted;
-  }
-  return QuotaUsageWorkloadStatuses.Pending;
-};
+): QuotaUsageWorkloadStatus => KUEUE_TO_QUOTA_USAGE_STATUS[kueueStatus];
 
 export const getWorkloadAcceleratorCount = (workload: WorkloadKind): number =>
   workload.spec.podSets.reduce((podSetTotal, podSet) => {
@@ -336,6 +426,7 @@ export const mapWorkloadToRow = (
   pods: PodKind[],
   localQueueByName: Map<string, LocalQueueKind>,
   resourceFlavorByName: Map<string, ResourceFlavorKind>,
+  jobKindByUid: ReadonlyMap<string, WorkloadJobKind> = new Map(),
   clusterQueueName?: string,
 ): ClusterQueueWorkloadRow => {
   const kueueStatus = getKueueWorkloadStatusWithMessage(workload);
@@ -346,7 +437,7 @@ export const mapWorkloadToRow = (
     namespace,
     project: projectDisplayName,
     clusterQueue: clusterQueueName ?? resolveWorkloadClusterQueue(workload, localQueueByName),
-    type: resolveWorkloadType(workload, pods),
+    type: resolveWorkloadType(workload, pods, jobKindByUid),
     status,
     localQueue: workload.spec.queueName ?? '',
     accelerators: getWorkloadAcceleratorCount(workload),
@@ -363,7 +454,7 @@ export const filterAndMapClusterQueueWorkloads = (
   resourceFlavorByName: Map<string, ResourceFlavorKind>,
   includeTerminal = false,
 ): ClusterQueueWorkloadRow[] =>
-  namespaceData.flatMap(({ namespace, workloads, localQueues, pods }) => {
+  namespaceData.flatMap(({ namespace, workloads, localQueues, pods, jobKindByUid }) => {
     const localQueueByName = buildLocalQueueByName(localQueues);
     const projectDisplayName = projectDisplayNames.get(namespace) ?? namespace;
 
@@ -382,6 +473,7 @@ export const filterAndMapClusterQueueWorkloads = (
           pods,
           localQueueByName,
           resourceFlavorByName,
+          jobKindByUid,
           clusterQueueName,
         ),
       );
@@ -389,7 +481,7 @@ export const filterAndMapClusterQueueWorkloads = (
 
 /** All workloads in a namespace, regardless of cluster queue. */
 export const filterAndMapNamespaceWorkloads = (
-  { namespace, workloads, localQueues, pods }: NamespaceWorkloadData,
+  { namespace, workloads, localQueues, pods, jobKindByUid }: NamespaceWorkloadData,
   projectDisplayName: string,
   resourceFlavorByName: Map<string, ResourceFlavorKind>,
   includeTerminal = false,
@@ -406,6 +498,7 @@ export const filterAndMapNamespaceWorkloads = (
         pods,
         localQueueByName,
         resourceFlavorByName,
+        jobKindByUid,
       ),
     );
 };
@@ -427,7 +520,7 @@ export const fetchQueuePositions = async (
   const workloadsByQueue = new Map<string, ClusterQueueWorkloadRow[]>();
 
   for (const row of rows) {
-    if (row.status !== QuotaUsageWorkloadStatuses.Queued || !row.localQueue) {
+    if (!QUOTA_USAGE_STATUSES_WITH_QUEUE_POSITION.includes(row.status) || !row.localQueue) {
       continue;
     }
     const queueKey = `${row.namespace}/${row.localQueue}`;
@@ -464,7 +557,7 @@ export const applyQueuePositions = (
   positions: Map<QueuePositionKey, number>,
 ): ClusterQueueWorkloadRow[] =>
   rows.map((row) => {
-    if (row.status === QuotaUsageWorkloadStatuses.Admitted) {
+    if (QUOTA_USAGE_STATUSES_PAST_ADMISSION.includes(row.status)) {
       return row;
     }
 

--- a/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
+++ b/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
@@ -21,6 +21,7 @@ import {
 import { KueueWorkloadStatus } from '@odh-dashboard/k8s-core/kueue/types';
 import { buildResourceFlavorByName, resolveWorkloadHardwareProfile } from './hardwareModels';
 import { isAcceleratorResource } from './clusterQueueUtils';
+import parseK8sQuantity from './parseK8sQuantity';
 import {
   type ClusterQueueWorkloadRow,
   QUOTA_USAGE_STATUSES_PAST_ADMISSION,
@@ -161,6 +162,9 @@ export const isKueueManagedWorkload = (
 
   if (isServingWorkload(workload, pods)) {
     const servingPods = findServingWorkloadPods(workload, pods);
+    if (servingPods.length === 0) {
+      return false;
+    }
     return servingPods.some((pod) => Boolean(pod.metadata.labels?.[KUEUE_QUEUE_LABEL]));
   }
 
@@ -369,19 +373,22 @@ export const getWorkloadAcceleratorCount = (workload: WorkloadKind): number =>
   workload.spec.podSets.reduce((podSetTotal, podSet) => {
     const perPod = podSet.template.spec.containers.reduce((containerTotal, container) => {
       const requests = container.resources?.requests ?? {};
-      const acceleratorCount = Object.entries(requests).reduce((resourceTotal, [name, value]) => {
+      const limits = container.resources?.limits ?? {};
+      const resourceNames = new Set([...Object.keys(requests), ...Object.keys(limits)]);
+
+      const acceleratorCount = [...resourceNames].reduce((resourceTotal, name) => {
         if (!isAcceleratorResource(name)) {
           return resourceTotal;
         }
-        const parsed = Number(value);
-        return resourceTotal + (Number.isFinite(parsed) ? parsed : 0);
+        const value = requests[name] ?? limits[name];
+        return resourceTotal + parseK8sQuantity(value);
       }, 0);
       return containerTotal + acceleratorCount;
     }, 0);
     return podSetTotal + perPod * podSet.count;
   }, 0);
 
-/** True when the workload requests at least one accelerator resource in podSet container requests. */
+/** True when the workload requests at least one accelerator resource in podSet container resources. */
 export const isGpuAwareWorkload = (workload: WorkloadKind): boolean =>
   getWorkloadAcceleratorCount(workload) > 0;
 

--- a/packages/gpuaas/src/utils/hardwareModels.ts
+++ b/packages/gpuaas/src/utils/hardwareModels.ts
@@ -1,8 +1,53 @@
-import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/k8s-core';
+import { ClusterQueueKind, ResourceFlavorKind, type WorkloadKind } from '@odh-dashboard/k8s-core';
 import parseK8sQuantity from './parseK8sQuantity';
 import { ACCELERATOR_RESOURCE_REGEX } from '../const';
 
 const ACCELERATOR_RE = new RegExp(ACCELERATOR_RESOURCE_REGEX);
+
+const GPU_PRODUCT_LABELS = [
+  'nvidia.com/gpu.product',
+  'amd.com/gpu.product',
+  'intel.com/gpu.product',
+] as const;
+
+export const buildResourceFlavorByName = (
+  resourceFlavors: ResourceFlavorKind[],
+): Map<string, ResourceFlavorKind> =>
+  new Map(
+    resourceFlavors.flatMap((resourceFlavor) => {
+      const name = resourceFlavor.metadata?.name;
+      return name ? [[name, resourceFlavor] as const] : [];
+    }),
+  );
+
+/** Resolves admitted ResourceFlavor assignments to GPU product names. */
+export const resolveWorkloadHardwareProfile = (
+  workload: WorkloadKind,
+  resourceFlavorByName: Map<string, ResourceFlavorKind>,
+): string | undefined => {
+  const models = new Set<string>();
+
+  for (const assignment of workload.status?.admission?.podSetAssignments ?? []) {
+    for (const flavorName of Object.values(assignment.flavors ?? {})) {
+      const resourceFlavor = resourceFlavorByName.get(flavorName);
+      if (!resourceFlavor?.spec.nodeLabels) {
+        continue;
+      }
+      for (const label of GPU_PRODUCT_LABELS) {
+        const value = resourceFlavor.spec.nodeLabels[label];
+        if (value) {
+          models.add(value);
+        }
+      }
+    }
+  }
+
+  if (models.size === 0) {
+    return undefined;
+  }
+
+  return [...models].toSorted((a, b) => a.localeCompare(b)).join(', ');
+};
 
 export type ModelGpuCount = {
   model: string;
@@ -10,12 +55,6 @@ export type ModelGpuCount = {
   nominal: number;
   borrowed?: number;
 };
-
-const GPU_PRODUCT_LABELS = [
-  'nvidia.com/gpu.product',
-  'amd.com/gpu.product',
-  'intel.com/gpu.product',
-] as const;
 
 /**
  * Resolves hardware model names for each ClusterQueue by mapping through

--- a/packages/gpuaas/src/utils/kueueProjects.ts
+++ b/packages/gpuaas/src/utils/kueueProjects.ts
@@ -1,7 +1,13 @@
 import { isAiProject, KnownLabels, type ProjectKind } from '@odh-dashboard/k8s-core';
 
+export const isKueueManagedDataScienceProject = (project: ProjectKind): boolean =>
+  isAiProject(project) && project.metadata.labels?.[KnownLabels.KUEUE_MANAGED] === 'true';
+
 export const isNonKueueManagedDataScienceProject = (project: ProjectKind): boolean =>
   isAiProject(project) && project.metadata.labels?.[KnownLabels.KUEUE_MANAGED] !== 'true';
+
+export const getKueueManagedDataScienceProjects = (projects: ProjectKind[]): ProjectKind[] =>
+  projects.filter(isKueueManagedDataScienceProject);
 
 export const getNonKueueManagedDataScienceProjects = (projects: ProjectKind[]): ProjectKind[] =>
   projects.filter(isNonKueueManagedDataScienceProject);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://redhat.atlassian.net/browse/RHOAIENG-88179

## Description
Data layer for the Infrastructure **Quota usage** workloads drawer (no UI in this PR).
Adds hooks and utilities to fetch and map Kueue `Workload` CRs across Kueue-managed Data Science Project namespaces into table rows for a selected cluster queue.
**Hooks**
- `useWorkloadRows` — core fetch (cluster-queue or namespace scope)
- `useClusterQueueWorkloads(clusterQueueName)` — single CQ for drawer UX (`undefined` = skip fetch)
- `useClusterQueueWorkloadsData` — batch multi-CQ fetch (if needed later)
- `useNamespaceWorkloads` — future namespace tab
**Utils (`clusterQueueWorkloads.ts`)**
- Fan-out per namespace: Workloads, LocalQueues, Pods
- Filter admitted (by `status.admission.clusterQueue`) and pending (via LocalQueue → CQ)
- Active-only by default (exclude Complete/Failed)
- Kueue-managed filter (`isKueueManagedWorkload`)
- Type taxonomy: Workbench, Train, Serve, Ray cluster, Unknown (pipeline → Unknown)
- Status mapping: Pending / Queued / Admitted
- Queue position via Visibility API (403-safe)
- Priority + hardware profile from admission ResourceFlavor
**Also**
- `getKueueManagedDataScienceProjects` helper
- `resolveWorkloadHardwareProfile` in `hardwareModels.ts`
- Row/types constants in `types.ts` and `const.ts`
<img width="928" height="410" alt="workbench" src="https://github.com/user-attachments/assets/259fc41e-0cee-4628-98c9-4e0561e73d7f" />


<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Manual test with console.log 
1. Create packages/gpuaas/src/components/WorkloadHooksDebug.tsx:

```
import * as React from 'react';
import useClusterQueueWorkloads from '../hooks/useClusterQueueWorkloads';
const WorkloadHooksDebug: React.FC<{ clusterQueueName?: string }> = ({ clusterQueueName }) => {
  const { workloads, loaded, error, isEmpty } = useClusterQueueWorkloads(clusterQueueName);
  React.useEffect(() => {
    if (!clusterQueueName) {
      console.log('[workload-hooks] drawer closed — fetch skipped');
      return;
    }
    if (!loaded) {
      console.log(`[workload-hooks] ${clusterQueueName} loading…`);
      return;
    }
    console.log(`[workload-hooks] ${clusterQueueName}:`, { workloads, isEmpty });
  }, [clusterQueueName, loaded, workloads, isEmpty]);
  React.useEffect(() => {
    if (error) console.error('[workload-hooks] error:', error);
  }, [error]);
  return null;
};
export default WorkloadHooksDebug;
```
2. In ClusterQueueUtilizationSection.tsx, before CohortAccordionGroup:

```
import WorkloadHooksDebug from './WorkloadHooksDebug';
// pick a real CQ from your cluster, e.g. 'default' or 'burst-training'
<WorkloadHooksDebug clusterQueueName="default" />
```
3. npm run dev → Infrastructure → Compute profile utilization → DevTools Console
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact

cd packages/gpuaas
npm run test-unit -- --testPathPattern="clusterQueueWorkloads|useWorkloadRows|useClusterQueueWorkloads|kueueProjects|hardwareModels"

<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workload data views for cluster queues and namespaces.
  * Added workload status, type, priority, accelerator, hardware profile, and queue-position details.
  * Added filtering options and empty-state guidance for cluster queue workloads.
  * Added loading, error, and refresh states for workload information.
  * Added support for identifying Kueue-managed projects and workloads.

* **Tests**
  * Expanded coverage for workload retrieval, mapping, filtering, queue positions, project handling, and hardware profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->