### PR TITLE
fix(ci): block fork PRs from privileged Cypress E2E workflow

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -5,8 +5,14 @@ name: Cypress e2e Test
 # =============================================================================
 #
 # TRIGGERS:
-#   - Automatically after "Test" workflow completes on PRs
+#   - Automatically after "Test" workflow completes on same-repo PRs
 #   - Manually via workflow_dispatch (Actions tab → Run workflow)
+#
+# FORK PR SAFETY (PWN request mitigation):
+#   workflow_run listeners run with repository secrets. Fork PR head SHAs are
+#   attacker-controlled, so jobs gated on workflow_run only run when
+#   head_repository matches this repository (blocks external fork PRs).
+#   Fork E2E requires maintainer workflow_dispatch after review.
 #
 # CLUSTER FAILOVER:
 #   Primary:   dash-e2e-int (checked first via DSC health)
@@ -105,9 +111,10 @@ jobs:
   # ---------------------------------------------------------------------------
   select-cluster:
     if: >-
-      github.event_name == 'workflow_dispatch' || 
-      (github.event.workflow_run.event == 'pull_request' && 
-       github.event.workflow_run.conclusion == 'success')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: self-hosted
     outputs:
       cluster_name: ${{ steps.select.outputs.cluster_name }}
@@ -393,9 +400,10 @@ jobs:
   # ---------------------------------------------------------------------------
   set-pending-status:
     if: >-
-      github.event_name == 'workflow_dispatch' || 
-      (github.event.workflow_run.event == 'pull_request' && 
-       github.event.workflow_run.conclusion == 'success')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Set pending status
@@ -421,7 +429,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@c915c33a16f01166c17c4e35fe1d4085a2d71adb # v4.6.0
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
@@ -708,7 +716,7 @@ jobs:
       missing-packages: ${{ steps.ensure.outputs.missing-packages }}
       test-run-id: ${{ steps.ensure.outputs.test-run-id }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@c915c33a16f01166c17c4e35fe1d4085a2d71adb # v4.6.0
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
@@ -736,7 +744,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.ensure-cypress-builds.outputs.missing-packages) }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@c915c33a16f01166c17c4e35fe1d4085a2d71adb # v4.6.0
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
@@ -1048,7 +1056,7 @@ jobs:
           echo "✅ Cleanup complete (non-critical, continued on any errors)"
 
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@c915c33a16f01166c17c4e35fe1d4085a2d71adb # v4.6.0
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
@@ -1316,10 +1324,11 @@ jobs:
   set-final-status:
     needs: [select-cluster, e2e-tests]
     if: >-
-      always() && 
-      (github.event_name == 'workflow_dispatch' || 
-       (github.event.workflow_run.event == 'pull_request' && 
-        github.event.workflow_run.conclusion == 'success'))
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_repository.full_name == github.repository))
     runs-on: ubuntu-latest
     steps:
       - name: Set final status
@@ -1368,7 +1377,12 @@ jobs:
   cleanup:
     needs: [e2e-tests]
     runs-on: self-hosted
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success')) }}
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_repository.full_name == github.repository))
     steps:
       - name: Fix envtest binary permissions
         run: |


### PR DESCRIPTION
## Description

Mitigates a PWN request in the Cypress E2E workflow: `workflow_run` listeners run with repository secrets on self-hosted runners, but previously admitted any successful `Test` run on a `pull_request` event—including external fork PRs—and then checked out `workflow_run.head_sha` and executed attacker-controlled `package.json` scripts and local actions.

Changes:
- Gate privileged jobs (`select-cluster`, `set-pending-status`, `set-final-status`, `cleanup`) on `workflow_run.head_repository.full_name == github.repository`, blocking external fork PR auto-triggers while preserving same-repo PR and `workflow_dispatch` behavior.
- Upgrade `actions/checkout` to `c915c33` (v4.6.0) for fork-ref defense in depth.
- Document fork PR policy in workflow header (fork E2E requires maintainer `workflow_dispatch` after review).

Supersedes fork PR #9578 — opened directly on `opendatahub-io/odh-dashboard` so the workflow can be tested via **Actions → Cypress e2e Test → Run workflow** with branch `fix/cypress-e2e-fork-guard` selected.

**Follow-up (not in this PR):** rotate `GITLAB_TOKEN`/OCP E2E credentials and rebuild self-hosted runners if suspicious fork E2E runs occurred; longer-term split untrusted build from privileged E2E execution.

## How Has This Been Tested?

Workflow YAML change only. To validate on this branch:

1. Merge is not required for `workflow_dispatch` — use **Actions → Cypress e2e Test → Run workflow**, select branch `fix/cypress-e2e-fork-guard`.
2. After merge, same-repo PRs should still auto-trigger E2E after `Test` succeeds; external fork PRs should skip privileged jobs.

## Test Impact

No application or Cypress test changes. CI behavior change: external fork PRs no longer auto-trigger privileged E2E.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test workflow security by preventing automatic runs for pull requests from external forks.
  * Fork-based end-to-end tests remain available through manual execution.

* **Chores**
  * Updated workflow checkout actions for more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->