### PR TITLE
Show connected nim pvcs

### DIFF
--- a/frontend/src/pages/projects/screens/detail/connections/ConnectedResources.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectedResources.tsx
@@ -18,7 +18,7 @@ const CONNECTED_RESOURCE_LABEL_STYLES: Record<
   ConnectedResourceLabel['kind'],
   Pick<React.ComponentProps<typeof ResourceLabel>, 'resourceType' | 'outlineColor'>
 > = {
-  'deployed-model': { resourceType: ProjectObjectType.deployedModels, outlineColor: 'purple' },
+  'connected-models': { resourceType: ProjectObjectType.connectedModels, outlineColor: 'purple' },
 };
 
 export type ConnectedResourcesProps = EitherNotBoth<

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectedResources.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectedResources.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { LabelGroup, Spinner } from '@patternfly/react-core';
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import type { EitherNotBoth } from '@odh-dashboard/foundation';
+import type { ConnectedResourceLabel } from '@odh-dashboard/plugin-core/extension-points';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import {
   useRelatedNotebooks,
@@ -12,12 +13,28 @@ import { ProjectObjectType } from '#~/concepts/design/utils';
 import ResourceLabel from '#~/pages/projects/screens/detail/connections/ResourceLabel';
 import { useInferenceServicesForConnection } from '#~/pages/projects/useInferenceServicesForConnection';
 
+// Host owns how each contributed resource kind renders (icon + color); extensions only pick a kind.
+const CONNECTED_RESOURCE_LABEL_STYLES: Record<
+  ConnectedResourceLabel['kind'],
+  Pick<React.ComponentProps<typeof ResourceLabel>, 'resourceType' | 'outlineColor'>
+> = {
+  'deployed-model': { resourceType: ProjectObjectType.deployedModels, outlineColor: 'purple' },
+};
+
 export type ConnectedResourcesProps = EitherNotBoth<
   { connection: Connection },
   { pvc: PersistentVolumeClaimKind }
->;
+> & {
+  additionalResources?: ConnectedResourceLabel[];
+  additionalResourcesLoaded?: boolean;
+};
 
-const ConnectedResources: React.FC<ConnectedResourcesProps> = ({ connection, pvc }) => {
+const ConnectedResources: React.FC<ConnectedResourcesProps> = ({
+  connection,
+  pvc,
+  additionalResources = [],
+  additionalResourcesLoaded = true,
+}) => {
   const { notebooks: connectedNotebooks, loaded: notebooksLoaded } = useRelatedNotebooks(
     connection
       ? ConnectedNotebookContext.EXISTING_DATA_CONNECTION
@@ -26,11 +43,11 @@ const ConnectedResources: React.FC<ConnectedResourcesProps> = ({ connection, pvc
   );
   const connectedModels = useInferenceServicesForConnection(connection ?? pvc);
 
-  if (!notebooksLoaded) {
+  if (!notebooksLoaded || !additionalResourcesLoaded) {
     return <Spinner size="sm" />;
   }
 
-  if (!connectedNotebooks.length && !connectedModels.length) {
+  if (!connectedNotebooks.length && !connectedModels.length && !additionalResources.length) {
     return '--';
   }
 
@@ -54,10 +71,16 @@ const ConnectedResources: React.FC<ConnectedResourcesProps> = ({ connection, pvc
       />
     ));
 
+  const renderAdditionalResourceLabels = () =>
+    additionalResources.map(({ key, title, kind }) => (
+      <ResourceLabel key={key} title={title} {...CONNECTED_RESOURCE_LABEL_STYLES[kind]} />
+    ));
+
   return (
     <LabelGroup>
       {renderNotebookLabels()}
       {renderModelLabels()}
+      {renderAdditionalResourceLabels()}
     </LabelGroup>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
@@ -3,6 +3,7 @@ import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import { Table } from '@odh-dashboard/ui-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import DeletePVCModal from '#~/pages/projects/pvc/DeletePVCModal';
 import { getStorageClassConfig } from '#~/pages/storageClasses/utils';
 import useStorageClasses from '#~/concepts/k8s/useStorageClasses';
@@ -11,6 +12,7 @@ import { columns } from './data';
 import { StorageTableData } from './types';
 import ClusterStorageModal from './ClusterStorageModal';
 import { useStorageContextType } from './useStorageContextType';
+import { useClusterStorageConnectedResources } from './useClusterStorageConnectedResources';
 
 type StorageTableProps = {
   pvcs: PersistentVolumeClaimKind[];
@@ -41,6 +43,17 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
   const shouldShowAlert = isDeprecatedAlert && !alertDismissed && isStorageClassesAvailable;
   const workbenchEnabled = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
 
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  // Feature packages (e.g. KServe) contribute resources that may be connected to a PVC. The hook
+  // owns the extension resolution, per-hook fetching, and loaded-state short-circuits.
+  const {
+    hasExtensions: hasConnectedResourceExtensions,
+    loaded: connectedResourcesLoaded,
+    getConnectedResourceLabels,
+    hookNotifications,
+  } = useClusterStorageConnectedResources(currentProject);
+  const showConnectedResources = workbenchEnabled || hasConnectedResourceExtensions;
+
   const getStorageColumns = () => {
     let storageColumns = columns({ storageContextTypes });
 
@@ -48,7 +61,7 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
       storageColumns = storageColumns.filter((column) => column.field !== 'storage');
     }
 
-    if (!workbenchEnabled) {
+    if (!showConnectedResources) {
       storageColumns = storageColumns.filter((column) => column.field !== 'connected');
     }
 
@@ -57,6 +70,7 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
 
   return (
     <>
+      {hookNotifications}
       {shouldShowAlert && (
         <Alert
           data-testid="storage-class-deprecated-alert"
@@ -88,6 +102,9 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
             storageContextTypes={storageContextTypes}
             storageContextTypesLoaded={storageContextTypesLoaded}
             storageClassesLoaded={storageClassesLoaded}
+            showConnectedResources={showConnectedResources}
+            additionalResourcesLoaded={connectedResourcesLoaded}
+            getConnectedResourceLabels={getConnectedResourceLabels}
             onEditPVC={setEditPVC}
             onDeletePVC={setDeleteStorage}
             onAddPVC={onAddPVC}

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -12,6 +12,7 @@ import {
 import { ExclamationTriangleIcon, HddIcon } from '@patternfly/react-icons';
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import type { ConnectedResourceLabel } from '@odh-dashboard/plugin-core/extension-points';
 import {
   getDescriptionFromK8sResource,
   getDisplayNameFromK8sResource,
@@ -33,6 +34,9 @@ type StorageTableRowProps = {
   storageContextTypes?: StorageContextType[];
   storageContextTypesLoaded: boolean;
   storageClassesLoaded: boolean;
+  showConnectedResources: boolean;
+  additionalResourcesLoaded: boolean;
+  getConnectedResourceLabels: (pvc: PersistentVolumeClaimKind) => ConnectedResourceLabel[];
   onDeletePVC: (pvc: PersistentVolumeClaimKind) => void;
   onEditPVC: (pvc: PersistentVolumeClaimKind) => void;
   onAddPVC: () => void;
@@ -44,13 +48,15 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
   storageContextTypes,
   storageContextTypesLoaded,
   storageClassesLoaded,
+  showConnectedResources,
+  additionalResourcesLoaded,
+  getConnectedResourceLabels,
   onDeletePVC,
   onEditPVC,
   onAddPVC,
 }) => {
   const isRootVolume = useIsRootVolume(obj.pvc);
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
-  const workbenchEnabled = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
   const storageClassConfig = obj.storageClass && getStorageClassConfig(obj.storageClass);
   const actions: IAction[] = [
     {
@@ -170,9 +176,13 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
       <Td dataLabel="Storage size">
         <StorageSizeBar pvc={obj.pvc} />
       </Td>
-      {workbenchEnabled && (
+      {showConnectedResources && (
         <Td dataLabel="Connected resources">
-          <ConnectedResources pvc={obj.pvc} />
+          <ConnectedResources
+            pvc={obj.pvc}
+            additionalResources={getConnectedResourceLabels(obj.pvc)}
+            additionalResourcesLoaded={additionalResourcesLoaded}
+          />
         </Td>
       )}
       <Td isActionCell>

--- a/frontend/src/pages/projects/screens/detail/storage/__tests__/useClusterStorageConnectedResources.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/__tests__/useClusterStorageConnectedResources.spec.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+import { render, act } from '@testing-library/react';
+import type { LoadedExtension, ResolvedExtension } from '@openshift/dynamic-plugin-sdk';
+import { HookNotify, useExtensions, useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import type {
+  ClusterStorageConnectedResources,
+  ClusterStorageConnectedResourcesExtension,
+  ConnectedResourceLabel,
+} from '@odh-dashboard/plugin-core/extension-points';
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import type { PersistentVolumeClaimKind, ProjectKind } from '@odh-dashboard/k8s-core';
+import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { useClusterStorageConnectedResources } from '#~/pages/projects/screens/detail/storage/useClusterStorageConnectedResources';
+
+jest.mock('@odh-dashboard/plugin-core', () => ({
+  useExtensions: jest.fn(),
+  useResolvedExtensions: jest.fn(),
+  // Render nothing — tests drive onNotify/onUnmount directly off the captured props.
+  HookNotify: jest.fn(() => null),
+}));
+
+const mockUseExtensions = jest.mocked(useExtensions);
+const mockUseResolvedExtensions = jest.mocked(useResolvedExtensions);
+const mockHookNotify = jest.mocked(HookNotify);
+
+const project = mockProjectK8sResource({});
+const pvc = mockPVCK8sResource({});
+
+const makeExtension = (
+  uid: string,
+  getConnectedResources: (
+    pvc: PersistentVolumeClaimKind,
+    data: unknown,
+  ) => ConnectedResourceLabel[] = () => [],
+): LoadedExtension<ResolvedExtension<ClusterStorageConnectedResourcesExtension>> => ({
+  type: 'app.cluster-storage/connected-resources',
+  uid,
+  pluginName: 'test',
+  properties: {
+    useConnectedResources: jest.fn(),
+    getConnectedResources,
+  },
+});
+
+// useExtensions only needs a length, so any valid extension shape works.
+const unresolved = (count: number): LoadedExtension[] =>
+  Array.from({ length: count }, (_, i) => makeExtension(`unresolved-${i}`));
+
+describe('useClusterStorageConnectedResources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should report no extensions and be loaded when nothing is contributed', () => {
+    mockUseExtensions.mockReturnValue([]);
+    mockUseResolvedExtensions.mockReturnValue([[], true, []]);
+
+    const { result } = testHook(useClusterStorageConnectedResources)(project);
+
+    expect(result.current.hasExtensions).toBe(false);
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.getConnectedResourceLabels(pvc)).toEqual([]);
+    expect(result.current.hookNotifications).toEqual([]);
+  });
+
+  it('should not be loaded while resolution is pending', () => {
+    mockUseExtensions.mockReturnValue(unresolved(1));
+    mockUseResolvedExtensions.mockReturnValue([[], false, []]);
+
+    const { result } = testHook(useClusterStorageConnectedResources)(project);
+
+    expect(result.current.hasExtensions).toBe(true);
+    expect(result.current.loaded).toBe(false);
+  });
+
+  it('should stay unloaded until every extension hook reports loaded', () => {
+    mockUseExtensions.mockReturnValue(unresolved(1));
+    mockUseResolvedExtensions.mockReturnValue([[makeExtension('a')], true, []]);
+
+    const { result } = testHook(useClusterStorageConnectedResources)(project);
+
+    // No hook has notified yet, so the extension's data is missing → not loaded.
+    expect(result.current.loaded).toBe(false);
+  });
+
+  it('should render one HookNotify per resolved extension', () => {
+    const extensions = [makeExtension('a'), makeExtension('b')];
+    mockUseExtensions.mockReturnValue(unresolved(2));
+    mockUseResolvedExtensions.mockReturnValue([extensions, true, []]);
+
+    const { result } = testHook(useClusterStorageConnectedResources)(project);
+
+    expect(result.current.hookNotifications).toHaveLength(2);
+  });
+
+  it('should become loaded and merge labels once every hook notifies', () => {
+    const labelA: ConnectedResourceLabel = { key: 'a', title: 'Model A', kind: 'deployed-model' };
+    const labelB: ConnectedResourceLabel = { key: 'b', title: 'Model B', kind: 'deployed-model' };
+    const extensions = [makeExtension('a', () => [labelA]), makeExtension('b', () => [labelB])];
+    mockUseExtensions.mockReturnValue(unresolved(2));
+    mockUseResolvedExtensions.mockReturnValue([extensions, true, []]);
+
+    const renderResult = testHook(useClusterStorageConnectedResources)(project);
+
+    // Render the HookNotify elements so their props (onNotify) are captured.
+    render(<>{renderResult.result.current.hookNotifications}</>);
+
+    expect(renderResult.result.current.loaded).toBe(false);
+    expect(renderResult.result.current.getConnectedResourceLabels(pvc)).toEqual([]);
+
+    // `key` is stripped from props by React, so match extensions by their (unique) hook ref.
+    const notify = (
+      extension: (typeof extensions)[number],
+      value: ClusterStorageConnectedResources,
+    ) => {
+      const call = mockHookNotify.mock.calls.find(
+        ([props]) => props.useHook === extension.properties.useConnectedResources,
+      );
+      act(() => call?.[0].onNotify?.(value));
+    };
+
+    notify(extensions[0], { loaded: true, data: {} });
+    // Only one of two extensions has loaded.
+    expect(renderResult.result.current.loaded).toBe(false);
+
+    notify(extensions[1], { loaded: true, data: {} });
+    expect(renderResult.result.current.loaded).toBe(true);
+    expect(renderResult.result.current.getConnectedResourceLabels(pvc)).toEqual([labelA, labelB]);
+  });
+
+  it('should skip extensions whose hook has unmounted', () => {
+    const label: ConnectedResourceLabel = { key: 'a', title: 'Model A', kind: 'deployed-model' };
+    const extensions = [makeExtension('a', () => [label])];
+    mockUseExtensions.mockReturnValue(unresolved(1));
+    mockUseResolvedExtensions.mockReturnValue([extensions, true, []]);
+
+    const renderResult = testHook(useClusterStorageConnectedResources)(project);
+    render(<>{renderResult.result.current.hookNotifications}</>);
+
+    const props = mockHookNotify.mock.calls.find(
+      ([p]) => p.useHook === extensions[0].properties.useConnectedResources,
+    )?.[0];
+
+    act(() => props?.onNotify?.({ loaded: true, data: {} }));
+    expect(renderResult.result.current.getConnectedResourceLabels(pvc)).toEqual([label]);
+
+    act(() => props?.onUnmount?.());
+    // Data cleared → no labels and no longer loaded.
+    expect(renderResult.result.current.getConnectedResourceLabels(pvc)).toEqual([]);
+    expect(renderResult.result.current.loaded).toBe(false);
+  });
+
+  it('should pass the project to each extension hook', () => {
+    const extensions = [makeExtension('a')];
+    mockUseExtensions.mockReturnValue(unresolved(1));
+    mockUseResolvedExtensions.mockReturnValue([extensions, true, []]);
+
+    const otherProject: ProjectKind = mockProjectK8sResource({ k8sName: 'other' });
+    const renderResult = testHook(useClusterStorageConnectedResources)(otherProject);
+    render(<>{renderResult.result.current.hookNotifications}</>);
+
+    const props = mockHookNotify.mock.calls.find(
+      ([p]) => p.useHook === extensions[0].properties.useConnectedResources,
+    )?.[0];
+    expect(props?.useHook).toBe(extensions[0].properties.useConnectedResources);
+    expect(props?.args).toEqual([otherProject]);
+  });
+});

--- a/frontend/src/pages/projects/screens/detail/storage/__tests__/useClusterStorageConnectedResources.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/__tests__/useClusterStorageConnectedResources.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { render, act } from '@testing-library/react';
+import React, { act } from 'react';
+import { render } from '@testing-library/react';
 import type { LoadedExtension, ResolvedExtension } from '@openshift/dynamic-plugin-sdk';
 import { HookNotify, useExtensions, useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import type {
@@ -95,8 +95,8 @@ describe('useClusterStorageConnectedResources', () => {
   });
 
   it('should become loaded and merge labels once every hook notifies', () => {
-    const labelA: ConnectedResourceLabel = { key: 'a', title: 'Model A', kind: 'deployed-model' };
-    const labelB: ConnectedResourceLabel = { key: 'b', title: 'Model B', kind: 'deployed-model' };
+    const labelA: ConnectedResourceLabel = { key: 'a', title: 'Model A', kind: 'connected-models' };
+    const labelB: ConnectedResourceLabel = { key: 'b', title: 'Model B', kind: 'connected-models' };
     const extensions = [makeExtension('a', () => [labelA]), makeExtension('b', () => [labelB])];
     mockUseExtensions.mockReturnValue(unresolved(2));
     mockUseResolvedExtensions.mockReturnValue([extensions, true, []]);
@@ -130,7 +130,7 @@ describe('useClusterStorageConnectedResources', () => {
   });
 
   it('should skip extensions whose hook has unmounted', () => {
-    const label: ConnectedResourceLabel = { key: 'a', title: 'Model A', kind: 'deployed-model' };
+    const label: ConnectedResourceLabel = { key: 'a', title: 'Model A', kind: 'connected-models' };
     const extensions = [makeExtension('a', () => [label])];
     mockUseExtensions.mockReturnValue(unresolved(1));
     mockUseResolvedExtensions.mockReturnValue([extensions, true, []]);

--- a/frontend/src/pages/projects/screens/detail/storage/useClusterStorageConnectedResources.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/useClusterStorageConnectedResources.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import type { PersistentVolumeClaimKind, ProjectKind } from '@odh-dashboard/k8s-core';
+import { HookNotify, useExtensions, useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import {
+  isClusterStorageConnectedResourcesExtension,
+  type ClusterStorageConnectedResources,
+  type ConnectedResourceLabel,
+} from '@odh-dashboard/plugin-core/extension-points';
+
+export type ClusterStorageConnectedResourcesResult = {
+  /** Whether any package contributes connected resources — drives the column's visibility. */
+  hasExtensions: boolean;
+  /** True once every contributed hook has reported loaded. */
+  loaded: boolean;
+  /** Merged per-PVC label descriptors contributed by all extensions. */
+  getConnectedResourceLabels: (pvc: PersistentVolumeClaimKind) => ConnectedResourceLabel[];
+  /** HookNotify elements the caller MUST render so each extension's list hook runs once. */
+  hookNotifications: React.ReactNode;
+};
+
+/**
+ * Encapsulates the cluster-storage "connected resources" extension plumbing for the storage table:
+ * resolves the contributed extensions, runs each one's list hook exactly once (via HookNotify),
+ * tracks their fetched data, and exposes a per-row label lookup plus an aggregate `loaded` flag.
+ */
+export const useClusterStorageConnectedResources = (
+  project: ProjectKind,
+): ClusterStorageConnectedResourcesResult => {
+  const extensions = useExtensions(isClusterStorageConnectedResourcesExtension);
+  const [resolvedExtensions, resolved] = useResolvedExtensions(
+    isClusterStorageConnectedResourcesExtension,
+  );
+  const [connectedResourceData, setConnectedResourceData] = React.useState<
+    Record<string, ClusterStorageConnectedResources | undefined>
+  >({});
+
+  const hasExtensions = extensions.length > 0;
+
+  // Shortcut: no extensions contributed → done loading.
+  const loaded =
+    !hasExtensions ||
+    (resolved &&
+      resolvedExtensions.every((extension) => connectedResourceData[extension.uid]?.loaded));
+
+  const getConnectedResourceLabels = React.useCallback(
+    (pvc: PersistentVolumeClaimKind): ConnectedResourceLabel[] =>
+      resolvedExtensions.flatMap((extension) => {
+        const entry = connectedResourceData[extension.uid];
+        return entry ? extension.properties.getConnectedResources(pvc, entry.data) : [];
+      }),
+    [resolvedExtensions, connectedResourceData],
+  );
+
+  const hookNotifications = resolvedExtensions.map((extension) => (
+    <HookNotify
+      key={extension.uid}
+      useHook={extension.properties.useConnectedResources}
+      args={[project]}
+      onNotify={(value) =>
+        setConnectedResourceData((prev) => ({ ...prev, [extension.uid]: value }))
+      }
+      onUnmount={() =>
+        setConnectedResourceData((prev) => ({ ...prev, [extension.uid]: undefined }))
+      }
+    />
+  ));
+
+  return { hasExtensions, loaded, getConnectedResourceLabels, hookNotifications };
+};

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
@@ -28,6 +28,7 @@ import {
   ProjectModel,
   StorageClassModel,
   InferenceServiceModel,
+  ServingRuntimeModel,
 } from '../../../../utils/models';
 import { storageClassesPage } from '../../../../pages/storageClasses';
 import { AccessMode } from '../../../../types';
@@ -39,6 +40,13 @@ type HandlersProps = {
 
 const initInterceptors = ({ isEmpty = false, storageClassName }: HandlersProps) => {
   cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));
+  // The cluster storage table fetches serving runtimes and inference services (KServe
+  // connected-resources extension) to show which deployments use each PVC.
+  cy.interceptK8sList({ model: ServingRuntimeModel, ns: 'test-project' }, mockK8sResourceList([]));
+  cy.interceptK8sList(
+    { model: InferenceServiceModel, ns: 'test-project' },
+    mockK8sResourceList([]),
+  );
   cy.interceptK8sList(PodModel, mockK8sResourceList([mockPodK8sResource({})]));
   cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProjectK8sResource({})]));
   cy.interceptK8s(ProjectModel, mockProjectK8sResource({}));

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
@@ -39,8 +39,6 @@ type HandlersProps = {
 
 const initInterceptors = ({ isEmpty = false, storageClassName }: HandlersProps) => {
   cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));
-  // The cluster storage table fetches serving runtimes and inference services (KServe
-  // connected-resources extension) to show which deployments use each PVC.
   cy.interceptK8sList(PodModel, mockK8sResourceList([mockPodK8sResource({})]));
   cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProjectK8sResource({})]));
   cy.interceptK8s(ProjectModel, mockProjectK8sResource({}));

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
@@ -28,7 +28,6 @@ import {
   ProjectModel,
   StorageClassModel,
   InferenceServiceModel,
-  ServingRuntimeModel,
 } from '../../../../utils/models';
 import { storageClassesPage } from '../../../../pages/storageClasses';
 import { AccessMode } from '../../../../types';
@@ -42,11 +41,6 @@ const initInterceptors = ({ isEmpty = false, storageClassName }: HandlersProps) 
   cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));
   // The cluster storage table fetches serving runtimes and inference services (KServe
   // connected-resources extension) to show which deployments use each PVC.
-  cy.interceptK8sList({ model: ServingRuntimeModel, ns: 'test-project' }, mockK8sResourceList([]));
-  cy.interceptK8sList(
-    { model: InferenceServiceModel, ns: 'test-project' },
-    mockK8sResourceList([]),
-  );
   cy.interceptK8sList(PodModel, mockK8sResourceList([mockPodK8sResource({})]));
   cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProjectK8sResource({})]));
   cy.interceptK8s(ProjectModel, mockProjectK8sResource({}));

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -25,6 +25,7 @@ import type {
 import type { WizardField } from '@odh-dashboard/model-serving/shared/types/form-data';
 import type {
   AreaExtension,
+  ClusterStorageConnectedResourcesExtension,
   RouteExtension,
   TabRouteTabExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
@@ -34,6 +35,7 @@ import type { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import type { TimeoutFieldValue } from './src/wizardFields/timeout/TimeoutField';
 import type { KServeServingRuntimeFieldType } from './src/wizardFields/servingRuntime/KServeServingRuntimeField';
 import type { KServeDeployment } from './src/types';
+import type { KServeConnectedResourcesData } from './src/clusterStorage/connectedResources';
 
 export const KSERVE_ID = 'kserve';
 const ADMIN_USER = 'ADMIN_USER';
@@ -175,6 +177,7 @@ const extensions: (
   | DeploymentWizardFieldOverrideExtension<KServeDeployment>
   | TabRouteTabExtension
   | RouteExtension
+  | ClusterStorageConnectedResourcesExtension<KServeConnectedResourcesData>
 )[] = [
   {
     type: 'app.area',
@@ -183,6 +186,22 @@ const extensions: (
       featureFlags: ['disableKServe'],
       requiredComponents: [DataScienceStackComponent.K_SERVE],
       reliantAreas: [SupportedArea.MODEL_SERVING],
+    },
+  },
+  {
+    type: 'app.cluster-storage/connected-resources',
+    properties: {
+      useConnectedResources: () =>
+        import('./src/clusterStorage/connectedResources').then(
+          (m) => m.useConnectedKServeResources,
+        ),
+      getConnectedResources: () =>
+        import('./src/clusterStorage/connectedResources').then(
+          (m) => m.getConnectedKServeResourceLabels,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.K_SERVE],
     },
   },
   {

--- a/packages/kserve/src/clusterStorage/__tests__/connectedResources.spec.tsx
+++ b/packages/kserve/src/clusterStorage/__tests__/connectedResources.spec.tsx
@@ -52,7 +52,7 @@ describe('getConnectedKServeResourceLabels', () => {
     const labels = getConnectedKServeResourceLabels(pvc, { inferenceServices, servingRuntimes });
     // Only the inference service whose runtime mounts the PVC, labeled with the inference service
     // display name (not the serving runtime name).
-    expect(labels).toEqual([{ key: 'is-match', title: 'My NIM Model', kind: 'deployed-model' }]);
+    expect(labels).toEqual([{ key: 'is-match', title: 'My NIM Model', kind: 'connected-models' }]);
   });
 
   it('should exclude an inference service whose runtime has no matching serving runtime', () => {

--- a/packages/kserve/src/clusterStorage/__tests__/connectedResources.spec.tsx
+++ b/packages/kserve/src/clusterStorage/__tests__/connectedResources.spec.tsx
@@ -118,4 +118,24 @@ describe('useConnectedKServeResources', () => {
     renderResult.rerender(project);
     expect(renderResult.result.current.loaded).toBe(true);
   });
+
+  it('should be loaded when the inference services watch errors', () => {
+    mockUseWatchInferenceServices.mockReturnValue([[], false, new Error('boom')]);
+    mockUseWatchServingRuntimes.mockReturnValue([[], false, undefined]);
+
+    const renderResult = testHook(useConnectedKServeResources)(project);
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('should be loaded when the serving runtimes watch errors, even with inference services present', () => {
+    mockUseWatchInferenceServices.mockReturnValue([
+      [mockInferenceServiceK8sResource({ name: 'is-1', runtimeName: 'sr-1' })],
+      true,
+      undefined,
+    ]);
+    mockUseWatchServingRuntimes.mockReturnValue([[], false, new Error('boom')]);
+
+    const renderResult = testHook(useConnectedKServeResources)(project);
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
 });

--- a/packages/kserve/src/clusterStorage/__tests__/connectedResources.spec.tsx
+++ b/packages/kserve/src/clusterStorage/__tests__/connectedResources.spec.tsx
@@ -1,0 +1,121 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
+import { mockServingRuntimeK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockServingRuntimeK8sResource';
+import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
+import {
+  getConnectedKServeResourceLabels,
+  useConnectedKServeResources,
+} from '../connectedResources';
+import * as watchModule from '../../api/watch';
+
+jest.mock('../../api/watch');
+
+const mockUseWatchInferenceServices = watchModule.useWatchInferenceServices as jest.Mock;
+const mockUseWatchServingRuntimes = watchModule.useWatchServingRuntimes as jest.Mock;
+
+const runtimeWithClaims = (name: string, claimNames: string[]): ServingRuntimeKind => {
+  const servingRuntime = mockServingRuntimeK8sResource({ name });
+  return {
+    ...servingRuntime,
+    spec: {
+      ...servingRuntime.spec,
+      volumes: claimNames.map((claimName) => ({
+        name: claimName,
+        persistentVolumeClaim: { claimName },
+      })),
+    },
+  };
+};
+
+describe('getConnectedKServeResourceLabels', () => {
+  it('should label each inference service whose serving runtime mounts the PVC, using the inference service display name', () => {
+    const pvc = mockPVCK8sResource({ name: 'my-pvc' });
+    const servingRuntimes = [
+      runtimeWithClaims('sr-match', ['my-pvc']),
+      runtimeWithClaims('sr-other', ['different-pvc']),
+    ];
+    const inferenceServices = [
+      mockInferenceServiceK8sResource({
+        name: 'is-match',
+        displayName: 'My NIM Model',
+        runtimeName: 'sr-match',
+      }),
+      mockInferenceServiceK8sResource({
+        name: 'is-other',
+        displayName: 'Other Model',
+        runtimeName: 'sr-other',
+      }),
+    ];
+
+    const labels = getConnectedKServeResourceLabels(pvc, { inferenceServices, servingRuntimes });
+    // Only the inference service whose runtime mounts the PVC, labeled with the inference service
+    // display name (not the serving runtime name).
+    expect(labels).toEqual([{ key: 'is-match', title: 'My NIM Model', kind: 'deployed-model' }]);
+  });
+
+  it('should exclude an inference service whose runtime has no matching serving runtime', () => {
+    const pvc = mockPVCK8sResource({ name: 'my-pvc' });
+    const inferenceServices = [
+      mockInferenceServiceK8sResource({ name: 'is-orphan', runtimeName: 'missing-sr' }),
+    ];
+
+    expect(
+      getConnectedKServeResourceLabels(pvc, { inferenceServices, servingRuntimes: [] }),
+    ).toHaveLength(0);
+  });
+
+  it('should return an empty array when no serving runtime references the PVC', () => {
+    const pvc = mockPVCK8sResource({ name: 'lonely-pvc' });
+    const servingRuntimes = [runtimeWithClaims('sr-a', ['other']), runtimeWithClaims('sr-b', [])];
+    const inferenceServices = [
+      mockInferenceServiceK8sResource({ name: 'is-a', runtimeName: 'sr-a' }),
+      mockInferenceServiceK8sResource({ name: 'is-b', runtimeName: 'sr-b' }),
+    ];
+
+    expect(
+      getConnectedKServeResourceLabels(pvc, { inferenceServices, servingRuntimes }),
+    ).toHaveLength(0);
+  });
+});
+
+describe('useConnectedKServeResources', () => {
+  const project = mockProjectK8sResource({ k8sName: 'test-project' });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not be loaded while both lists are still loading', () => {
+    mockUseWatchInferenceServices.mockReturnValue([[], false, undefined]);
+    mockUseWatchServingRuntimes.mockReturnValue([[], false, undefined]);
+
+    const renderResult = testHook(useConnectedKServeResources)(project);
+    expect(renderResult.result.current.loaded).toBe(false);
+  });
+
+  it('should be loaded once inference services load empty, without waiting on serving runtimes', () => {
+    mockUseWatchInferenceServices.mockReturnValue([[], true, undefined]);
+    mockUseWatchServingRuntimes.mockReturnValue([[], false, undefined]);
+
+    const renderResult = testHook(useConnectedKServeResources)(project);
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('should wait on serving runtimes when inference services are present', () => {
+    mockUseWatchInferenceServices.mockReturnValue([
+      [mockInferenceServiceK8sResource({ name: 'is-1', runtimeName: 'sr-1' })],
+      true,
+      undefined,
+    ]);
+    mockUseWatchServingRuntimes.mockReturnValue([[], false, undefined]);
+
+    const renderResult = testHook(useConnectedKServeResources)(project);
+    expect(renderResult.result.current.loaded).toBe(false);
+
+    mockUseWatchServingRuntimes.mockReturnValue([[], true, undefined]);
+    renderResult.rerender(project);
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+});

--- a/packages/kserve/src/clusterStorage/connectedResources.tsx
+++ b/packages/kserve/src/clusterStorage/connectedResources.tsx
@@ -19,17 +19,23 @@ export type KServeConnectedResourcesData = {
 export const useConnectedKServeResources = (
   project: ProjectKind,
 ): ClusterStorageConnectedResources<KServeConnectedResourcesData> => {
-  const [inferenceServices, inferenceServicesLoaded] = useWatchInferenceServices(project);
-  const [servingRuntimes, servingRuntimesLoaded] = useWatchServingRuntimes(project);
+  const [inferenceServices, inferenceServicesLoaded, inferenceServicesError] =
+    useWatchInferenceServices(project);
+  const [servingRuntimes, servingRuntimesLoaded, servingRuntimesError] =
+    useWatchServingRuntimes(project);
+
+  const inferenceServicesFinished = inferenceServicesLoaded || !!inferenceServicesError;
+  const servingRuntimesFinished = servingRuntimesLoaded || !!servingRuntimesError;
 
   return React.useMemo(
     () => ({
       // Labels are derived by filtering inference services, so with zero of them there is nothing to
       // show regardless of serving runtimes — no need to wait on that second list.
-      loaded: inferenceServicesLoaded && (inferenceServices.length === 0 || servingRuntimesLoaded),
+      loaded:
+        inferenceServicesFinished && (inferenceServices.length === 0 || servingRuntimesFinished),
       data: { inferenceServices, servingRuntimes },
     }),
-    [inferenceServices, inferenceServicesLoaded, servingRuntimes, servingRuntimesLoaded],
+    [inferenceServices, inferenceServicesFinished, servingRuntimes, servingRuntimesFinished],
   );
 };
 

--- a/packages/kserve/src/clusterStorage/connectedResources.tsx
+++ b/packages/kserve/src/clusterStorage/connectedResources.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import type { PersistentVolumeClaimKind, ProjectKind } from '@odh-dashboard/k8s-core';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import type { InferenceServiceKind, ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
+import type {
+  ClusterStorageConnectedResources,
+  ConnectedResourceLabel,
+} from '@odh-dashboard/plugin-core/extension-points';
+import { useWatchInferenceServices, useWatchServingRuntimes } from '../api/watch';
+
+export type KServeConnectedResourcesData = {
+  inferenceServices: InferenceServiceKind[];
+  servingRuntimes: ServingRuntimeKind[];
+};
+
+/**
+ * Lists the project's inference services and their serving runtimes.
+ */
+export const useConnectedKServeResources = (
+  project: ProjectKind,
+): ClusterStorageConnectedResources<KServeConnectedResourcesData> => {
+  const [inferenceServices, inferenceServicesLoaded] = useWatchInferenceServices(project);
+  const [servingRuntimes, servingRuntimesLoaded] = useWatchServingRuntimes(project);
+
+  return React.useMemo(
+    () => ({
+      // Labels are derived by filtering inference services, so with zero of them there is nothing to
+      // show regardless of serving runtimes — no need to wait on that second list.
+      loaded: inferenceServicesLoaded && (inferenceServices.length === 0 || servingRuntimesLoaded),
+      data: { inferenceServices, servingRuntimes },
+    }),
+    [inferenceServices, inferenceServicesLoaded, servingRuntimes, servingRuntimesLoaded],
+  );
+};
+
+const servingRuntimeUsesPVC = (servingRuntime: ServingRuntimeKind, pvcName: string): boolean =>
+  servingRuntime.spec.volumes?.some(
+    (volume) => volume.persistentVolumeClaim?.claimName === pvcName,
+  ) ?? false;
+
+/**
+ * Returns a label descriptor for each inference service whose serving runtime mounts `pvc` as a
+ * volume (matching `claimName`).
+ */
+export const getConnectedKServeResourceLabels = (
+  pvc: PersistentVolumeClaimKind,
+  { inferenceServices, servingRuntimes }: KServeConnectedResourcesData,
+): ConnectedResourceLabel[] =>
+  inferenceServices
+    .filter((inferenceService) => {
+      const servingRuntime = servingRuntimes.find(
+        (runtime) => runtime.metadata.name === inferenceService.spec.predictor.model?.runtime,
+      );
+      return servingRuntime ? servingRuntimeUsesPVC(servingRuntime, pvc.metadata.name) : false;
+    })
+    .map((inferenceService) => ({
+      key: inferenceService.metadata.name,
+      title: getDisplayNameFromK8sResource(inferenceService),
+      kind: 'deployed-model',
+    }));

--- a/packages/kserve/src/clusterStorage/connectedResources.tsx
+++ b/packages/kserve/src/clusterStorage/connectedResources.tsx
@@ -56,5 +56,5 @@ export const getConnectedKServeResourceLabels = (
     .map((inferenceService) => ({
       key: inferenceService.metadata.name,
       title: getDisplayNameFromK8sResource(inferenceService),
-      kind: 'deployed-model',
+      kind: 'connected-models',
     }));

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -536,11 +536,25 @@ describe('NIM Models Deployments', () => {
         }),
       ]),
     );
+    // KServe contributes the "Connected resources" column: a serving runtime mounting the PVC plus
+    // the inference service targeting that runtime surface the deployment on the PVC's row.
+    cy.interceptK8sList(
+      ServingRuntimeModel,
+      mockK8sResourceList([mockNimServingRuntime({ pvcName: 'nim-cache' })]),
+    );
+    cy.interceptK8sList(InferenceServiceModel, mockK8sResourceList([mockNimInferenceService()]));
 
     clusterStorage.visit('test-project');
 
     // The nim-serving package contributes the "NIM storage" context, so the PVC is labelled by it
     clusterStorage.getClusterStorageRow('NIM Cache').shouldHaveStorageTypeValue('NIM storage');
+
+    // The connected KServe deployment is listed by its inference service display name (not the
+    // serving runtime's generic "NVIDIA NIM" name)
+    clusterStorage
+      .getClusterStorageRow('NIM Cache')
+      .findConnectedResources()
+      .should('contain.text', 'Test Name');
 
     // TODO followup PR: can edit and update subpath
   });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -544,4 +544,37 @@ describe('NIM Models Deployments', () => {
 
     // TODO followup PR: can edit and update subpath
   });
+
+  it('should manage NIM PVCs in cluster storage tab', () => {
+    initInterceptsToEnableNim();
+    cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));
+    cy.interceptK8s(ProjectModel, mockNimProject({}));
+    // NotebookModel backs the per-row root-volume/delete-action logic and the connected resources
+    // column (useRelatedNotebooks) — mock it empty so those resolve instead of spinning
+    cy.interceptK8sList(NotebookModel, mockK8sResourceList([]));
+    cy.interceptK8sList(StorageClassModel, mockStorageClassList());
+    // Mocks the "Storage size" column response
+    cy.interceptOdh('POST /api/prometheus/pvc', {
+      code: 200,
+      response: mockPrometheusQueryVectorResponse({ result: [] }),
+    });
+
+    // A PVC caching a NIM model is annotated by the NIM deploy path
+    cy.interceptK8sList(
+      { model: PVCModel, ns: 'test-project' },
+      mockK8sResourceList([
+        mockNimModelPVC({
+          displayName: 'NIM Cache',
+          name: 'nim-cache',
+        }),
+      ]),
+    );
+
+    clusterStorage.visit('test-project');
+
+    // The nim-serving package contributes the "NIM storage" context, so the PVC is labelled by it
+    clusterStorage.getClusterStorageRow('NIM Cache').shouldHaveStorageTypeValue('NIM storage');
+
+    // TODO followup PR: can edit and update subpath
+  });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -558,37 +558,4 @@ describe('NIM Models Deployments', () => {
 
     // TODO followup PR: can edit and update subpath
   });
-
-  it('should manage NIM PVCs in cluster storage tab', () => {
-    initInterceptsToEnableNim();
-    cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));
-    cy.interceptK8s(ProjectModel, mockNimProject({}));
-    // NotebookModel backs the per-row root-volume/delete-action logic and the connected resources
-    // column (useRelatedNotebooks) — mock it empty so those resolve instead of spinning
-    cy.interceptK8sList(NotebookModel, mockK8sResourceList([]));
-    cy.interceptK8sList(StorageClassModel, mockStorageClassList());
-    // Mocks the "Storage size" column response
-    cy.interceptOdh('POST /api/prometheus/pvc', {
-      code: 200,
-      response: mockPrometheusQueryVectorResponse({ result: [] }),
-    });
-
-    // A PVC caching a NIM model is annotated by the NIM deploy path
-    cy.interceptK8sList(
-      { model: PVCModel, ns: 'test-project' },
-      mockK8sResourceList([
-        mockNimModelPVC({
-          displayName: 'NIM Cache',
-          name: 'nim-cache',
-        }),
-      ]),
-    );
-
-    clusterStorage.visit('test-project');
-
-    // The nim-serving package contributes the "NIM storage" context, so the PVC is labelled by it
-    clusterStorage.getClusterStorageRow('NIM Cache').shouldHaveStorageTypeValue('NIM storage');
-
-    // TODO followup PR: can edit and update subpath
-  });
 });

--- a/packages/plugin-core/src/extension-points/cluster-storage.ts
+++ b/packages/plugin-core/src/extension-points/cluster-storage.ts
@@ -30,7 +30,7 @@ export type ClusterStorageConnectedResources<TData = unknown> = {
   data: TData;
 };
 
-export type ConnectedResourceKind = 'deployed-model';
+export type ConnectedResourceKind = 'connected-models';
 
 export type ConnectedResourceLabel = {
   /** Stable identity for React reconciliation (e.g. the resource name). */

--- a/packages/plugin-core/src/extension-points/cluster-storage.ts
+++ b/packages/plugin-core/src/extension-points/cluster-storage.ts
@@ -1,4 +1,4 @@
-import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
+import type { PersistentVolumeClaimKind, ProjectKind } from '@odh-dashboard/k8s-core';
 import type { CodeRef, Extension } from '@openshift/dynamic-plugin-sdk';
 // eslint-disable-next-line no-restricted-syntax
 import { createExtensionGuard } from './utils';
@@ -24,3 +24,48 @@ export type ClusterStorageContextExtension = Extension<
 
 export const isClusterStorageContextExtension =
   createExtensionGuard<ClusterStorageContextExtension>('app.cluster-storage/storage-context');
+
+export type ClusterStorageConnectedResources<TData = unknown> = {
+  loaded: boolean;
+  data: TData;
+};
+
+export type ConnectedResourceKind = 'deployed-model';
+
+export type ConnectedResourceLabel = {
+  /** Stable identity for React reconciliation (e.g. the resource name). */
+  key: string;
+  /** Human-meaningful text shown on the label. */
+  title: string;
+  /** Which kind of resource this is; the host maps it to an icon and color. */
+  kind: ConnectedResourceKind;
+};
+
+export type ClusterStorageConnectedResourcesProperties<TData = unknown> = {
+  /**
+   * Hook listing the project resources that may be connected to a PVC.
+   */
+  useConnectedResources: CodeRef<(project: ProjectKind) => ClusterStorageConnectedResources<TData>>;
+  /**
+   * Given a PVC and the data fetched by `useConnectedResources`, returns label descriptors for the
+   * resources connected to that PVC (empty when none).
+   */
+  getConnectedResources: CodeRef<
+    (pvc: PersistentVolumeClaimKind, data: TData) => ConnectedResourceLabel[]
+  >;
+};
+
+/**
+ * Contributes "connected resources" to the cluster storage table: a feature package lists its own
+ * resources for the project (e.g. KServe ServingRuntimes) and renders which ones reference a given
+ * PVC, without the host knowing about those resource types.
+ */
+export type ClusterStorageConnectedResourcesExtension<TData = unknown> = Extension<
+  'app.cluster-storage/connected-resources',
+  ClusterStorageConnectedResourcesProperties<TData>
+>;
+
+export const isClusterStorageConnectedResourcesExtension =
+  createExtensionGuard<ClusterStorageConnectedResourcesExtension>(
+    'app.cluster-storage/connected-resources',
+  );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-88034

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds an extension for the cluster storage tab to fetch resources and to check if a pvc shows up in that resource(s). This is added to kserve generically because kserve knows how to fetch and interpret InferenceService + ServingRuntimes best, and the logic technically isn't really specific to NIM. 

The extension has a hook which is ran at the table level. It returns a Generic result based on the extension. The extension then has a parser function which links each PVC in the row with an array of names it's connected to. 

In `useClusterStorageConnectedResources`, I use both `useExtensions` and `useResolvedExtensions`. because useExtensions knows the list of extensions at compile time while the resolved variant only tells you the number after it is finished resolved it. This optimizes the loader and the visibility of the column a little bit

Also in the kserve extension hook, it will return `loaded: true` early if there are 0 inferenceServices.

<img width="1077" height="648" alt="image" src="https://github.com/user-attachments/assets/db675205-5663-448b-9ef0-b88446ea44d5" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Baseline behavior
1. Create a new project
2. Create a new cluster storage, it should have no connected resources

New NIM
1. Enable NIM, deploy a model, and select creating a new PVC
2. Go to the cluster storage tab, it should show the PVC with the name of the NIM model you created

New NIM with existing PVC
1. Deploy a new NIM model, select an existing PVC,  the one from the other NIM model
2. It should show both models as connected resources

<img width="1092" height="390" alt="image" src="https://github.com/user-attachments/assets/f8b35199-bc04-4266-9066-b7624a729aa2" />

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
kserve connected resource logic has jest tests
the nim cluster storage cypress mock test was updated to check one as a connected resource

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster storage now displays resources connected to each PVC, including deployed model names.
  * Connected-resource information can be provided by supported extensions and appears with resource-specific labels.
  * Added loading indicators and notifications while connected-resource details are retrieved.
* **Bug Fixes**
  * Improved handling of empty, loading, and unmatched connected-resource states.
  * Added support for displaying connected resources when extensions are available, even if workbenches are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->