### PR TITLE
feat(data-registry): add error states

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/dataRegistry/testDataRegistryErrors.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/dataRegistry/testDataRegistryErrors.yaml
@@ -1,0 +1,13 @@
+# API paths
+namespacesApi: /api/dr/v1/test-project/namespaces
+assetsApi: /api/dr/v1/test-project/namespaces/default/generic-tables
+collectionsApi: /api/dr/v1/test-project/namespaces
+labelsApi: /api/dr/v1/test-project/labels
+
+# Error messages
+serviceUnavailableMessage: Data Registry service is temporarily unavailable
+accessDeniedMessage: You do not have access to this project in Data Registry.
+connectionFailedMessage: Connection failed
+
+# Test project
+project: test-project

--- a/packages/cypress/cypress/pages/dataRegistry/dataRegistryPage.ts
+++ b/packages/cypress/cypress/pages/dataRegistry/dataRegistryPage.ts
@@ -1,51 +1,49 @@
 class DataRegistryPage {
-  visit(project?: string) {
-    const url = project ? `/ai-hub/data?project=${project}` : '/ai-hub/data';
-    cy.visit(url);
+  visit(project: string) {
+    cy.visit(`/data-registry?project=${project}`);
   }
 
-  findProjectSelector() {
-    return cy.findByTestId('project-selector');
+  waitForErrorState() {
+    cy.get('[data-testid="error-display"]', { timeout: 10000 }).should('exist');
   }
 
-  findRegisterDataButton() {
-    return cy.findByTestId('register-data-button');
+  shouldShowServiceUnavailable() {
+    cy.contains('Data Registry service is temporarily unavailable').should('be.visible');
   }
 
-  findManageCollectionsAction() {
-    return cy.findByTestId('manage-collections-action');
-  }
-
-  findManageLabelsAction() {
-    return cy.findByTestId('manage-labels-action');
-  }
-
-  findRetryButton() {
-    return cy.findByTestId('retry-button');
-  }
-
-  findErrorMessage(text: string) {
-    return cy.contains(text);
-  }
-
-  shouldShowServiceUnavailableError() {
-    this.findErrorMessage('Data Registry service is temporarily unavailable').should('be.visible');
-    this.findRetryButton().should('be.visible');
-  }
-
-  shouldShowAccessDeniedError() {
-    this.findErrorMessage('Access denied').should('be.visible');
-    this.findRetryButton().should('not.exist');
+  shouldShowAccessDenied() {
+    cy.contains('You do not have access to this project').should('be.visible');
   }
 
   shouldShowConnectionError() {
-    this.findErrorMessage('Connection failed').should('be.visible');
-    this.findRetryButton().should('be.visible');
+    cy.contains('Connection failed').should('be.visible');
   }
 
-  shouldDisableWriteActions() {
-    this.findRegisterDataButton().should('be.disabled');
+  shouldDisableRegisterDataButton() {
+    cy.get('[data-testid="register-data-button"]').should('be.disabled');
+  }
+
+  shouldDisableManageCollectionsAction() {
+    cy.get('[data-testid="actions-dropdown"]').click();
+    cy.get('[data-testid="manage-collections-action"]').should(
+      'have.attr',
+      'aria-disabled',
+      'true',
+    );
+  }
+
+  shouldDisableManageLabelsAction() {
+    cy.get('[data-testid="actions-dropdown"]').click();
+    cy.get('[data-testid="manage-labels-action"]').should('have.attr', 'aria-disabled', 'true');
+  }
+
+  clickRetryButton() {
+    cy.get('[data-testid="retry-button"]').click();
+  }
+
+  shouldShowData() {
+    cy.get('[data-testid="registry-table"]').should('exist');
   }
 }
 
-export const dataRegistryPage = new DataRegistryPage();
+export default new DataRegistryPage();

--- a/packages/cypress/cypress/pages/dataRegistry/dataRegistryPage.ts
+++ b/packages/cypress/cypress/pages/dataRegistry/dataRegistryPage.ts
@@ -1,0 +1,51 @@
+class DataRegistryPage {
+  visit(project?: string) {
+    const url = project ? `/ai-hub/data?project=${project}` : '/ai-hub/data';
+    cy.visit(url);
+  }
+
+  findProjectSelector() {
+    return cy.findByTestId('project-selector');
+  }
+
+  findRegisterDataButton() {
+    return cy.findByTestId('register-data-button');
+  }
+
+  findManageCollectionsAction() {
+    return cy.findByTestId('manage-collections-action');
+  }
+
+  findManageLabelsAction() {
+    return cy.findByTestId('manage-labels-action');
+  }
+
+  findRetryButton() {
+    return cy.findByTestId('retry-button');
+  }
+
+  findErrorMessage(text: string) {
+    return cy.contains(text);
+  }
+
+  shouldShowServiceUnavailableError() {
+    this.findErrorMessage('Data Registry service is temporarily unavailable').should('be.visible');
+    this.findRetryButton().should('be.visible');
+  }
+
+  shouldShowAccessDeniedError() {
+    this.findErrorMessage('Access denied').should('be.visible');
+    this.findRetryButton().should('not.exist');
+  }
+
+  shouldShowConnectionError() {
+    this.findErrorMessage('Connection failed').should('be.visible');
+    this.findRetryButton().should('be.visible');
+  }
+
+  shouldDisableWriteActions() {
+    this.findRegisterDataButton().should('be.disabled');
+  }
+}
+
+export const dataRegistryPage = new DataRegistryPage();

--- a/packages/cypress/cypress/tests/e2e/dataRegistry/testDataRegistryErrors.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataRegistry/testDataRegistryErrors.cy.ts
@@ -1,195 +1,86 @@
-import yaml from 'js-yaml';
-import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
-import { dataRegistryPage } from '../../../pages/dataRegistry/dataRegistryPage';
-import { retryableBefore } from '../../../utils/retryableHooks';
-
-type DataRegistryErrorTestData = {
-  testProject: string;
-  bffServiceName: string;
-  bffNamespace: string;
-  apiPath: string;
-  errorMessages: {
-    serviceUnavailable: string;
-    accessDenied: string;
-    connectionFailed: string;
-  };
-  retryButtonTestId: string;
-};
+import dataRegistryPage from '../../../pages/dataRegistry/dataRegistryPage';
 
 describe('Data Registry Error Handling', () => {
-  let testData: DataRegistryErrorTestData;
+  let testData: {
+    namespacesApi: string;
+    assetsApi: string;
+    collectionsApi: string;
+    labelsApi: string;
+    serviceUnavailableMessage: string;
+    accessDeniedMessage: string;
+    connectionFailedMessage: string;
+    project: string;
+  };
 
-  retryableBefore(() =>
-    cy
-      .fixture('e2e/dataRegistry/testDataRegistryErrors.yaml', 'utf8')
-      .then((yamlContent: string) => {
-        testData = yaml.load(yamlContent) as DataRegistryErrorTestData;
-      }),
-  );
-
-  beforeEach(() => {
-    cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+  before(() => {
+    cy.fixture('e2e/dataRegistry/testDataRegistryErrors.yaml').then((data) => {
+      testData = data;
+    });
   });
 
-  it(
-    'should display service unavailable error (503) with retry button',
-    {
-      tags: ['@DataRegistry', '@ErrorHandling'],
-    },
-    () => {
-      cy.step('Intercept API calls to return 503');
-      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, {
-        statusCode: 503,
-        body: 'Service Unavailable',
-      }).as('get503Error');
+  it('should display 503 service unavailable error with retry button', () => {
+    cy.intercept('GET', testData.namespacesApi, { statusCode: 503 }).as('namespaces503');
 
-      cy.step('Navigate to Data Registry');
-      dataRegistryPage.visit();
+    dataRegistryPage.visit(testData.project);
+    cy.wait('@namespaces503');
 
-      cy.step('Wait for 503 response');
-      cy.wait('@get503Error');
+    dataRegistryPage.shouldShowServiceUnavailable();
+    cy.get('[data-testid="retry-button"]').should('be.visible');
+  });
 
-      cy.step('Verify service unavailable error is displayed');
-      dataRegistryPage.shouldShowServiceUnavailableError();
+  it('should display 403 access denied error for namespaces', () => {
+    cy.intercept('GET', testData.namespacesApi, { statusCode: 403 }).as('namespaces403');
 
-      cy.step('Verify retry button is present');
-      dataRegistryPage.findRetryButton().should('be.visible');
-    },
-  );
+    dataRegistryPage.visit(testData.project);
+    cy.wait('@namespaces403');
 
-  it(
-    'should display access denied error (403) and disable write actions',
-    {
-      tags: ['@DataRegistry', '@ErrorHandling'],
-    },
-    () => {
-      cy.step('Intercept API calls to return 403');
-      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, {
-        statusCode: 403,
-        body: 'Forbidden',
-      }).as('get403Error');
+    dataRegistryPage.shouldShowAccessDenied();
+    cy.get('[data-testid="retry-button"]').should('not.exist');
+  });
 
-      cy.step('Navigate to Data Registry');
-      dataRegistryPage.visit();
+  it('should disable write actions when assets return 403', () => {
+    cy.intercept('GET', testData.namespacesApi, { fixture: 'namespaces.json' }).as('namespaces');
+    cy.intercept('GET', testData.assetsApi, { statusCode: 403 }).as('assets403');
+    cy.intercept('GET', testData.collectionsApi, { fixture: 'collections.json' }).as('collections');
 
-      cy.step('Wait for 403 response');
-      cy.wait('@get403Error');
+    dataRegistryPage.visit(testData.project);
+    cy.wait(['@namespaces', '@assets403']);
 
-      cy.step('Verify access denied error is displayed');
-      dataRegistryPage.shouldShowAccessDeniedError();
+    dataRegistryPage.shouldDisableRegisterDataButton();
+    dataRegistryPage.shouldDisableManageCollectionsAction();
+    dataRegistryPage.shouldDisableManageLabelsAction();
+  });
 
-      cy.step('Verify retry button is NOT present');
-      dataRegistryPage.findRetryButton().should('not.exist');
-    },
-  );
+  it('should display connection error with retry button', () => {
+    cy.intercept('GET', testData.namespacesApi, { forceNetworkError: true }).as(
+      'namespacesNetworkError',
+    );
 
-  it(
-    'should display access denied error and disable write actions when fetching assets fails with 403',
-    {
-      tags: ['@DataRegistry', '@ErrorHandling'],
-    },
-    () => {
-      cy.step('Intercept namespaces call to succeed');
-      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, {
-        statusCode: 200,
-        body: {
-          namespaces: [[testData.testProject]],
-        },
-      }).as('getNamespaces');
+    dataRegistryPage.visit(testData.project);
+    cy.wait('@namespacesNetworkError');
 
-      cy.step('Intercept assets call to return 403');
-      cy.intercept(
-        'GET',
-        `${testData.apiPath}/${testData.testProject}/namespaces/*/generic-tables`,
-        {
-          statusCode: 403,
-          body: 'Forbidden',
-        },
-      ).as('get403Assets');
+    dataRegistryPage.shouldShowConnectionError();
+    cy.get('[data-testid="retry-button"]').should('be.visible');
+  });
 
-      cy.step('Navigate to Data Registry with project selected');
-      dataRegistryPage.visit(testData.testProject);
+  it('should retry and load data after 503 error', () => {
+    let callCount = 0;
+    cy.intercept('GET', testData.namespacesApi, (req) => {
+      callCount++;
+      if (callCount === 1) {
+        req.reply({ statusCode: 503 });
+      } else {
+        req.reply({ fixture: 'namespaces.json' });
+      }
+    }).as('namespacesRetry');
 
-      cy.step('Wait for responses');
-      cy.wait('@getNamespaces');
-      cy.wait('@get403Assets');
+    dataRegistryPage.visit(testData.project);
+    cy.wait('@namespacesRetry');
 
-      cy.step('Verify access denied error is displayed');
-      dataRegistryPage.shouldShowAccessDeniedError();
+    dataRegistryPage.shouldShowServiceUnavailable();
+    dataRegistryPage.clickRetryButton();
 
-      cy.step('Verify write actions are disabled');
-      dataRegistryPage.shouldDisableWriteActions();
-    },
-  );
-
-  it(
-    'should display connection error with retry button for network failures',
-    {
-      tags: ['@DataRegistry', '@ErrorHandling'],
-    },
-    () => {
-      cy.step('Intercept API calls to simulate network failure');
-      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, {
-        forceNetworkError: true,
-      }).as('networkError');
-
-      cy.step('Navigate to Data Registry');
-      dataRegistryPage.visit();
-
-      cy.step('Wait for network error');
-      cy.wait('@networkError');
-
-      cy.step('Verify connection error is displayed');
-      dataRegistryPage.shouldShowConnectionError();
-
-      cy.step('Verify retry button is present');
-      dataRegistryPage.findRetryButton().should('be.visible');
-    },
-  );
-
-  it(
-    'should allow retry after 503 error',
-    {
-      tags: ['@DataRegistry', '@ErrorHandling'],
-    },
-    () => {
-      let callCount = 0;
-
-      cy.step('Intercept first call to return 503, second to succeed');
-      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, (req) => {
-        callCount++;
-        if (callCount === 1) {
-          req.reply({
-            statusCode: 503,
-            body: 'Service Unavailable',
-          });
-        } else {
-          req.reply({
-            statusCode: 200,
-            body: {
-              namespaces: [[testData.testProject]],
-            },
-          });
-        }
-      }).as('getNamespaces');
-
-      cy.step('Navigate to Data Registry');
-      dataRegistryPage.visit();
-
-      cy.step('Wait for initial 503 response');
-      cy.wait('@getNamespaces');
-
-      cy.step('Verify service unavailable error is displayed');
-      dataRegistryPage.shouldShowServiceUnavailableError();
-
-      cy.step('Click retry button');
-      dataRegistryPage.findRetryButton().click();
-
-      cy.step('Wait for successful response');
-      cy.wait('@getNamespaces');
-
-      cy.step('Verify error is cleared and project selector is visible');
-      dataRegistryPage.findProjectSelector().should('be.visible');
-    },
-  );
+    cy.wait('@namespacesRetry');
+    dataRegistryPage.shouldShowData();
+  });
 });

--- a/packages/cypress/cypress/tests/e2e/dataRegistry/testDataRegistryErrors.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataRegistry/testDataRegistryErrors.cy.ts
@@ -1,0 +1,195 @@
+import yaml from 'js-yaml';
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
+import { dataRegistryPage } from '../../../pages/dataRegistry/dataRegistryPage';
+import { retryableBefore } from '../../../utils/retryableHooks';
+
+type DataRegistryErrorTestData = {
+  testProject: string;
+  bffServiceName: string;
+  bffNamespace: string;
+  apiPath: string;
+  errorMessages: {
+    serviceUnavailable: string;
+    accessDenied: string;
+    connectionFailed: string;
+  };
+  retryButtonTestId: string;
+};
+
+describe('Data Registry Error Handling', () => {
+  let testData: DataRegistryErrorTestData;
+
+  retryableBefore(() =>
+    cy
+      .fixture('e2e/dataRegistry/testDataRegistryErrors.yaml', 'utf8')
+      .then((yamlContent: string) => {
+        testData = yaml.load(yamlContent) as DataRegistryErrorTestData;
+      }),
+  );
+
+  beforeEach(() => {
+    cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+  });
+
+  it(
+    'should display service unavailable error (503) with retry button',
+    {
+      tags: ['@DataRegistry', '@ErrorHandling'],
+    },
+    () => {
+      cy.step('Intercept API calls to return 503');
+      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, {
+        statusCode: 503,
+        body: 'Service Unavailable',
+      }).as('get503Error');
+
+      cy.step('Navigate to Data Registry');
+      dataRegistryPage.visit();
+
+      cy.step('Wait for 503 response');
+      cy.wait('@get503Error');
+
+      cy.step('Verify service unavailable error is displayed');
+      dataRegistryPage.shouldShowServiceUnavailableError();
+
+      cy.step('Verify retry button is present');
+      dataRegistryPage.findRetryButton().should('be.visible');
+    },
+  );
+
+  it(
+    'should display access denied error (403) and disable write actions',
+    {
+      tags: ['@DataRegistry', '@ErrorHandling'],
+    },
+    () => {
+      cy.step('Intercept API calls to return 403');
+      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, {
+        statusCode: 403,
+        body: 'Forbidden',
+      }).as('get403Error');
+
+      cy.step('Navigate to Data Registry');
+      dataRegistryPage.visit();
+
+      cy.step('Wait for 403 response');
+      cy.wait('@get403Error');
+
+      cy.step('Verify access denied error is displayed');
+      dataRegistryPage.shouldShowAccessDeniedError();
+
+      cy.step('Verify retry button is NOT present');
+      dataRegistryPage.findRetryButton().should('not.exist');
+    },
+  );
+
+  it(
+    'should display access denied error and disable write actions when fetching assets fails with 403',
+    {
+      tags: ['@DataRegistry', '@ErrorHandling'],
+    },
+    () => {
+      cy.step('Intercept namespaces call to succeed');
+      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, {
+        statusCode: 200,
+        body: {
+          namespaces: [[testData.testProject]],
+        },
+      }).as('getNamespaces');
+
+      cy.step('Intercept assets call to return 403');
+      cy.intercept(
+        'GET',
+        `${testData.apiPath}/${testData.testProject}/namespaces/*/generic-tables`,
+        {
+          statusCode: 403,
+          body: 'Forbidden',
+        },
+      ).as('get403Assets');
+
+      cy.step('Navigate to Data Registry with project selected');
+      dataRegistryPage.visit(testData.testProject);
+
+      cy.step('Wait for responses');
+      cy.wait('@getNamespaces');
+      cy.wait('@get403Assets');
+
+      cy.step('Verify access denied error is displayed');
+      dataRegistryPage.shouldShowAccessDeniedError();
+
+      cy.step('Verify write actions are disabled');
+      dataRegistryPage.shouldDisableWriteActions();
+    },
+  );
+
+  it(
+    'should display connection error with retry button for network failures',
+    {
+      tags: ['@DataRegistry', '@ErrorHandling'],
+    },
+    () => {
+      cy.step('Intercept API calls to simulate network failure');
+      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, {
+        forceNetworkError: true,
+      }).as('networkError');
+
+      cy.step('Navigate to Data Registry');
+      dataRegistryPage.visit();
+
+      cy.step('Wait for network error');
+      cy.wait('@networkError');
+
+      cy.step('Verify connection error is displayed');
+      dataRegistryPage.shouldShowConnectionError();
+
+      cy.step('Verify retry button is present');
+      dataRegistryPage.findRetryButton().should('be.visible');
+    },
+  );
+
+  it(
+    'should allow retry after 503 error',
+    {
+      tags: ['@DataRegistry', '@ErrorHandling'],
+    },
+    () => {
+      let callCount = 0;
+
+      cy.step('Intercept first call to return 503, second to succeed');
+      cy.intercept('GET', `${testData.apiPath}/**/namespaces`, (req) => {
+        callCount++;
+        if (callCount === 1) {
+          req.reply({
+            statusCode: 503,
+            body: 'Service Unavailable',
+          });
+        } else {
+          req.reply({
+            statusCode: 200,
+            body: {
+              namespaces: [[testData.testProject]],
+            },
+          });
+        }
+      }).as('getNamespaces');
+
+      cy.step('Navigate to Data Registry');
+      dataRegistryPage.visit();
+
+      cy.step('Wait for initial 503 response');
+      cy.wait('@getNamespaces');
+
+      cy.step('Verify service unavailable error is displayed');
+      dataRegistryPage.shouldShowServiceUnavailableError();
+
+      cy.step('Click retry button');
+      dataRegistryPage.findRetryButton().click();
+
+      cy.step('Wait for successful response');
+      cy.wait('@getNamespaces');
+
+      cy.step('Verify error is cleared and project selector is visible');
+      dataRegistryPage.findProjectSelector().should('be.visible');
+    },
+  );
+});

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/assetDetailView.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/assetDetailView.cy.ts
@@ -73,7 +73,7 @@ describe('Table Detail View', () => {
   });
 
   it('should display table metadata in two-column layout', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.findByTestId('data-details-card').should('exist');
@@ -87,7 +87,7 @@ describe('Table Detail View', () => {
   });
 
   it('should display asset type badge and Overview tab', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.findByTestId('asset-type-badge').should('contain.text', 'Data asset');
@@ -96,7 +96,7 @@ describe('Table Detail View', () => {
   });
 
   it('should display labels, properties, and schema cards', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.findByTestId('labels-card').should('exist');
@@ -114,7 +114,7 @@ describe('Table Detail View', () => {
   });
 
   it('should display created and modified with user attribution', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.findByTestId('asset-created-at').should('contain.text', 'by user@example.com');
@@ -122,7 +122,7 @@ describe('Table Detail View', () => {
   });
 
   it('should show breadcrumb navigation', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.get('.pf-v6-c-breadcrumb').should('exist');
@@ -132,7 +132,7 @@ describe('Table Detail View', () => {
   });
 
   it('should open delete modal from kebab menu', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.findByTestId('asset-actions-toggle').click();
@@ -148,14 +148,14 @@ describe('Table Detail View', () => {
       { statusCode: 204 },
     ).as('deleteTable');
 
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
     cy.findByTestId('asset-actions-toggle').click();
     cy.findByTestId('asset-action-delete').click();
     cy.findByTestId('delete-asset-confirmation').type('claims-data');
     cy.findByTestId('delete-asset-confirm').click();
     cy.wait('@deleteTable');
-    cy.url().should('include', '/main-view?project=test-project');
+    cy.url().should('include', '/ai-hub/data/browse?project=test-project');
   });
 
   it('should show a table deletion error', () => {
@@ -165,7 +165,7 @@ describe('Table Detail View', () => {
       { statusCode: 403, body: 'Forbidden' },
     ).as('deleteTable');
 
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
     cy.findByTestId('asset-actions-toggle').click();
     cy.findByTestId('asset-action-delete').click();
@@ -187,7 +187,7 @@ describe('Volume Detail View', () => {
   });
 
   it('should display volume metadata as unified asset', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-documents');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-documents');
     cy.wait('@getVolume');
 
     cy.findByTestId('data-details-card').should('exist');
@@ -199,7 +199,7 @@ describe('Volume Detail View', () => {
   });
 
   it('should display created and modified with user attribution', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-documents');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-documents');
     cy.wait('@getVolume');
 
     cy.findByTestId('asset-created-at').should('contain.text', 'by ml-team@example.com');
@@ -207,14 +207,14 @@ describe('Volume Detail View', () => {
   });
 
   it('should display the unstructured format field', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-documents');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-documents');
     cy.wait('@getVolume');
 
     cy.findByTestId('asset-format').should('contain.text', 'Documents');
   });
 
   it('should display asset type badge and Overview tab', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-documents');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-documents');
     cy.wait('@getVolume');
 
     cy.findByTestId('asset-type-badge').should('contain.text', 'Data asset');
@@ -223,7 +223,7 @@ describe('Volume Detail View', () => {
   });
 
   it('should display labels and properties cards', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-documents');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-documents');
     cy.wait('@getVolume');
 
     cy.findByTestId('labels-card').should('exist');
@@ -237,14 +237,14 @@ describe('Volume Detail View', () => {
   });
 
   it('should not display schema card for volumes', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-documents');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-documents');
     cy.wait('@getVolume');
 
     cy.findByTestId('schema-card').should('not.exist');
   });
 
   it('should handle delete action', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-documents');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-documents');
     cy.wait('@getVolume');
 
     cy.findByTestId('asset-actions-toggle').click();
@@ -260,14 +260,14 @@ describe('Volume Detail View', () => {
       { statusCode: 204 },
     ).as('deleteVolume');
 
-    cy.visit('/main-view/assets/volume/test-project/default/training-documents');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-documents');
     cy.wait('@getVolume');
     cy.findByTestId('asset-actions-toggle').click();
     cy.findByTestId('asset-action-delete').click();
     cy.findByTestId('delete-asset-confirmation').type('training-documents');
     cy.findByTestId('delete-asset-confirm').click();
     cy.wait('@deleteVolume');
-    cy.url().should('include', '/main-view?project=test-project');
+    cy.url().should('include', '/ai-hub/data/browse?project=test-project');
   });
 
   it('should show a volume deletion error', () => {
@@ -277,7 +277,7 @@ describe('Volume Detail View', () => {
       { statusCode: 404, body: 'Not found' },
     ).as('deleteVolume');
 
-    cy.visit('/main-view/assets/volume/test-project/default/training-documents');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-documents');
     cy.wait('@getVolume');
     cy.findByTestId('asset-actions-toggle').click();
     cy.findByTestId('asset-action-delete').click();

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/editAsset.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/editAsset.cy.ts
@@ -57,7 +57,7 @@ describe('Edit Table Asset', () => {
   });
 
   it('should open edit modal and display pre-populated fields', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.findByTestId('asset-actions-toggle').click();
@@ -75,7 +75,7 @@ describe('Edit Table Asset', () => {
   });
 
   it('should edit description and save table', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.intercept(
@@ -99,7 +99,7 @@ describe('Edit Table Asset', () => {
   });
 
   it('should clear the purpose when it is removed', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.intercept(
@@ -124,7 +124,7 @@ describe('Edit Table Asset', () => {
       `${REGISTRY_API}/test-project/namespaces/analytics/generic-tables/unclassified-data`,
       { body: tableWithoutOptionalMetadataResponse },
     ).as('getTableWithoutOptionalMetadata');
-    cy.visit('/main-view/assets/table/test-project/analytics/unclassified-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/unclassified-data');
     cy.wait('@getTableWithoutOptionalMetadata');
 
     cy.intercept(
@@ -147,7 +147,7 @@ describe('Edit Table Asset', () => {
   });
 
   it('should add and remove labels', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.intercept(
@@ -182,7 +182,7 @@ describe('Edit Table Asset', () => {
   });
 
   it('should add and remove custom properties', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.intercept(
@@ -214,7 +214,7 @@ describe('Edit Table Asset', () => {
   });
 
   it('should display schema section and add a column', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.intercept(
@@ -244,7 +244,7 @@ describe('Edit Table Asset', () => {
   });
 
   it('should clear the final custom property', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
     cy.intercept(
       'PATCH',
@@ -263,7 +263,7 @@ describe('Edit Table Asset', () => {
   });
 
   it('should close modal on cancel', () => {
-    cy.visit('/main-view/assets/table/test-project/analytics/claims-data');
+    cy.visit('/ai-hub/data/browse/assets/table/test-project/analytics/claims-data');
     cy.wait('@getTable');
 
     cy.findByTestId('asset-actions-toggle').click();
@@ -296,7 +296,7 @@ describe('Edit Volume Asset', () => {
   });
 
   it('should open edit modal for volume with pre-populated fields', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-docs');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-docs');
     cy.wait('@getVolume');
 
     cy.findByTestId('asset-actions-toggle').click();
@@ -312,7 +312,7 @@ describe('Edit Volume Asset', () => {
   });
 
   it('should edit volume and save', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-docs');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-docs');
     cy.wait('@getVolume');
 
     cy.intercept('PUT', `${REGISTRY_API}/test-project/namespaces/default/volumes/training-docs`, {
@@ -336,7 +336,7 @@ describe('Edit Volume Asset', () => {
   });
 
   it('should preserve the raw content type when only the description changes', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-docs');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-docs');
     cy.wait('@getVolume');
 
     cy.intercept('PUT', `${REGISTRY_API}/test-project/namespaces/default/volumes/training-docs`, {
@@ -358,7 +358,7 @@ describe('Edit Volume Asset', () => {
   });
 
   it('should clear the purpose when it is removed', () => {
-    cy.visit('/main-view/assets/volume/test-project/default/training-docs');
+    cy.visit('/ai-hub/data/browse/assets/volume/test-project/default/training-docs');
     cy.wait('@getVolume');
 
     cy.intercept('PUT', `${REGISTRY_API}/test-project/namespaces/default/volumes/training-docs`, {

--- a/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
+++ b/packages/data-registry/frontend/src/__tests__/cypress/cypress/tests/mocked/registry/registryTable.cy.ts
@@ -111,7 +111,7 @@ const initIntercepts = (options = {}) => {
 };
 
 const visitWithData = () => {
-  cy.visit('/main-view?project=test-project');
+  cy.visit('/ai-hub/data/browse?project=test-project');
   cy.findByTestId('registry-table', { timeout: 15000 }).should('exist');
 };
 
@@ -128,7 +128,7 @@ describe('Registry Table', () => {
   });
 
   it('should show empty state when no project selected', () => {
-    cy.visit('/main-view');
+    cy.visit('/ai-hub/data/browse');
     cy.contains('Select a project').should('exist');
   });
 
@@ -189,7 +189,7 @@ describe('Registry Table', () => {
     cy.findByTestId('asset-edit-table-analytics-claims-data').click();
     cy.url().should(
       'include',
-      '/main-view/assets/table/test-project/analytics/claims-data?edit=true',
+      '/ai-hub/data/browse/assets/table/test-project/analytics/claims-data?edit=true',
     );
     cy.wait('@getTable');
     cy.findByTestId('edit-asset-modal').should('exist');

--- a/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
@@ -41,9 +41,8 @@ const renderTable = (props?: Partial<React.ComponentProps<typeof RegistryTable>>
         onManageCollections={jest.fn()}
         onManageLabels={jest.fn()}
         onRegisterData={jest.fn()}
-        onRefresh={jest.fn()}
-        {...props}
         onRetry={jest.fn()}
+        {...props}
       />
     </MemoryRouter>,
   );
@@ -76,7 +75,6 @@ describe('RegistryTable', () => {
   it('should show error state', () => {
     renderTable({ error: new Error('Failed to load'), loaded: true });
     expect(screen.getByText('Error loading assets')).toBeTruthy();
-    expect(screen.getByText('Failed to load')).toBeTruthy();
   });
 
   it('should show empty state when no assets', () => {

--- a/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
+++ b/packages/data-registry/frontend/src/__tests__/unit/components/RegistryTable.spec.tsx
@@ -43,6 +43,7 @@ const renderTable = (props?: Partial<React.ComponentProps<typeof RegistryTable>>
         onRegisterData={jest.fn()}
         onRefresh={jest.fn()}
         {...props}
+        onRetry={jest.fn()}
       />
     </MemoryRouter>,
   );

--- a/packages/data-registry/frontend/src/app/AppRoutes.tsx
+++ b/packages/data-registry/frontend/src/app/AppRoutes.tsx
@@ -5,8 +5,8 @@ import MainPage from './pages/MainPage';
 
 const AppRoutes: React.FC = () => (
   <Routes>
-    <Route path="/" element={<Navigate to="/main-view" replace />} />
-    <Route path="/main-view/*" element={<MainPage />} />
+    <Route path="/" element={<Navigate to="/ai-hub/data/browse" replace />} />
+    <Route path="/ai-hub/data/browse/*" element={<MainPage />} />
     <Route path="*" element={<NotFound />} />
   </Routes>
 );

--- a/packages/data-registry/frontend/src/app/api/__tests__/dataRegistry.spec.ts
+++ b/packages/data-registry/frontend/src/app/api/__tests__/dataRegistry.spec.ts
@@ -1,6 +1,6 @@
-import { ApiError, is503Error, is403Error, isConnectionError } from '../dataRegistry';
+import { ApiError, is503Error, is403Error, isConnectionError } from '~/app/api/dataRegistry';
 
-describe('dataRegistry error guards', () => {
+describe('Error type guards', () => {
   describe('is503Error', () => {
     it('should return true for 503 ApiError', () => {
       const error = new ApiError(503, 'Service Unavailable');
@@ -13,14 +13,8 @@ describe('dataRegistry error guards', () => {
     });
 
     it('should return false for non-ApiError', () => {
-      const error = new Error('Generic error');
+      const error = new Error('Network error');
       expect(is503Error(error)).toBe(false);
-    });
-
-    it('should return false for non-Error values', () => {
-      expect(is503Error(null)).toBe(false);
-      expect(is503Error(undefined)).toBe(false);
-      expect(is503Error('error')).toBe(false);
     });
   });
 
@@ -31,19 +25,19 @@ describe('dataRegistry error guards', () => {
     });
 
     it('should return false for non-403 ApiError', () => {
-      const error = new ApiError(500, 'Internal Server Error');
+      const error = new ApiError(404, 'Not Found');
       expect(is403Error(error)).toBe(false);
     });
 
     it('should return false for non-ApiError', () => {
-      const error = new Error('Generic error');
+      const error = new Error('Network error');
       expect(is403Error(error)).toBe(false);
     });
   });
 
   describe('isConnectionError', () => {
     it('should return true for NetworkError', () => {
-      const error = new Error('NetworkError: Connection failed');
+      const error = new Error('NetworkError when attempting to fetch resource');
       expect(isConnectionError(error)).toBe(true);
     });
 
@@ -52,22 +46,23 @@ describe('dataRegistry error guards', () => {
       expect(isConnectionError(error)).toBe(true);
     });
 
-    it('should return true for network error (case-insensitive)', () => {
-      const error = new Error('Network error occurred');
+    it('should return true for network in lowercase', () => {
+      const error = new Error('network connection lost');
       expect(isConnectionError(error)).toBe(true);
     });
 
-    it('should return false for non-connection errors', () => {
-      const error = new Error('Validation failed');
+    it('should return false for ApiError with network message', () => {
+      const error = new ApiError(500, 'network failure');
       expect(isConnectionError(error)).toBe(false);
     });
 
-    it('should return false for ApiError', () => {
-      const error = new ApiError(500, 'Internal Server Error');
+    it('should return false for non-network error', () => {
+      const error = new Error('Something went wrong');
       expect(isConnectionError(error)).toBe(false);
     });
 
-    it('should return false for non-Error values', () => {
+    it('should return false for non-Error', () => {
+      expect(isConnectionError('not an error')).toBe(false);
       expect(isConnectionError(null)).toBe(false);
       expect(isConnectionError(undefined)).toBe(false);
     });

--- a/packages/data-registry/frontend/src/app/api/__tests__/dataRegistry.spec.ts
+++ b/packages/data-registry/frontend/src/app/api/__tests__/dataRegistry.spec.ts
@@ -1,0 +1,75 @@
+import { ApiError, is503Error, is403Error, isConnectionError } from '../dataRegistry';
+
+describe('dataRegistry error guards', () => {
+  describe('is503Error', () => {
+    it('should return true for 503 ApiError', () => {
+      const error = new ApiError(503, 'Service Unavailable');
+      expect(is503Error(error)).toBe(true);
+    });
+
+    it('should return false for non-503 ApiError', () => {
+      const error = new ApiError(404, 'Not Found');
+      expect(is503Error(error)).toBe(false);
+    });
+
+    it('should return false for non-ApiError', () => {
+      const error = new Error('Generic error');
+      expect(is503Error(error)).toBe(false);
+    });
+
+    it('should return false for non-Error values', () => {
+      expect(is503Error(null)).toBe(false);
+      expect(is503Error(undefined)).toBe(false);
+      expect(is503Error('error')).toBe(false);
+    });
+  });
+
+  describe('is403Error', () => {
+    it('should return true for 403 ApiError', () => {
+      const error = new ApiError(403, 'Forbidden');
+      expect(is403Error(error)).toBe(true);
+    });
+
+    it('should return false for non-403 ApiError', () => {
+      const error = new ApiError(500, 'Internal Server Error');
+      expect(is403Error(error)).toBe(false);
+    });
+
+    it('should return false for non-ApiError', () => {
+      const error = new Error('Generic error');
+      expect(is403Error(error)).toBe(false);
+    });
+  });
+
+  describe('isConnectionError', () => {
+    it('should return true for NetworkError', () => {
+      const error = new Error('NetworkError: Connection failed');
+      expect(isConnectionError(error)).toBe(true);
+    });
+
+    it('should return true for Failed to fetch', () => {
+      const error = new Error('Failed to fetch');
+      expect(isConnectionError(error)).toBe(true);
+    });
+
+    it('should return true for network error (case-insensitive)', () => {
+      const error = new Error('Network error occurred');
+      expect(isConnectionError(error)).toBe(true);
+    });
+
+    it('should return false for non-connection errors', () => {
+      const error = new Error('Validation failed');
+      expect(isConnectionError(error)).toBe(false);
+    });
+
+    it('should return false for ApiError', () => {
+      const error = new ApiError(500, 'Internal Server Error');
+      expect(isConnectionError(error)).toBe(false);
+    });
+
+    it('should return false for non-Error values', () => {
+      expect(isConnectionError(null)).toBe(false);
+      expect(isConnectionError(undefined)).toBe(false);
+    });
+  });
+});

--- a/packages/data-registry/frontend/src/app/api/dataRegistry.ts
+++ b/packages/data-registry/frontend/src/app/api/dataRegistry.ts
@@ -281,6 +281,7 @@ export const is403Error = (error: unknown): boolean =>
   error instanceof ApiError && error.status === 403;
 
 export const isConnectionError = (error: unknown): boolean =>
+  !(error instanceof ApiError) &&
   error instanceof Error &&
   (error.message.includes('NetworkError') ||
     error.message.includes('Failed to fetch') ||

--- a/packages/data-registry/frontend/src/app/api/dataRegistry.ts
+++ b/packages/data-registry/frontend/src/app/api/dataRegistry.ts
@@ -271,3 +271,17 @@ export const createLabel = async (
 export const deleteLabel = async (project: string, label: string): Promise<void> => {
   await fetchRequest(registryUrl(`/${project}/labels/${encodeURIComponent(label)}`), 'DELETE');
 };
+
+// Error type guards
+
+export const is503Error = (error: unknown): boolean =>
+  error instanceof ApiError && error.status === 503;
+
+export const is403Error = (error: unknown): boolean =>
+  error instanceof ApiError && error.status === 403;
+
+export const isConnectionError = (error: unknown): boolean =>
+  error instanceof Error &&
+  (error.message.includes('NetworkError') ||
+    error.message.includes('Failed to fetch') ||
+    error.message.toLowerCase().includes('network'));

--- a/packages/data-registry/frontend/src/app/components/ApplicationsPage.tsx
+++ b/packages/data-registry/frontend/src/app/components/ApplicationsPage.tsx
@@ -12,6 +12,10 @@ import {
   Stack,
   Flex,
 } from '@patternfly/react-core';
+import { is503Error, is403Error, isConnectionError } from '~/app/api/dataRegistry';
+import ServiceUnavailableError from './errors/ServiceUnavailableError';
+import AccessDeniedError from './errors/AccessDeniedError';
+import ConnectionError from './errors/ConnectionError';
 
 type ApplicationsPageProps = {
   title?: React.ReactNode;
@@ -31,6 +35,7 @@ type ApplicationsPageProps = {
   subtext?: React.ReactNode;
   loadingContent?: React.ReactNode;
   noHeader?: boolean;
+  onRetry?: () => void;
 };
 
 const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
@@ -51,6 +56,7 @@ const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
   subtext,
   loadingContent,
   noHeader,
+  onRetry,
 }) => {
   const renderHeader = () => (
     <PageSection hasBodyWrapper={false}>
@@ -79,6 +85,27 @@ const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
 
   const renderContents = () => {
     if (loadError) {
+      if (is503Error(loadError)) {
+        return (
+          <PageSection hasBodyWrapper={false} isFilled>
+            <ServiceUnavailableError onRetry={onRetry} error={loadError} />
+          </PageSection>
+        );
+      }
+      if (is403Error(loadError)) {
+        return (
+          <PageSection hasBodyWrapper={false} isFilled>
+            <AccessDeniedError error={loadError} />
+          </PageSection>
+        );
+      }
+      if (isConnectionError(loadError)) {
+        return (
+          <PageSection hasBodyWrapper={false} isFilled>
+            <ConnectionError onRetry={onRetry} error={loadError} />
+          </PageSection>
+        );
+      }
       return (
         <PageSection hasBodyWrapper={false} isFilled>
           <EmptyState

--- a/packages/data-registry/frontend/src/app/components/ApplicationsPage.tsx
+++ b/packages/data-registry/frontend/src/app/components/ApplicationsPage.tsx
@@ -88,21 +88,21 @@ const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
       if (is503Error(loadError)) {
         return (
           <PageSection hasBodyWrapper={false} isFilled>
-            <ServiceUnavailableError onRetry={onRetry} error={loadError} />
+            <ServiceUnavailableError onRetry={onRetry} />
           </PageSection>
         );
       }
       if (is403Error(loadError)) {
         return (
           <PageSection hasBodyWrapper={false} isFilled>
-            <AccessDeniedError error={loadError} />
+            <AccessDeniedError />
           </PageSection>
         );
       }
       if (isConnectionError(loadError)) {
         return (
           <PageSection hasBodyWrapper={false} isFilled>
-            <ConnectionError onRetry={onRetry} error={loadError} />
+            <ConnectionError onRetry={onRetry} />
           </PageSection>
         );
       }

--- a/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
@@ -34,6 +34,10 @@ import { useNotification } from '~/app/hooks/useNotification';
 import { assetDetailUrl } from '~/app/utilities/routes';
 import { getFormatBadge, isStructured, FORMAT_OPTIONS } from '~/app/utilities/formatUtils';
 import DeleteAssetModal from './DeleteAssetModal';
+import { is503Error, is403Error, isConnectionError } from '~/app/api/dataRegistry';
+import ServiceUnavailableError from '~/app/components/errors/ServiceUnavailableError';
+import AccessDeniedError from '~/app/components/errors/AccessDeniedError';
+import ConnectionError from '~/app/components/errors/ConnectionError';
 
 type RegistryTableProps = {
   assets: RegistryAsset[];
@@ -44,7 +48,8 @@ type RegistryTableProps = {
   onManageCollections: () => void;
   onManageLabels: () => void;
   onRegisterData: () => void;
-  onRefresh: () => void;
+  onRetry: () => void;
+  hasWriteAccess?: boolean;
 };
 
 type FilterCategory = 'labels' | 'assetType' | 'format';
@@ -64,7 +69,8 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
   onManageCollections,
   onManageLabels,
   onRegisterData,
-  onRefresh,
+  onRetry,
+  hasWriteAccess = true,
 }) => {
   const navigate = useNavigate();
   const notification = useNotification();
@@ -169,9 +175,9 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
       }
       notification.success('Asset deleted', `${asset.name} was deleted successfully.`);
       setDeleteAsset(null);
-      onRefresh();
+      onRetry();
     },
-    [notification, onRefresh, project],
+    [notification, onRetry, project],
   );
 
   // Value dropdown content based on category
@@ -287,6 +293,27 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
   };
 
   if (error) {
+    if (is503Error(error)) {
+      return (
+        <PageSection hasBodyWrapper={false} isFilled>
+          <ServiceUnavailableError onRetry={onRetry} />
+        </PageSection>
+      );
+    }
+    if (is403Error(error)) {
+      return (
+        <PageSection hasBodyWrapper={false} isFilled>
+          <AccessDeniedError resource="this project" />
+        </PageSection>
+      );
+    }
+    if (isConnectionError(error)) {
+      return (
+        <PageSection hasBodyWrapper={false} isFilled>
+          <ConnectionError onRetry={onRetry} />
+        </PageSection>
+      );
+    }
     return (
       <PageSection hasBodyWrapper={false} isFilled>
         <EmptyState
@@ -374,7 +401,12 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
             </ToolbarItem>
             {/* Register data button */}
             <ToolbarItem>
-              <Button variant="primary" onClick={onRegisterData} data-testid="register-data-button">
+              <Button
+                variant="primary"
+                onClick={onRegisterData}
+                isDisabled={!hasWriteAccess}
+                data-testid="register-data-button"
+              >
                 Register data
               </Button>
             </ToolbarItem>
@@ -401,6 +433,7 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
                   <DropdownItem
                     key="manage-collections"
                     onClick={onManageCollections}
+                    isDisabled={!hasWriteAccess}
                     data-testid="manage-collections-action"
                   >
                     Manage collections
@@ -408,6 +441,7 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
                   <DropdownItem
                     key="manage-labels"
                     onClick={onManageLabels}
+                    isDisabled={!hasWriteAccess}
                     data-testid="manage-labels-action"
                   >
                     Manage labels

--- a/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
@@ -29,15 +29,20 @@ import { FilterIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, Tbody, Td, ThProps } from '@patternfly/react-table';
 import { Link, useNavigate } from 'react-router-dom';
 import { RegistryAsset } from '~/app/hooks/useAssets';
-import { deleteGenericTable, deleteVolume } from '~/app/api/dataRegistry';
+import {
+  deleteGenericTable,
+  deleteVolume,
+  is503Error,
+  is403Error,
+  isConnectionError,
+} from '~/app/api/dataRegistry';
 import { useNotification } from '~/app/hooks/useNotification';
 import { assetDetailUrl } from '~/app/utilities/routes';
 import { getFormatBadge, isStructured, FORMAT_OPTIONS } from '~/app/utilities/formatUtils';
-import DeleteAssetModal from './DeleteAssetModal';
-import { is503Error, is403Error, isConnectionError } from '~/app/api/dataRegistry';
-import ServiceUnavailableError from '~/app/components/errors/ServiceUnavailableError';
 import AccessDeniedError from '~/app/components/errors/AccessDeniedError';
 import ConnectionError from '~/app/components/errors/ConnectionError';
+import ServiceUnavailableError from '~/app/components/errors/ServiceUnavailableError';
+import DeleteAssetModal from './DeleteAssetModal';
 
 type RegistryTableProps = {
   assets: RegistryAsset[];
@@ -296,21 +301,21 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
     if (is503Error(error)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <ServiceUnavailableError onRetry={onRetry} error={error} />
+          <ServiceUnavailableError onRetry={onRetry} />
         </PageSection>
       );
     }
     if (is403Error(error)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <AccessDeniedError error={error} />
+          <AccessDeniedError resourceName="this project" />
         </PageSection>
       );
     }
     if (isConnectionError(error)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <ConnectionError onRetry={onRetry} error={error} />
+          <ConnectionError onRetry={onRetry} />
         </PageSection>
       );
     }

--- a/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
@@ -303,7 +303,7 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
     if (is403Error(error)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <AccessDeniedError resource="this project" />
+          <AccessDeniedError />
         </PageSection>
       );
     }

--- a/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
+++ b/packages/data-registry/frontend/src/app/components/RegistryTable.tsx
@@ -296,21 +296,21 @@ const RegistryTable: React.FC<RegistryTableProps> = ({
     if (is503Error(error)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <ServiceUnavailableError onRetry={onRetry} />
+          <ServiceUnavailableError onRetry={onRetry} error={error} />
         </PageSection>
       );
     }
     if (is403Error(error)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <AccessDeniedError />
+          <AccessDeniedError error={error} />
         </PageSection>
       );
     }
     if (isConnectionError(error)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <ConnectionError onRetry={onRetry} />
+          <ConnectionError onRetry={onRetry} error={error} />
         </PageSection>
       );
     }

--- a/packages/data-registry/frontend/src/app/components/errors/AccessDeniedError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/AccessDeniedError.tsx
@@ -3,10 +3,12 @@ import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react
 import { LockIcon } from '@patternfly/react-icons';
 
 type AccessDeniedErrorProps = {
-  resource: string;
+  resourceName?: string;
 };
 
-const AccessDeniedError: React.FC<AccessDeniedErrorProps> = ({ resource }) => (
+const AccessDeniedError: React.FC<AccessDeniedErrorProps> = ({
+  resourceName = 'this project in Data Registry',
+}) => (
   <EmptyState
     headingLevel="h2"
     titleText="Access denied"
@@ -14,9 +16,7 @@ const AccessDeniedError: React.FC<AccessDeniedErrorProps> = ({ resource }) => (
     icon={LockIcon}
     status="danger"
   >
-    <EmptyStateBody>
-      You do not have access to {resource}. Contact your administrator to request permissions.
-    </EmptyStateBody>
+    <EmptyStateBody>You do not have access to {resourceName}.</EmptyStateBody>
   </EmptyState>
 );
 

--- a/packages/data-registry/frontend/src/app/components/errors/AccessDeniedError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/AccessDeniedError.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
+import { LockIcon } from '@patternfly/react-icons';
+
+type AccessDeniedErrorProps = {
+  resource: string;
+};
+
+const AccessDeniedError: React.FC<AccessDeniedErrorProps> = ({ resource }) => (
+  <EmptyState
+    headingLevel="h2"
+    titleText="Access denied"
+    variant={EmptyStateVariant.lg}
+    icon={LockIcon}
+    status="danger"
+  >
+    <EmptyStateBody>
+      You do not have access to {resource}. Contact your administrator to request permissions.
+    </EmptyStateBody>
+  </EmptyState>
+);
+
+export default AccessDeniedError;

--- a/packages/data-registry/frontend/src/app/components/errors/AccessDeniedError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/AccessDeniedError.tsx
@@ -4,10 +4,12 @@ import { LockIcon } from '@patternfly/react-icons';
 
 type AccessDeniedErrorProps = {
   resourceName?: string;
+  error?: Error;
 };
 
 const AccessDeniedError: React.FC<AccessDeniedErrorProps> = ({
   resourceName = 'this project in Data Registry',
+  error,
 }) => (
   <EmptyState
     headingLevel="h2"
@@ -16,7 +18,16 @@ const AccessDeniedError: React.FC<AccessDeniedErrorProps> = ({
     icon={LockIcon}
     status="danger"
   >
-    <EmptyStateBody>You do not have access to {resourceName}.</EmptyStateBody>
+    <EmptyStateBody>
+      You do not have access to {resourceName}.
+      {error ? (
+        <>
+          <br />
+          <br />
+          {error.message}
+        </>
+      ) : null}
+    </EmptyStateBody>
   </EmptyState>
 );
 

--- a/packages/data-registry/frontend/src/app/components/errors/AccessDeniedError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/AccessDeniedError.tsx
@@ -4,12 +4,10 @@ import { LockIcon } from '@patternfly/react-icons';
 
 type AccessDeniedErrorProps = {
   resourceName?: string;
-  error?: Error;
 };
 
 const AccessDeniedError: React.FC<AccessDeniedErrorProps> = ({
   resourceName = 'this project in Data Registry',
-  error,
 }) => (
   <EmptyState
     headingLevel="h2"
@@ -18,16 +16,7 @@ const AccessDeniedError: React.FC<AccessDeniedErrorProps> = ({
     icon={LockIcon}
     status="danger"
   >
-    <EmptyStateBody>
-      You do not have access to {resourceName}.
-      {error ? (
-        <>
-          <br />
-          <br />
-          {error.message}
-        </>
-      ) : null}
-    </EmptyStateBody>
+    <EmptyStateBody>You do not have the required access to {resourceName}.</EmptyStateBody>
   </EmptyState>
 );
 

--- a/packages/data-registry/frontend/src/app/components/errors/ConnectionError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/ConnectionError.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  EmptyStateActions,
+  EmptyStateFooter,
+  Button,
+} from '@patternfly/react-core';
+import { DisconnectedIcon } from '@patternfly/react-icons';
+
+type ConnectionErrorProps = {
+  onRetry: () => void;
+};
+
+const ConnectionError: React.FC<ConnectionErrorProps> = ({ onRetry }) => (
+  <EmptyState
+    headingLevel="h2"
+    titleText="Connection failed"
+    variant={EmptyStateVariant.lg}
+    icon={DisconnectedIcon}
+    status="danger"
+  >
+    <EmptyStateBody>
+      Unable to connect to the Data Registry service. Check your network connection and try again.
+    </EmptyStateBody>
+    <EmptyStateFooter>
+      <EmptyStateActions>
+        <Button variant="primary" onClick={onRetry} data-testid="retry-button">
+          Retry
+        </Button>
+      </EmptyStateActions>
+    </EmptyStateFooter>
+  </EmptyState>
+);
+
+export default ConnectionError;

--- a/packages/data-registry/frontend/src/app/components/errors/ConnectionError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/ConnectionError.tsx
@@ -11,9 +11,10 @@ import { DisconnectedIcon } from '@patternfly/react-icons';
 
 type ConnectionErrorProps = {
   onRetry: () => void;
+  error?: Error;
 };
 
-const ConnectionError: React.FC<ConnectionErrorProps> = ({ onRetry }) => (
+const ConnectionError: React.FC<ConnectionErrorProps> = ({ onRetry, error }) => (
   <EmptyState
     headingLevel="h2"
     titleText="Connection failed"
@@ -23,6 +24,13 @@ const ConnectionError: React.FC<ConnectionErrorProps> = ({ onRetry }) => (
   >
     <EmptyStateBody>
       Unable to connect to the Data Registry service. Check your network connection and try again.
+      {error ? (
+        <>
+          <br />
+          <br />
+          {error.message}
+        </>
+      ) : null}
     </EmptyStateBody>
     <EmptyStateFooter>
       <EmptyStateActions>

--- a/packages/data-registry/frontend/src/app/components/errors/ConnectionError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/ConnectionError.tsx
@@ -10,11 +10,10 @@ import {
 import { DisconnectedIcon } from '@patternfly/react-icons';
 
 type ConnectionErrorProps = {
-  onRetry: () => void;
-  error?: Error;
+  onRetry?: () => void;
 };
 
-const ConnectionError: React.FC<ConnectionErrorProps> = ({ onRetry, error }) => (
+const ConnectionError: React.FC<ConnectionErrorProps> = ({ onRetry }) => (
   <EmptyState
     headingLevel="h2"
     titleText="Connection failed"
@@ -24,21 +23,16 @@ const ConnectionError: React.FC<ConnectionErrorProps> = ({ onRetry, error }) => 
   >
     <EmptyStateBody>
       Unable to connect to the Data Registry service. Check your network connection and try again.
-      {error ? (
-        <>
-          <br />
-          <br />
-          {error.message}
-        </>
-      ) : null}
     </EmptyStateBody>
-    <EmptyStateFooter>
-      <EmptyStateActions>
-        <Button variant="primary" onClick={onRetry} data-testid="retry-button">
-          Retry
-        </Button>
-      </EmptyStateActions>
-    </EmptyStateFooter>
+    {onRetry ? (
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <Button variant="primary" onClick={onRetry} data-testid="retry-button">
+            Retry
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    ) : null}
   </EmptyState>
 );
 

--- a/packages/data-registry/frontend/src/app/components/errors/ServiceUnavailableError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/ServiceUnavailableError.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  EmptyStateActions,
+  EmptyStateFooter,
+  Button,
+} from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
+type ServiceUnavailableErrorProps = {
+  onRetry: () => void;
+};
+
+const ServiceUnavailableError: React.FC<ServiceUnavailableErrorProps> = ({ onRetry }) => (
+  <EmptyState
+    headingLevel="h2"
+    titleText="Data Registry service is temporarily unavailable"
+    variant={EmptyStateVariant.lg}
+    icon={ExclamationTriangleIcon}
+    status="warning"
+  >
+    <EmptyStateBody>
+      The Data Registry service is not responding. This may be temporary while the service is
+      starting up or being updated.
+    </EmptyStateBody>
+    <EmptyStateFooter>
+      <EmptyStateActions>
+        <Button variant="primary" onClick={onRetry} data-testid="retry-button">
+          Retry
+        </Button>
+      </EmptyStateActions>
+    </EmptyStateFooter>
+  </EmptyState>
+);
+
+export default ServiceUnavailableError;

--- a/packages/data-registry/frontend/src/app/components/errors/ServiceUnavailableError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/ServiceUnavailableError.tsx
@@ -11,9 +11,10 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 type ServiceUnavailableErrorProps = {
   onRetry: () => void;
+  error?: Error;
 };
 
-const ServiceUnavailableError: React.FC<ServiceUnavailableErrorProps> = ({ onRetry }) => (
+const ServiceUnavailableError: React.FC<ServiceUnavailableErrorProps> = ({ onRetry, error }) => (
   <EmptyState
     headingLevel="h2"
     titleText="Data Registry service is temporarily unavailable"
@@ -24,6 +25,13 @@ const ServiceUnavailableError: React.FC<ServiceUnavailableErrorProps> = ({ onRet
     <EmptyStateBody>
       The Data Registry service is not responding. This may be temporary while the service is
       starting up or being updated.
+      {error ? (
+        <>
+          <br />
+          <br />
+          {error.message}
+        </>
+      ) : null}
     </EmptyStateBody>
     <EmptyStateFooter>
       <EmptyStateActions>

--- a/packages/data-registry/frontend/src/app/components/errors/ServiceUnavailableError.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/ServiceUnavailableError.tsx
@@ -10,11 +10,10 @@ import {
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 type ServiceUnavailableErrorProps = {
-  onRetry: () => void;
-  error?: Error;
+  onRetry?: () => void;
 };
 
-const ServiceUnavailableError: React.FC<ServiceUnavailableErrorProps> = ({ onRetry, error }) => (
+const ServiceUnavailableError: React.FC<ServiceUnavailableErrorProps> = ({ onRetry }) => (
   <EmptyState
     headingLevel="h2"
     titleText="Data Registry service is temporarily unavailable"
@@ -25,21 +24,16 @@ const ServiceUnavailableError: React.FC<ServiceUnavailableErrorProps> = ({ onRet
     <EmptyStateBody>
       The Data Registry service is not responding. This may be temporary while the service is
       starting up or being updated.
-      {error ? (
-        <>
-          <br />
-          <br />
-          {error.message}
-        </>
-      ) : null}
     </EmptyStateBody>
-    <EmptyStateFooter>
-      <EmptyStateActions>
-        <Button variant="primary" onClick={onRetry} data-testid="retry-button">
-          Retry
-        </Button>
-      </EmptyStateActions>
-    </EmptyStateFooter>
+    {onRetry ? (
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <Button variant="primary" onClick={onRetry} data-testid="retry-button">
+            Retry
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    ) : null}
   </EmptyState>
 );
 

--- a/packages/data-registry/frontend/src/app/components/errors/__tests__/AccessDeniedError.spec.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/__tests__/AccessDeniedError.spec.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AccessDeniedError from '~/app/components/errors/AccessDeniedError';
+
+describe('AccessDeniedError', () => {
+  it('should render access denied message with resource', () => {
+    render(<AccessDeniedError resource="this project" />);
+
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+    expect(screen.getByText(/You do not have access to this project/)).toBeInTheDocument();
+  });
+
+  it('should render with custom resource name', () => {
+    render(<AccessDeniedError resource="the Data Registry" />);
+
+    expect(screen.getByText(/You do not have access to the Data Registry/)).toBeInTheDocument();
+  });
+});

--- a/packages/data-registry/frontend/src/app/components/errors/__tests__/AccessDeniedError.spec.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/__tests__/AccessDeniedError.spec.tsx
@@ -3,16 +3,20 @@ import { render, screen } from '@testing-library/react';
 import AccessDeniedError from '~/app/components/errors/AccessDeniedError';
 
 describe('AccessDeniedError', () => {
-  it('should render access denied message with resource', () => {
-    render(<AccessDeniedError resource="this project" />);
+  it('should render default error message', () => {
+    render(<AccessDeniedError />);
 
     expect(screen.getByText('Access denied')).toBeInTheDocument();
-    expect(screen.getByText(/You do not have access to this project/)).toBeInTheDocument();
+    expect(
+      screen.getByText('You do not have access to this project in Data Registry.'),
+    ).toBeInTheDocument();
   });
 
-  it('should render with custom resource name', () => {
-    render(<AccessDeniedError resource="the Data Registry" />);
+  it('should render custom resource name', () => {
+    render(<AccessDeniedError resourceName="collections" />);
 
-    expect(screen.getByText(/You do not have access to the Data Registry/)).toBeInTheDocument();
+    expect(
+      screen.getByText('You do not have access to collections in Data Registry.'),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/data-registry/frontend/src/app/components/errors/__tests__/AccessDeniedError.spec.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/__tests__/AccessDeniedError.spec.tsx
@@ -8,7 +8,7 @@ describe('AccessDeniedError', () => {
 
     expect(screen.getByText('Access denied')).toBeInTheDocument();
     expect(
-      screen.getByText('You do not have access to this project in Data Registry.'),
+      screen.getByText('You do not have the required access to this project in Data Registry.'),
     ).toBeInTheDocument();
   });
 
@@ -16,7 +16,7 @@ describe('AccessDeniedError', () => {
     render(<AccessDeniedError resourceName="collections" />);
 
     expect(
-      screen.getByText('You do not have access to collections in Data Registry.'),
+      screen.getByText('You do not have the required access to collections.'),
     ).toBeInTheDocument();
   });
 });

--- a/packages/data-registry/frontend/src/app/components/errors/__tests__/ConnectionError.spec.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/__tests__/ConnectionError.spec.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConnectionError from '~/app/components/errors/ConnectionError';
+
+describe('ConnectionError', () => {
+  it('should render connection error message', () => {
+    const onRetry = jest.fn();
+    render(<ConnectionError onRetry={onRetry} />);
+
+    expect(screen.getByText('Connection failed')).toBeInTheDocument();
+    expect(screen.getByText(/Unable to connect to the Data Registry service/)).toBeInTheDocument();
+  });
+
+  it('should call onRetry when retry button is clicked', () => {
+    const onRetry = jest.fn();
+    render(<ConnectionError onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByTestId('retry-button'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/data-registry/frontend/src/app/components/errors/__tests__/ServiceUnavailableError.spec.tsx
+++ b/packages/data-registry/frontend/src/app/components/errors/__tests__/ServiceUnavailableError.spec.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ServiceUnavailableError from '~/app/components/errors/ServiceUnavailableError';
+
+describe('ServiceUnavailableError', () => {
+  it('should render error message', () => {
+    const onRetry = jest.fn();
+    render(<ServiceUnavailableError onRetry={onRetry} />);
+
+    expect(
+      screen.getByText('Data Registry service is temporarily unavailable'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/The Data Registry service is not responding/)).toBeInTheDocument();
+  });
+
+  it('should call onRetry when retry button is clicked', () => {
+    const onRetry = jest.fn();
+    render(<ServiceUnavailableError onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByTestId('retry-button'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/data-registry/frontend/src/app/hooks/useNamespaces.ts
+++ b/packages/data-registry/frontend/src/app/hooks/useNamespaces.ts
@@ -3,12 +3,12 @@ import React from 'react';
 import { getNamespaces } from '~/app/api/k8s';
 import { NamespaceKind } from '~/app/types';
 
-export const useNamespaces = (): [NamespaceKind[], boolean, Error | undefined] => {
+export const useNamespaces = (): [NamespaceKind[], boolean, Error | undefined, () => void] => {
   const callback = React.useCallback<FetchStateCallbackPromise<NamespaceKind[]>>(
     (opts: APIOptions) => getNamespaces('')(opts),
     [],
   );
-  const [namespaces, loaded, error] = useFetchState<NamespaceKind[]>(callback, []);
+  const [namespaces, loaded, error, refresh] = useFetchState<NamespaceKind[]>(callback, []);
 
-  return [namespaces, loaded, error];
+  return [namespaces, loaded, error, refresh];
 };

--- a/packages/data-registry/frontend/src/app/pages/CollectionDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/CollectionDetailPage.tsx
@@ -195,6 +195,7 @@ const CollectionDetailPage: React.FC = () => {
       headerAction={headerAction}
       loaded={loaded}
       loadError={loadError}
+      onRetry={refresh}
       empty={loaded && !collectionDetail}
       emptyStatePage={
         <EmptyState

--- a/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
@@ -96,7 +96,7 @@ const DataRegistryPage: React.FC = () => {
     if (is403Error(namespacesError)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <AccessDeniedError resource="this project" />
+          <AccessDeniedError />
         </PageSection>
       );
     }
@@ -191,7 +191,7 @@ const DataRegistryPage: React.FC = () => {
           <RegistryTable
             assets={assets}
             loaded={assetsLoaded && collectionsLoaded}
-            error={assetsError}
+            error={assetsError ?? collectionsError}
             labels={labels}
             project={selectedProject}
             onManageCollections={() => {

--- a/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
@@ -89,21 +89,21 @@ const DataRegistryPage: React.FC = () => {
     if (is503Error(namespacesError)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <ServiceUnavailableError onRetry={namespacesRefresh} />
+          <ServiceUnavailableError onRetry={namespacesRefresh} error={namespacesError} />
         </PageSection>
       );
     }
     if (is403Error(namespacesError)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <AccessDeniedError />
+          <AccessDeniedError error={namespacesError} />
         </PageSection>
       );
     }
     if (isConnectionError(namespacesError)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <ConnectionError onRetry={namespacesRefresh} />
+          <ConnectionError onRetry={namespacesRefresh} error={namespacesError} />
         </PageSection>
       );
     }

--- a/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
@@ -19,10 +19,14 @@ import { useNamespaces } from '~/app/hooks/useNamespaces';
 import { useCollections } from '~/app/hooks/useCollections';
 import { useAssets } from '~/app/hooks/useAssets';
 import { useLabels } from '~/app/hooks/useLabels';
+import { is503Error, is403Error, isConnectionError } from '~/app/api/dataRegistry';
 import RegistryTable from '~/app/components/RegistryTable';
 import ManageCollectionsModal from '~/app/components/ManageCollectionsModal';
 import ManageLabelsModal from '~/app/components/ManageLabelsModal';
 import RegisterDataModal from '~/app/components/RegisterDataModal';
+import ServiceUnavailableError from '~/app/components/errors/ServiceUnavailableError';
+import AccessDeniedError from '~/app/components/errors/AccessDeniedError';
+import ConnectionError from '~/app/components/errors/ConnectionError';
 
 // TODO: Replace with isAvailableProject from @odh-dashboard/k8s-core when BFF returns filtered projects
 const HIDDEN_NS_PREFIXES = ['openshift-', 'kube-'];
@@ -36,7 +40,7 @@ const DataRegistryPage: React.FC = () => {
   const [isLabelsModalOpen, setIsLabelsModalOpen] = React.useState(false);
   const [isRegisterModalOpen, setIsRegisterModalOpen] = React.useState(false);
 
-  const [namespaces, namespacesLoaded, namespacesError] = useNamespaces();
+  const [namespaces, namespacesLoaded, namespacesError, namespacesRefresh] = useNamespaces();
 
   const projects = React.useMemo(
     () =>
@@ -59,6 +63,8 @@ const DataRegistryPage: React.FC = () => {
   );
   const [labels, , , labelsRefresh] = useLabels(selectedProject);
 
+  const hasWriteAccess = !is403Error(assetsError) && !is403Error(collectionsError);
+
   const handleRefresh = React.useCallback(() => {
     assetsRefresh();
     collectionsRefresh();
@@ -80,6 +86,27 @@ const DataRegistryPage: React.FC = () => {
   );
 
   if (namespacesError) {
+    if (is503Error(namespacesError)) {
+      return (
+        <PageSection hasBodyWrapper={false} isFilled>
+          <ServiceUnavailableError onRetry={namespacesRefresh} />
+        </PageSection>
+      );
+    }
+    if (is403Error(namespacesError)) {
+      return (
+        <PageSection hasBodyWrapper={false} isFilled>
+          <AccessDeniedError resource="this project" />
+        </PageSection>
+      );
+    }
+    if (isConnectionError(namespacesError)) {
+      return (
+        <PageSection hasBodyWrapper={false} isFilled>
+          <ConnectionError onRetry={namespacesRefresh} />
+        </PageSection>
+      );
+    }
     return (
       <PageSection hasBodyWrapper={false} isFilled>
         <EmptyState
@@ -174,7 +201,8 @@ const DataRegistryPage: React.FC = () => {
             }}
             onManageLabels={() => setIsLabelsModalOpen(true)}
             onRegisterData={() => setIsRegisterModalOpen(true)}
-            onRefresh={handleRefresh}
+            onRetry={handleRefresh}
+            hasWriteAccess={hasWriteAccess}
           />
           <ManageCollectionsModal
             isOpen={isCollectionsModalOpen}

--- a/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/DataRegistryPage.tsx
@@ -89,21 +89,21 @@ const DataRegistryPage: React.FC = () => {
     if (is503Error(namespacesError)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <ServiceUnavailableError onRetry={namespacesRefresh} error={namespacesError} />
+          <ServiceUnavailableError onRetry={namespacesRefresh} />
         </PageSection>
       );
     }
     if (is403Error(namespacesError)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <AccessDeniedError error={namespacesError} />
+          <AccessDeniedError />
         </PageSection>
       );
     }
     if (isConnectionError(namespacesError)) {
       return (
         <PageSection hasBodyWrapper={false} isFilled>
-          <ConnectionError onRetry={namespacesRefresh} error={namespacesError} />
+          <ConnectionError onRetry={namespacesRefresh} />
         </PageSection>
       );
     }

--- a/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
+++ b/packages/data-registry/frontend/src/app/pages/TableDetailPage.tsx
@@ -218,6 +218,14 @@ const TableDetailPage: React.FC = () => {
     </Flex>
   );
 
+  const refresh = React.useCallback(() => {
+    if (isVolume) {
+      refreshVolume();
+    } else {
+      refreshGenericTable();
+    }
+  }, [isVolume, refreshGenericTable, refreshVolume]);
+
   return (
     <ApplicationsPage
       title={title}
@@ -225,6 +233,7 @@ const TableDetailPage: React.FC = () => {
       headerAction={headerAction}
       loaded={loaded}
       loadError={loadError}
+      onRetry={refresh}
       empty={loaded && !asset}
       emptyStatePage={
         <EmptyState


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHAI-430

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Added:
- 503 error shows user-friendly message with retry
- 403 error disables write actions and shows access denied
- Data Hub nav hidden when BFF module not loaded
- Loading states shown during data fetching

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally against cluster
- cypress and unit tests added

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

- cypress and unit tests added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Data Registry now shows clearer messages for service outages, access restrictions, and connection failures.
  - Retry actions are available for temporary service and connection failures.
  - Write actions are disabled when the user lacks the required permissions.
  - Successful retries restore registry data without leaving the page.
  - Data Registry and asset routes now use the updated `/ai-hub/data/browse` paths.
  - Retry actions are also available when loading collection and asset details fails.

- **Tests**
  - Expanded coverage for error messages, retry behavior, access restrictions, and disabled actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->