### PR TITLE
RHOAIENG-83655: add status condition fidelity tests

### DIFF
--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -661,8 +661,14 @@ func (r *DashboardReconciler) reconcileDegradedCondition(
 	if degradedModules > 0 {
 		cm.MarkTrue(string(common.ConditionTypeDegraded),
 			conditions.WithReason("ModulesDegraded"),
-			conditions.WithError(fmt.Errorf("%d module(s) degraded", degradedModules)),
-			conditions.WithSeverity(common.ConditionSeverityInfo))
+			conditions.WithMessage("%d module(s) degraded", degradedModules),
+			conditions.WithSeverity(common.ConditionSeverityError))
+		// Degraded is a negative-polarity condition. The condition manager only
+		// rolls up false/unknown dependents, so explicitly make Ready unhappy when
+		// Degraded=True.
+		cm.MarkFalse(string(common.ConditionTypeReady),
+			conditions.WithReason("ModulesDegraded"),
+			conditions.WithMessage("%d module(s) degraded", degradedModules))
 	}
 }
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -766,6 +766,35 @@ func TestReconcile_StatusContract(t *testing.T) {
 	}
 }
 
+func TestReconcileDegradedCondition(t *testing.T) {
+	dashboard := &v1alpha1.Dashboard{}
+	cm := conditions.NewManager(
+		dashboard,
+		string(common.ConditionTypeReady),
+		string(common.ConditionTypeDegraded),
+	)
+	r := &ctrlpkg.DashboardReconciler{}
+
+	r.ReconcileDegradedCondition(cm, map[string]v1alpha1.ModuleStatus{
+		"modelRegistry": {Phase: v1alpha1.ModulePhaseDegraded},
+		"genAi":         {Phase: v1alpha1.ModulePhaseDegraded},
+		"mlflow":        {Phase: v1alpha1.ModulePhaseDeployed},
+	})
+
+	degraded := conditions.FindStatusCondition(dashboard, string(common.ConditionTypeDegraded))
+	require.NotNil(t, degraded)
+	assert.Equal(t, metav1.ConditionTrue, degraded.Status)
+	assert.Equal(t, "ModulesDegraded", degraded.Reason)
+	assert.Equal(t, "2 module(s) degraded", degraded.Message)
+	assert.Equal(t, common.ConditionSeverityError, degraded.Severity)
+	ready := conditions.FindStatusCondition(dashboard, string(common.ConditionTypeReady))
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, "ModulesDegraded", ready.Reason)
+	assert.Equal(t, "2 module(s) degraded", ready.Message)
+	assert.False(t, cm.IsHappy())
+}
+
 func TestReconcile_DistinctNamespaces(t *testing.T) {
 	s := testScheme(t)
 

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -5,6 +5,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 )
 
