### PR TITLE
fix(mlflow): return full MCP registry update responses and reject reserved alias (RHOAIENG-91279)

### DIFF
--- a/packages/mlflow/bff/internal/api/mcp_registry_handler.go
+++ b/packages/mlflow/bff/internal/api/mcp_registry_handler.go
@@ -24,6 +24,10 @@ var (
 	mcpServerSlugRegex      = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$`)
 )
 
+// reservedMCPServerAlias is reserved by MLflow for automatic resolution to
+// the newest version and cannot be set via SetMCPServerAlias.
+const reservedMCPServerAlias = "latest"
+
 // mcpServerReservedSlugs are slugs that collide with the sub-resource path
 // segments this BFF's catch-all routing reserves.
 var mcpServerReservedSlugs = map[string]bool{
@@ -689,6 +693,10 @@ func (app *App) mlflowSetMCPServerAlias(w http.ResponseWriter, r *http.Request, 
 	}
 	if req.Alias == "" {
 		app.badRequestResponse(w, r, errors.New("alias is required"))
+		return
+	}
+	if req.Alias == reservedMCPServerAlias {
+		app.badRequestResponse(w, r, fmt.Errorf("alias %q is reserved", reservedMCPServerAlias))
 		return
 	}
 	if req.Version == "" {

--- a/packages/mlflow/bff/internal/api/mcp_registry_handler_test.go
+++ b/packages/mlflow/bff/internal/api/mcp_registry_handler_test.go
@@ -458,6 +458,8 @@ func TestUpdateMCPServerSuccess(t *testing.T) {
 
 	now := time.Now()
 	mockClient.On("UpdateMCPServer", tmock.Anything, testMCPServerName, tmock.Anything).
+		Return(&mcpregistry.MCPServer{Name: testMCPServerName}, nil)
+	mockClient.On("GetMCPServer", tmock.Anything, testMCPServerName).
 		Return(&mcpregistry.MCPServer{Name: testMCPServerName, DisplayName: "New Name", CreationTimestamp: now, LastUpdatedTimestamp: now}, nil)
 
 	body := `{"display_name":"New Name"}`
@@ -566,6 +568,8 @@ func TestRegisterMCPServerSuccess(t *testing.T) {
 			CreationTimestamp: now, LastUpdatedTimestamp: now,
 		}, nil)
 	mockClient.On("UpdateMCPServer", tmock.Anything, testMCPServerName, tmock.Anything).
+		Return(&mcpregistry.MCPServer{Name: testMCPServerName, CreationTimestamp: now, LastUpdatedTimestamp: now}, nil)
+	mockClient.On("GetMCPServer", tmock.Anything, testMCPServerName).
 		Return(&mcpregistry.MCPServer{Name: testMCPServerName, CreationTimestamp: now, LastUpdatedTimestamp: now}, nil)
 	mockClient.On("SetMCPServerTag", tmock.Anything, testMCPServerName, "team", "platform").Return(nil)
 
@@ -800,6 +804,21 @@ func TestSetMCPServerAliasMissingFields(t *testing.T) {
 	body := `{"alias":"production"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp-registry/servers/"+testMCPServerName+"/aliases", strings.NewReader(body))
 	req = requestWithMLflowClient(req, &mlflowpkg.MockClient{})
+	rr := httptest.NewRecorder()
+
+	app.MLflowMCPServerCatchAllPostHandler(rr, req, restParam("/"+testMCPServerName+"/aliases"))
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestSetMCPServerAliasReservedLatest(t *testing.T) {
+	app := newTestAppWithMCPRegistryRepos()
+	app.config = config.EnvConfig{AuthMethod: config.AuthMethodDisabled}
+
+	body := `{"alias":"latest","version":"1.0.0"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp-registry/servers/"+testMCPServerName+"/aliases?workspace=my-ns", strings.NewReader(body))
+	req = requestWithMLflowClient(req, &mlflowpkg.MockClient{})
+	req = withWorkspace(req, "my-ns")
 	rr := httptest.NewRecorder()
 
 	app.MLflowMCPServerCatchAllPostHandler(rr, req, restParam("/"+testMCPServerName+"/aliases"))
@@ -1212,6 +1231,8 @@ func TestUpdateMCPAccessEndpointSuccess(t *testing.T) {
 
 	now := time.Now()
 	mockClient.On("UpdateMCPAccessEndpoint", tmock.Anything, testMCPServerName, "ep-1", tmock.Anything).
+		Return(&mcpregistry.MCPAccessEndpoint{ID: "ep-1", ServerName: testMCPServerName}, nil)
+	mockClient.On("GetMCPAccessEndpoint", tmock.Anything, testMCPServerName, "ep-1").
 		Return(&mcpregistry.MCPAccessEndpoint{
 			ID: "ep-1", ServerName: testMCPServerName, EndpointURL: "https://mcp.example.com/new",
 			CreationTimestamp: now, LastUpdatedTimestamp: now,
@@ -1511,6 +1532,8 @@ func TestMCPRegistryHandlerPermissions(t *testing.T) {
 				now := time.Now()
 				m.On("UpdateMCPServer", tmock.Anything, testMCPServerName, tmock.Anything).
 					Return(&mcpregistry.MCPServer{Name: testMCPServerName, CreationTimestamp: now, LastUpdatedTimestamp: now}, nil)
+				m.On("GetMCPServer", tmock.Anything, testMCPServerName).
+					Return(&mcpregistry.MCPServer{Name: testMCPServerName, DisplayName: "New Name", CreationTimestamp: now, LastUpdatedTimestamp: now}, nil)
 			},
 		},
 		{

--- a/packages/mlflow/bff/internal/api/mcp_registry_routes_test.go
+++ b/packages/mlflow/bff/internal/api/mcp_registry_routes_test.go
@@ -134,6 +134,8 @@ func TestRoutesMCPServerCatchAll(t *testing.T) {
 			setupMock: func(m *mlflowpkg.MockClient) {
 				m.On("UpdateMCPServer", tmock.Anything, testMCPServerName, tmock.Anything).
 					Return(&mcpregistry.MCPServer{Name: testMCPServerName, CreationTimestamp: now, LastUpdatedTimestamp: now}, nil)
+				m.On("GetMCPServer", tmock.Anything, testMCPServerName).
+					Return(&mcpregistry.MCPServer{Name: testMCPServerName, CreationTimestamp: now, LastUpdatedTimestamp: now}, nil)
 			},
 			wantStatus: http.StatusOK,
 		},

--- a/packages/mlflow/bff/internal/repositories/mcp_registry.go
+++ b/packages/mlflow/bff/internal/repositories/mcp_registry.go
@@ -227,16 +227,30 @@ func (r *MCPRegistryRepository) UpdateServer(ctx context.Context, name string, r
 		opts = append(opts, mcpregistry.WithUpdatedServerIcons(*req.Icons))
 	}
 
-	server, err := client.UpdateMCPServer(ctx, name, opts...)
-	if err != nil {
+	if _, err := client.UpdateMCPServer(ctx, name, opts...); err != nil {
 		return nil, fmt.Errorf("updating MCP server %q: %w", name, err)
 	}
-	if server == nil {
-		return nil, fmt.Errorf("UpdateMCPServer returned nil for %q", name)
-	}
 
-	result := toMCPServer(server)
-	return &result, nil
+	// MLflow PATCH/GET may return sparse bodies; re-fetch then overlay fields
+	// we just asked to update so callers see the new values.
+	result, err := r.GetServer(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	applyMCPServerUpdate(result, req)
+	return result, nil
+}
+
+func applyMCPServerUpdate(server *models.MCPServer, req models.UpdateMCPServerRequest) {
+	if req.DisplayName != nil {
+		server.DisplayName = *req.DisplayName
+	}
+	if req.Description != nil {
+		server.Description = *req.Description
+	}
+	if req.Icons != nil {
+		server.Icons = *req.Icons
+	}
 }
 
 // DeleteServer removes an MCP server and all of its versions, access
@@ -567,16 +581,33 @@ func (r *MCPRegistryRepository) UpdateAccessEndpoint(ctx context.Context, server
 		opts = append(opts, mcpregistry.WithUpdatedEndpointServerAlias(*req.ServerAlias))
 	}
 
-	endpoint, err := client.UpdateMCPAccessEndpoint(ctx, serverName, endpointID, opts...)
-	if err != nil {
+	if _, err := client.UpdateMCPAccessEndpoint(ctx, serverName, endpointID, opts...); err != nil {
 		return nil, fmt.Errorf("updating access endpoint %q for MCP server %q: %w", endpointID, serverName, err)
 	}
-	if endpoint == nil {
-		return nil, fmt.Errorf("UpdateMCPAccessEndpoint returned nil for %q", endpointID)
-	}
 
-	result := toMCPAccessEndpoint(endpoint)
-	return &result, nil
+	// MLflow PATCH/GET may return sparse bodies; re-fetch then overlay fields
+	// we just asked to update so callers see the new values.
+	result, err := r.GetAccessEndpoint(ctx, serverName, endpointID)
+	if err != nil {
+		return nil, err
+	}
+	applyMCPAccessEndpointUpdate(result, req)
+	return result, nil
+}
+
+func applyMCPAccessEndpointUpdate(endpoint *models.MCPAccessEndpoint, req models.UpdateMCPAccessEndpointRequest) {
+	if req.EndpointURL != nil {
+		endpoint.EndpointURL = *req.EndpointURL
+	}
+	if req.TransportType != nil {
+		endpoint.TransportType = *req.TransportType
+	}
+	if req.ServerVersion != nil {
+		endpoint.ServerVersion = *req.ServerVersion
+	}
+	if req.ServerAlias != nil {
+		endpoint.ServerAlias = *req.ServerAlias
+	}
 }
 
 func (r *MCPRegistryRepository) DeleteAccessEndpoint(ctx context.Context, serverName, endpointID string) error {

--- a/packages/mlflow/bff/internal/repositories/mcp_registry_test.go
+++ b/packages/mlflow/bff/internal/repositories/mcp_registry_test.go
@@ -380,7 +380,10 @@ func TestUpdateServerSuccess(t *testing.T) {
 
 	mockClient.On("UpdateMCPServer", tmock.Anything, "my-server", tmock.MatchedBy(func(opts []mcpregistry.UpdateMCPServerOption) bool {
 		return len(opts) == 1 // display name only
-	})).Return(&mcpregistry.MCPServer{Name: "my-server", DisplayName: displayName, CreationTimestamp: now, LastUpdatedTimestamp: now}, nil)
+	})).Return(&mcpregistry.MCPServer{Name: "my-server"}, nil)
+	mockClient.On("GetMCPServer", tmock.Anything, "my-server").Return(&mcpregistry.MCPServer{
+		Name: "my-server", DisplayName: displayName, CreationTimestamp: now, LastUpdatedTimestamp: now,
+	}, nil)
 
 	repo := NewMCPRegistryRepository()
 	ctx := contextWithMockClient(mockClient)
@@ -401,6 +404,7 @@ func TestUpdateServerAllFields(t *testing.T) {
 	mockClient.On("UpdateMCPServer", tmock.Anything, "my-server", tmock.MatchedBy(func(opts []mcpregistry.UpdateMCPServerOption) bool {
 		return len(opts) == 3
 	})).Return(&mcpregistry.MCPServer{Name: "my-server"}, nil)
+	mockClient.On("GetMCPServer", tmock.Anything, "my-server").Return(&mcpregistry.MCPServer{Name: "my-server"}, nil)
 
 	repo := NewMCPRegistryRepository()
 	ctx := contextWithMockClient(mockClient)
@@ -421,6 +425,7 @@ func TestUpdateServerNoFieldsSet(t *testing.T) {
 	mockClient.On("UpdateMCPServer", tmock.Anything, "my-server", tmock.MatchedBy(func(opts []mcpregistry.UpdateMCPServerOption) bool {
 		return len(opts) == 0
 	})).Return(&mcpregistry.MCPServer{Name: "my-server"}, nil)
+	mockClient.On("GetMCPServer", tmock.Anything, "my-server").Return(&mcpregistry.MCPServer{Name: "my-server"}, nil)
 
 	repo := NewMCPRegistryRepository()
 	ctx := contextWithMockClient(mockClient)
@@ -1108,7 +1113,8 @@ func TestUpdateAccessEndpointSuccess(t *testing.T) {
 
 	mockClient.On("UpdateMCPAccessEndpoint", tmock.Anything, "my-server", "ep-1", tmock.MatchedBy(func(opts []mcpregistry.UpdateMCPAccessEndpointOption) bool {
 		return len(opts) == 1 // URL only
-	})).Return(&mcpregistry.MCPAccessEndpoint{
+	})).Return(&mcpregistry.MCPAccessEndpoint{ID: "ep-1", ServerName: "my-server"}, nil)
+	mockClient.On("GetMCPAccessEndpoint", tmock.Anything, "my-server", "ep-1").Return(&mcpregistry.MCPAccessEndpoint{
 		ID: "ep-1", ServerName: "my-server", EndpointURL: url,
 		CreationTimestamp: now, LastUpdatedTimestamp: now,
 	}, nil)
@@ -1133,6 +1139,7 @@ func TestUpdateAccessEndpointAllFields(t *testing.T) {
 	mockClient.On("UpdateMCPAccessEndpoint", tmock.Anything, "my-server", "ep-1", tmock.MatchedBy(func(opts []mcpregistry.UpdateMCPAccessEndpointOption) bool {
 		return len(opts) == 4
 	})).Return(&mcpregistry.MCPAccessEndpoint{ID: "ep-1", ServerName: "my-server"}, nil)
+	mockClient.On("GetMCPAccessEndpoint", tmock.Anything, "my-server", "ep-1").Return(&mcpregistry.MCPAccessEndpoint{ID: "ep-1", ServerName: "my-server"}, nil)
 
 	repo := NewMCPRegistryRepository()
 	ctx := contextWithMockClient(mockClient)


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-91279

## Description

Fixes 3 failing MLflow contract tests on `main` caused by sparse MCP registry PATCH responses and missing reserved-alias validation.

**Root cause:** MLflow returns sparse bodies from `UpdateMCPServer` / `UpdateMCPAccessEndpoint` PATCH calls. The BFF forwarded those responses directly, so fields like `display_name` and `endpoint_url` were missing even though the update succeeded.

**Changes:**
- After MCP server and access endpoint updates, re-fetch the resource and overlay request fields onto the response
- Reject reserved alias `"latest"` in `mlflowSetMCPServerAlias` with HTTP 400 before calling MLflow
- Update handler, repository, and route unit test mocks for the re-fetch pattern

## How Has This Been Tested?

```bash
cd packages/mlflow/bff && go test ./... -count=1
cd packages/mlflow && npm run test:contract
```

- MLflow BFF unit tests: all pass
- MLflow contract tests: **52/52 pass** (was 49/52 on `main`)

## Test Impact

- Updated `mcp_registry_handler_test.go`, `mcp_registry_routes_test.go`, and `mcp_registry_test.go` for re-fetch mocks
- Added `TestSetMCPServerAliasReservedLatest` handler test

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reserved the alias `latest`; attempts to assign it now return a 400 error.

* **Bug Fixes**
  * Updated MCP servers and access endpoints now return complete, current resource details, including fields omitted from update responses.
  * PATCH operations more reliably reflect the requested changes in their responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->