### PR TITLE
chore(security): bump js-yaml, fast-uri, postcss to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4401,9 +4401,9 @@
       }
     },
     "node_modules/@cypress/code-coverage/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5003,9 +5003,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5784,9 +5784,9 @@
       }
     },
     "node_modules/@kubernetes/client-node/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -17559,9 +17559,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -21735,9 +21735,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -21779,9 +21779,9 @@
       }
     },
     "node_modules/js-yaml-loader/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27205,9 +27205,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.27.tgz",
+      "integrity": "sha512-79Iho8QeYyooJ8e9lCRyTVlyTAkS/kXBYKff6TMzS3kEWGQ8Ds5UEtXpGrSUDLUWok6QTvxeYy0GO8fopHnaSA==",
       "dev": true,
       "funding": [
         {
@@ -27225,7 +27225,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -34531,9 +34531,9 @@
       }
     },
     "node_modules/xmlbuilder2/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -154,14 +154,14 @@
     "@rspack/core": "2.1.10",
     "@rspack/cli": "2.1.10",
     "serialize-javascript": ">=7.0.5",
-    "fast-uri": ">=3.1.6 <4.0.0",
+    "fast-uri": ">=3.1.7 <4.0.0",
     "koa": ">=3.1.2",
     "adm-zip": ">=0.6.0",
     "postcss": ">=8.5.23 <9.0.0",
     "js-yaml@^3": "3.15.2",
     "js-yaml@^4": "4.3.2",
     "@cypress/code-coverage": {
-      "js-yaml": ">=4.3.2"
+      "js-yaml": ">=4.3.2 <5.0.0"
     },
     "xmlbuilder2": {
       "js-yaml": "3.15.2"

--- a/package.json
+++ b/package.json
@@ -154,14 +154,17 @@
     "@rspack/core": "2.1.10",
     "@rspack/cli": "2.1.10",
     "serialize-javascript": ">=7.0.5",
-    "fast-uri": ">=3.1.4 <4.0.0",
+    "fast-uri": ">=3.1.6 <4.0.0",
     "koa": ">=3.1.2",
     "adm-zip": ">=0.6.0",
+    "postcss": ">=8.5.23 <9.0.0",
+    "js-yaml@^3": "3.15.2",
+    "js-yaml@^4": "4.3.2",
     "@cypress/code-coverage": {
-      "js-yaml": ">=4.3.0"
+      "js-yaml": ">=4.3.2"
     },
     "xmlbuilder2": {
-      "js-yaml": "^3.14.2"
+      "js-yaml": "3.15.2"
     }
   }
 }


### PR DESCRIPTION
<!--- https://issues.redhat.com/browse/RHOAIENG-90409 -->

## Description

Bumps three vulnerable transitive dependencies in the **root lockfile** (which produces the `rhoai/odh-dashboard-rhel9` image) to their patched versions, remediating the following Red Hat PSIRT CVE Security Tracking issues (all `[rhoai-3.4]`, all `pscomponent:rhoai/odh-dashboard-rhel9`):

| Dependency | From → To | CVEs / Jira |
|---|---|---|
| `fast-uri` | `3.1.5` → `3.1.7` | CVE-2026-76172 ([RHOAIENG-89323](https://issues.redhat.com/browse/RHOAIENG-89323)), CVE-2026-75975 ([RHOAIENG-89224](https://issues.redhat.com/browse/RHOAIENG-89224)), CVE-2026-75899 ([RHOAIENG-89193](https://issues.redhat.com/browse/RHOAIENG-89193)), CVE-2026-75931 ([RHOAIENG-88866](https://issues.redhat.com/browse/RHOAIENG-88866)), CVE-2026-18446 ([RHOAIENG-85325](https://issues.redhat.com/browse/RHOAIENG-85325)), CVE-2026-16221 ([RHOAIENG-85287](https://issues.redhat.com/browse/RHOAIENG-85287)) |
| `js-yaml` | 4.x `4.1.0`/`4.2.0` → `4.3.2`; 3.x `3.14.1`/`3.14.2` → `3.15.2` | CVE-2026-84375 ([RHOAIENG-90409](https://issues.redhat.com/browse/RHOAIENG-90409)) |
| `postcss` | `8.5.15` → `8.5.27` | CVE-2026-69153 ([RHOAIENG-85469](https://issues.redhat.com/browse/RHOAIENG-85469)) |

Applied via npm `overrides`. **No major version changes** — `js-yaml` stays within its 3.x and 4.x majors, `fast-uri` within 3.x, `postcss` within 8.x — so no breaking changes are expected. The lockfile diff is intentionally surgical: only the vulnerable nodes were re-pinned (plus `postcss`'s `nanoid` range, which its `8.5.27` release requires and which is already satisfied by the tree at `3.3.18`).

## How Has This Been Tested?

- `npm ci` succeeds against the updated lockfile (all integrity hashes verified).
- `npm audit` confirms the `fast-uri`, `js-yaml`, and `postcss` advisories are **cleared** (total advisories dropped 42 → 32).
- `npm run type-check` passes for 17/20 workspaces; the single failure (`@odh-dashboard/eval-hub`, react-query retry typings + implicit `any` in `useEvaluationJobDetailPolling.ts`) is pre-existing on `main` and unrelated to these dependencies (none of them are imported there).

## Test Impact

No tests added — this is a transitive dependency version bump with no source changes. Correctness is covered by `npm audit` (advisory oracle) and `npm ci` (integrity/installability). Existing unit/Cypress suites exercise the affected build/runtime tooling indirectly.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-89323]: https://redhat.atlassian.net/browse/RHOAIENG-89323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-89224]: https://redhat.atlassian.net/browse/RHOAIENG-89224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-89193]: https://redhat.atlassian.net/browse/RHOAIENG-89193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-88866]: https://redhat.atlassian.net/browse/RHOAIENG-88866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-85325]: https://redhat.atlassian.net/browse/RHOAIENG-85325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-85287]: https://redhat.atlassian.net/browse/RHOAIENG-85287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-90409]: https://redhat.atlassian.net/browse/RHOAIENG-90409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated package configuration to improve compatibility across supported build and development tooling.
  - Standardized version constraints for more consistent project tooling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->