@@ -50,6 +52,13 @@ func (r *DashboardReconciler) ReconcileNamespacedRBAC(ctx context.Context, dashb
 
 func (r *DashboardReconciler) CleanupNamespacedRBAC(ctx context.Context) error {
 	return r.cleanupNamespacedRBAC(ctx)
+}
+
+func (r *DashboardReconciler) ReconcileDegradedCondition(
+	cm *conditions.Manager,
+	statuses map[string]v1alpha1.ModuleStatus,
+) {
+	r.reconcileDegradedCondition(cm, statuses)
 }
 
 func (r *DashboardReconciler) GCStaleNamespacedRBAC(ctx context.Context, desired map[string]bool) error {

--- a/dashboard-operator/internal/controller/status_conditions_integration_test.go
+++ b/dashboard-operator/internal/controller/status_conditions_integration_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+)
+
+func TestIntegration_ConditionReady_TracksSubConditions(t *testing.T) {
+	r, manifests := setupStatusContractDashboard(t, nil)
+
+	dashboard := getDashboard(t)
+	assertConditionStatus(t, dashboard, common.ConditionTypeReady, metav1.ConditionTrue)
+	assertConditionStatus(t, dashboard, common.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue)
+	assert.Equal(t, common.PhaseReady, dashboard.Status.Phase)
+
+	r.ManifestsBasePath = t.TempDir()
+	_, err := r.Reconcile(context.Background(), dashboardRequest())
+	require.Error(t, err)
+
+	dashboard = getDashboard(t)
+	assertConditionStatus(t, dashboard, common.ConditionTypeReady, metav1.ConditionFalse)
+	provisioning := assertConditionStatus(t, dashboard, common.ConditionTypeProvisioningSucceeded, metav1.ConditionFalse)
+	assert.NotEmpty(t, provisioning.Reason)
+	assert.NotEmpty(t, provisioning.Message)
+	assert.Equal(t, common.PhaseNotReady, dashboard.Status.Phase)
+
+	r.ManifestsBasePath = manifests
+	reconcile(t, r)
+
+	dashboard = getDashboard(t)
+	assertConditionStatus(t, dashboard, common.ConditionTypeReady, metav1.ConditionTrue)
+	assertConditionStatus(t, dashboard, common.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue)
+	assert.Equal(t, common.PhaseReady, dashboard.Status.Phase)
+}
+
+func TestIntegration_ConditionDegraded_ReflectsModuleHealth(t *testing.T) {
+	r, _ := setupStatusContractDashboard(t, []string{"modelRegistry"})
+
+	setModuleReadyReplicas(t, "model-registry", 1)
+	reconcile(t, r)
+	assertStatusHealthy(t, getDashboard(t))
+
+	setModuleReadyReplicas(t, "model-registry", 0)
+	reconcile(t, r)
+
+	dashboard := getDashboard(t)
+	moduleStatus := dashboard.Status.ModuleStatuses["modelRegistry"]
+	assert.Equal(t, v1alpha1.ModulePhaseDegraded, moduleStatus.Phase)
+	degraded := assertConditionStatus(t, dashboard, common.ConditionTypeDegraded, metav1.ConditionTrue)
+	assert.Equal(t, "ModulesDegraded", degraded.Reason)
+	assert.Contains(t, degraded.Message, "1 module(s) degraded")
+	assertConditionStatus(t, dashboard, common.ConditionTypeReady, metav1.ConditionFalse)
+	assert.Equal(t, common.PhaseNotReady, dashboard.Status.Phase)
+
+	setModuleReadyReplicas(t, "model-registry", 1)
+	reconcile(t, r)
+	assertStatusHealthy(t, getDashboard(t))
+}
+
+func TestIntegration_ObservedGeneration_UpdatedPerReconcile(t *testing.T) {
+	r, _ := setupStatusContractDashboard(t, nil)
+
+	dashboard := getDashboard(t)
+	require.Equal(t, dashboard.Generation, dashboard.Status.ObservedGeneration)
+	initialGeneration := dashboard.Generation
+
+	dashboard.Spec.Gateway.Domain = "updated.example.com"
+	require.NoError(t, k8sClient.Update(context.Background(), dashboard))
+
+	dashboard = getDashboard(t)
+	require.Greater(t, dashboard.Generation, initialGeneration)
+	assert.NotEqual(t, dashboard.Generation, dashboard.Status.ObservedGeneration)
+
+	reconcile(t, r)
+
+	dashboard = getDashboard(t)
+	assert.Equal(t, dashboard.Generation, dashboard.Status.ObservedGeneration)
+	assertConditionStatus(t, dashboard, common.ConditionTypeReady, metav1.ConditionTrue)
+}
+
+func TestIntegration_PhaseTransitions_ReadyNotReady(t *testing.T) {
+	r, _ := setupStatusContractDashboard(t, []string{"modelRegistry"})
+
+	setModuleReadyReplicas(t, "model-registry", 1)
+	reconcile(t, r)
+	assertStatusHealthy(t, getDashboard(t))
+
+	setModuleReadyReplicas(t, "model-registry", 0)
+	reconcile(t, r)
+
+	dashboard := getDashboard(t)
+	assert.Equal(t, common.PhaseNotReady, dashboard.Status.Phase)
+	assertConditionStatus(t, dashboard, common.ConditionTypeReady, metav1.ConditionFalse)
+	assertConditionStatus(t, dashboard, common.ConditionTypeDegraded, metav1.ConditionTrue)
+
+	setModuleReadyReplicas(t, "model-registry", 1)
+	reconcile(t, r)
+	assertStatusHealthy(t, getDashboard(t))
+}
+
+func setupStatusContractDashboard(t *testing.T, enabledModules []string) (*ctrlpkg.DashboardReconciler, string) {
+	t.Helper()
+
+	manifestSlugs := make([]string, 0, len(enabledModules))
+	for _, module := range enabledModules {
+		if module == "modelRegistry" {
+			manifestSlugs = append(manifestSlugs, "model-registry")
+		}
+	}
+	manifests := createIntegrationManifests(t, manifestSlugs)
+	r := newManifestReconciler(manifests)
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules: disableAllModulesExcept(enabledModules...),
+	})
+
+	require.NoError(t, k8sClient.Create(context.Background(), dashboard))
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+	})
+
+	// The first reconcile adds the finalizer; the second runs the deployment pipeline.
+	reconcile(t, r)
+	reconcile(t, r)
+
+	return r, manifests
+}
+
+func setModuleReadyReplicas(t *testing.T, component string, ready int32) {
+	t.Helper()
+
+	deployments := listDeployments(t, component)
+	require.Len(t, deployments, 1)
+	deployment := deployments[0].DeepCopy()
+	deployment.Status.Replicas = 1
+	deployment.Status.UpdatedReplicas = ready
+	deployment.Status.ReadyReplicas = ready
+	deployment.Status.AvailableReplicas = ready
+	require.NoError(t, k8sClient.Status().Update(context.Background(), deployment))
+}
+
+func dashboardRequest() ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName}}
+}
+
+func assertConditionStatus(
+	t *testing.T,
+	dashboard *v1alpha1.Dashboard,
+	conditionType common.ConditionType,
+	want metav1.ConditionStatus,
+) *common.Condition {
+	t.Helper()
+
+	condition := conditions.FindStatusCondition(dashboard, string(conditionType))
+	require.NotNil(t, condition, "%s condition should be present", conditionType)
+	assert.Equal(t, want, condition.Status, "%s condition status", conditionType)
+
+	return condition
+}
+
+func assertStatusHealthy(t *testing.T, dashboard *v1alpha1.Dashboard) {
+	t.Helper()
+
+	assertConditionStatus(t, dashboard, common.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue)
+	assertConditionStatus(t, dashboard, common.ConditionTypeDegraded, metav1.ConditionFalse)
+	assertConditionStatus(t, dashboard, common.ConditionTypeReady, metav1.ConditionTrue)
+	assert.Equal(t, common.PhaseReady, dashboard.Status.Phase)
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-83655

## Description

Adds envtest coverage for the Dashboard operator status trust contract:

- verifies `Ready` tracks provisioning success and recovers after a render failure
- verifies module Deployment health drives `Degraded`, `Ready`, and `Phase`
- verifies `status.observedGeneration` follows spec generation changes
- verifies `Phase` transitions from Ready to NotReady and back to Ready

The new degradation coverage exposed that `Degraded=True` was informational and therefore left `Ready=True` and `Phase=Ready`. This change treats module degradation as an error condition and explicitly marks the negative-polarity `Ready` condition false, preserving the `ModulesDegraded` reason and degraded-module count.

## How Has This Been Tested?

From `dashboard-operator`:

```text
make test-integration
make test
make lint
git diff --check
```

All commands pass. `make lint` reports 0 issues.

## Test Impact

Adds the following envtest integration tests:

- `TestIntegration_ConditionReady_TracksSubConditions`
- `TestIntegration_ConditionDegraded_ReflectsModuleHealth`
- `TestIntegration_ObservedGeneration_UpdatedPerReconcile`
- `TestIntegration_PhaseTransitions_ReadyNotReady`

Also adds focused unit coverage for degraded-condition aggregation, reason/message fidelity, severity, and Ready roll-up.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change. (Not applicable: no UI changes.)
- [ ] Included tags to the UX team if it was a UI/UX change. (Not applicable: no UI/UX changes.)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dashboard status reporting when modules are degraded.
  - The **Degraded** condition now provides a clear message identifying the number of affected modules.
  - The **Ready** condition is explicitly marked false while modules remain degraded.
  - Dashboard readiness, degraded status, observed generation, and phase transitions now update consistently during failed and recovered reconciliations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->