### PR TITLE
fix: fire Model Updated instead of Model Deployed in edit flow

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -56,7 +56,7 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
 }) => {
   const onRefresh = useRefreshWizardPage(existingDeployment);
   const { isExitModalOpen, openExitModal, closeExitModal, handleExitConfirm, exitWizardOnSubmit } =
-    useExitDeploymentWizard({ returnRoute, cancelReturnRoute });
+    useExitDeploymentWizard({ returnRoute, cancelReturnRoute, isEdit: !!existingDeployment });
 
   const isYAMLViewerEnabled = useIsAreaAvailable(SupportedArea.YAML_VIEWER).status;
   const [viewMode, setViewMode] = React.useState<ModelDeploymentWizardViewMode>(

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -44,6 +44,7 @@ export const useModelDeploymentSubmit = (
     formState,
     initialWizardData,
     deployMethod?.properties.platform,
+    !!existingDeployment,
   );
   const { applyAllFieldDataFn, applyExtensionsLoaded } = useWizardFieldApply(
     formState,

--- a/packages/model-serving/src/components/deploymentWizard/exitModal/useExitDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/exitModal/useExitDeploymentWizard.ts
@@ -7,6 +7,7 @@ import { fireModelDeployed } from '../../../shared/tracking/deploymentTracking';
 type UseExitWizardOptions = {
   returnRoute?: string;
   cancelReturnRoute?: string;
+  isEdit?: boolean;
 };
 
 type UseExitWizardReturn = {
@@ -20,6 +21,7 @@ type UseExitWizardReturn = {
 export const useExitDeploymentWizard = ({
   returnRoute,
   cancelReturnRoute,
+  isEdit,
 }: UseExitWizardOptions): UseExitWizardReturn => {
   const navigate = useNavigate();
   const trackEvent = useTrackEvent();
@@ -43,10 +45,10 @@ export const useExitDeploymentWizard = ({
   }, [navigate, returnRoute]);
 
   const handleExitConfirm = React.useCallback(() => {
-    fireModelDeployed(trackEvent, { outcome: TrackingOutcome.cancel });
+    fireModelDeployed(trackEvent, { outcome: TrackingOutcome.cancel }, isEdit);
     setIsExitModalOpen(false);
     exitWizardOnCancel();
-  }, [trackEvent, exitWizardOnCancel]);
+  }, [trackEvent, exitWizardOnCancel, isEdit]);
 
   return {
     isExitModalOpen,

--- a/packages/model-serving/src/shared/tracking/useModelDeployedTracking.ts
+++ b/packages/model-serving/src/shared/tracking/useModelDeployedTracking.ts
@@ -66,6 +66,7 @@ export const useModelDeployedTracking = (
   formState: WizardFormState,
   initialWizardData?: InitialWizardFormData,
   platformId?: string,
+  isEdit?: boolean,
 ): {
   fireModelDeployedTracking: (
     outcome: 'submit' | 'cancel',
@@ -99,6 +100,7 @@ export const useModelDeployedTracking = (
       fireDeploymentFormTracking(
         trackEvent,
         toDeploymentTrackingProperties(wizardProperties, errorMessage),
+        isEdit,
       );
     },
     [
@@ -107,6 +109,7 @@ export const useModelDeployedTracking = (
       formState,
       getTrackingProperties,
       trackEvent,
+      isEdit,
     ],
   );
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-82390

## Description

Follow-up to the model deployment tracking PR. The `fireModelDeployed` helper already accepted
an `isEdit` flag to emit `"Model Updated"` vs `"Model Deployed"`, but the flag was never
threaded through from the wizard to either tracking call site. As a result, every event fired
as `"Model Deployed"` — even when editing an existing deployment — breaking the
_"Model Updated"_ Amplitude reports and diverging from the legacy `ManageKServeModal` behaviour.

**Root cause:** Two call sites both ignored the available `isEdit` signal:

1. **Submit path** — `useModelDeployedTracking` did not accept or forward `isEdit` to
   `fireModelDeployed`.
2. **Cancel path** — `useExitDeploymentWizard` did not accept or forward `isEdit` to
   `fireModelDeployed`.

**Fix:** Thread `isEdit` (`!!existingDeployment`) from the wizard down to both call sites:

## How Has This Been Tested?

- Existing unit tests for `fireModelDeployed` already cover the `isEdit: true` → `"Model Updated"` and `isEdit: false` → `"Model Deployed"` branches (see `deploymentTracking.spec.ts`).
- Ran the full `shared/tracking` unit test suite locally — 24 tests pass.
- Manual verification: lint (`LINT OK`) and type-check (`tsc --noEmit` with no errors).

## Test Impact

No new tests required — the fix is purely plumbing the existing `isEdit` parameter through.
The correctness of `fireModelDeployed(isEdit=true)` → `"Model Updated"` is already covered
by `packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts`
(`"should fire Model Updated event when isEdit is true"`).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`