### PR TITLE
Align Subscriptions and Auth Policies No Models Warning

### DIFF
--- a/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import {
   ActionGroup,
   Alert,
@@ -260,8 +260,9 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
             title="No models available"
             data-testid="policy-no-models-warning"
           >
-            There are no model endpoints available on the cluster. Deploy a model and create a
-            MaaSModelRef before creating an authorization policy.
+            There are no model endpoints available on the cluster. To create an authorization
+            policy, first deploy a model from the{' '}
+            <Link to="/ai-hub/models/deployments">Deployments page</Link> and create a MaaSModelRef.
           </Alert>
         ) : (
           <>

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -421,9 +421,9 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
             title="No models available"
             data-testid="no-models-warning"
           >
-            There are no model endpoints available on the cluster. Deploy a model on the{' '}
-            <Link to="/ai-hub/models/deployments">Deployments page</Link> and create a MaaSModelRef
-            before creating a subscription.
+            There are no model endpoints available on the cluster. To create a subscription, first
+            deploy a model from the <Link to="/ai-hub/models/deployments">Deployments page</Link>{' '}
+            and create a MaaSModelRef.
           </Alert>
         ) : (
           <MaasModelsSection


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-87555](https://redhat.atlassian.net/browse/RHOAIENG-87555)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updates the text in both alerts and adds a new link to the authorization policy alert

Subs:
<img width="784" height="138" alt="Screenshot 2026-09-03 at 11 25 13 AM" src="https://github.com/user-attachments/assets/c1f29df7-1784-421d-bdf8-3013717828d7" />

Policies:
<img width="781" height="127" alt="Screenshot 2026-09-03 at 11 25 21 AM" src="https://github.com/user-attachments/assets/84300c92-af65-4139-841c-3dcd0151c7ab" />



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

to test:

- easiest to run in mock mode and comment out the mock data to see the alerts

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-87555]: https://redhat.atlassian.net/browse/RHOAIENG-87555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated guidance when no models are available in policy and subscription forms.
  * Added a direct link to the Deployments page, clarifying that users must deploy a model and create a model reference before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->