### PR TITLE
fix(e2e): wait for dashboard label and Active before project list lookup

### DIFF
--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -19,7 +19,7 @@ class ProjectListToolbar extends Contextual<HTMLElement> {
     return this.find().findByLabelText(`Filter by ${name}`);
   }
 
-  findNameFilter(): Cypress.Chainable<JQuery<HTMLElement>> {
+  findNameFilter(): Cypress.Chainable<JQuery<HTMLInputElement>> {
     // data-testid is on the PF TextInputGroup wrapper; type/clear need the input.
     return this.find().findByTestId('project-list-name-filter').find('input');
   }

--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -20,7 +20,8 @@ class ProjectListToolbar extends Contextual<HTMLElement> {
   }
 
   findNameFilter(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().findByTestId('project-list-name-filter');
+    // data-testid is on the PF TextInputGroup wrapper; type/clear need the input.
+    return this.find().findByTestId('project-list-name-filter').find('input');
   }
 
   findUserFilter(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -85,9 +86,88 @@ class ProjectListPage {
     this.wait();
   }
 
+  /**
+   * Wait until the projects page has finished loading. During Loading the page title
+   * exists in the DOM but has zero height, so visibility on app-page-title flakes.
+   */
+  private waitForProjectsPageReady(): void {
+    cy.findByTestId('app-page-title', { timeout: 30000 }).should('exist');
+    cy.get('[data-testid="project-view-table"], [data-testid="no-project"]', {
+      timeout: 60000,
+    }).should('be.visible');
+  }
+
   private wait() {
-    cy.findByTestId('app-page-title', { timeout: 15000 }).should('be.visible');
+    this.waitForProjectsPageReady();
     cy.testA11y();
+  }
+
+  private waitForProjectList(): void {
+    this.waitForProjectsPageReady();
+  }
+
+  private projectLinkHrefSelector(projectName: string): string {
+    return `[data-testid="project-view-table"] a[href$="/projects/${projectName}"], [data-testid="project-view-table"] a[href$="/projects/${projectName}/"]`;
+  }
+
+  private tableHasProjectLink(projectName: string): boolean {
+    const hrefSuffix = `/projects/${projectName}`;
+    return Cypress.$('[data-testid="project-view-table"] a[href]')
+      .toArray()
+      .some((el) => {
+        const path = (el.getAttribute('href') || '').split('?')[0];
+        return path.endsWith(hrefSuffix) || path.endsWith(`${hrefSuffix}/`);
+      });
+  }
+
+  /**
+   * Poll the live table for the project href. A one-shot jQuery find right after
+   * typing the name filter misses the row while React/k8s watch catch up.
+   * Do not pass a function to findByRole({ name }) — Cypress stringifies it.
+   */
+  private waitForProjectLinkInTable(projectName: string): Cypress.Chainable<boolean> {
+    const settleMs = 15000;
+    const pollMs = 500;
+    return cy.wrap(null, { log: false }).then(
+      { timeout: settleMs + 5000 },
+      () =>
+        new Cypress.Promise<boolean>((resolve) => {
+          const deadline = Date.now() + settleMs;
+          const poll = () => {
+            if (this.tableHasProjectLink(projectName)) {
+              resolve(true);
+            } else if (Date.now() >= deadline) {
+              resolve(false);
+            } else {
+              setTimeout(poll, pollMs);
+            }
+          };
+          poll();
+        }),
+    );
+  }
+
+  private applyNameFilter(projectName: string): void {
+    cy.findByTestId('projects-table-toolbar', { timeout: 30000 }).should('be.visible');
+    this.findProjectsTable().should('be.visible', { timeout: 60000 });
+    this.findProjectTypeDropdownToggleIfPresent().then((present) => {
+      if (present) {
+        this.getTableToolbar()
+          .findProjectTypeDropdownToggle()
+          .then(($toggle) => {
+            if (!$toggle.text().includes('All projects')) {
+              this.getTableToolbar().selectProjectType('All projects');
+            }
+          });
+      }
+    });
+    this.getTableToolbar().findNameFilter().should('be.visible').clear().type(projectName);
+  }
+
+  private findProjectTypeDropdownToggleIfPresent(): Cypress.Chainable<boolean> {
+    return cy
+      .get('body')
+      .then(($body) => $body.find('[data-testid="project-type-dropdown-toggle"]').length > 0);
   }
 
   findPageTitle() {
@@ -126,10 +206,13 @@ class ProjectListPage {
   }
 
   findProjectLink(projectName: string, timeout?: number) {
-    return this.findProjectsTable().findByRole('link', {
-      name: projectName,
-      ...(timeout !== undefined ? { timeout } : {}),
-    });
+    const t = timeout ?? Cypress.config('defaultCommandTimeout');
+    if (Cypress.env('MOCK')) {
+      return this.findProjectsTable().findByRole('link', { name: projectName, timeout: t });
+    }
+    // E2E: PatternFly Truncate leaves the link without a usable accessible name.
+    // Cypress also stringifies function `name` matchers, so use the k8s href.
+    return cy.get(this.projectLinkHrefSelector(projectName), { timeout: t });
   }
 
   findEmptyResults() {
@@ -153,13 +236,32 @@ class ProjectListPage {
   }
 
   /**
-   * Filter Project by name using the Project filter from the Projects view
-   * @param projectName Project Name
+   * Filter the project list by name and wait until that project appears.
+   * Reloads if the first list fetch ran before the project was visible to the UI.
    */
   filterProjectByName = (projectName: string) => {
-    cy.findByTestId('projects-table-toolbar', { timeout: 30000 }).should('be.visible');
-    const projectListToolbar = projectListPage.getTableToolbar();
-    projectListToolbar.findNameFilter().type(projectName);
+    const maxAttempts = 6;
+    const waitForLink = (attemptNumber = 1): Cypress.Chainable<boolean> => {
+      this.applyNameFilter(projectName);
+      return this.waitForProjectLinkInTable(projectName).then((found) => {
+        if (found) {
+          cy.log(`✅ Project "${projectName}" visible in list`);
+          return cy.wrap(true);
+        }
+        if (attemptNumber >= maxAttempts) {
+          return this.findProjectLink(projectName, 60000)
+            .should('exist')
+            .then(() => cy.wrap(true));
+        }
+        cy.log(
+          `⏳ Project "${projectName}" not in list yet (attempt ${attemptNumber}/${maxAttempts}), reloading`,
+        );
+        cy.reload();
+        this.waitForProjectList();
+        return waitForLink(attemptNumber + 1);
+      });
+    };
+    return waitForLink();
   };
 
   /**

--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -1,4 +1,4 @@
-import { pollUntilSuccess } from './baseCommands';
+import { pollUntilSuccess, waitForNamespace } from './baseCommands';
 import type { CommandLineResult, DashboardConfig } from '../../types';
 import { handleOCCommandResult } from '../errorHandling';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
@@ -25,15 +25,24 @@ export const createOpenShiftProject = (
                 stderr: ${result.stderr}`);
       throw new Error(`Command failed with code ${result.exitCode}`);
     }
-    // Add dashboard label immediately after project creation
-    const labelCommand = `oc label namespace ${projectName} opendatahub.io/dashboard=true --overwrite`;
-    return cy.exec(labelCommand, { failOnNonZeroExit: false }).then((labelResult) => {
-      if (labelResult.exitCode !== 0) {
-        cy.log(`WARNING: Failed to add dashboard label to ${projectName}
-                  stdout: ${labelResult.stdout}
-                  stderr: ${labelResult.stderr}`);
-      }
-      return cy.wrap(result);
+    // Wait until the namespace is patchable, then require the dashboard label
+    // and Active phase so the A.I. projects filter can see it.
+    return waitForNamespace(projectName, 30, 1000).then(() => {
+      const labelCommand = `oc label namespace ${projectName} opendatahub.io/dashboard=true --overwrite`;
+      return cy.exec(labelCommand, { failOnNonZeroExit: false }).then((labelResult) => {
+        if (labelResult.exitCode !== 0) {
+          throw new Error(
+            `Failed to add dashboard label to ${projectName}: ${
+              labelResult.stderr || labelResult.stdout
+            }`,
+          );
+        }
+        return pollUntilSuccess(
+          `oc get project ${projectName} -o json | jq -e '.metadata.labels["opendatahub.io/dashboard"] == "true" and .status.phase == "Active"'`,
+          `project ${projectName} dashboard-ready`,
+          { maxAttempts: 15, pollIntervalMs: 1000 },
+        ).then(() => cy.wrap(result));
+      });
     });
   });
 };

--- a/packages/cypress/cypress/utils/projectChecker.ts
+++ b/packages/cypress/cypress/utils/projectChecker.ts
@@ -5,17 +5,16 @@ import {
 } from './oc_commands/project';
 import { ensureAdminOcSession } from './oc_commands/baseCommands';
 
-export const createAndVerifyProject = (projectName: string): void => {
+export const createAndVerifyProject = (projectName: string): Cypress.Chainable<boolean> =>
   createOpenShiftProject(projectName).then((result) => {
     expect(result.exitCode).to.equal(0);
+    return verifyOpenShiftProjectExists(projectName).then((exists) => {
+      if (!exists) {
+        throw new Error(`Expected project ${projectName} to exist, but it does not.`);
+      }
+      return cy.wrap(true);
+    });
   });
-
-  verifyOpenShiftProjectExists(projectName).then((exists) => {
-    if (!exists) {
-      throw new Error(`Expected project ${projectName} to exist, but it does not.`);
-    }
-  });
-};
 
 // Best-effort cleanup for after() hooks — failures are logged, never thrown.
 export const cleanupTestProject = (projectName: string): void => {
@@ -31,11 +30,11 @@ export const cleanupTestProject = (projectName: string): void => {
   });
 };
 
-export const createCleanProject = (projectName: string): void => {
+export const createCleanProject = (projectName: string): Cypress.Chainable<boolean> =>
   verifyOpenShiftProjectExists(projectName).then((exists) => {
     if (exists) {
       cy.log(`Project ${projectName} already exists. Deleting it.`);
-      deleteOpenShiftProject(projectName, { wait: true }).then(() => {
+      return deleteOpenShiftProject(projectName, { wait: true }).then(() => {
         // Verify the project is actually gone before creating a new one
         // Projects can be in "Terminating" state even after delete --wait returns
         cy.log(`Waiting for project ${projectName} to be fully deleted...`);
@@ -52,14 +51,12 @@ export const createCleanProject = (projectName: string): void => {
             },
           );
         };
-        checkDeleted().then(() => {
+        return checkDeleted().then(() => {
           cy.log(`Creating project ${projectName}`);
-          createAndVerifyProject(projectName);
+          return createAndVerifyProject(projectName);
         });
       });
-    } else {
-      cy.log(`Creating project ${projectName}`);
-      createAndVerifyProject(projectName);
     }
+    cy.log(`Creating project ${projectName}`);
+    return createAndVerifyProject(projectName);
   });
-};


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-88567

## Description

Fixes flaky Cypress E2E failures after `oc new-project` when navigating the Projects list.

- Wait for namespace readiness before UI lookup.
- Improve Projects table polling and loading handling.
- Fix name-filter input clearing.
- Return chainables from `createCleanProject`.

## How Has This Been Tested?

- **Cluster:** `ods-qe-psi-03` — RHOAI 3.6.0-ea.1, OCP 4.20.15
- **Specs:** `testWorkbenchStatus.cy.ts`, `testProjectEditing.cy.ts` — passing.
- **Lint:** Changed Cypress files — clean.

## Test Impact

Cypress E2E page-object/helper changes only. Existing specs using `createCleanProject` → `filterProjectByName` benefit from the fix.

## Request Review Criteria

- [x] Manually tested and verified.
- [x] Testing instructions added.
- [x] Tests added or testing rationale provided.
- [x] Code follows project best practices.

## Before Merge

- [ ] Test the solution on a cluster using the PR image built for `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved project-list test reliability by waiting for loading and empty states, refining project-name filtering, and adding retry handling.
  * Enhanced project creation checks to confirm namespaces are ready, labels are applied successfully, and projects become active.
  * Updated project setup and cleanup checks to wait for operations to complete before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->