### PR TITLE
feat(data-registry): add connections support

### DIFF
--- a/packages/data-registry/bff/internal/api/app.go
+++ b/packages/data-registry/bff/internal/api/app.go
@@ -30,9 +30,10 @@ const (
 	Version         = "1.0.0"
 	PathPrefix      = "/data-registry"
 	ApiPathPrefix   = "/api/v1"
-	HealthCheckPath = "/healthcheck"
-	UserPath        = ApiPathPrefix + "/user"
-	NamespacePath   = ApiPathPrefix + "/namespaces"
+	HealthCheckPath  = "/healthcheck"
+	UserPath         = ApiPathPrefix + "/user"
+	NamespacePath    = ApiPathPrefix + "/namespaces"
+	ConnectionsPath  = ApiPathPrefix + "/connections/:namespace"
 
 	// DataRegistryPathPrefix is the root under which the Data Registry API catchall proxy is
 	// mounted. It intentionally matches ApiPathPrefix so the publicly exposed route shape stays
@@ -226,6 +227,7 @@ func (app *App) Routes() http.Handler {
 	// Minimal Kubernetes-backed starter endpoints
 	apiRouter.GET(UserPath, app.UserHandler)
 	apiRouter.GET(NamespacePath, app.GetNamespacesHandler)
+	apiRouter.GET(ConnectionsPath, app.GetConnectionsHandler)
 
 	// Inter-BFF Communication routes — wire your target BFF endpoints here.
 	// Example:
@@ -245,6 +247,7 @@ func (app *App) Routes() http.Handler {
 	// vs. the root pattern further down).
 	appMux.Handle(UserPath, apiRouter)
 	appMux.Handle(NamespacePath, apiRouter)
+	appMux.Handle(ApiPathPrefix+"/connections/", apiRouter)
 	appMux.Handle(PathPrefix+ApiPathPrefix+"/", http.StripPrefix(PathPrefix, apiRouter))
 
 	// Data Registry API catchall proxy (Iceberg REST Catalog-compatible + RHOAI extensions):

--- a/packages/data-registry/bff/internal/api/connections_handler.go
+++ b/packages/data-registry/bff/internal/api/connections_handler.go
@@ -33,7 +33,7 @@ func (app *App) GetConnectionsHandler(w http.ResponseWriter, r *http.Request, ps
 		return
 	}
 
-	connections, err := app.repositories.Connection.GetConnections(client, ctx, namespace, identity)
+	connections, err := app.repositories.Connection.GetConnections(client, ctx, namespace)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/packages/data-registry/bff/internal/api/connections_handler.go
+++ b/packages/data-registry/bff/internal/api/connections_handler.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/opendatahub-io/data-registry/bff/internal/models"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+type ConnectionsEnvelope Envelope[[]models.ConnectionModel, None]
+
+func (app *App) GetConnectionsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	namespace := ps.ByName("namespace")
+	if namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace parameter"))
+		return
+	}
+
+	ctx := r.Context()
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to get Kubernetes client: %w", err))
+		return
+	}
+
+	connections, err := app.repositories.Connection.GetConnections(client, ctx, namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	envelope := ConnectionsEnvelope{
+		Data: connections,
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, envelope, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/packages/data-registry/bff/internal/api/connections_handler.go
+++ b/packages/data-registry/bff/internal/api/connections_handler.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/opendatahub-io/data-registry/bff/internal/constants"
+	"github.com/opendatahub-io/data-registry/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/data-registry/bff/internal/models"
 
 	"github.com/julienschmidt/httprouter"
@@ -19,6 +21,11 @@ func (app *App) GetConnectionsHandler(w http.ResponseWriter, r *http.Request, ps
 	}
 
 	ctx := r.Context()
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*kubernetes.RequestIdentity)
+	if !ok || identity == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing RequestIdentity in context"))
+		return
+	}
 
 	client, err := app.kubernetesClientFactory.GetClient(ctx)
 	if err != nil {
@@ -26,7 +33,7 @@ func (app *App) GetConnectionsHandler(w http.ResponseWriter, r *http.Request, ps
 		return
 	}
 
-	connections, err := app.repositories.Connection.GetConnections(client, ctx, namespace)
+	connections, err := app.repositories.Connection.GetConnections(client, ctx, namespace, identity)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/packages/data-registry/bff/internal/integrations/kubernetes/client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/client.go
@@ -11,6 +11,7 @@ const ComponentLabelValue = "mod-arch"
 // KubernetesClientInterface exposes only the minimal surface needed by the starter project.
 type KubernetesClientInterface interface {
 	GetNamespaces(ctx context.Context, identity *RequestIdentity) ([]corev1.Namespace, error)
+	GetConnections(ctx context.Context, namespace string) ([]corev1.Secret, error)
 	IsClusterAdmin(identity *RequestIdentity) (bool, error)
 	GetUser(identity *RequestIdentity) (string, error)
 }

--- a/packages/data-registry/bff/internal/integrations/kubernetes/client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/client.go
@@ -11,7 +11,7 @@ const ComponentLabelValue = "mod-arch"
 // KubernetesClientInterface exposes only the minimal surface needed by the starter project.
 type KubernetesClientInterface interface {
 	GetNamespaces(ctx context.Context, identity *RequestIdentity) ([]corev1.Namespace, error)
-	GetConnections(ctx context.Context, namespace string) ([]corev1.Secret, error)
+	GetConnections(ctx context.Context, namespace string, identity *RequestIdentity) ([]corev1.Secret, error)
 	IsClusterAdmin(identity *RequestIdentity) (bool, error)
 	GetUser(identity *RequestIdentity) (string, error)
 }

--- a/packages/data-registry/bff/internal/integrations/kubernetes/client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/client.go
@@ -11,7 +11,7 @@ const ComponentLabelValue = "mod-arch"
 // KubernetesClientInterface exposes only the minimal surface needed by the starter project.
 type KubernetesClientInterface interface {
 	GetNamespaces(ctx context.Context, identity *RequestIdentity) ([]corev1.Namespace, error)
-	GetConnections(ctx context.Context, namespace string, identity *RequestIdentity) ([]corev1.Secret, error)
+	GetConnections(ctx context.Context, namespace string) ([]corev1.Secret, error)
 	IsClusterAdmin(identity *RequestIdentity) (bool, error)
 	GetUser(identity *RequestIdentity) (string, error)
 }

--- a/packages/data-registry/bff/internal/integrations/kubernetes/internal_k8s_client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/internal_k8s_client.go
@@ -184,6 +184,35 @@ func (kc *InternalKubernetesClient) GetNamespaces(ctx context.Context, identity 
 	return allowed, nil
 }
 
+func (kc *InternalKubernetesClient) GetConnections(ctx context.Context, namespace string) ([]corev1.Secret, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	secretList, err := kc.Client.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "opendatahub.io/dashboard=true",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets in namespace %s: %w", namespace, err)
+	}
+
+	var connections []corev1.Secret
+	for _, secret := range secretList.Items {
+		annotations := secret.Annotations
+		if annotations == nil {
+			continue
+		}
+		if _, ok := annotations["opendatahub.io/connection-type"]; ok {
+			connections = append(connections, secret)
+			continue
+		}
+		if _, ok := annotations["opendatahub.io/connection-type-ref"]; ok {
+			connections = append(connections, secret)
+		}
+	}
+
+	return connections, nil
+}
+
 func (kc *InternalKubernetesClient) IsClusterAdmin(identity *RequestIdentity) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/packages/data-registry/bff/internal/integrations/kubernetes/internal_k8s_client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/internal_k8s_client.go
@@ -184,33 +184,6 @@ func (kc *InternalKubernetesClient) GetNamespaces(ctx context.Context, identity 
 	return allowed, nil
 }
 
-func (kc *InternalKubernetesClient) GetConnections(ctx context.Context, namespace string, identity *RequestIdentity) ([]corev1.Secret, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	sar := &authv1.SubjectAccessReview{
-		Spec: authv1.SubjectAccessReviewSpec{
-			User:   identity.UserID,
-			Groups: identity.Groups,
-			ResourceAttributes: &authv1.ResourceAttributes{
-				Verb:      "list",
-				Resource:  "secrets",
-				Namespace: namespace,
-			},
-		},
-	}
-
-	response, err := kc.Client.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to check secret access in namespace %s: %w", namespace, err)
-	}
-	if !response.Status.Allowed {
-		return nil, fmt.Errorf("user %s is not authorized to list secrets in namespace %s", identity.UserID, namespace)
-	}
-
-	return kc.SharedClientLogic.GetConnections(ctx, namespace, identity)
-}
-
 func (kc *InternalKubernetesClient) IsClusterAdmin(identity *RequestIdentity) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/packages/data-registry/bff/internal/integrations/kubernetes/internal_k8s_client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/internal_k8s_client.go
