### PR TITLE
Feat(RHOAIENG-79841) : Quota usage tree view changes

### DIFF
--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -136,12 +136,29 @@ class InfrastructurePage {
     return cy.findByTestId('quota-usage-breadcrumb');
   }
 
+  findQuotaUsageBreadcrumbSegment(segment: string) {
+    return cy.findByTestId(`quota-usage-breadcrumb-${segment}`);
+  }
+
   findQuotaUsageDetailTitle() {
     return cy.findByTestId('quota-usage-detail-title');
   }
 
   findQuotaUsageNavSearch() {
     return cy.findByTestId('quota-usage-nav-search');
+  }
+
+  findQuotaUsageNavSearchEmpty() {
+    return cy.findByTestId('quota-usage-nav-search-empty');
+  }
+
+  findQuotaUsageNavSearchOrEmptyState() {
+    return cy.get('[data-testid="quota-usage-nav-search"], [data-testid="quota-usage-empty"]');
+  }
+
+  shouldHaveQuotaUsageNavSearchOrEmptyState() {
+    this.findQuotaUsageNavSearchOrEmptyState().should('exist');
+    return this;
   }
 
   findQuotaUsageCollapseAll() {

--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -129,7 +129,7 @@ class InfrastructurePage {
   }
 
   findQuotaUsageTreeNode(name: string) {
-    return this.findQuotaUsageSection().findByTestId(`quota-usage-tree-node-${name}`);
+    return this.findQuotaUsageSection().findByTestId(`gpuaas-quota-usage-tree-node-${name}`);
   }
 
   findQuotaUsageBreadcrumb() {

--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -152,11 +152,15 @@ class InfrastructurePage {
     return cy.findByTestId('quota-usage-nav-search-empty');
   }
 
-  findQuotaUsageNavSearchOrEmptyState() {
-    return cy.get('[data-testid="quota-usage-nav-search"], [data-testid="quota-usage-empty"]');
+  findQuotaUsageNavSearchOrEmptyState(timeout = 60000) {
+    return cy.get(
+      '[data-testid="quota-usage-nav-search"], [data-testid="quota-usage-section"], [data-testid="quota-usage-empty"], [data-testid="quota-usage-error"]',
+      { timeout },
+    );
   }
 
   shouldHaveQuotaUsageNavSearchOrEmptyState() {
+    this.findQuotaUsageSection().should('be.visible');
     this.findQuotaUsageNavSearchOrEmptyState().should('exist');
     return this;
   }

--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -16,12 +16,12 @@ class InfrastructurePage {
     return cy.findByTestId('infrastructure-tab-utilization');
   }
 
-  findClusterQueueUtilizationTab() {
-    return cy.findByTestId('infrastructure-tab-cluster-queue-utilization');
+  findQuotaUsageTab() {
+    return cy.findByTestId('infrastructure-tab-quota-usage');
   }
 
-  switchToClusterQueueUtilizationTab() {
-    this.findClusterQueueUtilizationTab().click();
+  switchToQuotaUsageTab() {
+    this.findQuotaUsageTab().click();
     return this;
   }
 
@@ -53,8 +53,8 @@ class InfrastructurePage {
     return cy.findByTestId('hardware-usage-error');
   }
 
-  findClusterQueueUtilizationSection() {
-    return cy.findByTestId('infrastructure-cluster-queue-utilization-section');
+  findQuotaUsageSection() {
+    return cy.findByTestId('infrastructure-quota-usage-section');
   }
 
   findTotalAcceleratorsCard() {
@@ -71,6 +71,10 @@ class InfrastructurePage {
 
   findRefreshBadge() {
     return cy.findByTestId('infrastructure-refresh-badge');
+  }
+
+  findQuotaRefreshBadge() {
+    return cy.findByTestId('quota-usage-refresh-badge');
   }
 
   findHardwareUsageEmpty() {
@@ -116,77 +120,36 @@ class InfrastructurePage {
     return cy.findByTestId('borrowing-count-label');
   }
 
-  findCQUtilizationSection() {
-    return cy.findByTestId('infrastructure-cluster-queue-utilization-section');
+  findQuotaUsageDescription() {
+    return cy.findByTestId('infrastructure-quota-usage-description');
   }
 
-  scrollToCQUtilizationSection() {
-    this.findCQUtilizationSection().scrollIntoView();
-    return this;
+  findQuotaUsageEmptyState() {
+    return cy.findByTestId('quota-usage-empty');
   }
 
-  findCQUtilizationSubtitle() {
-    return cy.findByTestId('infrastructure-cluster-queue-utilization-description');
+  findQuotaUsageTreeNode(name: string) {
+    return this.findQuotaUsageSection().findByTestId(`quota-usage-tree-node-${name}`);
   }
 
-  findCQUtilizationEmptyState() {
-    return cy.findByTestId('cq-utilization-empty');
+  findQuotaUsageBreadcrumb() {
+    return cy.findByTestId('quota-usage-breadcrumb');
   }
 
-  findCQUtilizationError() {
-    return cy.findByTestId('cq-utilization-error');
+  findQuotaUsageDetailTitle() {
+    return cy.findByTestId('quota-usage-detail-title');
   }
 
-  findCohortAccordion(cohortName: string) {
-    return cy.findByTestId(`cohort-accordion-${cohortName}`);
+  findQuotaUsageNavSearch() {
+    return cy.findByTestId('quota-usage-nav-search');
   }
 
-  findCohortBorrowBadge() {
-    return cy.findByTestId('cohort-borrow-badge');
+  findQuotaUsageCollapseAll() {
+    return cy.findByTestId('quota-usage-collapse-all');
   }
 
-  findCohortUnallocatedBorrowable() {
-    return cy.findByTestId('cohort-unallocated-borrowable');
-  }
-
-  findCQCard(cqName: string) {
-    return cy.get(`[data-testid="cq-card-${cqName}"]`);
-  }
-
-  findCQBorrowBadge() {
-    return cy.findByTestId('cq-borrowed-badge');
-  }
-
-  findCQWorkloadCounts() {
-    return cy.findByTestId('cq-workload-counts');
-  }
-
-  findHardwareModelBadge(modelName: string) {
-    return cy.findByTestId(`hardware-model-badge-${modelName}`);
-  }
-
-  findAcceleratorDonutChart() {
-    return cy.findByTestId('accelerator-donut-chart');
-  }
-
-  findAcceleratorDonutChartInCard(cqName: string) {
-    return this.findCQCard(cqName).findByTestId('accelerator-donut-chart');
-  }
-
-  findDcgmComputeDonutInCard(cqName: string) {
-    return this.findCQCard(cqName).findByTestId('dcgm-compute-donut');
-  }
-
-  findDcgmMemoryDonutInCard(cqName: string) {
-    return this.findCQCard(cqName).findByTestId('dcgm-memory-donut');
-  }
-
-  findCQBorrowBadgeInCard(cqName: string) {
-    return this.findCQCard(cqName).find('[data-testid="cq-borrowed-badge"]');
-  }
-
-  findWorkloadCountsInCard(cqName: string) {
-    return this.findCQCard(cqName).find('[data-testid="cq-workload-counts"]');
+  findQuotaUsageExpandAll() {
+    return cy.findByTestId('quota-usage-expand-all');
   }
 
   findOpenPopover() {

--- a/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
@@ -40,9 +40,10 @@ describe('GPUaaS Infrastructure Page', () => {
       infrastructurePage.findBorrowingError().should('not.exist');
       infrastructurePage.shouldHaveBorrowingChartOrEmptyState();
 
-      cy.step('Click Compute profile utilization tab and verify section is present');
-      infrastructurePage.switchToClusterQueueUtilizationTab();
-      infrastructurePage.findClusterQueueUtilizationSection().should('be.visible');
+      cy.step('Click Quota usage tab and verify section is present');
+      infrastructurePage.switchToQuotaUsageTab();
+      infrastructurePage.findQuotaUsageSection().should('be.visible');
+      infrastructurePage.findQuotaUsageNavSearch().should('exist');
     },
   );
 

--- a/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
@@ -42,7 +42,6 @@ describe('GPUaaS Infrastructure Page', () => {
 
       cy.step('Click Quota usage tab and verify section is present');
       infrastructurePage.switchToQuotaUsageTab();
-      infrastructurePage.findQuotaUsageSection().should('be.visible');
       infrastructurePage.shouldHaveQuotaUsageNavSearchOrEmptyState();
     },
   );

--- a/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
@@ -43,7 +43,7 @@ describe('GPUaaS Infrastructure Page', () => {
       cy.step('Click Quota usage tab and verify section is present');
       infrastructurePage.switchToQuotaUsageTab();
       infrastructurePage.findQuotaUsageSection().should('be.visible');
-      infrastructurePage.findQuotaUsageNavSearch().should('exist');
+      infrastructurePage.shouldHaveQuotaUsageNavSearchOrEmptyState();
     },
   );
 

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -391,6 +391,27 @@ describe('GPUaaS Infrastructure Page', () => {
   });
 
   describe('Quota usage section', () => {
+    const nestedCohortQuotaUsageIntercepts: Pick<
+      InitInterceptsOptions,
+      'clusterQueues' | 'cohortNames' | 'resourceFlavors'
+    > = {
+      clusterQueues: [
+        {
+          name: 'prod-serving',
+          cohortName: 'inference-edge',
+          gpuFlavorName: 'a100-flavor',
+          gpuNominalQuota: 4,
+        },
+        {
+          name: 'legacy-batch',
+          gpuFlavorName: 'a100-flavor',
+          gpuNominalQuota: 2,
+        },
+      ],
+      cohortNames: ['production', { name: 'inference-edge', parentName: 'production' }],
+      resourceFlavors: [{ name: 'a100-flavor', gpuProduct: 'NVIDIA A100' }],
+    };
+
     beforeEach(() => {
       asClusterAdminUser();
     });
@@ -450,24 +471,27 @@ describe('GPUaaS Infrastructure Page', () => {
       infrastructurePage.findQuotaUsageCollapseAll().should('exist');
     });
 
+    it('should render nested cohort tree and navigate breadcrumb segments', () => {
+      initIntercepts(nestedCohortQuotaUsageIntercepts);
+      infrastructurePage.visit();
+      infrastructurePage.switchToQuotaUsageTab();
+      infrastructurePage.findQuotaUsageCollapseAll().should('exist');
+      infrastructurePage.findQuotaUsageTreeNode('production').should('exist');
+      infrastructurePage.findQuotaUsageTreeNode('inference-edge').should('exist');
+      infrastructurePage.findQuotaUsageTreeNode('prod-serving').click();
+      infrastructurePage.findQuotaUsageDetailTitle().should('contain.text', 'prod-serving');
+      infrastructurePage.findQuotaUsageBreadcrumb().should('contain.text', 'production');
+      infrastructurePage.findQuotaUsageBreadcrumb().should('contain.text', 'inference-edge');
+      infrastructurePage.findQuotaUsageBreadcrumbSegment('production').click();
+      infrastructurePage.findQuotaUsageDetailTitle().should('contain.text', 'production');
+      infrastructurePage.findQuotaUsageTreeNode('inference-edge').click();
+      infrastructurePage.findQuotaUsageDetailTitle().should('contain.text', 'inference-edge');
+      infrastructurePage.findQuotaUsageBreadcrumbSegment('production').click();
+      infrastructurePage.findQuotaUsageDetailTitle().should('contain.text', 'production');
+    });
+
     it('should select cohort nodes and filter tree results by search', () => {
-      initIntercepts({
-        clusterQueues: [
-          {
-            name: 'prod-serving',
-            cohortName: 'inference-edge',
-            gpuFlavorName: 'a100-flavor',
-            gpuNominalQuota: 4,
-          },
-          {
-            name: 'legacy-batch',
-            gpuFlavorName: 'a100-flavor',
-            gpuNominalQuota: 2,
-          },
-        ],
-        cohortNames: ['production', { name: 'inference-edge', parentName: 'production' }],
-        resourceFlavors: [{ name: 'a100-flavor', gpuProduct: 'NVIDIA A100' }],
-      });
+      initIntercepts(nestedCohortQuotaUsageIntercepts);
       infrastructurePage.visit();
       infrastructurePage.switchToQuotaUsageTab();
       infrastructurePage.findQuotaUsageTreeNode('Unassigned').should('exist');

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -87,7 +87,7 @@ type InitInterceptsOptions = {
   /** When set, per-model DCGM queries return data keyed by this model name. */
   dcgmModelName?: string;
   clusterQueues?: Parameters<typeof mockClusterQueueK8sResource>[0][];
-  cohortNames?: string[];
+  cohortNames?: (string | { name: string; parentName?: string })[];
   resourceFlavors?: Parameters<typeof mockResourceFlavorK8sResource>[0][];
   hasChartData?: boolean;
 };
@@ -143,7 +143,13 @@ const initIntercepts = ({
   );
   cy.interceptK8sList(
     CohortModel,
-    mockK8sResourceList(cohortNames.map((name) => mockCohortK8sResource({ name }))),
+    mockK8sResourceList(
+      cohortNames.map((entry) =>
+        typeof entry === 'string'
+          ? mockCohortK8sResource({ name: entry })
+          : mockCohortK8sResource(entry),
+      ),
+    ),
   );
   cy.interceptK8sList(
     ResourceFlavorModel,
@@ -268,7 +274,7 @@ describe('GPUaaS Infrastructure Page', () => {
       infrastructurePage.findComputeUtilizationCard().should('contain.text', '80%');
       infrastructurePage.findMemoryUtilizationCard().should('contain.text', '83%');
       infrastructurePage.findRefreshBadge().should('exist');
-      infrastructurePage.findRefreshBadge().should('contain.text', 'Last update');
+      infrastructurePage.findRefreshBadge().should('contain.text', 'Updated');
     });
 
     it('should display empty states when no accelerators are present', () => {
@@ -384,22 +390,22 @@ describe('GPUaaS Infrastructure Page', () => {
     });
   });
 
-  describe('Cluster queue utilization section', () => {
+  describe('Quota usage section', () => {
     beforeEach(() => {
       asClusterAdminUser();
     });
 
-    it('should show empty state when no GPU CQs exist or all are CPU-only', () => {
-      // Stage 1: no cluster queues at all
+    it('should show empty state when no cluster queues exist', () => {
       initIntercepts({ clusterQueues: [], cohortNames: [], resourceFlavors: [] });
       infrastructurePage.visit();
-      infrastructurePage.switchToClusterQueueUtilizationTab();
+      infrastructurePage.switchToQuotaUsageTab();
       infrastructurePage
-        .findCQUtilizationEmptyState()
+        .findQuotaUsageEmptyState()
         .should('exist')
         .should('contain.text', 'No accelerator cluster queues found');
+    });
 
-      // Stage 2: only CPU-only CQ — same empty state
+    it('should show empty state when all cluster queues are CPU-only', () => {
       initIntercepts({
         clusterQueues: [
           {
@@ -413,11 +419,11 @@ describe('GPUaaS Infrastructure Page', () => {
         resourceFlavors: [],
       });
       infrastructurePage.visit();
-      infrastructurePage.switchToClusterQueueUtilizationTab();
-      infrastructurePage.findCQUtilizationEmptyState().should('exist');
+      infrastructurePage.switchToQuotaUsageTab();
+      infrastructurePage.findQuotaUsageEmptyState().should('exist');
     });
 
-    it('should render CQ card with subtitle, hardware badge, donut, workload counts, and cohort accordion', () => {
+    it('should render tree with default cohort selection when no unassigned cluster queues exist', () => {
       initIntercepts({
         clusterQueues: [
           {
@@ -434,187 +440,44 @@ describe('GPUaaS Infrastructure Page', () => {
         resourceFlavors: [{ name: 'a100-flavor', gpuProduct: 'NVIDIA A100' }],
       });
       infrastructurePage.visit();
-      infrastructurePage.switchToClusterQueueUtilizationTab();
+      infrastructurePage.switchToQuotaUsageTab();
       infrastructurePage
-        .findCQUtilizationSubtitle()
-        .should('contain.text', 'Compute profile accelerator utilization grouped by Kueue cohort.');
-      infrastructurePage.findCohortAccordion('cohort-1').should('exist');
-      infrastructurePage.findCQCard('cq-gpu').should('exist');
-      infrastructurePage.findHardwareModelBadge('NVIDIA A100').should('exist');
-      infrastructurePage.findAcceleratorDonutChart().should('exist');
-      infrastructurePage
-        .findCQWorkloadCounts()
-        .should('contain.text', 'Workloads: 2 active, 1 pending');
+        .findQuotaUsageDescription()
+        .should('contain.text', 'View quota usage across cluster queues');
+      infrastructurePage.findQuotaUsageTreeNode('cohort-1').should('exist');
+      infrastructurePage.findQuotaUsageTreeNode('cq-gpu').should('exist');
+      infrastructurePage.findQuotaUsageDetailTitle().should('contain.text', 'cohort-1');
+      infrastructurePage.findQuotaUsageCollapseAll().should('exist');
     });
 
-    it('should render two CQ cards with DCGM utilization columns when telemetry is available', () => {
+    it('should select cohort nodes and filter tree results by search', () => {
       initIntercepts({
         clusterQueues: [
           {
-            name: 'notebook-queues',
-            cohortName: 'research-sandbox',
-            gpuFlavorName: 'mi300x-flavor',
-            gpuNominalQuota: 6,
-            gpuUsed: 2,
-            admittedWorkloads: 2,
-            pendingWorkloads: 2,
+            name: 'prod-serving',
+            cohortName: 'inference-edge',
+            gpuFlavorName: 'a100-flavor',
+            gpuNominalQuota: 4,
           },
           {
-            name: 'experiment-queues',
-            cohortName: 'research-sandbox',
-            gpuFlavorName: 'mi300x-flavor',
-            gpuNominalQuota: 4,
-            gpuUsed: 0,
-            admittedWorkloads: 0,
-            pendingWorkloads: 1,
+            name: 'legacy-batch',
+            gpuFlavorName: 'a100-flavor',
+            gpuNominalQuota: 2,
           },
         ],
-        cohortNames: ['research-sandbox'],
-        resourceFlavors: [{ name: 'mi300x-flavor', gpuProduct: 'AMD MI300X' }],
-        dcgmModelName: 'AMD MI300X',
+        cohortNames: ['production', { name: 'inference-edge', parentName: 'production' }],
+        resourceFlavors: [{ name: 'a100-flavor', gpuProduct: 'NVIDIA A100' }],
       });
       infrastructurePage.visit();
-      infrastructurePage.switchToClusterQueueUtilizationTab();
-      infrastructurePage.scrollToCQUtilizationSection();
-      infrastructurePage.findCohortAccordion('research-sandbox').should('exist');
-      infrastructurePage.findCQCard('notebook-queues').should('exist');
-      infrastructurePage.findCQCard('experiment-queues').should('exist');
-      // Scope to one card since both share the same model badge testid
-      infrastructurePage
-        .findCQCard('notebook-queues')
-        .findByTestId('hardware-model-badge-AMD MI300X')
-        .should('exist');
-      infrastructurePage.findAcceleratorDonutChartInCard('notebook-queues').should('exist');
-      infrastructurePage.findAcceleratorDonutChartInCard('experiment-queues').should('exist');
-    });
-
-    describe('borrow donut state', () => {
-      // a100-train-queues: 6 nominal, 4 used → 2 unallocated (available to borrow); burst-training: 8 nominal, 10 used, 2 borrowed
-      const COHORT = 'ml-training-cohort';
-      const FLAVOR = 'a100-flavor';
-
-      beforeEach(() => {
-        initIntercepts({
-          clusterQueues: [
-            {
-              name: 'a100-train-queues',
-              cohortName: COHORT,
-              gpuFlavorName: FLAVOR,
-              gpuNominalQuota: 6,
-              gpuUsed: 4,
-              admittedWorkloads: 1,
-              pendingWorkloads: 2,
-            },
-            {
-              name: 'burst-training',
-              cohortName: COHORT,
-              gpuFlavorName: FLAVOR,
-              gpuNominalQuota: 8,
-              gpuUsed: 10,
-              gpuBorrowed: 2,
-              admittedWorkloads: 2,
-              pendingWorkloads: 2,
-            },
-          ],
-          cohortNames: [COHORT],
-          resourceFlavors: [{ name: FLAVOR, gpuProduct: 'NVIDIA A100' }],
-          dcgmModelName: 'NVIDIA A100',
-        });
-        infrastructurePage.visit();
-        infrastructurePage.switchToClusterQueueUtilizationTab();
-        infrastructurePage.scrollToCQUtilizationSection();
-      });
-
-      it('shows borrow badge, no lent badge, workload counts, all chart columns, and per-model badge popovers', () => {
-        // Cohort-level badges
-        infrastructurePage.findCohortAccordion(COHORT).should('exist');
-        infrastructurePage.findCohortBorrowBadge().should('exist');
-        infrastructurePage
-          .findCohortUnallocatedBorrowable()
-          .should('contain.text', '2 available to borrow');
-
-        // Unallocated-capacity CQ — no borrow badge, normal donut
-        infrastructurePage
-          .findWorkloadCountsInCard('a100-train-queues')
-          .should('contain.text', 'Workloads: 1 active, 2 pending');
-        infrastructurePage.findAcceleratorDonutChartInCard('a100-train-queues').should('exist');
-        infrastructurePage
-          .findCQCard('a100-train-queues')
-          .should('contain.text', 'Compute consumption')
-          .should('contain.text', 'Memory consumption');
-
-        // Borrower card
-        infrastructurePage
-          .findCQBorrowBadgeInCard('burst-training')
-          .should('contain.text', 'Borrowed: 2');
-        infrastructurePage
-          .findWorkloadCountsInCard('burst-training')
-          .should('contain.text', 'Workloads: 2 active, 2 pending');
-        infrastructurePage.findAcceleratorDonutChartInCard('burst-training').should('exist');
-        infrastructurePage
-          .findCQCard('burst-training')
-          .should('contain.text', 'Compute consumption')
-          .should('contain.text', 'Memory consumption');
-
-        // Borrowed badge popover: shows per-model borrowed count
-        infrastructurePage.findCQBorrowBadgeInCard('burst-training').click();
-        infrastructurePage
-          .findOpenPopover()
-          .should('contain.text', 'Borrowed capacity')
-          .should('contain.text', '2 × NVIDIA A100');
-        cy.get('body').type('{esc}');
-      });
-
-      it('shows per-model breakdown in donut segment hover tooltip', () => {
-        // a100-train-queues has unallocated capacity but is shown as a normal donut (no Lent segment).
-        // Hovering the used segment shows the own-capacity tooltip.
-        infrastructurePage
-          .findAcceleratorDonutChartInCard('a100-train-queues')
-          .find('svg path')
-          .first()
-          .trigger('mouseover', { force: true });
-        infrastructurePage
-          .findCQCard('a100-train-queues')
-          .should('contain.text', 'NVIDIA A100: 4/6 in use');
-      });
-
-      describe('pure borrower CQ (nominal=0, used>0)', () => {
-        const PURE_BORROWER_COHORT = 'burst-cohort';
-        const PURE_BORROWER_FLAVOR = 'h100-flavor';
-
-        beforeEach(() => {
-          initIntercepts({
-            clusterQueues: [
-              {
-                name: 'pure-borrower-cq',
-                cohortName: PURE_BORROWER_COHORT,
-                gpuFlavorName: PURE_BORROWER_FLAVOR,
-                gpuNominalQuota: 0,
-                gpuUsed: 6,
-                admittedWorkloads: 1,
-                pendingWorkloads: 0,
-              },
-            ],
-            cohortNames: [PURE_BORROWER_COHORT],
-            resourceFlavors: [{ name: PURE_BORROWER_FLAVOR, gpuProduct: 'NVIDIA H100' }],
-            dcgmModelName: 'NVIDIA H100',
-          });
-          infrastructurePage.visit();
-          infrastructurePage.switchToClusterQueueUtilizationTab();
-        });
-
-        it('renders the CQ card with all 3 chart columns and a fully-filled borrowed donut', () => {
-          infrastructurePage.findAcceleratorDonutChartInCard('pure-borrower-cq').should('exist');
-          infrastructurePage
-            .findCQCard('pure-borrower-cq')
-            .findByText('Borrowed: 6')
-            .should('exist');
-          infrastructurePage
-            .findCQCard('pure-borrower-cq')
-            .should('contain.text', 'Compute consumption')
-            .should('contain.text', 'Memory consumption');
-        });
-      });
+      infrastructurePage.switchToQuotaUsageTab();
+      infrastructurePage.findQuotaUsageTreeNode('Unassigned').should('exist');
+      infrastructurePage.findQuotaUsageTreeNode('legacy-batch').click();
+      infrastructurePage.findQuotaUsageDetailTitle().should('contain.text', 'legacy-batch');
+      infrastructurePage.findQuotaUsageTreeNode('production').click();
+      infrastructurePage.findQuotaUsageDetailTitle().should('contain.text', 'production');
+      infrastructurePage.findQuotaUsageNavSearch().type('prod-serving');
+      infrastructurePage.findQuotaUsageTreeNode('prod-serving').should('exist');
+      infrastructurePage.findQuotaUsageTreeNode('legacy-batch').should('not.exist');
     });
   });
 });

--- a/packages/gpuaas/src/components/QuotaUsageSection.scss
+++ b/packages/gpuaas/src/components/QuotaUsageSection.scss
@@ -1,6 +1,6 @@
 // Prototype match: collapsed toggle points right, expanded points down (PF default caret is down/up).
-.quota-usage-section {
-  .quota-usage-tree {
+.gpuaas-quota-usage-section {
+  .gpuaas-quota-usage-tree {
     --pf-v6-c-tree-view__node-toggle-icon--base--Rotate: -90deg;
     --pf-v6-c-tree-view__list-item--m-expanded__node-toggle-icon--Rotate: 0deg;
   }

--- a/packages/gpuaas/src/components/QuotaUsageSection.scss
+++ b/packages/gpuaas/src/components/QuotaUsageSection.scss
@@ -1,0 +1,7 @@
+// Prototype match: collapsed toggle points right, expanded points down (PF default caret is down/up).
+.quota-usage-section {
+  .quota-usage-tree {
+    --pf-v6-c-tree-view__node-toggle-icon--base--Rotate: -90deg;
+    --pf-v6-c-tree-view__list-item--m-expanded__node-toggle-icon--Rotate: 0deg;
+  }
+}

--- a/packages/gpuaas/src/components/QuotaUsageSection.tsx
+++ b/packages/gpuaas/src/components/QuotaUsageSection.tsx
@@ -22,11 +22,7 @@ import {
   QUOTA_USAGE_TREE_DRAWER_PANEL_ID,
 } from '../const';
 import { QuotaSelection, QuotaTreeNode } from '../types';
-import {
-  findQuotaTreeNode,
-  getDefaultQuotaSelection,
-  nodeIdFromSelection,
-} from '../utils/quotaUsageTreeUtils';
+import { syncQuotaSelectionWithTree } from '../utils/quotaUsageTreeUtils';
 
 const drawerNavBodyStyle: React.CSSProperties = {
   minWidth: 0,
@@ -47,12 +43,7 @@ const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({ tree, loaded, err
       setSelection(undefined);
       return;
     }
-    setSelection((current) => {
-      if (current && findQuotaTreeNode(tree, nodeIdFromSelection(current))) {
-        return current;
-      }
-      return getDefaultQuotaSelection(tree);
-    });
+    setSelection((current) => syncQuotaSelectionWithTree(tree, current));
   }, [loaded, tree]);
 
   if (error) {
@@ -104,9 +95,9 @@ const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({ tree, loaded, err
             <DrawerPanelContent
               id={QUOTA_USAGE_TREE_DRAWER_PANEL_ID}
               isResizable
-              defaultSize="50%"
-              minSize="50%"
-              maxSize="82%"
+              defaultSize="75%"
+              minSize="60%"
+              maxSize="85%"
               data-testid="quota-usage-detail-drawer"
             >
               <QuotaUsageDetailPanel

--- a/packages/gpuaas/src/components/QuotaUsageSection.tsx
+++ b/packages/gpuaas/src/components/QuotaUsageSection.tsx
@@ -86,7 +86,7 @@ const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({ tree, loaded, err
     <Flex
       direction={{ default: 'column' }}
       grow={{ default: 'grow' }}
-      className="quota-usage-section"
+      className="gpuaas-quota-usage-section"
       data-testid="quota-usage-section"
     >
       <Drawer isExpanded isInline>

--- a/packages/gpuaas/src/components/QuotaUsageSection.tsx
+++ b/packages/gpuaas/src/components/QuotaUsageSection.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  Drawer,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelContent,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  Spinner,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+import QuotaUsageDetailPanel from './quotaUsage/QuotaUsageDetailPanel';
+import QuotaUsageNavPanel from './quotaUsage/QuotaUsageNavPanel';
+import './QuotaUsageSection.scss';
+import {
+  QUOTA_USAGE_EMPTY_BODY,
+  QUOTA_USAGE_EMPTY_TITLE,
+  QUOTA_USAGE_ERROR_TITLE,
+  QUOTA_USAGE_TREE_DRAWER_PANEL_ID,
+} from '../const';
+import { QuotaSelection, QuotaTreeNode } from '../types';
+import {
+  findQuotaTreeNode,
+  getDefaultQuotaSelection,
+  nodeIdFromSelection,
+} from '../utils/quotaUsageTreeUtils';
+
+const drawerNavBodyStyle: React.CSSProperties = {
+  minWidth: 0,
+  paddingRight: 'var(--pf-t--global--spacer--lg)',
+};
+
+type QuotaUsageSectionProps = {
+  tree: QuotaTreeNode[];
+  loaded: boolean;
+  error?: Error;
+};
+
+const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({ tree, loaded, error }) => {
+  const [selection, setSelection] = React.useState<QuotaSelection | undefined>();
+
+  React.useEffect(() => {
+    if (!loaded || tree.length === 0) {
+      setSelection(undefined);
+      return;
+    }
+    setSelection((current) => {
+      if (current && findQuotaTreeNode(tree, nodeIdFromSelection(current))) {
+        return current;
+      }
+      return getDefaultQuotaSelection(tree);
+    });
+  }, [loaded, tree]);
+
+  if (error) {
+    return (
+      <EmptyState
+        headingLevel="h4"
+        icon={CubesIcon}
+        titleText={QUOTA_USAGE_ERROR_TITLE}
+        variant={EmptyStateVariant.sm}
+        data-testid="quota-usage-error"
+      >
+        <EmptyStateBody>{error.message}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  if (!loaded) {
+    return (
+      <Bullseye data-testid="quota-usage-loading">
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (tree.length === 0) {
+    return (
+      <EmptyState
+        headingLevel="h4"
+        icon={CubesIcon}
+        titleText={QUOTA_USAGE_EMPTY_TITLE}
+        variant={EmptyStateVariant.sm}
+        data-testid="quota-usage-empty"
+      >
+        <EmptyStateBody>{QUOTA_USAGE_EMPTY_BODY}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <Flex
+      direction={{ default: 'column' }}
+      grow={{ default: 'grow' }}
+      className="quota-usage-section"
+      data-testid="quota-usage-section"
+    >
+      <Drawer isExpanded isInline>
+        <DrawerContent
+          panelContent={
+            <DrawerPanelContent
+              id={QUOTA_USAGE_TREE_DRAWER_PANEL_ID}
+              isResizable
+              defaultSize="50%"
+              minSize="50%"
+              maxSize="82%"
+              data-testid="quota-usage-detail-drawer"
+            >
+              <QuotaUsageDetailPanel
+                tree={tree}
+                selection={selection}
+                onSelectionChange={setSelection}
+              />
+            </DrawerPanelContent>
+          }
+        >
+          <DrawerContentBody style={drawerNavBodyStyle}>
+            <QuotaUsageNavPanel
+              tree={tree}
+              selection={selection}
+              onSelectionChange={setSelection}
+            />
+          </DrawerContentBody>
+        </DrawerContent>
+      </Drawer>
+    </Flex>
+  );
+};
+
+export default QuotaUsageSection;

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageDetailPanel.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageDetailPanel.tsx
@@ -125,15 +125,14 @@ const QuotaUsageDetailPanel: React.FC<QuotaUsageDetailPanelProps> = ({
               </Label>
             </FlexItem>
           </Flex>
+          <Content component="p" data-testid="quota-usage-detail-placeholder">
+            {selection.type === 'unassigned'
+              ? QUOTA_UNASSIGNED_TOOLTIP
+              : 'Summary and accelerator usage details will appear here.'}
+          </Content>
         </Stack>
       </DrawerHead>
-      <DrawerPanelBody className={scrollableBodyClassName}>
-        <Content component="p" data-testid="quota-usage-detail-placeholder">
-          {selection.type === 'unassigned'
-            ? QUOTA_UNASSIGNED_TOOLTIP
-            : 'Summary and accelerator usage details will appear here.'}
-        </Content>
-      </DrawerPanelBody>
+      <DrawerPanelBody className={scrollableBodyClassName} />
     </>
   );
 };

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageDetailPanel.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageDetailPanel.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Content,
+  DrawerHead,
+  DrawerPanelBody,
+  Flex,
+  FlexItem,
+  Label,
+  Stack,
+  Title,
+} from '@patternfly/react-core';
+import { InfrastructureIcon, ListIcon, ResourcesEmptyIcon } from '@patternfly/react-icons';
+import { QUOTA_UNASSIGNED_LABEL, QUOTA_UNASSIGNED_TOOLTIP } from '../../const';
+import { QuotaSelection, QuotaTreeNode } from '../../types';
+import { selectionFromPath } from '../../utils/quotaUsageTreeUtils';
+
+const scrollableBodyClassName = 'pf-v6-u-flex-fill pf-v6-u-min-height-0 pf-v6-u-overflow-auto';
+
+type QuotaUsageDetailPanelProps = {
+  tree: QuotaTreeNode[];
+  selection?: QuotaSelection;
+  onSelectionChange: (selection: QuotaSelection) => void;
+};
+
+const QuotaUsageDetailPanel: React.FC<QuotaUsageDetailPanelProps> = ({
+  tree,
+  selection,
+  onSelectionChange,
+}) => {
+  const handleBreadcrumbClick = React.useCallback(
+    (index: number) => {
+      if (!selection) {
+        return;
+      }
+      const pathPrefix = selection.path.slice(0, index + 1);
+      const nextSelection = selectionFromPath(tree, pathPrefix);
+      if (nextSelection) {
+        onSelectionChange(nextSelection);
+      }
+    },
+    [onSelectionChange, selection, tree],
+  );
+
+  if (!selection) {
+    return (
+      <DrawerPanelBody className={scrollableBodyClassName}>
+        <Content component="p" data-testid="quota-usage-detail-empty">
+          Select a cohort or cluster queue to view quota usage details.
+        </Content>
+      </DrawerPanelBody>
+    );
+  }
+
+  let displayName: string;
+  let typeLabel: string;
+  let typeIcon: React.ReactNode;
+  let labelColor: 'green' | 'blue' | undefined;
+
+  switch (selection.type) {
+    case 'unassigned':
+      displayName = QUOTA_UNASSIGNED_LABEL;
+      typeLabel = 'Unassigned';
+      typeIcon = <ResourcesEmptyIcon aria-hidden />;
+      labelColor = undefined;
+      break;
+    case 'cohort':
+      displayName = selection.cohortName;
+      typeLabel = 'Cohort';
+      typeIcon = <InfrastructureIcon aria-hidden />;
+      labelColor = 'green';
+      break;
+    default:
+      displayName = selection.clusterQueueName;
+      typeLabel = 'Cluster queue';
+      typeIcon = <ListIcon aria-hidden />;
+      labelColor = 'blue';
+      break;
+  }
+
+  const showBreadcrumb = selection.path.length > 1 && selection.path[0] !== QUOTA_UNASSIGNED_LABEL;
+
+  return (
+    <>
+      <DrawerHead data-testid="quota-usage-detail-panel">
+        <Stack hasGutter>
+          {showBreadcrumb && (
+            <Breadcrumb data-testid="quota-usage-breadcrumb">
+              {selection.path.map((segment, index) => {
+                const isActive = index === selection.path.length - 1;
+                if (isActive) {
+                  return (
+                    <BreadcrumbItem key={`${segment}-${index}`} isActive>
+                      {segment}
+                    </BreadcrumbItem>
+                  );
+                }
+                return (
+                  <BreadcrumbItem
+                    key={`${segment}-${index}`}
+                    component="button"
+                    onClick={() => handleBreadcrumbClick(index)}
+                    data-testid={`quota-usage-breadcrumb-${segment}`}
+                  >
+                    {segment}
+                  </BreadcrumbItem>
+                );
+              })}
+            </Breadcrumb>
+          )}
+          <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            flexWrap={{ default: 'wrap' }}
+            gap={{ default: 'gapMd' }}
+          >
+            <FlexItem>
+              <Title headingLevel="h2" size="lg" data-testid="quota-usage-detail-title">
+                {displayName}
+              </Title>
+            </FlexItem>
+            <FlexItem>
+              <Label color={labelColor} variant="filled" isCompact icon={typeIcon}>
+                {typeLabel}
+              </Label>
+            </FlexItem>
+          </Flex>
+        </Stack>
+      </DrawerHead>
+      <DrawerPanelBody className={scrollableBodyClassName}>
+        <Content component="p" data-testid="quota-usage-detail-placeholder">
+          {selection.type === 'unassigned'
+            ? QUOTA_UNASSIGNED_TOOLTIP
+            : 'Summary and accelerator usage details will appear here.'}
+        </Content>
+      </DrawerPanelBody>
+    </>
+  );
+};
+
+export default QuotaUsageDetailPanel;

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.tsx
@@ -160,7 +160,7 @@ const QuotaUsageNavPanel: React.FC<QuotaUsageNavPanelProps> = ({
             onClear={() => setSearchValue('')}
             aria-label="Search by name"
             style={fullWidthStyle}
-            data-testid="quota-usage-nav-search"
+            inputProps={{ 'data-testid': 'quota-usage-nav-search' }}
           />
         </ToolbarItem>
         <ToolbarItem alignSelf="center">

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.tsx
@@ -1,0 +1,183 @@
+import * as React from 'react';
+import { Button, SearchInput, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import QuotaUsageTreeView from './QuotaUsageTreeView';
+import { QuotaSelection, QuotaTreeNode } from '../../types';
+import {
+  collectAllExpandableNodeIds,
+  collectExpandedNodeIds,
+  filterQuotaTreeByName,
+  getAncestorNodeIds,
+  getExpandedIdsForSelection,
+  getQuotaNodePath,
+  nodeIdFromSelection,
+  selectionFromNode,
+} from '../../utils/quotaUsageTreeUtils';
+
+const toolbarInsetStyle: React.CSSProperties = {
+  paddingTop: 'var(--pf-t--global--spacer--sm)',
+  paddingInline: 'var(--pf-t--global--spacer--sm)',
+};
+
+const toolbarSearchItemStyle: React.CSSProperties = {
+  flexGrow: 1,
+  minWidth: 0,
+};
+
+const fullWidthStyle: React.CSSProperties = {
+  width: '100%',
+};
+
+type QuotaUsageNavPanelProps = {
+  tree: QuotaTreeNode[];
+  selection?: QuotaSelection;
+  onSelectionChange: (selection: QuotaSelection) => void;
+};
+
+const QuotaUsageNavPanel: React.FC<QuotaUsageNavPanelProps> = ({
+  tree,
+  selection,
+  onSelectionChange,
+}) => {
+  const [searchValue, setSearchValue] = React.useState('');
+  const [allExpanded, setAllExpanded] = React.useState<boolean | undefined>(true);
+  const [expandedNodeIds, setExpandedNodeIds] = React.useState<Set<string>>(() => new Set());
+  const allExpandedRef = React.useRef(allExpanded);
+  allExpandedRef.current = allExpanded;
+
+  React.useEffect(() => {
+    if (!selection || allExpandedRef.current !== undefined) {
+      return;
+    }
+    const ancestorIds = getExpandedIdsForSelection(tree, selection);
+    setExpandedNodeIds((prev) => new Set([...prev, ...ancestorIds]));
+  }, [selection, tree]);
+
+  const filteredTree = React.useMemo(
+    () => filterQuotaTreeByName(tree, searchValue),
+    [tree, searchValue],
+  );
+
+  const searchExpandedIds = React.useMemo(
+    () => collectExpandedNodeIds(filteredTree, searchValue),
+    [filteredTree, searchValue],
+  );
+
+  const isFullyCollapsed = allExpanded === false;
+
+  const mergedExpandedIds = React.useMemo(() => {
+    if (allExpanded === false) {
+      return new Set<string>();
+    }
+    if (allExpanded === true) {
+      return collectAllExpandableNodeIds(filteredTree);
+    }
+    const merged = new Set(expandedNodeIds);
+    searchExpandedIds.forEach((id) => merged.add(id));
+    return merged;
+  }, [allExpanded, expandedNodeIds, filteredTree, searchExpandedIds]);
+
+  const treeExpandKey =
+    allExpanded === false ? 'collapsed' : allExpanded === true ? 'expanded' : 'mixed';
+
+  const handleToggleExpandAll = React.useCallback(() => {
+    if (allExpanded === false) {
+      setExpandedNodeIds(collectAllExpandableNodeIds(filteredTree));
+      setAllExpanded(true);
+      return;
+    }
+    setAllExpanded(false);
+    setExpandedNodeIds(new Set());
+  }, [allExpanded, filteredTree]);
+
+  const selectedNodeId = selection ? nodeIdFromSelection(selection) : undefined;
+
+  const handleSelectNode = React.useCallback(
+    (node: QuotaTreeNode) => {
+      const path = getQuotaNodePath(tree, node.id);
+      if (!path) {
+        return;
+      }
+      const nextSelection = selectionFromNode(node, path);
+      if (nextSelection) {
+        if (allExpandedRef.current === undefined) {
+          const ancestors = getAncestorNodeIds(tree, node.id) ?? [];
+          setExpandedNodeIds((prev) => new Set([...prev, ...ancestors]));
+        }
+        onSelectionChange(nextSelection);
+      }
+    },
+    [onSelectionChange, tree],
+  );
+
+  const handleExpand = React.useCallback((nodeId: string) => {
+    setAllExpanded(undefined);
+    setExpandedNodeIds((prev) => new Set([...prev, nodeId]));
+  }, []);
+
+  const handleCollapse = React.useCallback(
+    (nodeId: string) => {
+      setAllExpanded(undefined);
+      setExpandedNodeIds((prev) => {
+        if (allExpandedRef.current === true) {
+          const next = collectAllExpandableNodeIds(filteredTree);
+          next.delete(nodeId);
+          return next;
+        }
+        const next = new Set(prev);
+        next.delete(nodeId);
+        return next;
+      });
+    },
+    [filteredTree],
+  );
+
+  const navToolbar = (
+    <Toolbar
+      inset={{ default: 'insetNone' }}
+      style={toolbarInsetStyle}
+      aria-label="Cohort hierarchy filters"
+    >
+      <ToolbarContent>
+        <ToolbarItem style={toolbarSearchItemStyle}>
+          <SearchInput
+            placeholder="Search by name"
+            value={searchValue}
+            onChange={(_event, value) => setSearchValue(value)}
+            onClear={() => setSearchValue('')}
+            aria-label="Search by name"
+            style={fullWidthStyle}
+            data-testid="quota-usage-nav-search"
+          />
+        </ToolbarItem>
+        <ToolbarItem alignSelf="center">
+          <Button
+            variant="link"
+            isInline
+            onClick={handleToggleExpandAll}
+            data-testid={isFullyCollapsed ? 'quota-usage-expand-all' : 'quota-usage-collapse-all'}
+          >
+            {isFullyCollapsed ? 'Expand all' : 'Collapse all'}
+          </Button>
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
+
+  return (
+    <>
+      {navToolbar}
+      <QuotaUsageTreeView
+        expandStateKey={treeExpandKey}
+        nodes={filteredTree}
+        selectedNodeId={selectedNodeId}
+        expandedNodeIds={mergedExpandedIds}
+        allExpanded={allExpanded}
+        onSelectNode={handleSelectNode}
+        onExpand={handleExpand}
+        onCollapse={handleCollapse}
+      />
+    </>
+  );
+};
+
+export default QuotaUsageNavPanel;

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Button, SearchInput, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import {
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  SearchInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
 import QuotaUsageTreeView from './QuotaUsageTreeView';
 import { QuotaSelection, QuotaTreeNode } from '../../types';
 import {
@@ -76,8 +84,14 @@ const QuotaUsageNavPanel: React.FC<QuotaUsageNavPanelProps> = ({
     return merged;
   }, [allExpanded, expandedNodeIds, filteredTree, searchExpandedIds]);
 
-  const treeExpandKey =
-    allExpanded === false ? 'collapsed' : allExpanded === true ? 'expanded' : 'mixed';
+  let treeExpandKey: string;
+  if (allExpanded === undefined) {
+    treeExpandKey = `mixed-${searchValue.trim()}`;
+  } else if (allExpanded) {
+    treeExpandKey = 'expanded';
+  } else {
+    treeExpandKey = 'collapsed';
+  }
 
   const handleToggleExpandAll = React.useCallback(() => {
     if (allExpanded === false) {
@@ -119,16 +133,16 @@ const QuotaUsageNavPanel: React.FC<QuotaUsageNavPanelProps> = ({
       setAllExpanded(undefined);
       setExpandedNodeIds((prev) => {
         if (allExpandedRef.current === true) {
-          const next = collectAllExpandableNodeIds(filteredTree);
-          next.delete(nodeId);
-          return next;
+          const expandableNodeIds = collectAllExpandableNodeIds(tree);
+          expandableNodeIds.delete(nodeId);
+          return expandableNodeIds;
         }
-        const next = new Set(prev);
-        next.delete(nodeId);
-        return next;
+        const expandableNodeIds = new Set(prev);
+        expandableNodeIds.delete(nodeId);
+        return expandableNodeIds;
       });
     },
-    [filteredTree],
+    [tree],
   );
 
   const navToolbar = (
@@ -176,6 +190,14 @@ const QuotaUsageNavPanel: React.FC<QuotaUsageNavPanelProps> = ({
         onExpand={handleExpand}
         onCollapse={handleCollapse}
       />
+      {filteredTree.length === 0 && (
+        <EmptyState
+          headingLevel="h4"
+          titleText="No results found"
+          variant={EmptyStateVariant.sm}
+          data-testid="quota-usage-nav-search-empty"
+        />
+      )}
     </>
   );
 };

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageTreeView.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageTreeView.tsx
@@ -50,14 +50,14 @@ const nodeName = (node: QuotaTreeNode): React.ReactNode => {
           variant="filled"
           isCompact
           icon={<ResourcesEmptyIcon aria-hidden />}
-          data-testid={`quota-usage-tree-node-${node.name}`}
+          data-testid={`gpuaas-quota-usage-tree-node-${node.name}`}
         >
           {QUOTA_UNASSIGNED_LABEL}
         </Label>
       </Tooltip>
     );
   }
-  return <span data-testid={`quota-usage-tree-node-${node.name}`}>{node.name}</span>;
+  return <span data-testid={`gpuaas-quota-usage-tree-node-${node.name}`}>{node.name}</span>;
 };
 
 const mapNodesToTreeData = (
@@ -128,7 +128,7 @@ const QuotaUsageTreeView: React.FC<QuotaUsageTreeViewProps> = ({
 
   return (
     <TreeView
-      className="quota-usage-tree"
+      className="gpuaas-quota-usage-tree"
       key={expandStateKey}
       data={treeData}
       defaultAllExpanded

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageTreeView.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageTreeView.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import { Icon, Label, Tooltip, TreeView, TreeViewDataItem } from '@patternfly/react-core';
+import { InfrastructureIcon, ListIcon, ResourcesEmptyIcon } from '@patternfly/react-icons';
+import { QUOTA_UNASSIGNED_LABEL } from '../../const';
+import { QuotaTreeNode } from '../../types';
+
+type QuotaUsageTreeViewProps = {
+  nodes: QuotaTreeNode[];
+  selectedNodeId?: string;
+  expandedNodeIds: Set<string>;
+  allExpanded?: boolean;
+  expandStateKey: string;
+  toolbar?: React.ReactNode;
+  onSelectNode: (node: QuotaTreeNode) => void;
+  onExpand: (nodeId: string) => void;
+  onCollapse: (nodeId: string) => void;
+};
+
+const nodeIcon = (node: QuotaTreeNode): React.ReactNode | undefined => {
+  if (node.type === 'cohort') {
+    return (
+      <Tooltip content="Cohort">
+        <Label color="green" variant="filled" isCompact aria-label="Cohort">
+          <Icon isInline size="sm">
+            <InfrastructureIcon aria-hidden />
+          </Icon>
+        </Label>
+      </Tooltip>
+    );
+  }
+  if (node.type === 'clusterQueue') {
+    return (
+      <Tooltip content="Cluster queue">
+        <Label color="blue" variant="filled" isCompact aria-label="Cluster queue">
+          <Icon isInline size="sm">
+            <ListIcon aria-hidden />
+          </Icon>
+        </Label>
+      </Tooltip>
+    );
+  }
+  return undefined;
+};
+
+const nodeName = (node: QuotaTreeNode): React.ReactNode => {
+  if (node.type === 'unassigned') {
+    return (
+      <Tooltip content={QUOTA_UNASSIGNED_LABEL}>
+        <Label
+          variant="filled"
+          isCompact
+          icon={<ResourcesEmptyIcon aria-hidden />}
+          data-testid={`quota-usage-tree-node-${node.name}`}
+        >
+          {QUOTA_UNASSIGNED_LABEL}
+        </Label>
+      </Tooltip>
+    );
+  }
+  return <span data-testid={`quota-usage-tree-node-${node.name}`}>{node.name}</span>;
+};
+
+const mapNodesToTreeData = (
+  nodes: QuotaTreeNode[],
+  expandedNodeIds: Set<string>,
+): TreeViewDataItem[] =>
+  nodes.map((node) => ({
+    id: node.id,
+    name: nodeName(node),
+    icon: nodeIcon(node),
+    children:
+      node.children.length > 0 ? mapNodesToTreeData(node.children, expandedNodeIds) : undefined,
+    defaultExpanded: expandedNodeIds.has(node.id),
+    selectable: node.selectable,
+  }));
+
+const QuotaUsageTreeView: React.FC<QuotaUsageTreeViewProps> = ({
+  nodes,
+  selectedNodeId,
+  expandedNodeIds,
+  allExpanded,
+  expandStateKey,
+  toolbar,
+  onSelectNode,
+  onExpand,
+  onCollapse,
+}) => {
+  const nodeById = React.useMemo(() => {
+    const map = new Map<string, QuotaTreeNode>();
+    const visit = (treeNodes: QuotaTreeNode[]): void => {
+      for (const node of treeNodes) {
+        map.set(node.id, node);
+        visit(node.children);
+      }
+    };
+    visit(nodes);
+    return map;
+  }, [nodes]);
+
+  const treeData = React.useMemo(
+    () => mapNodesToTreeData(nodes, expandedNodeIds),
+    [nodes, expandedNodeIds],
+  );
+
+  const activeItems = React.useMemo((): TreeViewDataItem[] | undefined => {
+    if (!selectedNodeId) {
+      return undefined;
+    }
+    const node = nodeById.get(selectedNodeId);
+    if (!node) {
+      return undefined;
+    }
+    return [{ id: node.id, name: node.name }];
+  }, [nodeById, selectedNodeId]);
+
+  const handleSelect = React.useCallback(
+    (_event: React.MouseEvent, item: TreeViewDataItem) => {
+      if (!item.id) {
+        return;
+      }
+      const node = nodeById.get(item.id);
+      if (node?.selectable) {
+        onSelectNode(node);
+      }
+    },
+    [nodeById, onSelectNode],
+  );
+
+  return (
+    <TreeView
+      className="quota-usage-tree"
+      key={expandStateKey}
+      data={treeData}
+      defaultAllExpanded
+      hasGuides
+      hasSelectableNodes
+      toolbar={toolbar}
+      activeItems={activeItems}
+      {...(allExpanded !== undefined ? { allExpanded } : {})}
+      onSelect={handleSelect}
+      onExpand={(_, item) => {
+        if (item.id) {
+          onExpand(item.id);
+        }
+      }}
+      onCollapse={(_, item) => {
+        if (item.id) {
+          onCollapse(item.id);
+        }
+      }}
+      aria-label="Nested cohorts"
+    />
+  );
+};
+
+export default QuotaUsageTreeView;

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -18,8 +18,23 @@ export const PROMETHEUS_CLUSTER_QUERY_RANGE_PATH = '/api/prometheus/cluster/quer
 
 export const INFRASTRUCTURE_TABS = [
   { id: 'utilization', title: 'Utilization' },
-  { id: 'cluster-queue-utilization', title: 'Compute profile utilization' },
+  { id: 'quota-usage', title: 'Quota usage' },
 ] as const;
+
+export type InfrastructureTabId = (typeof INFRASTRUCTURE_TABS)[number]['id'];
+
+export const QUOTA_USAGE_DESCRIPTION =
+  'View quota usage across cluster queues, which are entry points for workloads to access defined pools of hardware resources. Cluster queues organized into cohorts can borrow accelerators from the defined pool.';
+
+export const QUOTA_USAGE_EMPTY_TITLE = 'No accelerator cluster queues found';
+export const QUOTA_USAGE_EMPTY_BODY =
+  'No cluster queues with accelerator resources were detected. Configure cluster queues with GPU resource quotas to see utilization here.';
+export const QUOTA_USAGE_ERROR_TITLE = 'Error loading cluster queue data';
+
+export const QUOTA_UNASSIGNED_NODE_ID = 'quota-unassigned';
+export const QUOTA_UNASSIGNED_LABEL = 'Unassigned';
+export const QUOTA_UNASSIGNED_TOOLTIP = 'Cluster queues not assigned to a cohort.';
+export const QUOTA_USAGE_TREE_DRAWER_PANEL_ID = 'quota-usage-tree-drawer-panel';
 
 export const INFRASTRUCTURE_SECTIONS = [
   {
@@ -28,6 +43,8 @@ export const INFRASTRUCTURE_SECTIONS = [
     title: 'Summary',
     description: 'Cluster-wide accelerator allocation and average compute and memory consumption.',
     isPlain: true,
+    refreshBadgeTestId: undefined,
+    showKueueHelpLink: false,
   },
   {
     id: 'hardware-usage',
@@ -35,6 +52,8 @@ export const INFRASTRUCTURE_SECTIONS = [
     title: 'Hardware usage',
     description: 'Accelerator counts by hardware type.',
     isPlain: false,
+    refreshBadgeTestId: undefined,
+    showKueueHelpLink: false,
   },
   {
     id: 'borrowing',
@@ -43,13 +62,17 @@ export const INFRASTRUCTURE_SECTIONS = [
     description:
       '7-day borrowing trends by cluster queue. When a cluster queue uses its full quota, it can borrow accelerators from other queues.',
     isPlain: false,
+    refreshBadgeTestId: undefined,
+    showKueueHelpLink: false,
   },
   {
-    id: 'cluster-queue-utilization',
-    tab: 'cluster-queue-utilization',
-    title: 'Compute profile utilization',
-    description: 'Compute profile accelerator utilization grouped by Kueue cohort.',
+    id: 'quota-usage',
+    tab: 'quota-usage',
+    title: 'Quota usage',
+    description: QUOTA_USAGE_DESCRIPTION,
     isPlain: true,
+    refreshBadgeTestId: 'quota-usage-refresh-badge',
+    showKueueHelpLink: true,
   },
 ] as const;
 

--- a/packages/gpuaas/src/hooks/__tests__/useQuotaHierarchy.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useQuotaHierarchy.spec.ts
@@ -1,0 +1,84 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { listClusterQueues } from '@odh-dashboard/internal/api/k8s/clusterQueues';
+import { listCohorts } from '@odh-dashboard/internal/api/k8s/cohorts';
+import useFetch from '@odh-dashboard/ui-core/hooks/useFetch';
+import { ClusterQueueKind, CohortKind } from '@odh-dashboard/k8s-core';
+import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../../const';
+import { QuotaTreeNode } from '../../types';
+import { buildQuotaHierarchyTree } from '../../utils/buildQuotaHierarchyTree';
+import useQuotaHierarchy from '../useQuotaHierarchy';
+
+jest.mock('@odh-dashboard/ui-core/hooks/useFetch', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/api/k8s/clusterQueues', () => ({
+  listClusterQueues: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/api/k8s/cohorts', () => ({
+  listCohorts: jest.fn(),
+}));
+
+jest.mock('../../utils/buildQuotaHierarchyTree', () => ({
+  buildQuotaHierarchyTree: jest.fn(),
+}));
+
+const useFetchMock = jest.mocked(useFetch);
+const listClusterQueuesMock = jest.mocked(listClusterQueues);
+const listCohortsMock = jest.mocked(listCohorts);
+const buildQuotaHierarchyTreeMock = jest.mocked(buildQuotaHierarchyTree);
+
+const mockCohorts = [{ metadata: { name: 'production' } }] as CohortKind[];
+const mockClusterQueues = [{ metadata: { name: 'prod-serving' } }] as ClusterQueueKind[];
+const mockTree: QuotaTreeNode[] = [
+  {
+    id: 'cohort-production',
+    name: 'production',
+    type: 'cohort',
+    cohortName: 'production',
+    children: [],
+    selectable: true,
+  },
+];
+
+describe('useQuotaHierarchy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useFetchMock.mockReturnValue({
+      data: { tree: [] },
+      loaded: false,
+      error: undefined,
+      refresh: jest.fn(),
+    });
+  });
+
+  it('should register useFetch with empty initial tree and refresh interval', () => {
+    testHook(useQuotaHierarchy)();
+
+    expect(useFetchMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      { tree: [] },
+      {
+        refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL,
+      },
+    );
+  });
+
+  it('should list cohorts and cluster queues then build the navigation tree', async () => {
+    listCohortsMock.mockResolvedValue(mockCohorts);
+    listClusterQueuesMock.mockResolvedValue(mockClusterQueues);
+    buildQuotaHierarchyTreeMock.mockReturnValue(mockTree);
+
+    testHook(useQuotaHierarchy)();
+    const fetchQuotaHierarchy = useFetchMock.mock.calls[0][0] as () => Promise<{
+      tree: QuotaTreeNode[];
+    }>;
+
+    await expect(fetchQuotaHierarchy()).resolves.toEqual({ tree: mockTree });
+    expect(listCohortsMock).toHaveBeenCalledTimes(1);
+    expect(listClusterQueuesMock).toHaveBeenCalledTimes(1);
+    expect(buildQuotaHierarchyTreeMock).toHaveBeenCalledWith(mockCohorts, mockClusterQueues);
+  });
+});

--- a/packages/gpuaas/src/hooks/useInfrastructurePageTracking.ts
+++ b/packages/gpuaas/src/hooks/useInfrastructurePageTracking.ts
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import type { ClusterMetrics } from './useInfrastructureMetrics';
+import { INFRASTRUCTURE_SECTIONS } from '../const';
+import { GPUAAS_EVENTS, type PageViewedProperties } from '../tracking/gpuaasTrackingConstants';
+
+const useInfrastructurePageTracking = (
+  metrics: ClusterMetrics,
+  isKueueAvailable: boolean,
+): void => {
+  const hasTrackedPageView = React.useRef(false);
+
+  React.useEffect(() => {
+    if (metrics.loaded && !hasTrackedPageView.current) {
+      hasTrackedPageView.current = true;
+      const totalAccelerators = metrics.accelerators?.total;
+      const acceleratorsInUse = metrics.accelerators?.inUse;
+      const props: PageViewedProperties = {
+        path: '/observe-and-monitor/infrastructure',
+        sectionCount: INFRASTRUCTURE_SECTIONS.length,
+        hasKueueEnabled: isKueueAvailable,
+        totalAccelerators,
+        acceleratorsInUse,
+        totalUtilizationPct:
+          totalAccelerators && totalAccelerators > 0
+            ? Math.round(((acceleratorsInUse ?? 0) / totalAccelerators) * 100)
+            : undefined,
+        avgComputeUtilPct: metrics.computeUtilization?.percentage,
+        avgMemoryUtilPct: metrics.memoryUtilization?.percentage,
+      };
+      fireMiscTrackingEvent(GPUAAS_EVENTS.PAGE_VIEWED, props);
+    }
+  }, [
+    metrics.loaded,
+    metrics.accelerators,
+    metrics.computeUtilization,
+    metrics.memoryUtilization,
+    isKueueAvailable,
+  ]);
+};
+
+export default useInfrastructurePageTracking;

--- a/packages/gpuaas/src/hooks/useQuotaHierarchy.ts
+++ b/packages/gpuaas/src/hooks/useQuotaHierarchy.ts
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import useFetch, { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import { listClusterQueues } from '@odh-dashboard/internal/api/k8s/clusterQueues';
+import { listCohorts } from '@odh-dashboard/internal/api/k8s/cohorts';
+import { QuotaTreeNode } from '../types';
+import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../const';
+import { buildQuotaHierarchyTree } from '../utils/buildQuotaHierarchyTree';
+
+export type QuotaHierarchyData = {
+  tree: QuotaTreeNode[];
+};
+
+const useQuotaHierarchy = (
+  refreshRate = INFRASTRUCTURE_REFRESH_INTERVAL,
+): FetchStateObject<QuotaHierarchyData> =>
+  useFetch<QuotaHierarchyData>(
+    React.useCallback(async () => {
+      const [clusterQueues, cohorts] = await Promise.all([listClusterQueues(), listCohorts()]);
+      return { tree: buildQuotaHierarchyTree(cohorts, clusterQueues) };
+    }, []),
+    { tree: [] },
+    { refreshRate },
+  );
+
+export default useQuotaHierarchy;

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -10,15 +10,17 @@ import {
   Content,
   Flex,
   FlexItem,
+  PageGroup,
   PageSection,
   Stack,
   StackItem,
   Tab,
+  TabContent,
   Tabs,
   TabTitleIcon,
   TabTitleText,
-  Tooltip,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import { ClusterIcon, MicrochipIcon, SyncAltIcon } from '@patternfly/react-icons';
 import { relativeTime } from '@odh-dashboard/internal/utilities/time';
@@ -26,28 +28,82 @@ import {
   INFRASTRUCTURE_PAGE_DESCRIPTION,
   INFRASTRUCTURE_SECTIONS,
   INFRASTRUCTURE_TABS,
+  type InfrastructureTabId,
 } from '../const';
 import InfrastructureKueueHelpLink from '../components/InfrastructureKueueHelpLink';
 import { GPUAAS_EVENTS, type PageViewedProperties } from '../tracking/gpuaasTrackingConstants';
 import ClusterSummaryCards from '../components/ClusterSummaryCards';
 import HardwareUsageSection from '../components/HardwareUsageSection';
 import BorrowingLendingSection from '../components/BorrowingLendingSection';
-import ClusterQueueUtilizationSection from '../components/ClusterQueueUtilizationSection';
+import QuotaUsageSection from '../components/QuotaUsageSection';
 import useInfrastructureMetrics from '../hooks/useInfrastructureMetrics';
+import useQuotaHierarchy from '../hooks/useQuotaHierarchy';
 
 type SectionId = (typeof INFRASTRUCTURE_SECTIONS)[number]['id'];
-type TabId = (typeof INFRASTRUCTURE_TABS)[number]['id'];
+type InfrastructureSection = (typeof INFRASTRUCTURE_SECTIONS)[number];
 
-const TAB_ICONS: Record<TabId, React.ComponentType> = {
+const TAB_ICONS: Record<InfrastructureTabId, React.ComponentType> = {
   utilization: MicrochipIcon,
-  'cluster-queue-utilization': ClusterIcon,
+  'quota-usage': ClusterIcon,
 };
+
+const getTabPanelId = (tabId: InfrastructureTabId): string => `infrastructure-tab-panel-${tabId}`;
+
+type SectionRenderOptions = {
+  headerAction?: React.ReactNode;
+  descriptionAddon?: React.ReactNode;
+};
+
+const renderInfrastructureSection = (
+  { id, title, description, isPlain }: InfrastructureSection,
+  section: React.ReactNode,
+  { headerAction, descriptionAddon }: SectionRenderOptions = {},
+): React.ReactNode => (
+  <StackItem key={id}>
+    <Stack hasGutter>
+      <StackItem>
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          flexWrap={{ default: 'wrap' }}
+          gap={{ default: 'gapMd' }}
+        >
+          <FlexItem>
+            <Title headingLevel="h2" data-testid={`infrastructure-${id}-title`}>
+              {title}
+            </Title>
+          </FlexItem>
+          {headerAction && <FlexItem>{headerAction}</FlexItem>}
+        </Flex>
+        <Content component="p" data-testid={`infrastructure-${id}-description`}>
+          {description}
+          {descriptionAddon && <> {descriptionAddon}</>}
+        </Content>
+      </StackItem>
+      <StackItem>
+        <Card isPlain={isPlain} data-testid={`infrastructure-${id}-section`}>
+          {isPlain ? section : <CardBody>{section}</CardBody>}
+        </Card>
+      </StackItem>
+    </Stack>
+  </StackItem>
+);
 
 const InfrastructurePage: React.FC = () => {
   const metrics = useInfrastructureMetrics();
+  const quotaHierarchy = useQuotaHierarchy();
+  const { refresh: refreshQuotaHierarchy } = quotaHierarchy;
   const isKueueAvailable = useIsAreaAvailable(SupportedArea.KUEUE).status;
   const hasTrackedPageView = React.useRef(false);
-  const [activeTabKey, setActiveTabKey] = React.useState<string>(INFRASTRUCTURE_TABS[0].id);
+  const [activeTabKey, setActiveTabKey] = React.useState<InfrastructureTabId>(
+    INFRASTRUCTURE_TABS[0].id,
+  );
+  const utilizationContentRef = React.useRef<HTMLElement>(null);
+  const quotaUsageContentRef = React.useRef<HTMLElement>(null);
+  const tabContentRefs: Record<InfrastructureTabId, React.RefObject<HTMLElement>> = {
+    utilization: utilizationContentRef,
+    'quota-usage': quotaUsageContentRef,
+  };
 
   React.useEffect(() => {
     if (metrics.loaded && !hasTrackedPageView.current) {
@@ -86,115 +142,148 @@ const InfrastructurePage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- .refresh is stable from useFetch
   }, [metrics.lastRefreshed, metrics.refresh]);
 
-  const SECTION_COMPONENTS: Record<SectionId, React.ReactElement | null> = {
+  const handleQuotaRefresh = React.useCallback(() => {
+    void refreshQuotaHierarchy();
+    handleRefresh();
+  }, [handleRefresh, refreshQuotaHierarchy]);
+
+  const handleTabSelect = React.useCallback(
+    (
+      _event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+      eventKey: string | number,
+    ) => {
+      const tab = INFRASTRUCTURE_TABS.find((tabInfo) => tabInfo.id === eventKey);
+      if (tab) {
+        setActiveTabKey(tab.id);
+      }
+    },
+    [],
+  );
+
+  const sectionComponents: Record<SectionId, React.ReactElement | null> = {
     cluster: <ClusterSummaryCards metrics={metrics} />,
     'hardware-usage': <HardwareUsageSection metrics={metrics} />,
     borrowing: <BorrowingLendingSection />,
-    'cluster-queue-utilization': <ClusterQueueUtilizationSection />,
+    'quota-usage': (
+      <QuotaUsageSection
+        tree={quotaHierarchy.data.tree}
+        loaded={quotaHierarchy.loaded}
+        error={quotaHierarchy.error}
+      />
+    ),
   };
 
-  const lastUpdatedBadge = metrics.lastRefreshed ? (
-    <Flex
-      justifyContent={{ default: 'justifyContentFlexEnd' }}
-      alignItems={{ default: 'alignItemsCenter' }}
-      spaceItems={{ default: 'spaceItemsSm' }}
-      data-testid="infrastructure-refresh-badge"
-    >
-      <FlexItem>
-        <Tooltip content="Refresh">
-          <Button variant="plain" aria-label="Refresh" onClick={handleRefresh}>
-            <SyncAltIcon />
-          </Button>
-        </Tooltip>
-      </FlexItem>
-      <FlexItem>
-        <Content component="small">
-          Last updated {relativeTime(Date.now(), metrics.lastRefreshed.getTime())}
-        </Content>
-      </FlexItem>
-    </Flex>
-  ) : null;
+  const renderRefreshBadge = (
+    onRefresh: () => void,
+    testId = 'infrastructure-refresh-badge',
+  ): React.ReactNode =>
+    metrics.lastRefreshed ? (
+      <Flex
+        justifyContent={{ default: 'justifyContentFlexEnd' }}
+        alignItems={{ default: 'alignItemsCenter' }}
+        spaceItems={{ default: 'spaceItemsSm' }}
+        data-testid={testId}
+      >
+        <FlexItem>
+          <Tooltip content="Refresh">
+            <Button variant="plain" aria-label="Refresh" onClick={onRefresh}>
+              <SyncAltIcon />
+            </Button>
+          </Tooltip>
+        </FlexItem>
+        <FlexItem>
+          <Content component="small" className="pf-v6-u-color-200">
+            Updated {relativeTime(Date.now(), metrics.lastRefreshed.getTime())}
+          </Content>
+        </FlexItem>
+      </Flex>
+    ) : null;
+
+  const lastUpdatedBadge = renderRefreshBadge(handleRefresh);
+
+  const getSectionRenderOptions = (section: InfrastructureSection): SectionRenderOptions => ({
+    headerAction: section.refreshBadgeTestId
+      ? renderRefreshBadge(handleQuotaRefresh, section.refreshBadgeTestId)
+      : undefined,
+    descriptionAddon: section.showKueueHelpLink ? <InfrastructureKueueHelpLink /> : undefined,
+  });
+
+  const renderTabPanel = (tabId: InfrastructureTabId): React.ReactNode => {
+    const tabSections = INFRASTRUCTURE_SECTIONS.filter((section) => section.tab === tabId);
+
+    return (
+      <Stack hasGutter>
+        {tabId === 'utilization' && lastUpdatedBadge && <StackItem>{lastUpdatedBadge}</StackItem>}
+        {tabSections.map((section) =>
+          renderInfrastructureSection(
+            section,
+            sectionComponents[section.id],
+            getSectionRenderOptions(section),
+          ),
+        )}
+      </Stack>
+    );
+  };
 
   return (
-    <ApplicationsPage
-      title="Infrastructure"
-      description={
-        <>
-          {INFRASTRUCTURE_PAGE_DESCRIPTION}
-          {isKueueAvailable && (
-            <>
-              {' '}
-              <InfrastructureKueueHelpLink />
-            </>
-          )}
-        </>
-      }
-      loaded
-      empty={false}
-      provideChildrenPadding
-    >
-      <Tabs
-        activeKey={activeTabKey}
-        onSelect={(_event, eventKey) => setActiveTabKey(String(eventKey))}
-        aria-label="Infrastructure page tabs"
-        data-testid="infrastructure-tabs"
-      >
-        {INFRASTRUCTURE_TABS.map((tabInfo) => {
-          const TabIcon = TAB_ICONS[tabInfo.id];
-          return (
-            <Tab
-              key={tabInfo.id}
-              eventKey={tabInfo.id}
-              title={
-                <>
-                  <TabTitleIcon>
-                    <TabIcon />
-                  </TabTitleIcon>
-                  <TabTitleText>{tabInfo.title}</TabTitleText>
-                </>
-              }
-              data-testid={`infrastructure-tab-${tabInfo.id}`}
-            >
-              <PageSection
-                hasBodyWrapper={false}
-                isFilled
-                className={tabInfo.id === 'utilization' ? 'pf-v6-u-pt-0' : undefined}
+    <ApplicationsPage loaded empty={false} noHeader provideChildrenPadding={false}>
+      <PageGroup isFilled={false} stickyOnBreakpoint={{ default: 'top' }}>
+        <PageSection hasBodyWrapper={false} id="infrastructure-hub-header" className="pf-v6-u-pb-0">
+          <Stack hasGutter>
+            <StackItem>
+              <Content component="h1" data-testid="app-page-title">
+                Infrastructure
+              </Content>
+              <Content component="p" data-testid="app-page-description">
+                {INFRASTRUCTURE_PAGE_DESCRIPTION}
+              </Content>
+            </StackItem>
+            <StackItem>
+              <Tabs
+                activeKey={activeTabKey}
+                onSelect={handleTabSelect}
+                aria-label="Infrastructure page tabs"
+                data-testid="infrastructure-tabs"
               >
-                <Stack hasGutter>
-                  {tabInfo.id === 'utilization' && lastUpdatedBadge && (
-                    <StackItem>{lastUpdatedBadge}</StackItem>
-                  )}
-                  {INFRASTRUCTURE_SECTIONS.filter((section) => section.tab === tabInfo.id).map(
-                    ({ id, title, description, isPlain }) => (
-                      <StackItem key={id}>
-                        <Stack hasGutter>
-                          <StackItem>
-                            <Title headingLevel="h2" data-testid={`infrastructure-${id}-title`}>
-                              {title}
-                            </Title>
-                            <Content component="p" data-testid={`infrastructure-${id}-description`}>
-                              {description}
-                            </Content>
-                          </StackItem>
-                          <StackItem>
-                            <Card isPlain={isPlain} data-testid={`infrastructure-${id}-section`}>
-                              {isPlain ? (
-                                SECTION_COMPONENTS[id]
-                              ) : (
-                                <CardBody>{SECTION_COMPONENTS[id]}</CardBody>
-                              )}
-                            </Card>
-                          </StackItem>
-                        </Stack>
-                      </StackItem>
-                    ),
-                  )}
-                </Stack>
-              </PageSection>
-            </Tab>
-          );
-        })}
-      </Tabs>
+                {INFRASTRUCTURE_TABS.map((tabInfo) => {
+                  const TabIcon = TAB_ICONS[tabInfo.id];
+                  return (
+                    <Tab
+                      key={tabInfo.id}
+                      eventKey={tabInfo.id}
+                      title={
+                        <>
+                          <TabTitleIcon>
+                            <TabIcon />
+                          </TabTitleIcon>
+                          <TabTitleText>{tabInfo.title}</TabTitleText>
+                        </>
+                      }
+                      tabContentId={getTabPanelId(tabInfo.id)}
+                      tabContentRef={tabContentRefs[tabInfo.id]}
+                      data-testid={`infrastructure-tab-${tabInfo.id}`}
+                    />
+                  );
+                })}
+              </Tabs>
+            </StackItem>
+          </Stack>
+        </PageSection>
+      </PageGroup>
+      <PageSection isFilled className="pf-v6-u-pt-0" id="infrastructure-hub-content">
+        {INFRASTRUCTURE_TABS.map((tabInfo) => (
+          <TabContent
+            className="pf-v6-u-px-lg"
+            key={tabInfo.id}
+            id={getTabPanelId(tabInfo.id)}
+            eventKey={tabInfo.id}
+            ref={tabContentRefs[tabInfo.id]}
+            hidden={activeTabKey !== tabInfo.id}
+          >
+            {activeTabKey === tabInfo.id ? renderTabPanel(tabInfo.id) : null}
+          </TabContent>
+        ))}
+      </PageSection>
     </ApplicationsPage>
   );
 };

--- a/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
+++ b/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
@@ -15,6 +15,11 @@ jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', (
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
   SupportedArea: { KUEUE: 'kueue' },
   useIsAreaAvailable: jest.fn(),
+}));
+
+jest.mock('../../components/InfrastructureKueueHelpLink', () => ({
+  __esModule: true,
+  default: () => null,
 }));
 
 jest.mock('@odh-dashboard/ui-core', () => {
@@ -69,9 +74,18 @@ jest.mock('../../components/BorrowingLendingSection', () => ({
   default: () => <div data-testid="borrowing" />,
 }));
 
-jest.mock('../../components/ClusterQueueUtilizationSection', () => ({
+jest.mock('../../hooks/useQuotaHierarchy', () => ({
   __esModule: true,
-  default: () => <div data-testid="cluster-queue" />,
+  default: () => ({
+    data: { tree: [] },
+    loaded: true,
+    refresh: jest.fn(),
+  }),
+}));
+
+jest.mock('../../components/QuotaUsageSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="quota-usage" />,
 }));
 
 const mockFireMisc = jest.mocked(fireMiscTrackingEvent);
@@ -138,7 +152,10 @@ describe('InfrastructurePage - Tracking Events', () => {
       const user = userEvent.setup();
       render(<InfrastructurePage />);
 
-      const refreshButton = screen.getByRole('button', { name: 'Refresh' });
+      const refreshButton = within(screen.getByTestId('infrastructure-refresh-badge')).getByRole(
+        'button',
+        { name: 'Refresh' },
+      );
       await user.click(refreshButton);
 
       expect(mockFireMisc).toHaveBeenCalledWith(GPUAAS_EVENTS.DATA_REFRESHED, expect.any(Object));
@@ -154,7 +171,10 @@ describe('InfrastructurePage - Tracking Events', () => {
       };
       render(<InfrastructurePage />);
 
-      const refreshButton = screen.getByRole('button', { name: 'Refresh' });
+      const refreshButton = within(screen.getByTestId('infrastructure-refresh-badge')).getByRole(
+        'button',
+        { name: 'Refresh' },
+      );
       await user.click(refreshButton);
 
       expect(mockFireMisc).toHaveBeenCalledWith(

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -1,5 +1,33 @@
 import { ClusterQueueKind, CohortKind, ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
 
+export const QUOTA_NODE_TYPE = {
+  unassigned: 'unassigned',
+  cohort: 'cohort',
+  clusterQueue: 'clusterQueue',
+} as const;
+
+export type QuotaNodeType = (typeof QUOTA_NODE_TYPE)[keyof typeof QUOTA_NODE_TYPE];
+
+export type QuotaTreeNode = {
+  id: string;
+  name: string;
+  type: QuotaNodeType;
+  children: QuotaTreeNode[];
+  clusterQueue?: ClusterQueueKind;
+  cohortName?: string;
+  selectable: boolean;
+};
+
+export type QuotaSelection =
+  | { type: 'unassigned'; path: string[] }
+  | { type: 'cohort'; cohortName: string; path: string[] }
+  | {
+      type: 'clusterQueue';
+      clusterQueueName: string;
+      path: string[];
+      clusterQueue: ClusterQueueKind;
+    };
+
 export type CohortState = 'explicit' | 'implicit' | 'standalone';
 
 export type ResourceQuota = {

--- a/packages/gpuaas/src/utils/__tests__/buildQuotaHierarchyTree.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/buildQuotaHierarchyTree.spec.ts
@@ -1,0 +1,85 @@
+import { makeCohort, makeCQ } from './quotaHierarchyFixtures';
+import { QUOTA_UNASSIGNED_NODE_ID } from '../../const';
+import { QUOTA_NODE_TYPE } from '../../types';
+import { buildQuotaHierarchyTree } from '../buildQuotaHierarchyTree';
+
+describe('buildQuotaHierarchyTree', () => {
+  it('returns empty tree when no accelerator cluster queues exist', () => {
+    expect(buildQuotaHierarchyTree([], [])).toEqual([]);
+    expect(
+      buildQuotaHierarchyTree([makeCohort('cohort-1')], [makeCQ('cpu-only', 'cohort-1', '0')]),
+    ).toEqual([]);
+  });
+
+  it('places standalone cluster queues under Unassigned', () => {
+    const tree = buildQuotaHierarchyTree([], [makeCQ('legacy-batch'), makeCQ('shared-inference')]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe(QUOTA_UNASSIGNED_NODE_ID);
+    expect(tree[0].children.map((child) => child.name)).toEqual([
+      'legacy-batch',
+      'shared-inference',
+    ]);
+  });
+
+  it('places Unassigned before cohort roots', () => {
+    const tree = buildQuotaHierarchyTree(
+      [makeCohort('production')],
+      [makeCQ('legacy-batch'), makeCQ('prod-serving', 'production')],
+    );
+
+    expect(tree).toHaveLength(2);
+    expect(tree[0].type).toBe(QUOTA_NODE_TYPE.unassigned);
+    expect(tree[0].children.map((child) => child.name)).toEqual(['legacy-batch']);
+    expect(tree[1].name).toBe('production');
+  });
+
+  it('nests cohorts via parentName and attaches cluster queue leaves', () => {
+    const tree = buildQuotaHierarchyTree(
+      [makeCohort('production'), makeCohort('inference-edge', 'production')],
+      [makeCQ('prod-serving', 'inference-edge'), makeCQ('staging-serving', 'inference-edge')],
+    );
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('production');
+    expect(tree[0].children).toHaveLength(1);
+    expect(tree[0].children[0].name).toBe('inference-edge');
+    expect(tree[0].children[0].children.map((child) => child.name)).toEqual([
+      'prod-serving',
+      'staging-serving',
+    ]);
+  });
+
+  it('supports flat cohorts with direct cluster queue children', () => {
+    const tree = buildQuotaHierarchyTree([makeCohort('cohort-1')], [makeCQ('cq-a', 'cohort-1')]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('cohort-1');
+    expect(tree[0].children).toHaveLength(1);
+    expect(tree[0].children[0].name).toBe('cq-a');
+  });
+
+  it('includes implicit cohorts referenced only by cluster queues', () => {
+    const tree = buildQuotaHierarchyTree([], [makeCQ('cq-a', 'implicit-cohort')]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('implicit-cohort');
+    expect(tree[0].children[0].name).toBe('cq-a');
+  });
+
+  it('includes cohort resources without cluster queues', () => {
+    const tree = buildQuotaHierarchyTree([makeCohort('empty-cohort')], []);
+
+    expect(tree).toHaveLength(0);
+  });
+
+  it('treats cohorts with missing parent as roots', () => {
+    const tree = buildQuotaHierarchyTree(
+      [makeCohort('child', 'missing-parent')],
+      [makeCQ('cq-a', 'child')],
+    );
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('child');
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/quotaHierarchyFixtures.ts
+++ b/packages/gpuaas/src/utils/__tests__/quotaHierarchyFixtures.ts
@@ -1,0 +1,51 @@
+import { ClusterQueueKind, CohortKind, ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+import { buildQuotaHierarchyTree } from '../buildQuotaHierarchyTree';
+import { QuotaTreeNode } from '../../types';
+
+export const makeCohort = (name: string, parentName?: string): CohortKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
+  kind: 'Cohort',
+  metadata: { name },
+  spec: {
+    ...(parentName ? { parentName } : {}),
+    resourceGroups: [],
+  },
+});
+
+const GPU_RESOURCE = 'nvidia.com/gpu' as ContainerResourceAttributes;
+
+export const makeCQ = (name: string, cohortName?: string, gpuQuota = '4'): ClusterQueueKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
+  kind: 'ClusterQueue',
+  metadata: { name },
+  spec: {
+    ...(cohortName ? { cohortName } : {}),
+    resourceGroups: [
+      {
+        coveredResources: [GPU_RESOURCE],
+        flavors: [
+          {
+            name: 'gpu-flavor',
+            resources: [{ name: GPU_RESOURCE, nominalQuota: gpuQuota }],
+          },
+        ],
+      },
+    ],
+  },
+  status: {
+    admittedWorkloads: 0,
+    pendingWorkloads: 0,
+    flavorsUsage: [],
+  },
+});
+
+/** Unassigned CQ + nested production/inference-edge cohorts — shared utils test tree. */
+export const buildQuotaUtilsTestTree = (): QuotaTreeNode[] =>
+  buildQuotaHierarchyTree(
+    [makeCohort('production'), makeCohort('inference-edge', 'production')],
+    [makeCQ('prod-serving', 'inference-edge'), makeCQ('legacy-batch')],
+  );
+
+/** Cohort-only tree with no unassigned bucket. */
+export const buildCohortOnlyQuotaTree = (): QuotaTreeNode[] =>
+  buildQuotaHierarchyTree([makeCohort('production')], [makeCQ('prod-serving', 'production')]);

--- a/packages/gpuaas/src/utils/__tests__/quotaHierarchyFixtures.ts
+++ b/packages/gpuaas/src/utils/__tests__/quotaHierarchyFixtures.ts
@@ -49,3 +49,41 @@ export const buildQuotaUtilsTestTree = (): QuotaTreeNode[] =>
 /** Cohort-only tree with no unassigned bucket. */
 export const buildCohortOnlyQuotaTree = (): QuotaTreeNode[] =>
   buildQuotaHierarchyTree([makeCohort('production')], [makeCQ('prod-serving', 'production')]);
+
+/** Same-named CQ/cohort siblings under production — tests selectionFromPath backtracking. */
+export const buildDuplicateSiblingNameQuotaTree = (): QuotaTreeNode[] => [
+  {
+    id: 'cohort-production',
+    name: 'production',
+    type: 'cohort',
+    cohortName: 'production',
+    selectable: true,
+    children: [
+      {
+        id: 'cq-inference-edge',
+        name: 'inference-edge',
+        type: 'clusterQueue',
+        selectable: true,
+        children: [],
+        clusterQueue: makeCQ('inference-edge', 'production'),
+      },
+      {
+        id: 'cohort-inference-edge',
+        name: 'inference-edge',
+        type: 'cohort',
+        cohortName: 'inference-edge',
+        selectable: true,
+        children: [
+          {
+            id: 'cq-prod-serving',
+            name: 'prod-serving',
+            type: 'clusterQueue',
+            selectable: true,
+            children: [],
+            clusterQueue: makeCQ('prod-serving', 'inference-edge'),
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/gpuaas/src/utils/__tests__/quotaUsageTreeUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/quotaUsageTreeUtils.spec.ts
@@ -1,0 +1,92 @@
+import { buildCohortOnlyQuotaTree, buildQuotaUtilsTestTree } from './quotaHierarchyFixtures';
+import { QUOTA_NODE_TYPE } from '../../types';
+import {
+  collectAllExpandableNodeIds,
+  collectExpandedNodeIds,
+  findQuotaTreeNode,
+  getAncestorNodeIds,
+  getDefaultQuotaSelection,
+  getExpandedIdsForSelection,
+  getQuotaNodePath,
+  filterQuotaTreeByName,
+  nodeIdFromSelection,
+  selectionFromPath,
+} from '../quotaUsageTreeUtils';
+
+describe('quotaUsageTreeUtils', () => {
+  const tree = buildQuotaUtilsTestTree();
+  const cohortOnlyTree = buildCohortOnlyQuotaTree();
+
+  it.each([
+    ['quota-unassigned', ['Unassigned']],
+    ['cq-legacy-batch', ['Unassigned', 'legacy-batch']],
+    ['cohort-production', ['production']],
+    ['cohort-inference-edge', ['production', 'inference-edge']],
+    ['cq-prod-serving', ['production', 'inference-edge', 'prod-serving']],
+  ] as const)('round-trips path and selection for %s', (nodeId, expectedPath) => {
+    expect(getQuotaNodePath(tree, nodeId)).toEqual(expectedPath);
+    const selection = selectionFromPath(tree, [...expectedPath]);
+    if (!selection) {
+      expect(selection).toBeDefined();
+      return;
+    }
+    expect(nodeIdFromSelection(selection)).toBe(nodeId);
+  });
+
+  it.each([
+    ['known node', 'cq-prod-serving', 'prod-serving'],
+    ['missing node', 'cq-missing', undefined],
+  ] as const)('findQuotaTreeNode returns %s', (_label, nodeId, expectedName) => {
+    const node = findQuotaTreeNode(tree, nodeId);
+    if (expectedName === undefined) {
+      expect(node).toBeUndefined();
+      return;
+    }
+    expect(node?.name).toBe(expectedName);
+  });
+
+  it('collects ancestor and expanded ids for nested selections', () => {
+    const selection = selectionFromPath(tree, ['production', 'inference-edge', 'prod-serving']);
+    expect(getAncestorNodeIds(tree, 'cq-prod-serving')).toEqual([
+      'cohort-production',
+      'cohort-inference-edge',
+    ]);
+    expect(getExpandedIdsForSelection(tree, selection)).toEqual(
+      new Set(['cohort-production', 'cohort-inference-edge']),
+    );
+  });
+
+  it.each([
+    [
+      'when unassigned bucket exists',
+      tree,
+      { type: QUOTA_NODE_TYPE.unassigned, path: ['Unassigned'] },
+    ],
+    [
+      'when no unassigned cluster queues exist',
+      cohortOnlyTree,
+      { type: QUOTA_NODE_TYPE.cohort, cohortName: 'production', path: ['production'] },
+    ],
+  ] as const)('defaults selection %s', (_label, testTree, expected) => {
+    expect(getDefaultQuotaSelection(testTree)).toEqual(expected);
+  });
+
+  it('filters tree nodes by search query and leaves tree unchanged for empty search', () => {
+    expect(filterQuotaTreeByName(tree, '')).toBe(tree);
+    const filtered = filterQuotaTreeByName(tree, 'prod-serving');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].name).toBe('production');
+    expect(filtered[0].children[0].children[0].name).toBe('prod-serving');
+  });
+
+  it('collects expandable and search-expanded node ids', () => {
+    const expandable = collectAllExpandableNodeIds(tree);
+    expect(expandable.has('quota-unassigned')).toBe(true);
+    expect(expandable.has('cohort-production')).toBe(true);
+    expect(expandable.has('cq-prod-serving')).toBe(false);
+
+    const searchExpanded = collectExpandedNodeIds(tree, 'prod-serving');
+    expect(searchExpanded.has('cohort-production')).toBe(true);
+    expect(searchExpanded.has('cohort-inference-edge')).toBe(true);
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/quotaUsageTreeUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/quotaUsageTreeUtils.spec.ts
@@ -1,4 +1,11 @@
-import { buildCohortOnlyQuotaTree, buildQuotaUtilsTestTree } from './quotaHierarchyFixtures';
+import {
+  buildCohortOnlyQuotaTree,
+  buildDuplicateSiblingNameQuotaTree,
+  buildQuotaUtilsTestTree,
+  makeCQ,
+  makeCohort,
+} from './quotaHierarchyFixtures';
+import { buildQuotaHierarchyTree } from '../buildQuotaHierarchyTree';
 import { QUOTA_NODE_TYPE } from '../../types';
 import {
   collectAllExpandableNodeIds,
@@ -11,6 +18,7 @@ import {
   filterQuotaTreeByName,
   nodeIdFromSelection,
   selectionFromPath,
+  syncQuotaSelectionWithTree,
 } from '../quotaUsageTreeUtils';
 
 describe('quotaUsageTreeUtils', () => {
@@ -77,6 +85,66 @@ describe('quotaUsageTreeUtils', () => {
     expect(filtered).toHaveLength(1);
     expect(filtered[0].name).toBe('production');
     expect(filtered[0].children[0].children[0].name).toBe('prod-serving');
+  });
+
+  it('keeps full subtree when a parent cohort name matches the search query', () => {
+    const filtered = filterQuotaTreeByName(tree, 'production');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].name).toBe('production');
+    expect(filtered[0].children[0].name).toBe('inference-edge');
+    expect(filtered[0].children[0].children[0].name).toBe('prod-serving');
+  });
+
+  it('keeps unassigned cluster queues when the unassigned bucket name matches', () => {
+    const filtered = filterQuotaTreeByName(tree, 'unassigned');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].name).toBe('Unassigned');
+    expect(filtered[0].children[0].name).toBe('legacy-batch');
+  });
+
+  it('backtracks to the next same-named sibling when the first path match is a dead end', () => {
+    const duplicateNameTree = buildDuplicateSiblingNameQuotaTree();
+    const clusterQueueSelection = selectionFromPath(duplicateNameTree, [
+      'production',
+      'inference-edge',
+      'prod-serving',
+    ]);
+
+    expect(clusterQueueSelection?.type).toBe(QUOTA_NODE_TYPE.clusterQueue);
+    if (clusterQueueSelection?.type !== QUOTA_NODE_TYPE.clusterQueue) {
+      return;
+    }
+    expect(nodeIdFromSelection(clusterQueueSelection)).toBe('cq-prod-serving');
+    expect(clusterQueueSelection.clusterQueueName).toBe('prod-serving');
+  });
+
+  it('re-derives cluster queue selection from refreshed tree data', () => {
+    const staleSelection = selectionFromPath(tree, [
+      'production',
+      'inference-edge',
+      'prod-serving',
+    ]);
+    if (!staleSelection || staleSelection.type !== QUOTA_NODE_TYPE.clusterQueue) {
+      expect(staleSelection?.type).toBe(QUOTA_NODE_TYPE.clusterQueue);
+      return;
+    }
+
+    const refreshedTree = buildQuotaHierarchyTree(
+      [makeCohort('production'), makeCohort('inference-edge', 'production')],
+      [makeCQ('prod-serving', 'inference-edge', '8'), makeCQ('legacy-batch')],
+    );
+
+    const syncedSelection = syncQuotaSelectionWithTree(refreshedTree, staleSelection);
+    if (!syncedSelection || syncedSelection.type !== QUOTA_NODE_TYPE.clusterQueue) {
+      expect(syncedSelection?.type).toBe(QUOTA_NODE_TYPE.clusterQueue);
+      return;
+    }
+
+    expect(syncedSelection.clusterQueue).not.toBe(staleSelection.clusterQueue);
+    expect(
+      syncedSelection.clusterQueue.spec.resourceGroups?.[0]?.flavors?.[0]?.resources?.[0]
+        ?.nominalQuota,
+    ).toBe('8');
   });
 
   it('collects expandable and search-expanded node ids', () => {

--- a/packages/gpuaas/src/utils/buildQuotaHierarchyTree.ts
+++ b/packages/gpuaas/src/utils/buildQuotaHierarchyTree.ts
@@ -1,0 +1,146 @@
+import { ClusterQueueKind, CohortKind } from '@odh-dashboard/k8s-core';
+import { filterAcceleratorCQs } from './clusterQueueUtils';
+import { QUOTA_UNASSIGNED_LABEL, QUOTA_UNASSIGNED_NODE_ID } from '../const';
+import { QuotaTreeNode } from '../types';
+
+const cohortNodeId = (name: string): string => `cohort-${name}`;
+const clusterQueueNodeId = (name: string): string => `cq-${name}`;
+
+const sortChildren = (children: QuotaTreeNode[]): QuotaTreeNode[] =>
+  [...children].toSorted((a, b) => {
+    if (a.type !== b.type) {
+      if (a.type === 'cohort') {
+        return -1;
+      }
+      if (b.type === 'cohort') {
+        return 1;
+      }
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+const createCohortNode = (name: string): QuotaTreeNode => ({
+  id: cohortNodeId(name),
+  name,
+  type: 'cohort',
+  cohortName: name,
+  children: [],
+  selectable: true,
+});
+
+const createClusterQueueNode = (cq: ClusterQueueKind): QuotaTreeNode => {
+  const name = cq.metadata?.name ?? '';
+  return {
+    id: clusterQueueNodeId(name),
+    name,
+    type: 'clusterQueue',
+    children: [],
+    clusterQueue: cq,
+    selectable: true,
+  };
+};
+
+const createUnassignedNode = (clusterQueues: ClusterQueueKind[]): QuotaTreeNode => ({
+  id: QUOTA_UNASSIGNED_NODE_ID,
+  name: QUOTA_UNASSIGNED_LABEL,
+  type: 'unassigned',
+  children: sortChildren(clusterQueues.map(createClusterQueueNode)),
+  selectable: true,
+});
+
+/**
+ * Builds the Quota usage navigation tree from raw Kueue cohort and cluster queue resources.
+ */
+export const buildQuotaHierarchyTree = (
+  cohorts: CohortKind[],
+  clusterQueues: ClusterQueueKind[],
+): QuotaTreeNode[] => {
+  const acceleratorCQs = filterAcceleratorCQs(clusterQueues);
+  if (acceleratorCQs.length === 0) {
+    return [];
+  }
+
+  const cohortResourceByName = new Map(
+    cohorts.flatMap((cohort) => {
+      const name = cohort.metadata?.name;
+      return name ? [[name, cohort] as const] : [];
+    }),
+  );
+
+  const cqsByCohortName = new Map<string, ClusterQueueKind[]>();
+  const unassignedCQs: ClusterQueueKind[] = [];
+
+  for (const cq of acceleratorCQs) {
+    const { cohortName } = cq.spec;
+    if (!cohortName) {
+      unassignedCQs.push(cq);
+      continue;
+    }
+    const existing = cqsByCohortName.get(cohortName) ?? [];
+    existing.push(cq);
+    cqsByCohortName.set(cohortName, existing);
+  }
+
+  const cohortNames = new Set<string>([...cohortResourceByName.keys(), ...cqsByCohortName.keys()]);
+
+  const cohortNodes = new Map<string, QuotaTreeNode>();
+  for (const name of cohortNames) {
+    cohortNodes.set(name, createCohortNode(name));
+  }
+
+  for (const [cohortName, cqs] of cqsByCohortName) {
+    const node = cohortNodes.get(cohortName);
+    if (!node) {
+      continue;
+    }
+    node.children.push(...cqs.map(createClusterQueueNode));
+    node.children = sortChildren(node.children);
+  }
+
+  const childCohortNames = new Set<string>();
+
+  for (const [name, cohortResource] of cohortResourceByName) {
+    const { parentName } = cohortResource.spec;
+    if (!parentName || parentName === name) {
+      continue;
+    }
+
+    const childNode = cohortNodes.get(name);
+    const parentNode = cohortNodes.get(parentName);
+    if (!childNode || !parentNode) {
+      continue;
+    }
+
+    if (parentNode.children.some((child) => child.id === childNode.id)) {
+      continue;
+    }
+
+    const firstClusterQueueIndex = parentNode.children.findIndex(
+      (child) => child.type === 'clusterQueue',
+    );
+    if (firstClusterQueueIndex === -1) {
+      parentNode.children.push(childNode);
+    } else {
+      parentNode.children.splice(firstClusterQueueIndex, 0, childNode);
+    }
+    childCohortNames.add(name);
+  }
+
+  const roots: QuotaTreeNode[] = [];
+
+  for (const [name, node] of cohortNodes) {
+    if (childCohortNames.has(name)) {
+      continue;
+    }
+    roots.push(node);
+  }
+
+  if (unassignedCQs.length > 0) {
+    roots.unshift(createUnassignedNode(unassignedCQs));
+  }
+
+  const unassignedRoot = roots.find((node) => node.type === 'unassigned');
+  const cohortRoots = sortChildren(roots.filter((node) => node.type !== 'unassigned'));
+
+  return unassignedRoot ? [unassignedRoot, ...cohortRoots] : cohortRoots;
+};

--- a/packages/gpuaas/src/utils/quotaUsageTreeUtils.ts
+++ b/packages/gpuaas/src/utils/quotaUsageTreeUtils.ts
@@ -55,7 +55,10 @@ export const selectionFromPath = (
       if (segmentIndex === path.length - 1) {
         return node;
       }
-      return findNode(node.children, segmentIndex + 1);
+      const childMatch = findNode(node.children, segmentIndex + 1);
+      if (childMatch) {
+        return childMatch;
+      }
     }
     return undefined;
   };
@@ -144,6 +147,29 @@ export const getDefaultQuotaSelection = (tree: QuotaTreeNode[]): QuotaSelection 
   return path ? selectionFromNode(firstCohort, path) : undefined;
 };
 
+/** Keeps the current selection when possible, but re-derives it from the latest tree data. */
+export const syncQuotaSelectionWithTree = (
+  tree: QuotaTreeNode[],
+  current?: QuotaSelection,
+): QuotaSelection | undefined => {
+  if (!current) {
+    return getDefaultQuotaSelection(tree);
+  }
+
+  const nodeId = nodeIdFromSelection(current);
+  const node = findQuotaTreeNode(tree, nodeId);
+  if (!node) {
+    return getDefaultQuotaSelection(tree);
+  }
+
+  const path = getQuotaNodePath(tree, nodeId);
+  if (!path) {
+    return getDefaultQuotaSelection(tree);
+  }
+
+  return selectionFromNode(node, path) ?? getDefaultQuotaSelection(tree);
+};
+
 export const filterQuotaTreeByName = (nodes: QuotaTreeNode[], search: string): QuotaTreeNode[] => {
   const query = search.trim().toLowerCase();
   if (!query) {
@@ -151,18 +177,27 @@ export const filterQuotaTreeByName = (nodes: QuotaTreeNode[], search: string): Q
   }
 
   const filterNode = (node: QuotaTreeNode): QuotaTreeNode | undefined => {
+    const isNodeNameMatch = node.name.toLowerCase().includes(query);
+
     if (node.type === QUOTA_NODE_TYPE.unassigned) {
+      if (isNodeNameMatch) {
+        return { ...node, children: node.children };
+      }
       const children = node.children
         .map(filterNode)
         .filter((child): child is QuotaTreeNode => child !== undefined);
       return children.length > 0 ? { ...node, children } : undefined;
     }
 
+    if (isNodeNameMatch) {
+      return { ...node, children: node.children };
+    }
+
     const filteredChildren = node.children
       .map(filterNode)
       .filter((child): child is QuotaTreeNode => child !== undefined);
 
-    if (node.name.toLowerCase().includes(query) || filteredChildren.length > 0) {
+    if (filteredChildren.length > 0) {
       return { ...node, children: filteredChildren };
     }
     return undefined;

--- a/packages/gpuaas/src/utils/quotaUsageTreeUtils.ts
+++ b/packages/gpuaas/src/utils/quotaUsageTreeUtils.ts
@@ -1,0 +1,229 @@
+import { QUOTA_UNASSIGNED_NODE_ID } from '../const';
+import { QUOTA_NODE_TYPE, QuotaSelection, QuotaTreeNode } from '../types';
+
+export const findQuotaTreeNode = (
+  nodes: QuotaTreeNode[],
+  nodeId: string,
+): QuotaTreeNode | undefined => {
+  for (const node of nodes) {
+    if (node.id === nodeId) {
+      return node;
+    }
+    const match = findQuotaTreeNode(node.children, nodeId);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+};
+
+export const getQuotaNodePath = (
+  nodes: QuotaTreeNode[],
+  nodeId: string,
+  path: string[] = [],
+): string[] | undefined => {
+  for (const node of nodes) {
+    const nextPath = [...path, node.name];
+    if (node.id === nodeId) {
+      return nextPath;
+    }
+    const childPath = getQuotaNodePath(node.children, nodeId, nextPath);
+    if (childPath) {
+      return childPath;
+    }
+  }
+  return undefined;
+};
+
+export const selectionFromPath = (
+  nodes: QuotaTreeNode[],
+  path: string[],
+): QuotaSelection | undefined => {
+  if (path.length === 0) {
+    return undefined;
+  }
+
+  const findNode = (
+    currentNodes: QuotaTreeNode[],
+    segmentIndex: number,
+  ): QuotaTreeNode | undefined => {
+    const segment = path[segmentIndex];
+    for (const node of currentNodes) {
+      if (node.name !== segment) {
+        continue;
+      }
+      if (segmentIndex === path.length - 1) {
+        return node;
+      }
+      return findNode(node.children, segmentIndex + 1);
+    }
+    return undefined;
+  };
+
+  const node = findNode(nodes, 0);
+  if (!node) {
+    return undefined;
+  }
+  return selectionFromNode(node, path);
+};
+
+export const getAncestorNodeIds = (
+  nodes: QuotaTreeNode[],
+  nodeId: string,
+  ancestors: string[] = [],
+): string[] | undefined => {
+  for (const node of nodes) {
+    if (node.id === nodeId) {
+      return ancestors;
+    }
+    const match = getAncestorNodeIds(node.children, nodeId, [...ancestors, node.id]);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+};
+
+export const selectionFromNode = (
+  node: QuotaTreeNode,
+  path: string[],
+): QuotaSelection | undefined => {
+  if (!node.selectable) {
+    return undefined;
+  }
+  switch (node.type) {
+    case QUOTA_NODE_TYPE.unassigned:
+      return { type: QUOTA_NODE_TYPE.unassigned, path };
+    case QUOTA_NODE_TYPE.cohort:
+      if (!node.cohortName) {
+        return undefined;
+      }
+      return { type: QUOTA_NODE_TYPE.cohort, cohortName: node.cohortName, path };
+    case QUOTA_NODE_TYPE.clusterQueue:
+      if (!node.clusterQueue) {
+        return undefined;
+      }
+      return {
+        type: QUOTA_NODE_TYPE.clusterQueue,
+        clusterQueueName: node.name,
+        path,
+        clusterQueue: node.clusterQueue,
+      };
+    default:
+      return undefined;
+  }
+};
+
+const visitPreorder = (nodes: QuotaTreeNode[], visit: (node: QuotaTreeNode) => void): void => {
+  for (const node of nodes) {
+    visit(node);
+    visitPreorder(node.children, visit);
+  }
+};
+
+/** Default: Unassigned bucket when present, else first cohort node. */
+export const getDefaultQuotaSelection = (tree: QuotaTreeNode[]): QuotaSelection | undefined => {
+  const unassigned = tree.find((node) => node.type === QUOTA_NODE_TYPE.unassigned);
+  if (unassigned) {
+    const path = getQuotaNodePath(tree, unassigned.id);
+    return path ? selectionFromNode(unassigned, path) : undefined;
+  }
+
+  let firstCohort: QuotaTreeNode | undefined;
+  visitPreorder(tree, (node) => {
+    if (!firstCohort && node.type === QUOTA_NODE_TYPE.cohort) {
+      firstCohort = node;
+    }
+  });
+
+  if (!firstCohort) {
+    return undefined;
+  }
+
+  const path = getQuotaNodePath(tree, firstCohort.id);
+  return path ? selectionFromNode(firstCohort, path) : undefined;
+};
+
+export const filterQuotaTreeByName = (nodes: QuotaTreeNode[], search: string): QuotaTreeNode[] => {
+  const query = search.trim().toLowerCase();
+  if (!query) {
+    return nodes;
+  }
+
+  const filterNode = (node: QuotaTreeNode): QuotaTreeNode | undefined => {
+    if (node.type === QUOTA_NODE_TYPE.unassigned) {
+      const children = node.children
+        .map(filterNode)
+        .filter((child): child is QuotaTreeNode => child !== undefined);
+      return children.length > 0 ? { ...node, children } : undefined;
+    }
+
+    const filteredChildren = node.children
+      .map(filterNode)
+      .filter((child): child is QuotaTreeNode => child !== undefined);
+
+    if (node.name.toLowerCase().includes(query) || filteredChildren.length > 0) {
+      return { ...node, children: filteredChildren };
+    }
+    return undefined;
+  };
+
+  return nodes.map(filterNode).filter((node): node is QuotaTreeNode => node !== undefined);
+};
+
+/** Ancestor node ids that must be expanded to reveal the current selection. */
+export const getExpandedIdsForSelection = (
+  tree: QuotaTreeNode[],
+  selection?: QuotaSelection,
+): Set<string> => {
+  if (!selection) {
+    return new Set();
+  }
+  const ancestors = getAncestorNodeIds(tree, nodeIdFromSelection(selection));
+  return new Set(ancestors ?? []);
+};
+
+/** All nodes with children — used for expand-all. */
+export const collectAllExpandableNodeIds = (nodes: QuotaTreeNode[]): Set<string> => {
+  const expanded = new Set<string>();
+  const visit = (node: QuotaTreeNode): void => {
+    if (node.children.length > 0) {
+      expanded.add(node.id);
+    }
+    node.children.forEach(visit);
+  };
+  nodes.forEach(visit);
+  return expanded;
+};
+
+export const collectExpandedNodeIds = (nodes: QuotaTreeNode[], search: string): Set<string> => {
+  const expanded = new Set<string>();
+  const query = search.trim().toLowerCase();
+  if (!query) {
+    return expanded;
+  }
+
+  const visit = (node: QuotaTreeNode): boolean => {
+    const childMatches = node.children.map(visit);
+    const selfMatches =
+      node.type !== QUOTA_NODE_TYPE.unassigned && node.name.toLowerCase().includes(query);
+    const hasMatchingDescendant = childMatches.some(Boolean);
+
+    if (hasMatchingDescendant) {
+      expanded.add(node.id);
+    }
+    return selfMatches || hasMatchingDescendant;
+  };
+
+  nodes.forEach(visit);
+  return expanded;
+};
+
+export const nodeIdFromSelection = (selection: QuotaSelection): string => {
+  if (selection.type === QUOTA_NODE_TYPE.unassigned) {
+    return QUOTA_UNASSIGNED_NODE_ID;
+  }
+  return selection.type === QUOTA_NODE_TYPE.cohort
+    ? `cohort-${selection.cohortName}`
+    : `cq-${selection.clusterQueueName}`;
+};


### PR DESCRIPTION
Closes [RHOAIENG-79841](https://issues.redhat.com/browse/RHOAIENG-79841)
## Description

https://github.com/user-attachments/assets/702201bd-f351-4c05-bad3-d3163b65c178

<img width="1551" height="851" alt="Screenshot 2026-09-02 at 7 43 18 PM" src="https://github.com/user-attachments/assets/fed04a2a-ec3b-4b2e-9480-2cd68409f824" />

<img width="1573" height="866" alt="image" src="https://github.com/user-attachments/assets/01ace3fe-cccf-45f7-b6b8-41cc644f0f9a" />


This PR adds the tree navigation and detail panel shell.

- Left side: tree of cohorts and cluster queues (including an Unassigned group for queues with no cohort).
- Right side: detail panel with breadcrumb and title. You can resize the split.
- Search, expand/collapse all, and node selection work.
- Infrastructure page got small layout tweaks (sticky header/tabs, section wiring).
- On hover over the icons in the side panel we get a tooltip
- Detail panel content (summary + accelerator table) is not in this PR — that's RHOAIENG-88178.

E2E test update: the old test checked the compute profile accordion. That UI is removed, so the test now opens Quota usage and checks the section and search box show up.

## How Has This Been Tested?

- Unit tests in `packages/gpuaas`
- Mock Cypress tests for the quota tab
- Clicked around locally on the Quota usage tab (tree, search, resize)

## Test Impact

- New: `buildQuotaHierarchyTree.spec.ts`, `quotaUsageTreeUtils.spec.ts`
- Updated: `InfrastructurePage.tracking.spec.tsx`, Cypress page object, mocked + e2e infrastructure tests

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

### Manual test steps

1. Go to **Observe & monitor → Infrastructure** as admin.
2. **Utilization** tab should still work as before.
3. Open **Quota usage** — tree shows up (or empty/error if no cluster queues).
4. Click nodes — breadcrumb and title change.
5. Try search and collapse/expand all.
6. Drag the panel divider — layout should stay sane.

@kywalker-rh @ralombar 

[RHOAIENG-79841]: https://redhat.atlassian.net/browse/RHOAIENG-79841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the Cluster Queue Utilization view with a Quota Usage view on the Infrastructure page.
  * Browse nested cohorts and cluster queues in a hierarchical tree.
  * Search quota entries and expand or collapse all levels.
  * View selected quota details with breadcrumbs and synchronized navigation.
  * Added loading, error, empty, and unassigned quota states.
  * Added refresh indicators and Kueue help links where applicable.

* **Tests**
  * Expanded coverage for quota hierarchy navigation, filtering, selection, and empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->