### PR TITLE
fix(e2e): stabilize serving runtime row and project list lookups

### DIFF
--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -19,7 +19,7 @@ class ProjectListToolbar extends Contextual<HTMLElement> {
     return this.find().findByLabelText(`Filter by ${name}`);
   }
 
-  findNameFilter(): Cypress.Chainable<JQuery<HTMLElement>> {
+  findNameFilter(): Cypress.Chainable<JQuery<HTMLInputElement>> {
     // data-testid is on the PF TextInputGroup wrapper; type/clear need the input.
     return this.find().findByTestId('project-list-name-filter').find('input');
   }

--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -20,7 +20,8 @@ class ProjectListToolbar extends Contextual<HTMLElement> {
   }
 
   findNameFilter(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().findByTestId('project-list-name-filter');
+    // data-testid is on the PF TextInputGroup wrapper; type/clear need the input.
+    return this.find().findByTestId('project-list-name-filter').find('input');
   }
 
   findUserFilter(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -85,9 +86,88 @@ class ProjectListPage {
     this.wait();
   }
 
+  /**
+   * Wait until the projects page has finished loading. During Loading the page title
+   * exists in the DOM but has zero height, so visibility on app-page-title flakes.
+   */
+  private waitForProjectsPageReady(): void {
+    cy.findByTestId('app-page-title', { timeout: 30000 }).should('exist');
+    cy.get('[data-testid="project-view-table"], [data-testid="no-project"]', {
+      timeout: 60000,
+    }).should('be.visible');
+  }
+
   private wait() {
-    cy.findByTestId('app-page-title', { timeout: 15000 }).should('be.visible');
+    this.waitForProjectsPageReady();
     cy.testA11y();
+  }
+
+  private waitForProjectList(): void {
+    this.waitForProjectsPageReady();
+  }
+
+  private projectLinkHrefSelector(projectName: string): string {
+    return `[data-testid="project-view-table"] a[href$="/projects/${projectName}"], [data-testid="project-view-table"] a[href$="/projects/${projectName}/"]`;
+  }
+
+  private tableHasProjectLink(projectName: string): boolean {
+    const hrefSuffix = `/projects/${projectName}`;
+    return Cypress.$('[data-testid="project-view-table"] a[href]')
+      .toArray()
+      .some((el) => {
+        const path = (el.getAttribute('href') || '').split('?')[0];
+        return path.endsWith(hrefSuffix) || path.endsWith(`${hrefSuffix}/`);
+      });
+  }
+
+  /**
+   * Poll the live table for the project href. A one-shot jQuery find right after
+   * typing the name filter misses the row while React/k8s watch catch up.
+   * Do not pass a function to findByRole({ name }) — Cypress stringifies it.
+   */
+  private waitForProjectLinkInTable(projectName: string): Cypress.Chainable<boolean> {
+    const settleMs = 15000;
+    const pollMs = 500;
+    return cy.wrap(null, { log: false }).then(
+      { timeout: settleMs + 5000 },
+      () =>
+        new Cypress.Promise<boolean>((resolve) => {
+          const deadline = Date.now() + settleMs;
+          const poll = () => {
+            if (this.tableHasProjectLink(projectName)) {
+              resolve(true);
+            } else if (Date.now() >= deadline) {
+              resolve(false);
+            } else {
+              setTimeout(poll, pollMs);
+            }
+          };
+          poll();
+        }),
+    );
+  }
+
+  private applyNameFilter(projectName: string): void {
+    cy.findByTestId('projects-table-toolbar', { timeout: 30000 }).should('be.visible');
+    this.findProjectsTable(60000).should('be.visible');
+    this.findProjectTypeDropdownToggleIfPresent().then((present) => {
+      if (present) {
+        this.getTableToolbar()
+          .findProjectTypeDropdownToggle()
+          .then(($toggle) => {
+            if (!$toggle.text().includes('All projects')) {
+              this.getTableToolbar().selectProjectType('All projects');
+            }
+          });
+      }
+    });
+    this.getTableToolbar().findNameFilter().should('be.visible').clear().type(projectName);
+  }
+
+  private findProjectTypeDropdownToggleIfPresent(): Cypress.Chainable<boolean> {
+    return cy
+      .get('body')
+      .then(($body) => $body.find('[data-testid="project-type-dropdown-toggle"]').length > 0);
   }
 
   findPageTitle() {
@@ -117,8 +197,8 @@ class ProjectListPage {
     return cy.findByTestId('launch-standalone-notebook-server');
   }
 
-  findProjectsTable() {
-    return cy.findByTestId('project-view-table');
+  findProjectsTable(timeout?: number) {
+    return cy.findByTestId('project-view-table', timeout !== undefined ? { timeout } : {});
   }
 
   getProjectRow(projectName: string) {
@@ -126,10 +206,13 @@ class ProjectListPage {
   }
 
   findProjectLink(projectName: string, timeout?: number) {
-    return this.findProjectsTable().findByRole('link', {
-      name: projectName,
-      ...(timeout !== undefined ? { timeout } : {}),
-    });
+    const t = timeout ?? Cypress.config('defaultCommandTimeout');
+    if (Cypress.env('MOCK')) {
+      return this.findProjectsTable().findByRole('link', { name: projectName, timeout: t });
+    }
+    // E2E: PatternFly Truncate leaves the link without a usable accessible name.
+    // Cypress also stringifies function `name` matchers, so use the k8s href.
+    return cy.get(this.projectLinkHrefSelector(projectName), { timeout: t });
   }
 
   findEmptyResults() {
@@ -153,13 +236,32 @@ class ProjectListPage {
   }
 
   /**
-   * Filter Project by name using the Project filter from the Projects view
-   * @param projectName Project Name
+   * Filter the project list by name and wait until that project appears.
+   * Reloads if the first list fetch ran before the project was visible to the UI.
    */
   filterProjectByName = (projectName: string) => {
-    cy.findByTestId('projects-table-toolbar', { timeout: 30000 }).should('be.visible');
-    const projectListToolbar = projectListPage.getTableToolbar();
-    projectListToolbar.findNameFilter().type(projectName);
+    const maxAttempts = 6;
+    const waitForLink = (attemptNumber = 1): Cypress.Chainable<boolean> => {
+      this.applyNameFilter(projectName);
+      return this.waitForProjectLinkInTable(projectName).then((found) => {
+        if (found) {
+          cy.log(`✅ Project "${projectName}" visible in list`);
+          return cy.wrap(true);
+        }
+        if (attemptNumber >= maxAttempts) {
+          return this.findProjectLink(projectName, 60000)
+            .should('exist')
+            .then(() => cy.wrap(true));
+        }
+        cy.log(
+          `⏳ Project "${projectName}" not in list yet (attempt ${attemptNumber}/${maxAttempts}), reloading`,
+        );
+        cy.reload();
+        this.waitForProjectList();
+        return waitForLink(attemptNumber + 1);
+      });
+    };
+    return waitForLink();
   };
 
   /**

--- a/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
@@ -86,14 +86,10 @@ describe('Verify Admins Can Import and Delete a Custom Single-Model Serving Runt
 
       // Edit the created model serving platform and delete
       cy.step(`Verify the model ${modelServingSingleName} has been created`);
-      cy.contains(metadataSingleDisplayName).should('be.visible');
-      servingRuntimeTemplates
-        .getRowById(modelServingSingleName)
-        .find()
-        .within(() => {
-          servingRuntimeTemplates.findEditModel().click();
-        });
-      servingRuntimeTemplates.findDeleteModel().click();
+      const runtimeRow = servingRuntimeTemplates.getRowById(modelServingSingleName);
+      runtimeRow.find().should('exist');
+      runtimeRow.findKebabToggle().click();
+      runtimeRow.findDeleteButton().click();
 
       servingRuntimeTemplates
         .findDeleteModal()

--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -1,4 +1,4 @@
-import { pollUntilSuccess } from './baseCommands';
+import { pollUntilSuccess, waitForNamespace } from './baseCommands';
 import type { CommandLineResult, DashboardConfig } from '../../types';
 import { handleOCCommandResult } from '../errorHandling';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
@@ -25,15 +25,24 @@ export const createOpenShiftProject = (
                 stderr: ${result.stderr}`);
       throw new Error(`Command failed with code ${result.exitCode}`);
     }
-    // Add dashboard label immediately after project creation
-    const labelCommand = `oc label namespace ${projectName} opendatahub.io/dashboard=true --overwrite`;
-    return cy.exec(labelCommand, { failOnNonZeroExit: false }).then((labelResult) => {
-      if (labelResult.exitCode !== 0) {
-        cy.log(`WARNING: Failed to add dashboard label to ${projectName}
-                  stdout: ${labelResult.stdout}
-                  stderr: ${labelResult.stderr}`);
-      }
-      return cy.wrap(result);
+    // Wait until the namespace exists, then require the dashboard label
+    // and Active phase so the A.I. projects filter can see it.
+    return waitForNamespace(projectName, 30, 1000).then(() => {
+      const labelCommand = `oc label namespace ${projectName} opendatahub.io/dashboard=true --overwrite`;
+      return cy.exec(labelCommand, { failOnNonZeroExit: false }).then((labelResult) => {
+        if (labelResult.exitCode !== 0) {
+          throw new Error(
+            `Failed to add dashboard label to ${projectName}: ${
+              labelResult.stderr || labelResult.stdout
+            }`,
+          );
+        }
+        return pollUntilSuccess(
+          `oc get project ${projectName} -o json | jq -e '.metadata.labels["opendatahub.io/dashboard"] == "true" and .status.phase == "Active"'`,
+          `project ${projectName} dashboard-ready`,
+          { maxAttempts: 15, pollIntervalMs: 1000 },
+        ).then(() => cy.wrap(result));
+      });
     });
   });
 };

--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -25,7 +25,7 @@ export const createOpenShiftProject = (
                 stderr: ${result.stderr}`);
       throw new Error(`Command failed with code ${result.exitCode}`);
     }
-    // Wait until the namespace exists, then require the dashboard label
+    // Wait until the namespace is patchable, then require the dashboard label
     // and Active phase so the A.I. projects filter can see it.
     return waitForNamespace(projectName, 30, 1000).then(() => {
       const labelCommand = `oc label namespace ${projectName} opendatahub.io/dashboard=true --overwrite`;

--- a/packages/cypress/cypress/utils/projectChecker.ts
+++ b/packages/cypress/cypress/utils/projectChecker.ts
@@ -5,17 +5,16 @@ import {
 } from './oc_commands/project';
 import { ensureAdminOcSession } from './oc_commands/baseCommands';
 
-export const createAndVerifyProject = (projectName: string): void => {
+export const createAndVerifyProject = (projectName: string): Cypress.Chainable<boolean> =>
   createOpenShiftProject(projectName).then((result) => {
     expect(result.exitCode).to.equal(0);
+    return verifyOpenShiftProjectExists(projectName).then((exists) => {
+      if (!exists) {
+        throw new Error(`Expected project ${projectName} to exist, but it does not.`);
+      }
+      return cy.wrap(true);
+    });
   });
-
-  verifyOpenShiftProjectExists(projectName).then((exists) => {
-    if (!exists) {
-      throw new Error(`Expected project ${projectName} to exist, but it does not.`);
-    }
-  });
-};
 
 // Best-effort cleanup for after() hooks — failures are logged, never thrown.
 export const cleanupTestProject = (projectName: string): void => {
@@ -31,11 +30,11 @@ export const cleanupTestProject = (projectName: string): void => {
   });
 };
 
-export const createCleanProject = (projectName: string): void => {
+export const createCleanProject = (projectName: string): Cypress.Chainable<boolean> =>
   verifyOpenShiftProjectExists(projectName).then((exists) => {
     if (exists) {
       cy.log(`Project ${projectName} already exists. Deleting it.`);
-      deleteOpenShiftProject(projectName, { wait: true }).then(() => {
+      return deleteOpenShiftProject(projectName, { wait: true }).then(() => {
         // Verify the project is actually gone before creating a new one
         // Projects can be in "Terminating" state even after delete --wait returns
         cy.log(`Waiting for project ${projectName} to be fully deleted...`);
@@ -52,14 +51,12 @@ export const createCleanProject = (projectName: string): void => {
             },
           );
         };
-        checkDeleted().then(() => {
+        return checkDeleted().then(() => {
           cy.log(`Creating project ${projectName}`);
-          createAndVerifyProject(projectName);
+          return createAndVerifyProject(projectName);
         });
       });
-    } else {
-      cy.log(`Creating project ${projectName}`);
-      createAndVerifyProject(projectName);
     }
+    cy.log(`Creating project ${projectName}`);
+    return createAndVerifyProject(projectName);
   });
-};


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-88567

## Description

Two Cypress E2E flakes that show up on Jenkins (full OOTB runtime lists / `oc new-project` racing the Projects table), not in a typical local cluster.

**Serving runtime templates:** After creating a custom runtime, the test asserted `cy.contains(displayName).should('be.visible')`. Jenkins installs enough out-of-the-box runtimes that the new row is in the DOM but clipped by page overflow, so Cypress treats it as hidden. Assert the row exists via `data-testid` and open delete from the row kebab (same pattern as `testServingRuntimesUnsupported.cy.ts`).

**Projects list (port of https://github.com/opendatahub-io/odh-dashboard/pull/9577):** `oc new-project` can return before the namespace is labeled and `Active`, so the A.I. projects filter misses the row. Wait for the namespace, require `opendatahub.io/dashboard=true` (fail if labeling fails), wait until labeled + Active, return chainables from `createCleanProject` / `createAndVerifyProject`, and stabilize `filterProjectByName` (wait for table vs loading title, type into the real filter input, poll by href, reload/retry).

`should('be.visible', { timeout: 60000 })` does not apply that timeout in Cypress; the 60s wait is on `findProjectsTable(60000)` instead.

## How Has This Been Tested?

- Lint-staged (eslint) passed on the changed Cypress files.
- Serving-runtime visibility failure was observed on Jenkins (`dash-e2e-odh`); locally the shorter runtime list does not reproduce it.
- Project-list helper behavior matches #9577 (`testWorkbenchStatus.cy.ts` / `testProjectEditing.cy.ts` passed on `ods-qe-psi-03` in that PR). Combined branch still needs a Jenkins rerun of the affected E2E specs.

## Test Impact

Cypress E2E only. No new specs.

- `testSingleServingRuntimeCreation.cy.ts` — assert row existence instead of viewport visibility.
- `createOpenShiftProject` / `createCleanProject` / `filterProjectByName` — used by project-list specs (`testWorkbenchStatus`, `testFeatureStoreWorkbenchConnect`, `testProjectEditing`, and others that filter by name after `oc new-project`).

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved project list test reliability by waiting for table or empty-state content and allowing additional time for projects to appear.
  * Updated project filtering and deletion checks to reflect current interface behavior.
  * Strengthened serving runtime creation and cleanup verification.
  * Improved project setup checks by confirming labels and active status before tests continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->