@@ -184,33 +184,31 @@ func (kc *InternalKubernetesClient) GetNamespaces(ctx context.Context, identity 
 	return allowed, nil
 }
 
-func (kc *InternalKubernetesClient) GetConnections(ctx context.Context, namespace string) ([]corev1.Secret, error) {
+func (kc *InternalKubernetesClient) GetConnections(ctx context.Context, namespace string, identity *RequestIdentity) ([]corev1.Secret, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	secretList, err := kc.Client.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "opendatahub.io/dashboard=true",
-	})
+	sar := &authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
+			User:   identity.UserID,
+			Groups: identity.Groups,
+			ResourceAttributes: &authv1.ResourceAttributes{
+				Verb:      "list",
+				Resource:  "secrets",
+				Namespace: namespace,
+			},
+		},
+	}
+
+	response, err := kc.Client.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list secrets in namespace %s: %w", namespace, err)
+		return nil, fmt.Errorf("failed to check secret access in namespace %s: %w", namespace, err)
+	}
+	if !response.Status.Allowed {
+		return nil, fmt.Errorf("user %s is not authorized to list secrets in namespace %s", identity.UserID, namespace)
 	}
 
-	var connections []corev1.Secret
-	for _, secret := range secretList.Items {
-		annotations := secret.Annotations
-		if annotations == nil {
-			continue
-		}
-		if _, ok := annotations["opendatahub.io/connection-type"]; ok {
-			connections = append(connections, secret)
-			continue
-		}
-		if _, ok := annotations["opendatahub.io/connection-type-ref"]; ok {
-			connections = append(connections, secret)
-		}
-	}
-
-	return connections, nil
+	return kc.SharedClientLogic.GetConnections(ctx, namespace, identity)
 }
 
 func (kc *InternalKubernetesClient) IsClusterAdmin(identity *RequestIdentity) (bool, error) {

--- a/packages/data-registry/bff/internal/integrations/kubernetes/shared_k8s_client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/shared_k8s_client.go
@@ -23,7 +23,7 @@ func (kc *SharedClientLogic) BearerToken() (string, error) { return kc.Token.Raw
 
 func (kc *SharedClientLogic) GetGroups(ctx context.Context) ([]string, error) { return []string{}, nil }
 
-func (kc *SharedClientLogic) GetConnections(ctx context.Context, namespace string, _ *RequestIdentity) ([]corev1.Secret, error) {
+func (kc *SharedClientLogic) GetConnections(ctx context.Context, namespace string) ([]corev1.Secret, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/packages/data-registry/bff/internal/integrations/kubernetes/shared_k8s_client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/shared_k8s_client.go
@@ -2,8 +2,12 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -18,3 +22,32 @@ type SharedClientLogic struct {
 func (kc *SharedClientLogic) BearerToken() (string, error) { return kc.Token.Raw(), nil }
 
 func (kc *SharedClientLogic) GetGroups(ctx context.Context) ([]string, error) { return []string{}, nil }
+
+func (kc *SharedClientLogic) GetConnections(ctx context.Context, namespace string, _ *RequestIdentity) ([]corev1.Secret, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	secretList, err := kc.Client.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "opendatahub.io/dashboard=true",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets in namespace %s: %w", namespace, err)
+	}
+
+	var connections []corev1.Secret
+	for _, secret := range secretList.Items {
+		annotations := secret.Annotations
+		if annotations == nil {
+			continue
+		}
+		if _, ok := annotations["opendatahub.io/connection-type"]; ok {
+			connections = append(connections, secret)
+			continue
+		}
+		if _, ok := annotations["opendatahub.io/connection-type-ref"]; ok {
+			connections = append(connections, secret)
+		}
+	}
+
+	return connections, nil
+}

--- a/packages/data-registry/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -158,35 +158,6 @@ func (kc *TokenKubernetesClient) CanAccessServiceInNamespace(ctx context.Context
 	return true, nil
 }
 
-func (kc *TokenKubernetesClient) GetConnections(ctx context.Context, namespace string) ([]corev1.Secret, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	secretList, err := kc.Client.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "opendatahub.io/dashboard=true",
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list secrets in namespace %s: %w", namespace, err)
-	}
-
-	var connections []corev1.Secret
-	for _, secret := range secretList.Items {
-		annotations := secret.Annotations
-		if annotations == nil {
-			continue
-		}
-		if _, ok := annotations["opendatahub.io/connection-type"]; ok {
-			connections = append(connections, secret)
-			continue
-		}
-		if _, ok := annotations["opendatahub.io/connection-type-ref"]; ok {
-			connections = append(connections, secret)
-		}
-	}
-
-	return connections, nil
-}
-
 // RequestIdentity is unused because the token already represents the user identity.
 // This endpoint is used only on dev mode that is why is safe to ignore permissions errors
 func (kc *TokenKubernetesClient) GetNamespaces(ctx context.Context, _ *RequestIdentity) ([]corev1.Namespace, error) {

--- a/packages/data-registry/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/data-registry/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -158,6 +158,35 @@ func (kc *TokenKubernetesClient) CanAccessServiceInNamespace(ctx context.Context
 	return true, nil
 }
 
+func (kc *TokenKubernetesClient) GetConnections(ctx context.Context, namespace string) ([]corev1.Secret, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	secretList, err := kc.Client.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "opendatahub.io/dashboard=true",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets in namespace %s: %w", namespace, err)
+	}
+
+	var connections []corev1.Secret
+	for _, secret := range secretList.Items {
+		annotations := secret.Annotations
+		if annotations == nil {
+			continue
+		}
+		if _, ok := annotations["opendatahub.io/connection-type"]; ok {
+			connections = append(connections, secret)
+			continue
+		}
+		if _, ok := annotations["opendatahub.io/connection-type-ref"]; ok {
+			connections = append(connections, secret)
+		}
+	}
+
+	return connections, nil
+}
+
 // RequestIdentity is unused because the token already represents the user identity.
 // This endpoint is used only on dev mode that is why is safe to ignore permissions errors
 func (kc *TokenKubernetesClient) GetNamespaces(ctx context.Context, _ *RequestIdentity) ([]corev1.Namespace, error) {

--- a/packages/data-registry/bff/internal/models/connection.go
+++ b/packages/data-registry/bff/internal/models/connection.go
@@ -1,0 +1,7 @@
+package models
+
+type ConnectionModel struct {
+	Name           string  `json:"name"`
+	DisplayName    *string `json:"displayName,omitempty"`
+	ConnectionType *string `json:"connectionType,omitempty"`
+}

--- a/packages/data-registry/bff/internal/repositories/connection.go
+++ b/packages/data-registry/bff/internal/repositories/connection.go
@@ -1,0 +1,42 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+
+	k8s "github.com/opendatahub-io/data-registry/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/data-registry/bff/internal/models"
+)
+
+type ConnectionRepository struct{}
+
+func NewConnectionRepository() *ConnectionRepository {
+	return &ConnectionRepository{}
+}
+
+func (r *ConnectionRepository) GetConnections(client k8s.KubernetesClientInterface, ctx context.Context, namespace string) ([]models.ConnectionModel, error) {
+	secrets, err := client.GetConnections(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching connections: %w", err)
+	}
+
+	connectionModels := make([]models.ConnectionModel, 0, len(secrets))
+	for _, secret := range secrets {
+		model := models.ConnectionModel{
+			Name: secret.Name,
+		}
+		if secret.Annotations != nil {
+			if displayName, ok := secret.Annotations["openshift.io/display-name"]; ok {
+				model.DisplayName = &displayName
+			}
+			if connType, ok := secret.Annotations["opendatahub.io/connection-type-ref"]; ok {
+				model.ConnectionType = &connType
+			} else if connType, ok := secret.Annotations["opendatahub.io/connection-type"]; ok {
+				model.ConnectionType = &connType
+			}
+		}
+		connectionModels = append(connectionModels, model)
+	}
+
+	return connectionModels, nil
+}

--- a/packages/data-registry/bff/internal/repositories/connection.go
+++ b/packages/data-registry/bff/internal/repositories/connection.go
@@ -14,8 +14,8 @@ func NewConnectionRepository() *ConnectionRepository {
 	return &ConnectionRepository{}
 }
 
-func (r *ConnectionRepository) GetConnections(client k8s.KubernetesClientInterface, ctx context.Context, namespace string) ([]models.ConnectionModel, error) {
-	secrets, err := client.GetConnections(ctx, namespace)
+func (r *ConnectionRepository) GetConnections(client k8s.KubernetesClientInterface, ctx context.Context, namespace string, identity *k8s.RequestIdentity) ([]models.ConnectionModel, error) {
+	secrets, err := client.GetConnections(ctx, namespace, identity)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching connections: %w", err)
 	}

--- a/packages/data-registry/bff/internal/repositories/connection.go
+++ b/packages/data-registry/bff/internal/repositories/connection.go
@@ -14,8 +14,8 @@ func NewConnectionRepository() *ConnectionRepository {
 	return &ConnectionRepository{}
 }
 
-func (r *ConnectionRepository) GetConnections(client k8s.KubernetesClientInterface, ctx context.Context, namespace string, identity *k8s.RequestIdentity) ([]models.ConnectionModel, error) {
-	secrets, err := client.GetConnections(ctx, namespace, identity)
+func (r *ConnectionRepository) GetConnections(client k8s.KubernetesClientInterface, ctx context.Context, namespace string) ([]models.ConnectionModel, error) {
+	secrets, err := client.GetConnections(ctx, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching connections: %w", err)
 	}

--- a/packages/data-registry/bff/internal/repositories/repositories.go
+++ b/packages/data-registry/bff/internal/repositories/repositories.go
@@ -5,6 +5,7 @@ type Repositories struct {
 	HealthCheck *HealthCheckRepository
 	User        *UserRepository
 	Namespace   *NamespaceRepository
+	Connection  *ConnectionRepository
 }
 
 func NewRepositories() *Repositories {
@@ -12,5 +13,6 @@ func NewRepositories() *Repositories {
 		HealthCheck: NewHealthCheckRepository(),
 		User:        NewUserRepository(),
 		Namespace:   NewNamespaceRepository(),
+		Connection:  NewConnectionRepository(),
 	}
 }

--- a/packages/data-registry/frontend/src/__mocks__/mockAssetResponse.ts
+++ b/packages/data-registry/frontend/src/__mocks__/mockAssetResponse.ts
@@ -14,7 +14,7 @@ export const mockAssetResponse = (overrides?: Partial<AssetResponse>): AssetResp
     { name: 'created_at', type: 'timestamp', nullable: false },
   ],
   collection: 'default',
-  connection_ref: { type: 'rhai', secret_name: 'my-s3-connection' },
+  connection_ref: 'my-s3-connection',
   owner: 'data-team',
   description: 'A test table for unit testing',
   labels: ['production', 'analytics'],

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -38,6 +38,11 @@ declare global {
           type: 'GET /api/:apiVersion/settings/role_bindings',
           options: { path: { apiVersion: string } },
           response: ApiResponse<RoleBindingKind[]>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/:apiVersion/connections/:namespace',
+          options: { path: { apiVersion: string; namespace: string } },
+          response: ApiResponse<unknown[]>,
         ) => Cypress.Chainable<null>);
     }
   }

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/assetDetailView.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/assetDetailView.cy.ts
@@ -76,7 +76,7 @@ describe('Table Detail View', () => {
     cy.findByTestId('asset-type').should('contain.text', 'Structured');
     cy.findByTestId('asset-location').should('contain.text', 's3://bucket/claims');
     cy.findByTestId('asset-owner').should('contain.text', 'data-team');
-    cy.findByTestId('connection-ref-rhai').should('contain.text', 'my-s3-connection');
+    cy.findByTestId('connection-ref-label').should('contain.text', 'my-s3-connection');
   });
 
   it('should display asset type badge and Overview tab', () => {

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
@@ -5,6 +5,12 @@ import { CLIENT_API_VERSION } from '~/__tests__/cypress/cypress/support/commands
 
 const REGISTRY_API = '/data-registry/api/v1';
 
+const mockConnectionsResponse = [
+  { name: 'my-s3-connection', displayName: 'My S3 Connection', connectionType: 's3' },
+  { name: 'my-uri-connection', displayName: 'My URI Connection', connectionType: 'uri' },
+  { name: 'db-connection', displayName: 'Database Connection', connectionType: 'postgresql' },
+];
+
 const mockCollectionsResponse = {
   namespaces: [['analytics'], ['default']],
 };
@@ -97,6 +103,11 @@ const initIntercepts = () => {
   cy.intercept('GET', `${REGISTRY_API}/test-project/labels`, {
     body: mockLabelsResponse,
   }).as('getLabels');
+  cy.interceptApi(
+    'GET /api/:apiVersion/connections/:namespace',
+    { path: { apiVersion: CLIENT_API_VERSION, namespace: 'test-project' } },
+    mockConnectionsResponse,
+  ).as('getConnections');
 };
 
 const visitWithData = () => {
@@ -679,5 +690,118 @@ describe('Register Table', () => {
     cy.wait('@createTableConflict');
     cy.contains('Error registering data asset').should('exist');
     cy.findByTestId('register-data-modal').should('exist');
+  });
+});
+
+describe('Connection Selector', () => {
+  beforeEach(() => {
+    initIntercepts();
+  });
+
+  it('should display available connections in dropdown', () => {
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+
+    cy.findByTestId('data-connection-toggle').click();
+    cy.contains('My S3 Connection').should('exist');
+    cy.contains('My URI Connection').should('exist');
+    cy.contains('Database Connection').should('exist');
+  });
+
+  it('should select a connection and display it in the toggle', () => {
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+
+    cy.findByTestId('data-connection-toggle').should('contain.text', 'Select a connection');
+    cy.findByTestId('data-connection-toggle').click();
+    cy.contains('My S3 Connection').click();
+
+    cy.findByTestId('data-connection-toggle').should('contain.text', 'My S3 Connection');
+  });
+
+  it('should show no connections available when empty', () => {
+    cy.interceptApi(
+      'GET /api/:apiVersion/connections/:namespace',
+      { path: { apiVersion: CLIENT_API_VERSION, namespace: 'test-project' } },
+      [],
+    ).as('getEmptyConnections');
+
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+
+    cy.findByTestId('data-connection-toggle').click();
+    cy.contains('No connections available').should('exist');
+  });
+
+  it('should include connection_ref in volume creation request', () => {
+    cy.intercept('POST', `${REGISTRY_API}/test-project/namespaces/analytics/volumes`, {
+      statusCode: 200,
+      body: {
+        name: 'connected-volume',
+        'catalog-name': 'test-project',
+        'schema-name': 'analytics',
+        'volume-type': 'other',
+        'storage-location': '',
+        config: {},
+      },
+    }).as('createVolumeWithConnection');
+
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+
+    cy.findByTestId('data-name-input').type('connected-volume');
+
+    cy.findByTestId('data-collection-toggle').click();
+    cy.contains('analytics').click();
+
+    cy.findByTestId('data-connection-toggle').click();
+    cy.contains('My S3 Connection').click();
+
+    cy.findByTestId('register-data-submit').click();
+
+    cy.wait('@createVolumeWithConnection').then((interception) => {
+      expect(interception.request.body).to.deep.include({
+        name: 'connected-volume',
+        content_type: 'other',
+        connection_ref: 'my-s3-connection',
+      });
+    });
+  });
+
+  it('should include connection_ref in table creation request', () => {
+    cy.intercept('POST', `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables`, {
+      statusCode: 200,
+      body: {
+        name: 'connected-table',
+        asset_type: 'table',
+        format: 'iceberg',
+        connection_ref: 'my-uri-connection',
+      },
+    }).as('createTableWithConnection');
+
+    visitWithData();
+    cy.findByTestId('register-data-button').click();
+
+    cy.findByTestId('asset-type-toggle').scrollIntoView();
+    cy.findByTestId('asset-type-toggle').click();
+    cy.findByTestId('asset-type-structured').click();
+
+    cy.findByTestId('data-name-input').type('connected-table');
+
+    cy.findByTestId('data-collection-toggle').click();
+    cy.contains('analytics').click();
+
+    cy.findByTestId('data-connection-toggle').click();
+    cy.contains('My URI Connection').click();
+
+    cy.findByTestId('register-data-submit').click();
+
+    cy.wait('@createTableWithConnection').then((interception) => {
+      expect(interception.request.body).to.deep.include({
+        name: 'connected-table',
+        format: 'iceberg',
+        connection_ref: 'my-uri-connection',
+      });
+    });
   });
 });

--- a/packages/data-registry/frontend/src/__tests__/unit/components/ConnectionRefLink.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/ConnectionRefLink.spec.tsx
@@ -7,8 +7,8 @@ import ConnectionRefLink from '~/app/components/ConnectionRefLink';
 describe('ConnectionRefLink', () => {
   it('should render rhai connection reference as text', () => {
     render(<ConnectionRefLink connectionRef={{ type: 'rhai', secret_name: 'my-secret' }} />);
-    const el = screen.getByTestId('connection-ref-rhai');
-    expect(el).toHaveTextContent('Connection: my-secret');
+    const el = screen.getByTestId('connection-ref-label');
+    expect(el).toHaveTextContent('my-secret');
     expect(el.tagName).toBe('SPAN');
   });
 
@@ -21,15 +21,20 @@ describe('ConnectionRefLink', () => {
         />
       </MemoryRouter>,
     );
-    const el = screen.getByTestId('connection-ref-rhai');
-    expect(el).toHaveTextContent('Connection: my-secret');
+    const el = screen.getByTestId('connection-ref-link');
+    expect(el).toHaveTextContent('my-secret');
     expect(el.tagName).toBe('A');
     expect(el).toHaveAttribute('href', '/connections/my-secret');
   });
 
   it('should render dch connection reference', () => {
     render(<ConnectionRefLink connectionRef={{ type: 'dch', id: 'conn-123' }} />);
-    expect(screen.getByTestId('connection-ref-dch')).toHaveTextContent('DCH Connection: conn-123');
+    expect(screen.getByTestId('connection-ref-label')).toHaveTextContent('conn-123');
+  });
+
+  it('should render plain string connection reference', () => {
+    render(<ConnectionRefLink connectionRef="my-s3-connection" />);
+    expect(screen.getByTestId('connection-ref-label')).toHaveTextContent('my-s3-connection');
   });
 
   it('should render dash when connectionRef is null', () => {

--- a/packages/data-registry/frontend/src/__tests__/unit/components/RegisterDataModal.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/RegisterDataModal.spec.tsx
@@ -3,11 +3,19 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RegisterDataModal from '~/app/components/RegisterDataModal';
 import * as dataRegistryApi from '~/app/api/dataRegistry';
+import * as connectionsHook from '~/app/hooks/useConnections';
 
 jest.mock('~/app/api/dataRegistry');
+jest.mock('~/app/hooks/useConnections');
 
 const mockCreateVolume = jest.mocked(dataRegistryApi.createVolume);
 const mockCreateGenericTable = jest.mocked(dataRegistryApi.createGenericTable);
+const mockUseConnections = jest.mocked(connectionsHook.useConnections);
+
+const mockConnections = [
+  { name: 'my-s3-connection', displayName: 'My S3 Connection', connectionType: 's3' },
+  { name: 'my-uri-connection', displayName: 'My URI Connection', connectionType: 'uri' },
+];
 
 describe('RegisterDataModal', () => {
   const defaultProps = {
@@ -21,6 +29,7 @@ describe('RegisterDataModal', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseConnections.mockReturnValue([mockConnections, true, undefined]);
   });
 
   it('should render modal with all form fields', () => {
@@ -218,6 +227,100 @@ describe('RegisterDataModal', () => {
 
     await user.click(screen.getByTestId('data-collection-toggle'));
     expect(screen.getByText('Create new collection')).toBeTruthy();
+  });
+
+  it('should display available connections in dropdown', async () => {
+    const user = userEvent.setup();
+    render(<RegisterDataModal {...defaultProps} />);
+
+    await user.click(screen.getByTestId('data-connection-toggle'));
+    expect(screen.getByText('My S3 Connection')).toBeTruthy();
+    expect(screen.getByText('My URI Connection')).toBeTruthy();
+  });
+
+  it('should show empty state when no connections available', async () => {
+    mockUseConnections.mockReturnValue([[], true, undefined]);
+    const user = userEvent.setup();
+    render(<RegisterDataModal {...defaultProps} />);
+
+    await user.click(screen.getByTestId('data-connection-toggle'));
+    expect(screen.getByText('No connections available')).toBeTruthy();
+  });
+
+  it('should include connection_ref when connection is selected for volume', async () => {
+    const user = userEvent.setup();
+    mockCreateVolume.mockResolvedValue({
+      name: 'test-volume',
+      'catalog-name': 'test-project',
+      'schema-name': 'collection-1',
+      'volume-type': 'other',
+      'storage-location': '',
+    });
+
+    render(<RegisterDataModal {...defaultProps} />);
+
+    await user.type(screen.getByTestId('data-name-input'), 'test-volume');
+
+    await user.click(screen.getByTestId('data-collection-toggle'));
+    await user.click(screen.getByText('collection-1'));
+
+    await user.click(screen.getByTestId('data-connection-toggle'));
+    await user.click(screen.getByText('My S3 Connection'));
+
+    await user.click(screen.getByTestId('register-data-submit'));
+
+    await waitFor(() => {
+      expect(mockCreateVolume).toHaveBeenCalledWith('test-project', 'collection-1', {
+        name: 'test-volume',
+        // eslint-disable-next-line camelcase
+        content_type: 'other',
+        // eslint-disable-next-line camelcase
+        connection_ref: 'my-s3-connection',
+      });
+    });
+  });
+
+  it('should include connection_ref when connection is selected for table', async () => {
+    const user = userEvent.setup();
+    /* eslint-disable camelcase */
+    mockCreateGenericTable.mockResolvedValue({
+      name: 'test-table',
+      asset_type: 'table',
+      format: 'iceberg',
+      location: '',
+      description: '',
+      labels: [],
+      collection: 'collection-1',
+      connection_ref: { type: 'rhai', secret_name: 'my-s3-connection' },
+      owner: '',
+      registered_by: '',
+      created_at: '',
+    });
+    /* eslint-enable camelcase */
+
+    render(<RegisterDataModal {...defaultProps} />);
+
+    await user.click(screen.getByTestId('asset-type-toggle'));
+    await user.click(screen.getByText('Structured'));
+
+    await user.type(screen.getByTestId('data-name-input'), 'test-table');
+
+    await user.click(screen.getByTestId('data-collection-toggle'));
+    await user.click(screen.getByText('collection-1'));
+
+    await user.click(screen.getByTestId('data-connection-toggle'));
+    await user.click(screen.getByText('My S3 Connection'));
+
+    await user.click(screen.getByTestId('register-data-submit'));
+
+    await waitFor(() => {
+      expect(mockCreateGenericTable).toHaveBeenCalledWith('test-project', 'collection-1', {
+        name: 'test-table',
+        format: 'iceberg',
+        // eslint-disable-next-line camelcase
+        connection_ref: 'my-s3-connection',
+      });
+    });
   });
 
   it('should not include default path "/" in request', async () => {

--- a/packages/data-registry/frontend/src/__tests__/unit/components/TableDetailView.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/TableDetailView.spec.tsx
@@ -40,11 +40,11 @@ describe('TableDetailView', () => {
     expect(link).toHaveTextContent('default');
   });
 
-  it('should render connection name without prefix', () => {
+  it('should render connection name', () => {
     const asset = mockAssetResponse();
     renderView(asset);
-    expect(screen.getByTestId('connection-ref-rhai')).toHaveTextContent('my-s3-connection');
-    expect(screen.getByTestId('connection-ref-rhai').textContent).not.toContain('Connection:');
+    const el = screen.getByTestId('connection-ref-label');
+    expect(el).toHaveTextContent('my-s3-connection');
   });
 
   it('should render created and last modified with user attribution', () => {

--- a/packages/data-registry/frontend/src/__tests__/unit/hooks/useConnections.spec.ts
+++ b/packages/data-registry/frontend/src/__tests__/unit/hooks/useConnections.spec.ts
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import * as k8sApi from '~/app/api/k8s';
+import { useConnections } from '~/app/hooks/useConnections';
+
+jest.mock('~/app/api/k8s');
+jest.mock('mod-arch-core', () => {
+  const actual = jest.requireActual('mod-arch-core');
+  return {
+    ...actual,
+    useFetchState: (callback: (opts: unknown) => Promise<unknown>, defaultValue: unknown) => {
+      const [data, setData] = require('react').useState(defaultValue);
+      const [loaded, setLoaded] = require('react').useState(false);
+      const [error, setError] = require('react').useState(undefined);
+
+      require('react').useEffect(() => {
+        let cancelled = false;
+        callback({})
+          .then((result: unknown) => {
+            if (!cancelled) {
+              setData(result);
+              setLoaded(true);
+            }
+          })
+          .catch((err: Error) => {
+            if (!cancelled) {
+              setError(err);
+              setLoaded(true);
+            }
+          });
+        return () => {
+          cancelled = true;
+        };
+      }, [callback]);
+
+      return [data, loaded, error];
+    },
+  };
+});
+
+const mockGetConnections = jest.fn();
+jest.mocked(k8sApi.getConnections).mockReturnValue(mockGetConnections);
+
+describe('useConnections', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(k8sApi.getConnections).mockReturnValue(mockGetConnections);
+  });
+
+  it('should return empty array when no namespace', async () => {
+    const { result } = renderHook(() => useConnections(''));
+
+    await waitFor(() => {
+      expect(result.current[1]).toBe(true);
+    });
+
+    expect(result.current[0]).toEqual([]);
+  });
+
+  it('should fetch connections for a namespace', async () => {
+    const mockData = [
+      { name: 'my-s3-connection', displayName: 'My S3', connectionType: 's3' },
+      { name: 'my-uri-connection', displayName: 'My URI', connectionType: 'uri' },
+    ];
+    mockGetConnections.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useConnections('test-project'));
+
+    await waitFor(() => {
+      expect(result.current[1]).toBe(true);
+    });
+
+    expect(result.current[0]).toEqual(mockData);
+    expect(result.current[0]).toHaveLength(2);
+    expect(result.current[0][0].name).toBe('my-s3-connection');
+    expect(result.current[0][1].connectionType).toBe('uri');
+  });
+
+  it('should handle API errors', async () => {
+    mockGetConnections.mockRejectedValue(new Error('Forbidden'));
+
+    const { result } = renderHook(() => useConnections('test-project'));
+
+    await waitFor(() => {
+      expect(result.current[1]).toBe(true);
+    });
+
+    expect(result.current[2]).toBeDefined();
+    expect(result.current[2]?.message).toBe('Forbidden');
+  });
+
+  it('should return empty array when connections are empty', async () => {
+    mockGetConnections.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useConnections('test-project'));
+
+    await waitFor(() => {
+      expect(result.current[1]).toBe(true);
+    });
+
+    expect(result.current[0]).toEqual([]);
+  });
+});

--- a/packages/data-registry/frontend/src/app/api/k8s.ts
+++ b/packages/data-registry/frontend/src/app/api/k8s.ts
@@ -6,7 +6,7 @@ import {
   restGET,
 } from 'mod-arch-core';
 import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
-import { NamespaceKind } from '~/app/types';
+import { ConnectionModel, NamespaceKind } from '~/app/types';
 
 export const getUser =
   (hostPath: string) =>
@@ -27,6 +27,23 @@ export const getNamespaces =
       restGET(hostPath, `${URL_PREFIX}/api/${BFF_API_VERSION}/namespaces`, {}, opts),
     ).then((response) => {
       if (isModArchResponse<NamespaceKind[]>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+
+export const getConnections =
+  (hostPath: string) =>
+  (opts: APIOptions, namespace: string): Promise<ConnectionModel[]> =>
+    handleRestFailures(
+      restGET(
+        hostPath,
+        `${URL_PREFIX}/api/${BFF_API_VERSION}/connections/${encodeURIComponent(namespace)}`,
+        {},
+        opts,
+      ),
+    ).then((response) => {
+      if (isModArchResponse<ConnectionModel[]>(response)) {
         return response.data;
       }
       throw new Error('Invalid response format');

--- a/packages/data-registry/frontend/src/app/components/ConnectionRefLink.tsx
+++ b/packages/data-registry/frontend/src/app/components/ConnectionRefLink.tsx
@@ -3,8 +3,15 @@ import { Link } from 'react-router-dom';
 import { ConnectionRef } from '~/app/types';
 
 type ConnectionRefLinkProps = {
-  connectionRef?: ConnectionRef | null;
+  connectionRef?: ConnectionRef | string | null;
   linkTo?: string;
+};
+
+const getLabel = (ref: ConnectionRef | string): string => {
+  if (typeof ref === 'string') {
+    return ref;
+  }
+  return ref.type === 'rhai' ? ref.secret_name : ref.id;
 };
 
 const ConnectionRefLink: React.FC<ConnectionRefLinkProps> = ({ connectionRef, linkTo }) => {
@@ -12,19 +19,17 @@ const ConnectionRefLink: React.FC<ConnectionRefLinkProps> = ({ connectionRef, li
     return <>-</>;
   }
 
-  const label = connectionRef.type === 'rhai' ? connectionRef.secret_name : connectionRef.id;
-
-  const testId = connectionRef.type === 'rhai' ? 'connection-ref-rhai' : 'connection-ref-dch';
+  const label = getLabel(connectionRef);
 
   if (linkTo) {
     return (
-      <Link to={linkTo} data-testid={testId}>
+      <Link to={linkTo} data-testid="connection-ref-link">
         {label}
       </Link>
     );
   }
 
-  return <span data-testid={testId}>{label}</span>;
+  return <span data-testid="connection-ref-label">{label}</span>;
 };
 
 export default ConnectionRefLink;

--- a/packages/data-registry/frontend/src/app/components/RegisterDataModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegisterDataModal.tsx
@@ -13,6 +13,7 @@ import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { createVolume, createGenericTable, createLabel, ApiError } from '~/app/api/dataRegistry';
 import { CreateVolumeRequest, CreateGenericTableRequest } from '~/app/types';
+import { useConnections } from '~/app/hooks/useConnections';
 import {
   registerDataSchema,
   registerDataDefaults,
@@ -44,6 +45,10 @@ const buildVolumeRequest = (data: RegisterDataFormData): CreateVolumeRequest => 
   }
   if (data.path && data.path !== '/') {
     request.location = data.path;
+  }
+  if (data.connection) {
+    // eslint-disable-next-line camelcase
+    request.connection_ref = data.connection;
   }
   if (data.labels.length > 0) {
     request.labels = data.labels;
@@ -83,6 +88,10 @@ const buildTableRequest = (data: RegisterDataFormData): CreateGenericTableReques
   }
   if (data.path && data.path !== '/') {
     request.location = data.path;
+  }
+  if (data.connection) {
+    // eslint-disable-next-line camelcase
+    request.connection_ref = data.connection;
   }
   if (data.labels.length > 0) {
     request.labels = data.labels;
@@ -131,6 +140,7 @@ const RegisterDataModal: React.FC<RegisterDataModalProps> = ({
   onCreated,
   onManageCollections,
 }) => {
+  const [connections, connectionsLoaded] = useConnections(project);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState('');
 
@@ -205,7 +215,7 @@ const RegisterDataModal: React.FC<RegisterDataModalProps> = ({
               collections={collections}
               onManageCollections={onManageCollections}
             />
-            <DataLocationSection />
+            <DataLocationSection connections={connections} connectionsLoaded={connectionsLoaded} />
             <PropertiesSection />
             <CustomPropertiesSection />
             {assetType === 'structured' ? <SchemaSection /> : null}

--- a/packages/data-registry/frontend/src/app/components/RegisterDataModal.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegisterDataModal.tsx
@@ -140,7 +140,7 @@ const RegisterDataModal: React.FC<RegisterDataModalProps> = ({
   onCreated,
   onManageCollections,
 }) => {
-  const [connections, connectionsLoaded] = useConnections(project);
+  const [connections, connectionsLoaded, connectionsError] = useConnections(project);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState('');
 
@@ -215,7 +215,11 @@ const RegisterDataModal: React.FC<RegisterDataModalProps> = ({
               collections={collections}
               onManageCollections={onManageCollections}
             />
-            <DataLocationSection connections={connections} connectionsLoaded={connectionsLoaded} />
+            <DataLocationSection
+              connections={connections}
+              connectionsLoaded={connectionsLoaded}
+              connectionsError={connectionsError}
+            />
             <PropertiesSection />
             <CustomPropertiesSection />
             {assetType === 'structured' ? <SchemaSection /> : null}

--- a/packages/data-registry/frontend/src/app/components/register-data/DataLocationSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-data/DataLocationSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Alert,
   FormGroup,
   FormSection,
   TextInput,
@@ -18,11 +19,13 @@ import { ConnectionModel } from '~/app/types';
 type DataLocationSectionProps = {
   connections: ConnectionModel[];
   connectionsLoaded: boolean;
+  connectionsError?: Error;
 };
 
 const DataLocationSection: React.FC<DataLocationSectionProps> = ({
   connections,
   connectionsLoaded,
+  connectionsError,
 }) => {
   const { control } = useFormContext<RegisterDataFormData>();
   const [isConnectionOpen, setIsConnectionOpen] = React.useState(false);
@@ -40,6 +43,17 @@ const DataLocationSection: React.FC<DataLocationSectionProps> = ({
       <Content component="p">
         Specify where the data is stored by selecting a connection or providing path details.
       </Content>
+
+      {connectionsError ? (
+        <Alert
+          variant="warning"
+          isInline
+          title="Unable to load connections"
+          data-testid="connections-error"
+        >
+          {connectionsError.message}
+        </Alert>
+      ) : null}
 
       <Controller
         name="connection"
@@ -60,6 +74,7 @@ const DataLocationSection: React.FC<DataLocationSectionProps> = ({
                   onClick={() => setIsConnectionOpen((prev) => !prev)}
                   isExpanded={isConnectionOpen}
                   isFullWidth
+                  isDisabled={!!connectionsError}
                   data-testid="data-connection-toggle"
                 >
                   {!connectionsLoaded ? <Spinner size="sm" /> : getToggleLabel(field.value)}

--- a/packages/data-registry/frontend/src/app/components/register-data/DataLocationSection.tsx
+++ b/packages/data-registry/frontend/src/app/components/register-data/DataLocationSection.tsx
@@ -9,13 +9,31 @@ import {
   MenuToggle,
   MenuToggleElement,
   Content,
+  Spinner,
 } from '@patternfly/react-core';
 import { Controller, useFormContext } from 'react-hook-form';
 import { RegisterDataFormData } from '~/app/schemas/registerData.schema';
+import { ConnectionModel } from '~/app/types';
 
-const DataLocationSection: React.FC = () => {
+type DataLocationSectionProps = {
+  connections: ConnectionModel[];
+  connectionsLoaded: boolean;
+};
+
+const DataLocationSection: React.FC<DataLocationSectionProps> = ({
+  connections,
+  connectionsLoaded,
+}) => {
   const { control } = useFormContext<RegisterDataFormData>();
   const [isConnectionOpen, setIsConnectionOpen] = React.useState(false);
+
+  const getToggleLabel = (value: string): string => {
+    if (!value) {
+      return 'Select a connection';
+    }
+    const match = connections.find((c) => c.name === value);
+    return match?.displayName || match?.name || value;
+  };
 
   return (
     <FormSection title="Data location" titleElement="h2">
@@ -44,14 +62,27 @@ const DataLocationSection: React.FC = () => {
                   isFullWidth
                   data-testid="data-connection-toggle"
                 >
-                  {field.value || 'Select a connection'}
+                  {!connectionsLoaded ? <Spinner size="sm" /> : getToggleLabel(field.value)}
                 </MenuToggle>
               )}
             >
               <SelectList>
-                <SelectOption value="" isDisabled>
-                  No connections available
-                </SelectOption>
+                {connections.length === 0 ? (
+                  <SelectOption value="" isDisabled>
+                    No connections available
+                  </SelectOption>
+                ) : (
+                  connections.map((conn) => (
+                    <SelectOption
+                      key={conn.name}
+                      value={conn.name}
+                      description={conn.connectionType}
+                      data-testid={`connection-option-${conn.name}`}
+                    >
+                      {conn.displayName || conn.name}
+                    </SelectOption>
+                  ))
+                )}
               </SelectList>
             </Select>
           </FormGroup>

--- a/packages/data-registry/frontend/src/app/hooks/useAssets.ts
+++ b/packages/data-registry/frontend/src/app/hooks/useAssets.ts
@@ -20,9 +20,11 @@ const mapTableAsset = (asset: AssetResponse, collection: string): RegistryAsset 
   assetType: 'table',
   location: asset.location || '',
   connectionRef: asset.connection_ref
-    ? asset.connection_ref.type === 'rhai'
-      ? asset.connection_ref.secret_name
-      : asset.connection_ref.id
+    ? typeof asset.connection_ref === 'string'
+      ? asset.connection_ref
+      : asset.connection_ref.type === 'rhai'
+        ? asset.connection_ref.secret_name
+        : asset.connection_ref.id
     : '',
   labels: asset.labels || [],
   collection,

--- a/packages/data-registry/frontend/src/app/hooks/useConnections.ts
+++ b/packages/data-registry/frontend/src/app/hooks/useConnections.ts
@@ -1,0 +1,21 @@
+import { useFetchState, APIOptions, FetchStateCallbackPromise } from 'mod-arch-core';
+import React from 'react';
+import { getConnections } from '~/app/api/k8s';
+import { ConnectionModel } from '~/app/types';
+
+export const useConnections = (
+  namespace: string,
+): [ConnectionModel[], boolean, Error | undefined] => {
+  const callback = React.useCallback<FetchStateCallbackPromise<ConnectionModel[]>>(
+    (opts: APIOptions) => {
+      if (!namespace) {
+        return Promise.resolve([]);
+      }
+      return getConnections('')(opts, namespace);
+    },
+    [namespace],
+  );
+  const [connections, loaded, error] = useFetchState<ConnectionModel[]>(callback, []);
+
+  return [connections, loaded, error];
+};

--- a/packages/data-registry/frontend/src/app/types.ts
+++ b/packages/data-registry/frontend/src/app/types.ts
@@ -60,7 +60,8 @@ export type AssetResponse = {
   content_type?: string;
   columns?: SchemaField[];
   collection?: string;
-  connection_ref?: ConnectionRef | null;
+  // Backend will return ConnectionRef object per OpenAPI spec; currently returns a plain string
+  connection_ref?: ConnectionRef | string | null;
   owner?: string;
   description?: string;
   labels?: string[];
@@ -112,7 +113,7 @@ export type CreateVolumeRequest = {
   name: string;
   location?: string;
   content_type?: string;
-  connection_ref?: ConnectionRef | null;
+  connection_ref?: string;
   description?: string;
   labels?: string[];
   properties?: Record<string, string>;
@@ -122,7 +123,7 @@ export type CreateGenericTableRequest = {
   name: string;
   format?: string;
   location?: string;
-  connection_ref?: ConnectionRef | null;
+  connection_ref?: string;
   description?: string;
   purpose?: string;
   license?: string;
@@ -153,4 +154,10 @@ export type ErrorResponse = {
     type: string;
     code: number;
   };
+};
+
+export type ConnectionModel = {
+  name: string;
+  displayName?: string;
+  connectionType?: string;
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->


https://issues.redhat.com/browse/RHAI-427

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds RHOAI connection selector to the data registry asset registration flow. When registering a data asset (structured or unstructured), users can now select from available RHOAI connections in the project namespace.

BFF: New GET /api/v1/connections/:namespace endpoint that lists K8s Secrets with opendatahub.io/dashboard=true label and connection-type annotations, returning name, display name, and connection type.

Frontend: DataLocationSection dropdown populated from the BFF endpoint via new useConnections hook. Selected connection is sent as connection_ref (string) in create requests. Display layer handles both string responses (current backend) and ConnectionRef object responses (per OpenAPI spec, future backend).

Connection selection:
<img width="2664" height="1084" alt="image" src="https://github.com/user-attachments/assets/4fb6c2b0-14dc-40e4-baa4-a70662294d9a" />

Connection associated with data asset on main view:
<img width="2322" height="984" alt="image" src="https://github.com/user-attachments/assets/18bd71a5-2b5b-4abb-8043-be4ea02a0e91" />

Connection visible in details page:
<img width="2323" height="989" alt="image" src="https://github.com/user-attachments/assets/a911fd37-a07f-4f4e-bcb1-f55894e6c48f" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Manually tested in federated mode against a live cluster with Feast backend and real RHOAI connections
- Registered both structured and unstructured assets with connection selected — verified connection_ref sent in request and displayed in table view + detail view
- Verified empty state when no connections available

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

- Unit tests: 4 new tests for useConnections hook, 4 new tests for RegisterDataModal connection selection, updated ConnectionRefLink and TableDetailView tests (102 total passing)
- Cypress mock tests: 5 new tests in Connection Selector describe block — dropdown display, selection, empty state, connection_ref in volume/table creation requests. Updated assetDetailView test for new test IDs. (48 total passing)

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection discovery for projects through the API.
  * Added a connection selector to data registration workflows, including connection names and types.
  * Selected connections are now included when creating volumes and tables.
  * Connection references support both plain-string and structured formats.
* **Bug Fixes**
  * Improved connection reference labels and display handling.
  * Added loading, empty-state, and error feedback when connections are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->