### PR TITLE
Revert "fix(ci): block fork PRs from privileged Cypress E2E workflow (#9578)"

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -5,14 +5,8 @@ name: Cypress e2e Test
 # =============================================================================
 #
 # TRIGGERS:
-#   - Automatically after "Test" workflow completes on same-repo PRs
+#   - Automatically after "Test" workflow completes on PRs
 #   - Manually via workflow_dispatch (Actions tab → Run workflow)
-#
-# FORK PR SAFETY (PWN request mitigation):
-#   workflow_run listeners run with repository secrets. Fork PR head SHAs are
-#   attacker-controlled, so jobs gated on workflow_run only run when
-#   head_repository matches this repository (blocks external fork PRs).
-#   Fork E2E requires maintainer workflow_dispatch after review.
 #
 # CLUSTER FAILOVER:
 #   Primary:   dash-e2e-int (checked first via DSC health)
@@ -111,10 +105,9 @@ jobs:
   # ---------------------------------------------------------------------------
   select-cluster:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.event == 'pull_request' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_repository.full_name == github.repository)
+      github.event_name == 'workflow_dispatch' || 
+      (github.event.workflow_run.event == 'pull_request' && 
+       github.event.workflow_run.conclusion == 'success')
     runs-on: self-hosted
     outputs:
       cluster_name: ${{ steps.select.outputs.cluster_name }}
@@ -400,10 +393,9 @@ jobs:
   # ---------------------------------------------------------------------------
   set-pending-status:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.event == 'pull_request' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_repository.full_name == github.repository)
+      github.event_name == 'workflow_dispatch' || 
+      (github.event.workflow_run.event == 'pull_request' && 
+       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - name: Set pending status
@@ -429,7 +421,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@c915c33a16f01166c17c4e35fe1d4085a2d71adb # v4.6.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
@@ -717,7 +709,7 @@ jobs:
       missing-packages: ${{ steps.ensure.outputs.missing-packages }}
       test-run-id: ${{ steps.ensure.outputs.test-run-id }}
     steps:
-      - uses: actions/checkout@c915c33a16f01166c17c4e35fe1d4085a2d71adb # v4.6.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
@@ -745,7 +737,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.ensure-cypress-builds.outputs.missing-packages) }}
     steps:
-      - uses: actions/checkout@c915c33a16f01166c17c4e35fe1d4085a2d71adb # v4.6.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
@@ -1057,7 +1049,7 @@ jobs:
           echo "✅ Cleanup complete (non-critical, continued on any errors)"
 
       - name: Checkout code
-        uses: actions/checkout@c915c33a16f01166c17c4e35fe1d4085a2d71adb # v4.6.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
@@ -1325,11 +1317,10 @@ jobs:
   set-final-status:
     needs: [select-cluster, e2e-tests]
     if: >-
-      always() &&
-      (github.event_name == 'workflow_dispatch' ||
-       (github.event.workflow_run.event == 'pull_request' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_repository.full_name == github.repository))
+      always() && 
+      (github.event_name == 'workflow_dispatch' || 
+       (github.event.workflow_run.event == 'pull_request' && 
+        github.event.workflow_run.conclusion == 'success'))
     runs-on: ubuntu-latest
     steps:
       - name: Set final status
@@ -1378,12 +1369,7 @@ jobs:
   cleanup:
     needs: [e2e-tests]
     runs-on: self-hosted
-    if: >-
-      always() &&
-      (github.event_name == 'workflow_dispatch' ||
-       (github.event.workflow_run.event == 'pull_request' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_repository.full_name == github.repository))
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success')) }}
     steps:
       - name: Fix envtest binary permissions
         run: |


### PR DESCRIPTION
## Description

Reverts #9578 to restore automatic Cypress E2E triggering for external fork PRs after a successful `Test` workflow run.

This temporarily rolls back the fork `head_repository` guard and the `actions/checkout` bump from #9578. A durable PWN-request mitigation (artifact-only privileged E2E or equivalent) will be revisited separately — tracked on [RHOAIENG-91575](https://issues.redhat.com/browse/RHOAIENG-91575).

**Security note:** Merging this re-exposes the privileged `workflow_run` path where fork PR head SHAs can be checked out and executed on self-hosted runners with repository secrets. Merge only with explicit team/security approval.

## How Has This Been Tested?

Workflow YAML revert only. After merge, fork PRs with passing `Test` runs should again auto-trigger `Cypress e2e Test` (including `test:*` labels such as `test:MaaS`).

## Test Impact

No application or Cypress test changes. CI behavior change: external fork PRs regain automatic privileged E2E after `Test` succeeds.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

[RHOAIENG-91575]: https://redhat.atlassian.net/browse/RHOAIENG-91575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated pull request checks so successful workflow runs from forked repositories are handled consistently with same-repository pull requests.
  - Updated the workflow execution environment for greater reliability.
  - Preserved manual workflow triggering and existing cleanup and final-status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->