### PR TITLE
feat(operator): orchestrate shared MaaS Consumer Portal module demand

### DIFF
--- a/.claude/rules/operator-controller.md
+++ b/.claude/rules/operator-controller.md
@@ -120,7 +120,8 @@ The reconciler must check `dashboard.Spec.ManagementState` after finalizer handl
 if dashboard.Spec.ManagementState == "Removed" {
     // Delete all resources labeled platform.opendatahub.io/part-of=dashboard
     // Clean up cross-namespace resources
-    // Set phase=NotReady, clear URL and moduleStatuses
+    // Set phase=NotReady and clear URL. Preserve the computed aggregate
+    // moduleStatuses for modules still required by another operand.
     // Set ProvisioningSucceeded=False (reason: Removed)
     return ctrl.Result{}, nil
 }

--- a/dashboard-operator/internal/controller/actions.go
+++ b/dashboard-operator/internal/controller/actions.go
@@ -27,26 +27,11 @@ import (
 )
 
 var (
-	ErrDashboardRouteNotReady           = errors.New("dashboard route not yet ready")
-	ErrPersesCRDNotFound                = errors.New("PersesDashboard CRD not installed")
-	ErrObservabilityDisabled            = errors.New("observability is not enabled")
-	ErrPersesServiceRequired            = errors.New("observability is enabled but PersesService is not configured")
-	ErrMaasConsumerPortalDisabled       = errors.New("maas consumer portal is not enabled")
-	ErrMaasConsumerPortalDomainRequired = errors.New("maas consumer portal is enabled but gateway domain is not set")
+	ErrDashboardRouteNotReady = errors.New("dashboard route not yet ready")
+	ErrPersesCRDNotFound      = errors.New("PersesDashboard CRD not installed")
+	ErrObservabilityDisabled  = errors.New("observability is not enabled")
+	ErrPersesServiceRequired  = errors.New("observability is enabled but PersesService is not configured")
 )
-
-// maasConsumerPortalConsoleLinkName is the fixed name of the MaaS Consumer Portal
-// ConsoleLink CR managed by the operator.
-const maasConsumerPortalConsoleLinkName = "maas-consumer-portal-link"
-
-// maasConsumerPortalPartOf is the platform.opendatahub.io/part-of label value
-// applied to maas consumer portal resources. It is deliberately distinct from the
-// core dashboard's value so the portal is an independent operand: the core
-// dashboard teardown (which selects part-of=dashboard) never matches portal
-// resources, and the portal is reconciled and removed solely by
-// reconcileMaasConsumerPortalConsoleLink — independent of the core dashboard's
-// managementState.
-const maasConsumerPortalPartOf = "maas-consumer-portal"
 
 // Ray Gateway RBAC must live in openshift-ingress; kustomize WithNamespace(apps)
 // would otherwise place these Role/RoleBinding objects in the applications namespace.
@@ -237,112 +222,6 @@ func deployObservabilityManifests(
 		Resources: rendered,
 	}); err != nil {
 		return fmt.Errorf("failed to deploy observability resources to %s: %w", obsNamespace, err)
-	}
-
-	return nil
-}
-
-// deployMaasConsumerPortalConsoleLink renders and applies the MaaS Consumer Portal
-// ConsoleLink. It returns ErrMaasConsumerPortalDisabled when the portal is not
-// enabled and ErrMaasConsumerPortalDomainRequired when the gateway domain (from
-// which the portal host is derived) is not set. The cluster-scoped ConsoleLink
-// is owned by the Dashboard CR so it is garbage-collected on CR deletion.
-func deployMaasConsumerPortalConsoleLink(
-	ctx context.Context,
-	cli client.Client,
-	dashboard *v1alpha1.Dashboard,
-	basePath string,
-	platform cluster.Platform,
-) error {
-	logger := log.FromContext(ctx)
-
-	if dashboard.Spec.MaasConsumerPortal == nil || dashboard.Spec.MaasConsumerPortal.ManagementState != "Managed" {
-		return ErrMaasConsumerPortalDisabled
-	}
-
-	domain := ""
-	if dashboard.Spec.Gateway != nil {
-		domain = dashboard.Spec.Gateway.Domain
-	}
-
-	maasConsumerPortalURLValue, ok := maasConsumerPortalURL(domain)
-	if !ok {
-		return ErrMaasConsumerPortalDomainRequired
-	}
-
-	// RHOAI-only feature; warn if enabled on ODH so the misconfig is visible.
-	if platform == cluster.OpenDataHub {
-		logger.Info("MaaS Consumer Portal ConsoleLink is an RHOAI-only feature; deploying it on Open Data Hub will use RHOAI branding")
-	}
-
-	m := maasConsumerPortalConsoleLinkManifestInfo(basePath)
-
-	// Inject the derived portal URL and the platform's section title into the
-	// portal manifest's own params.env before rendering.
-	manifestPath := m.String()
-	params := readExistingParams(filepath.Join(manifestPath, "params.env"))
-	params["maas-consumer-portal-url"] = maasConsumerPortalURLValue
-	if title, titleOK := sectionTitle[platform]; titleOK {
-		params["section-title"] = title
-	}
-	if err := writeParamsEnv(manifestPath, params); err != nil {
-		return fmt.Errorf("failed to write maas consumer portal params.env to %s: %w", manifestPath, err)
-	}
-
-	engine := kustomize.NewEngine()
-
-	rendered, err := engine.Render(m.String(), kustomize.WithNamespace(dashboard.Namespace))
-	if err != nil {
-		return fmt.Errorf("failed to render maas consumer portal manifests from %s: %w", m, err)
-	}
-
-	// Deploy only the ConsoleLink. The kustomize configMapGenerator produces a
-	// params ConfigMap used purely for replacements; deploying it would leave an
-	// orphan when the portal is disabled, so it is filtered out here to keep
-	// deploy/delete symmetric.
-	resources := make([]unstructured.Unstructured, 0, len(rendered))
-	for i := range rendered {
-		if rendered[i].GetKind() == "ConsoleLink" {
-			resources = append(resources, rendered[i])
-		}
-	}
-
-	logger.Info("Deploying maas consumer portal ConsoleLink", "url", maasConsumerPortalURLValue, "resources", len(resources))
-
-	deployer := deploy.NewDeployer(
-		deploy.WithFieldOwner("dashboard-operator"),
-		deploy.WithLabel(labels.PlatformPartOf, maasConsumerPortalPartOf),
-		deploy.WithApplyOrder(),
-	)
-
-	if err := deployer.Deploy(ctx, deploy.DeployInput{
-		Client:    cli,
-		Owner:     dashboard,
-		Release:   deploy.ReleaseInfo{Type: string(platform)},
-		Resources: resources,
-	}); err != nil {
-		return fmt.Errorf("failed to deploy maas consumer portal ConsoleLink: %w", err)
-	}
-
-	return nil
-}
-
-// deleteMaasConsumerPortalConsoleLink removes the portal ConsoleLink by name. It is
-// a no-op when the ConsoleLink CRD is not installed or the object is absent.
-func deleteMaasConsumerPortalConsoleLink(ctx context.Context, cli client.Client) error {
-	logger := log.FromContext(ctx)
-
-	cl := &unstructured.Unstructured{}
-	cl.SetGroupVersionKind(consoleLinkGVK)
-	cl.SetName(maasConsumerPortalConsoleLinkName)
-
-	logger.Info("Deleting maas consumer portal ConsoleLink", "name", maasConsumerPortalConsoleLinkName)
-	if err := cli.Delete(ctx, cl); client.IgnoreNotFound(err) != nil {
-		if meta.IsNoMatchError(err) {
-			return nil
-		}
-
-		return fmt.Errorf("deleting ConsoleLink %s: %w", maasConsumerPortalConsoleLinkName, err)
 	}
 
 	return nil

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -35,7 +35,6 @@ import (
 
 const dashboardFinalizer = "components.platform.opendatahub.io/cleanup"
 const conditionObservabilityAvailable = "ObservabilityAvailable"
-const conditionMaasConsumerPortalAvailable = "MaasConsumerPortalAvailable"
 
 var operatorDeploymentName = getOperatorDeploymentName()
 
@@ -208,14 +207,27 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if dashboard.Spec.ManagementState == "Removed" {
 		logger.Info("ManagementState is Removed, tearing down resources")
 
-		if err := r.teardownManagedResources(ctx, dashboard); err != nil {
+		// MaaS and GenAI are shared dependencies. Reconcile their aggregate
+		// demand before the core teardown so MaaS Consumer Portal-only operation retains them.
+		nextStatuses, err := r.reconcileModuleDemand(ctx, dashboard)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile MaaS Consumer Portal-required modules: %w", err)
+		}
+		preserveModuleStatusTransitionTimes(dashboard.Status.ModuleStatuses, nextStatuses)
+		dashboard.Status.ModuleStatuses = nextStatuses
+		r.setMaasConsumerPortalModuleCondition(cm, dashboard, nextStatuses)
+		if err := r.deployMaasConsumerPortalFederationConfigMap(ctx, dashboard, nextStatuses); err != nil {
+			r.markMaasConsumerPortalFederationConfigMapFailed(cm, err)
+			logger.Error(err, "Failed to deploy MaaS Consumer Portal federation ConfigMap")
+		}
+
+		if err := r.teardownManagedResources(ctx, dashboard, nextStatuses); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to tear down resources: %w", err)
 		}
 
 		dashboard.Status.ObservedGeneration = dashboard.Generation
 		dashboard.Status.Phase = common.PhaseNotReady
 		dashboard.Status.URL = ""
-		dashboard.Status.ModuleStatuses = nil
 		dashboard.Status.Distribution = nil
 
 		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
@@ -429,40 +441,23 @@ func (r *DashboardReconciler) reconcileDeployment(
 		return ctrl.Result{}, fmt.Errorf("failed to deploy resources: %w", err)
 	}
 
-	nextStatuses := resolveModuleStatuses(&dashboard.Spec)
-
-	if err := r.deployModuleManifests(ctx, dashboard, nextStatuses); err != nil {
+	nextStatuses, err := r.reconcileModuleDemand(ctx, dashboard)
+	if err != nil {
 		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
 			conditions.WithReason("ModuleDeployFailed"),
 			conditions.WithError(err))
 		return ctrl.Result{}, fmt.Errorf("failed to deploy module manifests: %w", err)
 	}
 
-	// GC disabled modules
-	if err := r.deleteModuleResources(ctx, nextStatuses); err != nil {
-		logger.Error(err, "Failed to clean up disabled module resources")
-	}
-
 	cm.MarkTrue(string(common.ConditionTypeProvisioningSucceeded),
 		conditions.WithReason("ResourcesApplied"),
 		conditions.WithMessage("Dashboard and module manifests applied successfully"))
 
-	// Overlay readiness from module deployments (before federation ConfigMap
-	// so the ConfigMap reflects actual deployment health, e.g. Degraded modules)
-	r.overlayStandaloneReadiness(ctx, nextStatuses)
-
 	// Persist module statuses now so early returns from steps 6-9 don't leave
 	// stale status on the CR (the outer Reconcile always calls Status().Update).
-	for name, next := range nextStatuses {
-		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
-			prev.Phase == next.Phase &&
-			prev.Reason == next.Reason &&
-			prev.Message == next.Message {
-			next.LastTransitionTime = prev.LastTransitionTime
-			nextStatuses[name] = next
-		}
-	}
+	preserveModuleStatusTransitionTimes(dashboard.Status.ModuleStatuses, nextStatuses)
 	dashboard.Status.ModuleStatuses = nextStatuses
+	r.setMaasConsumerPortalModuleCondition(cm, dashboard, nextStatuses)
 
 	// Reconcile cross-namespace RBAC (notebooks, model-registry)
 	rbacErr := r.reconcileNamespacedRBAC(ctx, dashboard)
@@ -484,6 +479,10 @@ func (r *DashboardReconciler) reconcileDeployment(
 			conditions.WithError(err))
 		logger.Error(err, "Failed to deploy federation ConfigMap")
 		return ctrl.Result{}, fmt.Errorf("federation ConfigMap: %w", err)
+	}
+	if err := r.deployMaasConsumerPortalFederationConfigMap(ctx, dashboard, nextStatuses); err != nil {
+		r.markMaasConsumerPortalFederationConfigMapFailed(cm, err)
+		logger.Error(err, "Failed to deploy MaaS Consumer Portal federation ConfigMap")
 	}
 
 	if err := r.patchDeploymentFederationHash(ctx, fedData); err != nil {
@@ -554,57 +553,6 @@ func (r *DashboardReconciler) reconcileObservability(
 			conditions.WithReason("DeployFailed"),
 			conditions.WithError(obsErr))
 		logger.Error(obsErr, "Failed to deploy observability manifests")
-	}
-}
-
-// reconcileMaasConsumerPortalConsoleLink deploys or removes the MaaS Consumer
-// Portal ConsoleLink based on spec.maasConsumerPortal, and reports the outcome via
-// the MaasConsumerPortalAvailable condition. All False states use Info severity so the
-// portal never affects the Ready rollup.
-func (r *DashboardReconciler) reconcileMaasConsumerPortalConsoleLink(
-	ctx context.Context,
-	dashboard *v1alpha1.Dashboard,
-	cm *conditions.Manager,
-) {
-	logger := log.FromContext(ctx)
-
-	switch maasConsumerPortalErr := deployMaasConsumerPortalConsoleLink(ctx, r.Client, dashboard, r.ManifestsBasePath, r.Platform); {
-	case maasConsumerPortalErr == nil:
-		cm.MarkTrue(conditionMaasConsumerPortalAvailable,
-			conditions.WithReason("Deployed"),
-			conditions.WithMessage("MaaS Consumer Portal ConsoleLink applied successfully"))
-	case errors.Is(maasConsumerPortalErr, ErrMaasConsumerPortalDisabled):
-		// Explicitly remove the ConsoleLink when the portal is disabled — the
-		// SSA deployer is additive and does not prune. Benign cases (absent
-		// object, ConsoleLink CRD not installed) are already treated as success
-		// inside deleteMaasConsumerPortalConsoleLink, so a non-nil error here is a
-		// genuine failure: surface it on the condition (Info severity, like the
-		// deploy-failed branch) rather than falsely reporting a clean Disabled
-		// state while a stale ConsoleLink lingers.
-		if delErr := deleteMaasConsumerPortalConsoleLink(ctx, r.Client); delErr != nil {
-			logger.Error(delErr, "Failed to delete maas consumer portal ConsoleLink")
-			cm.MarkFalse(conditionMaasConsumerPortalAvailable,
-				conditions.WithReason("MaasConsumerPortalDeleteFailed"),
-				conditions.WithMessage("failed to delete maas consumer portal ConsoleLink: %s", delErr.Error()),
-				conditions.WithSeverity(common.ConditionSeverityInfo))
-		} else {
-			cm.MarkFalse(conditionMaasConsumerPortalAvailable,
-				conditions.WithReason("Disabled"),
-				conditions.WithMessage("MaaS Consumer Portal is not enabled"),
-				conditions.WithSeverity(common.ConditionSeverityInfo))
-		}
-	case errors.Is(maasConsumerPortalErr, ErrMaasConsumerPortalDomainRequired):
-		cm.MarkFalse(conditionMaasConsumerPortalAvailable,
-			conditions.WithReason("MaasConsumerPortalDomainRequired"),
-			conditions.WithMessage("MaaS Consumer Portal is enabled but gateway domain is not set"),
-			conditions.WithSeverity(common.ConditionSeverityInfo))
-		logger.Info("MaaS Consumer Portal enabled but gateway domain not set, skipping ConsoleLink")
-	default:
-		cm.MarkFalse(conditionMaasConsumerPortalAvailable,
-			conditions.WithReason("MaasConsumerPortalDeployFailed"),
-			conditions.WithError(maasConsumerPortalErr),
-			conditions.WithSeverity(common.ConditionSeverityInfo))
-		logger.Error(maasConsumerPortalErr, "Failed to deploy maas consumer portal ConsoleLink")
 	}
 }
 
@@ -782,8 +730,12 @@ func (r *DashboardReconciler) cleanupCrossNamespaceResources(ctx context.Context
 // teardownManagedResources deletes all resources labeled with
 // platform.opendatahub.io/part-of=dashboard in the applications namespace,
 // and cleans up cross-namespace resources.
-func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dashboard *v1alpha1.Dashboard) error {
+func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dashboard *v1alpha1.Dashboard, statuses map[string]v1alpha1.ModuleStatus) error {
 	logger := log.FromContext(ctx)
+	maasConsumerPortalRequiredModules := maasConsumerPortalRequiredModuleSlugs(&dashboard.Spec, statuses)
+	shouldPreserve := func(resource client.Object) bool {
+		return maasConsumerPortalRequiredModules[resource.GetLabels()[moduleComponentLabel]]
+	}
 
 	matchLabels := client.MatchingLabels{
 		labels.PlatformPartOf: strings.ToLower(v1alpha1.DashboardKind),
@@ -804,7 +756,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 
 		items := extractItems(list)
 		for i := range items {
-			if isOperatorOwned(operatorResources, kind, items[i].GetName()) {
+			if isOperatorOwned(operatorResources, kind, items[i].GetName()) || shouldPreserve(items[i]) {
 				continue
 			}
 			logger.Info("Deleting managed resource", "kind", kind, "name", items[i].GetName())
@@ -822,7 +774,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	for i := range deployments.Items {
 		dep := &deployments.Items[i]
-		if isOperatorOwned(operatorResources, "Deployment", dep.Name) {
+		if isOperatorOwned(operatorResources, "Deployment", dep.Name) || shouldPreserve(dep) {
 			continue
 		}
 		logger.Info("Deleting managed resource", "kind", "Deployment", "name", dep.Name)
@@ -847,7 +799,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	for i := range serviceAccounts.Items {
 		sa := &serviceAccounts.Items[i]
-		if isOperatorOwned(operatorResources, "ServiceAccount", sa.Name) {
+		if isOperatorOwned(operatorResources, "ServiceAccount", sa.Name) || shouldPreserve(sa) {
 			continue
 		}
 		logger.Info("Deleting managed resource", "kind", "ServiceAccount", "name", sa.Name)
@@ -882,7 +834,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	for i := range clusterRoles.Items {
 		cr := &clusterRoles.Items[i]
-		if isOperatorOwned(operatorResources, "ClusterRole", cr.Name) {
+		if isOperatorOwned(operatorResources, "ClusterRole", cr.Name) || shouldPreserve(cr) {
 			continue
 		}
 		logger.Info("Deleting managed resource", "kind", "ClusterRole", "name", cr.Name)
@@ -897,7 +849,7 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	for i := range clusterRoleBindings.Items {
 		crb := &clusterRoleBindings.Items[i]
-		if isOperatorOwned(operatorResources, "ClusterRoleBinding", crb.Name) {
+		if isOperatorOwned(operatorResources, "ClusterRoleBinding", crb.Name) || shouldPreserve(crb) {
 			continue
 		}
 		logger.Info("Deleting managed resource", "kind", "ClusterRoleBinding", "name", crb.Name)

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -211,6 +211,7 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// demand before the core teardown so MaaS Consumer Portal-only operation retains them.
 		nextStatuses, err := r.reconcileModuleDemand(ctx, dashboard)
 		if err != nil {
+			r.persistRemovedFailureStatus(ctx, dashboard, cm, "ModuleDeployFailed", err)
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile MaaS Consumer Portal-required modules: %w", err)
 		}
 		preserveModuleStatusTransitionTimes(dashboard.Status.ModuleStatuses, nextStatuses)
@@ -222,6 +223,7 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		if err := r.teardownManagedResources(ctx, dashboard, nextStatuses); err != nil {
+			r.persistRemovedFailureStatus(ctx, dashboard, cm, "TeardownFailed", err)
 			return ctrl.Result{}, fmt.Errorf("failed to tear down resources: %w", err)
 		}
 
@@ -300,6 +302,25 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	return result, err
+}
+
+// persistRemovedFailureStatus records a retryable failure that occurs before
+// the normal Removed-state status update. A status-write failure is logged but
+// does not replace the original reconciliation error.
+func (r *DashboardReconciler) persistRemovedFailureStatus(
+	ctx context.Context,
+	dashboard *v1alpha1.Dashboard,
+	cm *conditions.Manager,
+	reason string,
+	failure error,
+) {
+	cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+		conditions.WithReason(reason),
+		conditions.WithMessage("Dashboard removal reconciliation failed: %s", failure))
+	cm.Sort()
+	if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
+		log.FromContext(ctx).Error(statusErr, "Failed to update status after removal failure")
+	}
 }
 
 const observabilityRetryInterval = 5 * time.Minute

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -332,6 +332,49 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+func TestReconcile_RemovedModuleDemandFailureUpdatesStatus(t *testing.T) {
+	scheme := testScheme(t)
+	manifests := t.TempDir()
+	maasModulePath := filepath.Join(manifests, "modules", "maas")
+	require.NoError(t, os.MkdirAll(maasModulePath, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(maasModulePath, "kustomization.yaml"), []byte("invalid: ["), 0644))
+	dashboard := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       v1alpha1.DashboardInstanceName,
+			Finalizers: []string{"components.platform.opendatahub.io/cleanup"},
+		},
+		Spec: v1alpha1.DashboardSpec{
+			ManagementSpec:     common.ManagementSpec{ManagementState: "Removed"},
+			MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(dashboard).
+		WithStatusSubresource(dashboard).
+		Build()
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                scheme,
+		ManifestsBasePath:     manifests,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+	})
+	require.Error(t, err)
+
+	updated := &v1alpha1.Dashboard{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
+	condition := conditions.FindStatusCondition(updated, string(common.ConditionTypeProvisioningSucceeded))
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, "ModuleDeployFailed", condition.Reason)
+}
+
 func TestReconcile_Deletion(t *testing.T) {
 	s := testScheme(t)
 

--- a/dashboard-operator/internal/controller/deployment_integration_test.go
+++ b/dashboard-operator/internal/controller/deployment_integration_test.go
@@ -57,7 +57,7 @@ func TestIntegration_DeploysResources(t *testing.T) {
 	}
 
 	// Federation ConfigMap lists both modules plus the always-present coreBff entry.
-	entries := parseFederationEntries(t, getFederationConfigMap(t))
+	entries := parseFederationEntries(t, getConfigMap(t, "federation-config"))
 	assert.NotNil(t, findFederationEntry(entries, "genAi"), "genAi should be in federation config")
 	assert.NotNil(t, findFederationEntry(entries, "maas"), "maas should be in federation config")
 	assert.NotNil(t, findFederationEntry(entries, "coreBff"), "coreBff should always be in federation config")

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -28,6 +28,10 @@ func (r *DashboardReconciler) PatchDeploymentFederationHash(ctx context.Context,
 	return r.patchDeploymentFederationHash(ctx, configData)
 }
 
+func (r *DashboardReconciler) ReconcileModuleDemand(ctx context.Context, dashboard *v1alpha1.Dashboard) (map[string]v1alpha1.ModuleStatus, error) {
+	return r.reconcileModuleDemand(ctx, dashboard)
+}
+
 func (r *DashboardReconciler) CleanupLegacySidecarResources(ctx context.Context) error {
 	return r.cleanupLegacySidecarResources(ctx)
 }
@@ -55,10 +59,6 @@ func (r *DashboardReconciler) CleanupNamespacedRBAC(ctx context.Context) error {
 func (r *DashboardReconciler) GCStaleNamespacedRBAC(ctx context.Context, desired map[string]bool) error {
 	return r.gcStaleNamespacedRBAC(ctx, desired)
 }
-
-const MaasConsumerPortalConsoleLinkName = maasConsumerPortalConsoleLinkName
-
-const ConditionMaasConsumerPortalAvailable = conditionMaasConsumerPortalAvailable
 
 var ConsoleLinkGVK = consoleLinkGVK
 

--- a/dashboard-operator/internal/controller/federation_integration_test.go
+++ b/dashboard-operator/internal/controller/federation_integration_test.go
@@ -113,7 +113,7 @@ func TestIntegration_FederationConfigMap_AllModulesEnabled(t *testing.T) {
 	reconcile(t, r)
 	reconcile(t, r)
 
-	entries := parseFederationEntries(t, getFederationConfigMap(t))
+	entries := parseFederationEntries(t, getConfigMap(t, "federation-config"))
 
 	// Every registered module has a federation entry.
 	for _, name := range ctrlpkg.ModuleNames() {

--- a/dashboard-operator/internal/controller/integration_test.go
+++ b/dashboard-operator/internal/controller/integration_test.go
@@ -19,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -81,7 +80,9 @@ func TestMain(m *testing.M) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: s})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create client: %v\n", err)
-		_ = testEnv.Stop()
+		if stopErr := testEnv.Stop(); stopErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to stop envtest: %v\n", stopErr)
+		}
 		os.Exit(1)
 	}
 
@@ -89,14 +90,19 @@ func TestMain(m *testing.M) {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: integrationNamespace}}
 	if err := k8sClient.Create(ctx, ns); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create test namespace: %v\n", err)
-		_ = testEnv.Stop()
+		if stopErr := testEnv.Stop(); stopErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to stop envtest: %v\n", stopErr)
+		}
 		os.Exit(1)
 	}
 
 	code := m.Run()
 
-	if err := testEnv.Stop(); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to stop envtest: %v\n", err)
+	if stopErr := testEnv.Stop(); stopErr != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop envtest: %v\n", stopErr)
+		if code == 0 {
+			code = 1
+		}
 	}
 	os.Exit(code)
 }
@@ -299,11 +305,11 @@ func listServices(t *testing.T, componentLabel string) []corev1.Service {
 	return services.Items
 }
 
-func getFederationConfigMap(t *testing.T) *corev1.ConfigMap {
+func getConfigMap(t *testing.T, name string) *corev1.ConfigMap {
 	t.Helper()
 	cm := &corev1.ConfigMap{}
 	err := k8sClient.Get(context.Background(), types.NamespacedName{
-		Name:      "federation-config",
+		Name:      name,
 		Namespace: integrationNamespace,
 	}, cm)
 	if err != nil {
@@ -365,265 +371,6 @@ func disableAllModulesExcept(enabled ...string) map[string]v1alpha1.ModuleOverri
 	return modules
 }
 
-// writeMaasConsumerPortalManifest writes the portal ConsoleLink kustomize bundle
-// into base/maas-consumer-portal-consolelink/rhoai so the reconciler can render it.
-func writeMaasConsumerPortalManifest(t *testing.T, base string) {
-	t.Helper()
-
-	dir := filepath.Join(base, "maas-consumer-portal-consolelink", "rhoai")
-	require.NoError(t, os.MkdirAll(dir, 0755))
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - consolelink.yaml
-configMapGenerator:
-  - name: maas-consumer-portal-params
-    env: params.env
-generatorOptions:
-  disableNameSuffixHash: true
-replacements:
-  - source:
-      kind: ConfigMap
-      name: maas-consumer-portal-params
-      fieldPath: data.section-title
-    targets:
-      - select:
-          kind: ConsoleLink
-          name: maas-consumer-portal-link
-        fieldPaths:
-          - spec.applicationMenu.section
-  - source:
-      kind: ConfigMap
-      name: maas-consumer-portal-params
-      fieldPath: data.maas-consumer-portal-url
-    targets:
-      - select:
-          kind: ConsoleLink
-          name: maas-consumer-portal-link
-        fieldPaths:
-          - spec.href
-`), 0644))
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "consolelink.yaml"), []byte(`apiVersion: console.openshift.io/v1
-kind: ConsoleLink
-metadata:
-  name: maas-consumer-portal-link
-spec:
-  applicationMenu:
-    section: section-title
-    imageURL: data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=
-  href: maas-consumer-portal-url
-  location: ApplicationMenu
-  text: MaaS Consumer Portal
-`), 0644))
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "params.env"), []byte("maas-consumer-portal-url=\nsection-title=\n"), 0644))
-}
-
-// getConsoleLink fetches a cluster-scoped ConsoleLink by name, returning nil
-// when it does not exist.
-func getConsoleLink(t *testing.T, name string) *unstructured.Unstructured {
-	t.Helper()
-
-	cl := &unstructured.Unstructured{}
-	cl.SetGroupVersionKind(ctrlpkg.ConsoleLinkGVK)
-	err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, cl)
-	if err != nil {
-		return nil
-	}
-
-	return cl
-}
-
-func deleteConsoleLinkIfExists(t *testing.T, name string) {
-	t.Helper()
-
-	cl := &unstructured.Unstructured{}
-	cl.SetGroupVersionKind(ctrlpkg.ConsoleLinkGVK)
-	cl.SetName(name)
-	_ = k8sClient.Delete(context.Background(), cl)
-}
-
-// conditionStatus returns the status of the named condition on the Dashboard,
-// or an empty string when the condition is absent.
-func conditionStatus(dashboard *v1alpha1.Dashboard, conditionType string) metav1.ConditionStatus {
-	for i := range dashboard.Status.Conditions {
-		if dashboard.Status.Conditions[i].Type == conditionType {
-			return dashboard.Status.Conditions[i].Status
-		}
-	}
-
-	return ""
-}
-
-func TestIntegration_MaasConsumerPortalConsoleLink(t *testing.T) {
-	base := createIntegrationManifests(t, []string{"model-registry"})
-	writeMaasConsumerPortalManifest(t, base)
-
-	r := &ctrlpkg.DashboardReconciler{
-		Client:                k8sClient,
-		Scheme:                k8sClient.Scheme(),
-		ManifestsBasePath:     base,
-		Platform:              cluster.OpenDataHub,
-		Namespace:             integrationNamespace,
-		ApplicationsNamespace: integrationNamespace,
-	}
-
-	dashboard := newDashboard(v1alpha1.DashboardSpec{
-		Gateway:            &v1alpha1.GatewaySpec{Domain: "test.example.com"},
-		Modules:            disableAllModulesExcept("modelRegistry"),
-		MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"},
-	})
-
-	ctx := context.Background()
-	require.NoError(t, k8sClient.Create(ctx, dashboard))
-
-	t.Cleanup(func() {
-		deleteDashboard(t)
-		cleanupModuleResources(t)
-		deleteConsoleLinkIfExists(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
-	})
-
-	reconcile(t, r)
-	reconcile(t, r)
-
-	// ConsoleLink is created with the derived href.
-	cl := getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
-	require.NotNil(t, cl, "maas-consumer-portal-link ConsoleLink should be created when enabled")
-
-	href, found, err := unstructured.NestedString(cl.Object, "spec", "href")
-	require.NoError(t, err)
-	require.True(t, found)
-	assert.Equal(t, "https://maas-consumer-portal.test.example.com/", href)
-
-	// ownerReference points to the Dashboard CR (for GC on CR deletion).
-	owners := cl.GetOwnerReferences()
-	require.Len(t, owners, 1, "ConsoleLink should have exactly one owner reference")
-	assert.Equal(t, v1alpha1.DashboardKind, owners[0].Kind)
-	assert.Equal(t, v1alpha1.DashboardInstanceName, owners[0].Name)
-
-	// The portal carries a distinct part-of label so the core dashboard teardown
-	// (which selects part-of=dashboard) never touches it. This makes the portal
-	// an independent operand — see TestIntegration_MaasConsumerPortalConsoleLinkPreservedWhenCoreRemoved.
-	assert.Equal(t, "maas-consumer-portal", cl.GetLabels()[labels.PlatformPartOf],
-		"portal ConsoleLink must carry part-of=maas-consumer-portal, not part-of=dashboard")
-
-	// Disable the portal — the ConsoleLink is removed.
-	dashboard = getDashboard(t)
-	dashboard.Spec.MaasConsumerPortal = &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Removed"}
-	require.NoError(t, k8sClient.Update(ctx, dashboard))
-
-	reconcile(t, r)
-
-	cl = getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
-	assert.Nil(t, cl, "maas-consumer-portal-link ConsoleLink should be deleted when disabled")
-}
-
-// TestIntegration_MaasConsumerPortalConsoleLinkPreservedWhenCoreRemoved verifies
-// that the portal ConsoleLink survives a core-dashboard teardown while the
-// portal itself stays enabled — the portal is independent of the core
-// dashboard's managementState, so core `managementState: Removed` with
-// `maasConsumerPortal.managementState: Managed` must keep the link visible.
-func TestIntegration_MaasConsumerPortalConsoleLinkPreservedWhenCoreRemoved(t *testing.T) {
-	base := createIntegrationManifests(t, []string{"model-registry"})
-	writeMaasConsumerPortalManifest(t, base)
-
-	r := &ctrlpkg.DashboardReconciler{
-		Client:                k8sClient,
-		Scheme:                k8sClient.Scheme(),
-		ManifestsBasePath:     base,
-		Platform:              cluster.OpenDataHub,
-		Namespace:             integrationNamespace,
-		ApplicationsNamespace: integrationNamespace,
-	}
-
-	dashboard := newDashboard(v1alpha1.DashboardSpec{
-		Gateway:            &v1alpha1.GatewaySpec{Domain: "test.example.com"},
-		Modules:            disableAllModulesExcept("modelRegistry"),
-		MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"},
-	})
-
-	ctx := context.Background()
-	require.NoError(t, k8sClient.Create(ctx, dashboard))
-
-	t.Cleanup(func() {
-		deleteDashboard(t)
-		cleanupModuleResources(t)
-		deleteConsoleLinkIfExists(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
-	})
-
-	reconcile(t, r)
-	reconcile(t, r)
-
-	require.NotNil(t, getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName),
-		"ConsoleLink should exist before Removed")
-
-	// Core dashboard is torn down but the portal stays enabled, so its
-	// ConsoleLink must be preserved.
-	dashboard = getDashboard(t)
-	dashboard.Spec.ManagementState = "Removed"
-	require.NoError(t, k8sClient.Update(ctx, dashboard))
-
-	reconcile(t, r)
-
-	assert.NotNil(t, getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName),
-		"ConsoleLink should be preserved when core is Removed but portal stays enabled")
-
-	updated := getDashboard(t)
-	assert.Equal(t, metav1.ConditionTrue, conditionStatus(updated, "MaasConsumerPortalAvailable"),
-		"MaasConsumerPortalAvailable should be True while the portal stays enabled")
-}
-
-// TestIntegration_MaasConsumerPortalConsoleLinkRemovedWhenDisabled verifies that a
-// core-dashboard teardown with the portal disabled removes the portal
-// ConsoleLink along with the rest of the managed resources.
-func TestIntegration_MaasConsumerPortalConsoleLinkRemovedWhenDisabled(t *testing.T) {
-	base := createIntegrationManifests(t, []string{"model-registry"})
-	writeMaasConsumerPortalManifest(t, base)
-
-	r := &ctrlpkg.DashboardReconciler{
-		Client:                k8sClient,
-		Scheme:                k8sClient.Scheme(),
-		ManifestsBasePath:     base,
-		Platform:              cluster.OpenDataHub,
-		Namespace:             integrationNamespace,
-		ApplicationsNamespace: integrationNamespace,
-	}
-
-	dashboard := newDashboard(v1alpha1.DashboardSpec{
-		Gateway:            &v1alpha1.GatewaySpec{Domain: "test.example.com"},
-		Modules:            disableAllModulesExcept("modelRegistry"),
-		MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"},
-	})
-
-	ctx := context.Background()
-	require.NoError(t, k8sClient.Create(ctx, dashboard))
-
-	t.Cleanup(func() {
-		deleteDashboard(t)
-		cleanupModuleResources(t)
-		deleteConsoleLinkIfExists(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
-	})
-
-	reconcile(t, r)
-	reconcile(t, r)
-
-	require.NotNil(t, getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName),
-		"ConsoleLink should exist before Removed")
-
-	// Portal disabled AND core Removed: nothing should keep the link alive.
-	dashboard = getDashboard(t)
-	dashboard.Spec.ManagementState = "Removed"
-	dashboard.Spec.MaasConsumerPortal = &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Removed"}
-	require.NoError(t, k8sClient.Update(ctx, dashboard))
-
-	reconcile(t, r)
-
-	assert.Nil(t, getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName),
-		"ConsoleLink should be removed when managementState is Removed and portal is disabled")
-}
-
 // newManifestReconciler builds a DashboardReconciler wired to the shared k8sClient.
 func newManifestReconciler(manifests string) *ctrlpkg.DashboardReconciler {
 	return newReconcilerWithClient(k8sClient, manifests)
@@ -647,9 +394,9 @@ func newReconcilerWithClient(cli client.Client, manifests string) *ctrlpkg.Dashb
 func deleteIgnoreNotFound(t *testing.T, objs ...client.Object) {
 	t.Helper()
 	ctx := context.Background()
-	for _, o := range objs {
-		if err := k8sClient.Delete(ctx, o); client.IgnoreNotFound(err) != nil {
-			t.Logf("warning: failed to delete %T %s: %v", o, o.GetName(), err)
+	for _, object := range objs {
+		if err := k8sClient.Delete(ctx, object); client.IgnoreNotFound(err) != nil {
+			t.Logf("warning: failed to delete %T %s: %v", object, object.GetName(), err)
 		}
 	}
 }
@@ -660,10 +407,10 @@ func deleteIgnoreNotFound(t *testing.T, objs ...client.Object) {
 // client's mapper that _PersesCRDNotFound relies on staying empty.
 func newIsolatedClient(t *testing.T) client.Client {
 	t.Helper()
-	c, err := client.New(restCfg, client.Options{Scheme: k8sClient.Scheme()})
+	cli, err := client.New(restCfg, client.Options{Scheme: k8sClient.Scheme()})
 	require.NoError(t, err)
 
-	return c
+	return cli
 }
 
 // readParamsEnv parses a KEY=VALUE params.env file into a map, mirroring the
@@ -679,8 +426,8 @@ func readParamsEnv(t *testing.T, path string) map[string]string {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		if k, v, ok := strings.Cut(line, "="); ok {
-			params[k] = v
+		if key, value, ok := strings.Cut(line, "="); ok {
+			params[key] = value
 		}
 	}
 
@@ -726,7 +473,7 @@ func TestIntegration_StandaloneEnableModule(t *testing.T) {
 	require.Len(t, svcs, 1, "expected exactly one model-registry Service")
 
 	// Verify federation ConfigMap contains the modelRegistry entry.
-	fedCM := getFederationConfigMap(t)
+	fedCM := getConfigMap(t, "federation-config")
 	require.NotNil(t, fedCM, "federation-config ConfigMap should exist")
 
 	entries := parseFederationEntries(t, fedCM)
@@ -803,7 +550,7 @@ func TestIntegration_StandaloneDisableModule(t *testing.T) {
 	assert.Empty(t, svcs, "model-registry Service should be deleted after disabling")
 
 	// Verify federation ConfigMap no longer contains modelRegistry.
-	fedCM := getFederationConfigMap(t)
+	fedCM := getConfigMap(t, "federation-config")
 	require.NotNil(t, fedCM)
 	entries := parseFederationEntries(t, fedCM)
 	entry := findFederationEntry(entries, "modelRegistry")

--- a/dashboard-operator/internal/controller/maas_consumer_portal.go
+++ b/dashboard-operator/internal/controller/maas_consumer_portal.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+const conditionMaasConsumerPortalAvailable = "MaasConsumerPortalAvailable"
+
+// maasConsumerPortalUnavailable reports whether an earlier reconciliation step
+// has already recorded the primary reason the portal is unavailable.
+func maasConsumerPortalUnavailable(cm *conditions.Manager) bool {
+	condition := cm.GetCondition(conditionMaasConsumerPortalAvailable)
+	return condition != nil && condition.Status == metav1.ConditionFalse
+}
+
+// setMaasConsumerPortalModuleCondition makes missing MaaS Consumer Portal dependencies
+// actionable without coupling shared-module logic to a URL model.
+func (r *DashboardReconciler) setMaasConsumerPortalModuleCondition(
+	cm *conditions.Manager,
+	dashboard *v1alpha1.Dashboard,
+	statuses map[string]v1alpha1.ModuleStatus,
+) {
+	if dashboard.Spec.MaasConsumerPortal == nil || dashboard.Spec.MaasConsumerPortal.ManagementState != "Managed" {
+		return
+	}
+	if maasConsumerPortalUnavailable(cm) {
+		return
+	}
+	for _, name := range maasConsumerPortalRequiredModuleNames() {
+		status := statuses[name]
+		if status.Phase == v1alpha1.ModulePhaseDeployed {
+			continue
+		}
+		cm.MarkFalse(conditionMaasConsumerPortalAvailable,
+			conditions.WithReason("RequiredModuleUnavailable"),
+			conditions.WithMessage("Required module %q is unavailable: %s", name, status.Message),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+		return
+	}
+}
+
+func (r *DashboardReconciler) markMaasConsumerPortalFederationConfigMapFailed(cm *conditions.Manager, err error) {
+	if maasConsumerPortalUnavailable(cm) {
+		return
+	}
+	cm.MarkFalse(conditionMaasConsumerPortalAvailable,
+		conditions.WithReason("MaasConsumerPortalFederationConfigMapFailed"),
+		conditions.WithMessage("MaaS Consumer Portal federation ConfigMap reconciliation failed: %s", err),
+		conditions.WithSeverity(common.ConditionSeverityInfo))
+}

--- a/dashboard-operator/internal/controller/maas_consumer_portal_consolelink.go
+++ b/dashboard-operator/internal/controller/maas_consumer_portal_consolelink.go
@@ -1,0 +1,225 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/render"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/render/kustomize"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+var (
+	ErrMaasConsumerPortalDisabled       = errors.New("maas consumer portal is not enabled")
+	ErrMaasConsumerPortalDomainRequired = errors.New("maas consumer portal is enabled but gateway domain is not set")
+)
+
+// maasConsumerPortalConsoleLinkName is the fixed name of the MaaS Consumer Portal
+// ConsoleLink CR managed by the operator.
+const maasConsumerPortalConsoleLinkName = "maas-consumer-portal-link"
+
+// maasConsumerPortalPartOf is the platform.opendatahub.io/part-of label value
+// applied to maas consumer portal resources. It is deliberately distinct from the
+// core dashboard's value so the portal is an independent operand: the core
+// dashboard teardown (which selects part-of=dashboard) never matches portal
+// resources, and the portal is reconciled and removed solely by
+// reconcileMaasConsumerPortalConsoleLink — independent of the core dashboard's
+// managementState.
+const maasConsumerPortalPartOf = "maas-consumer-portal"
+
+// maasConsumerPortalHostPrefix is prepended to Gateway.Domain to derive the
+// MaaS Consumer Portal host (e.g. maas-consumer-portal.<domain>).
+const maasConsumerPortalHostPrefix = "maas-consumer-portal"
+
+// maasConsumerPortalConsoleLinkManifestInfo points at the portal ConsoleLink
+// bundle. It always uses the /rhoai source: the portal is an RHOAI feature
+// and deploys on both self-managed and managed RHOAI when enabled, so it is
+// intentionally not gated by the platformPaths /not-supported overlay.
+func maasConsumerPortalConsoleLinkManifestInfo(basePath string) render.ManifestInfo {
+	return render.ManifestInfo{
+		Path:       basePath,
+		ContextDir: "maas-consumer-portal-consolelink",
+		SourcePath: "/rhoai",
+	}
+}
+
+// maasConsumerPortalURL derives the portal URL from the gateway domain. The
+// second return value is false when the domain is empty, meaning the URL
+// cannot be derived and the ConsoleLink must not be deployed.
+func maasConsumerPortalURL(domain string) (string, bool) {
+	if domain == "" {
+		return "", false
+	}
+
+	return fmt.Sprintf("https://%s.%s/", maasConsumerPortalHostPrefix, domain), true
+}
+
+// reconcileMaasConsumerPortalConsoleLink deploys or removes the MaaS Consumer
+// Portal ConsoleLink based on spec.maasConsumerPortal, and reports the outcome via
+// the MaasConsumerPortalAvailable condition. All False states use Info severity so the
+// portal never affects the Ready rollup.
+func (r *DashboardReconciler) reconcileMaasConsumerPortalConsoleLink(
+	ctx context.Context,
+	dashboard *v1alpha1.Dashboard,
+	cm *conditions.Manager,
+) {
+	logger := log.FromContext(ctx)
+
+	switch maasConsumerPortalErr := deployMaasConsumerPortalConsoleLink(ctx, r.Client, dashboard, r.ManifestsBasePath, r.Platform); {
+	case maasConsumerPortalErr == nil:
+		cm.MarkTrue(conditionMaasConsumerPortalAvailable,
+			conditions.WithReason("Deployed"),
+			conditions.WithMessage("MaaS Consumer Portal ConsoleLink applied successfully"))
+	case errors.Is(maasConsumerPortalErr, ErrMaasConsumerPortalDisabled):
+		// Explicitly remove the ConsoleLink when the portal is disabled — the
+		// SSA deployer is additive and does not prune. Benign cases (absent
+		// object, ConsoleLink CRD not installed) are already treated as success
+		// inside deleteMaasConsumerPortalConsoleLink, so a non-nil error here is a
+		// genuine failure: surface it on the condition (Info severity, like the
+		// deploy-failed branch) rather than falsely reporting a clean Disabled
+		// state while a stale ConsoleLink lingers.
+		if delErr := deleteMaasConsumerPortalConsoleLink(ctx, r.Client); delErr != nil {
+			logger.Error(delErr, "Failed to delete maas consumer portal ConsoleLink")
+			cm.MarkFalse(conditionMaasConsumerPortalAvailable,
+				conditions.WithReason("MaasConsumerPortalDeleteFailed"),
+				conditions.WithMessage("failed to delete maas consumer portal ConsoleLink: %s", delErr.Error()),
+				conditions.WithSeverity(common.ConditionSeverityInfo))
+		} else {
+			cm.MarkFalse(conditionMaasConsumerPortalAvailable,
+				conditions.WithReason("Disabled"),
+				conditions.WithMessage("MaaS Consumer Portal is not enabled"),
+				conditions.WithSeverity(common.ConditionSeverityInfo))
+		}
+	case errors.Is(maasConsumerPortalErr, ErrMaasConsumerPortalDomainRequired):
+		cm.MarkFalse(conditionMaasConsumerPortalAvailable,
+			conditions.WithReason("MaasConsumerPortalDomainRequired"),
+			conditions.WithMessage("MaaS Consumer Portal is enabled but gateway domain is not set"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+		logger.Info("MaaS Consumer Portal enabled but gateway domain not set, skipping ConsoleLink")
+	default:
+		cm.MarkFalse(conditionMaasConsumerPortalAvailable,
+			conditions.WithReason("MaasConsumerPortalDeployFailed"),
+			conditions.WithMessage("MaaS Consumer Portal ConsoleLink reconciliation failed: %s", maasConsumerPortalErr),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+		logger.Error(maasConsumerPortalErr, "Failed to deploy maas consumer portal ConsoleLink")
+	}
+}
+
+// deployMaasConsumerPortalConsoleLink renders and applies the MaaS Consumer Portal
+// ConsoleLink. It returns ErrMaasConsumerPortalDisabled when the portal is not
+// enabled and ErrMaasConsumerPortalDomainRequired when the gateway domain (from
+// which the portal host is derived) is not set. The cluster-scoped ConsoleLink
+// is owned by the Dashboard CR so it is garbage-collected on CR deletion.
+func deployMaasConsumerPortalConsoleLink(
+	ctx context.Context,
+	cli client.Client,
+	dashboard *v1alpha1.Dashboard,
+	basePath string,
+	platform cluster.Platform,
+) error {
+	logger := log.FromContext(ctx)
+
+	if dashboard.Spec.MaasConsumerPortal == nil || dashboard.Spec.MaasConsumerPortal.ManagementState != "Managed" {
+		return ErrMaasConsumerPortalDisabled
+	}
+
+	domain := ""
+	if dashboard.Spec.Gateway != nil {
+		domain = dashboard.Spec.Gateway.Domain
+	}
+
+	maasConsumerPortalURLValue, ok := maasConsumerPortalURL(domain)
+	if !ok {
+		return ErrMaasConsumerPortalDomainRequired
+	}
+
+	// RHOAI-only feature; warn if enabled on ODH so the misconfig is visible.
+	if platform == cluster.OpenDataHub {
+		logger.Info("MaaS Consumer Portal ConsoleLink is an RHOAI-only feature; deploying it on Open Data Hub will use RHOAI branding")
+	}
+
+	m := maasConsumerPortalConsoleLinkManifestInfo(basePath)
+
+	// Inject the derived portal URL and the platform's section title into the
+	// portal manifest's own params.env before rendering.
+	manifestPath := m.String()
+	params := readExistingParams(filepath.Join(manifestPath, "params.env"))
+	params["maas-consumer-portal-url"] = maasConsumerPortalURLValue
+	if title, titleOK := sectionTitle[platform]; titleOK {
+		params["section-title"] = title
+	}
+	if err := writeParamsEnv(manifestPath, params); err != nil {
+		return fmt.Errorf("failed to write maas consumer portal params.env to %s: %w", manifestPath, err)
+	}
+
+	engine := kustomize.NewEngine()
+
+	rendered, err := engine.Render(m.String(), kustomize.WithNamespace(dashboard.Namespace))
+	if err != nil {
+		return fmt.Errorf("failed to render maas consumer portal manifests from %s: %w", m, err)
+	}
+
+	// Deploy only the ConsoleLink. The kustomize configMapGenerator produces a
+	// params ConfigMap used purely for replacements; deploying it would leave an
+	// orphan when the portal is disabled, so it is filtered out here to keep
+	// deploy/delete symmetric.
+	resources := make([]unstructured.Unstructured, 0, len(rendered))
+	for i := range rendered {
+		if rendered[i].GetKind() == "ConsoleLink" {
+			resources = append(resources, rendered[i])
+		}
+	}
+
+	logger.Info("Deploying maas consumer portal ConsoleLink", "url", maasConsumerPortalURLValue, "resources", len(resources))
+
+	deployer := deploy.NewDeployer(
+		deploy.WithFieldOwner("dashboard-operator"),
+		deploy.WithLabel(labels.PlatformPartOf, maasConsumerPortalPartOf),
+		deploy.WithApplyOrder(),
+	)
+
+	if err := deployer.Deploy(ctx, deploy.DeployInput{
+		Client:    cli,
+		Owner:     dashboard,
+		Release:   deploy.ReleaseInfo{Type: string(platform)},
+		Resources: resources,
+	}); err != nil {
+		return fmt.Errorf("failed to deploy maas consumer portal ConsoleLink: %w", err)
+	}
+
+	return nil
+}
+
+// deleteMaasConsumerPortalConsoleLink removes the portal ConsoleLink by name. It is
+// a no-op when the ConsoleLink CRD is not installed or the object is absent.
+func deleteMaasConsumerPortalConsoleLink(ctx context.Context, cli client.Client) error {
+	logger := log.FromContext(ctx)
+
+	cl := &unstructured.Unstructured{}
+	cl.SetGroupVersionKind(consoleLinkGVK)
+	cl.SetName(maasConsumerPortalConsoleLinkName)
+
+	logger.Info("Deleting maas consumer portal ConsoleLink", "name", maasConsumerPortalConsoleLinkName)
+	if err := cli.Delete(ctx, cl); client.IgnoreNotFound(err) != nil {
+		if meta.IsNoMatchError(err) {
+			return nil
+		}
+
+		return fmt.Errorf("deleting ConsoleLink %s: %w", maasConsumerPortalConsoleLinkName, err)
+	}
+
+	return nil
+}

--- a/dashboard-operator/internal/controller/maas_consumer_portal_export_test.go
+++ b/dashboard-operator/internal/controller/maas_consumer_portal_export_test.go
@@ -1,0 +1,28 @@
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+func (r *DashboardReconciler) PatchMaasConsumerPortalDeploymentFederationHash(ctx context.Context, configData string) error {
+	return r.patchMaasConsumerPortalDeploymentFederationHash(ctx, configData)
+}
+
+func (r *DashboardReconciler) DeployMaasConsumerPortalFederationConfigMap(ctx context.Context, dashboard *v1alpha1.Dashboard, statuses map[string]v1alpha1.ModuleStatus) error {
+	return r.deployMaasConsumerPortalFederationConfigMap(ctx, dashboard, statuses)
+}
+
+func BuildMaasConsumerPortalFederationConfigMap(
+	r *DashboardReconciler,
+	statuses map[string]v1alpha1.ModuleStatus,
+) (*corev1.ConfigMap, error) {
+	return r.buildMaasConsumerPortalFederationConfigMap(statuses)
+}
+
+const MaasConsumerPortalConsoleLinkName = maasConsumerPortalConsoleLinkName
+
+const ConditionMaasConsumerPortalAvailable = conditionMaasConsumerPortalAvailable

--- a/dashboard-operator/internal/controller/maas_consumer_portal_federation.go
+++ b/dashboard-operator/internal/controller/maas_consumer_portal_federation.go
@@ -1,0 +1,138 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+const maasConsumerPortalFederationConfigMapName = "maas-consumer-portal-federation-config"
+
+const maasConsumerPortalFederationHashAnnotation = "dashboard.opendatahub.io/maas-consumer-portal-federation-config-hash"
+
+func maasConsumerPortalRequiredModuleNames() []string {
+	names := make([]string, 0, len(moduleRegistry))
+	for name, module := range moduleRegistry {
+		if module.RequiredByMaasConsumerPortal {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func maasConsumerPortalRequiredModuleSlugs(spec *v1alpha1.DashboardSpec, statuses map[string]v1alpha1.ModuleStatus) map[string]bool {
+	requiredModules := make(map[string]bool)
+	if spec.MaasConsumerPortal == nil || spec.MaasConsumerPortal.ManagementState != "Managed" {
+		return requiredModules
+	}
+
+	for _, name := range maasConsumerPortalRequiredModuleNames() {
+		module := moduleRegistry[name]
+		status := statuses[name]
+		if status.Phase == v1alpha1.ModulePhaseDeployed || status.Phase == v1alpha1.ModulePhaseDegraded {
+			requiredModules[module.ManifestSlug] = true
+		}
+	}
+	return requiredModules
+}
+
+// patchMaasConsumerPortalDeploymentFederationHash triggers a rollout only when
+// the MaaS Consumer Portal remote configuration changes. Task 2/4 own creation
+// of this Deployment, so an absent MaaS Consumer Portal workload is an expected no-op.
+func (r *DashboardReconciler) patchMaasConsumerPortalDeploymentFederationHash(ctx context.Context, configData string) error {
+	var deployment appsv1.Deployment
+	key := client.ObjectKey{Name: "maas-consumer-portal", Namespace: r.ApplicationsNamespace}
+	if err := r.Get(ctx, key, &deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("getting MaaS Consumer Portal deployment: %w", err)
+	}
+
+	hash := computeFederationConfigHash(configData)
+	if deployment.Spec.Template.Annotations != nil &&
+		deployment.Spec.Template.Annotations[maasConsumerPortalFederationHashAnnotation] == hash {
+		return nil
+	}
+	patch := client.MergeFrom(deployment.DeepCopy())
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = map[string]string{}
+	}
+	deployment.Spec.Template.Annotations[maasConsumerPortalFederationHashAnnotation] = hash
+	if err := r.Patch(ctx, &deployment, patch); err != nil {
+		return fmt.Errorf("patching MaaS Consumer Portal deployment with federation hash: %w", err)
+	}
+	return nil
+}
+
+// buildMaasConsumerPortalFederationConfigMap contains only services required by the
+// standalone MaaS Consumer Portal. The proxy paths are registry-owned; URL-model-specific
+// ingress rewriting remains outside aggregate module orchestration.
+func (r *DashboardReconciler) buildMaasConsumerPortalFederationConfigMap(
+	statuses map[string]v1alpha1.ModuleStatus,
+) (*corev1.ConfigMap, error) {
+	entries := make([]federationEntry, 0, 2)
+	for _, name := range maasConsumerPortalRequiredModuleNames() {
+		mod := moduleRegistry[name]
+		status := statuses[name]
+		if status.Phase != v1alpha1.ModulePhaseDeployed && status.Phase != v1alpha1.ModulePhaseDegraded {
+			continue
+		}
+		entries = append(entries, r.moduleFederationEntry(name, mod))
+	}
+	data, err := json.MarshalIndent(entries, "    ", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshalling MaaS Consumer Portal federation config: %w", err)
+	}
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: maasConsumerPortalFederationConfigMapName, Namespace: r.ApplicationsNamespace,
+			Labels: map[string]string{labels.PlatformPartOf: "maas-consumer-portal",
+				"app.kubernetes.io/part-of": "maas-consumer-portal", moduleComponentLabel: "maas-consumer-portal"}},
+		Data: map[string]string{federationConfigKey: string(data)},
+	}, nil
+}
+
+func (r *DashboardReconciler) deployMaasConsumerPortalFederationConfigMap(ctx context.Context, dashboard *v1alpha1.Dashboard, statuses map[string]v1alpha1.ModuleStatus) error {
+	if dashboard.Spec.MaasConsumerPortal == nil || dashboard.Spec.MaasConsumerPortal.ManagementState != "Managed" {
+		configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: maasConsumerPortalFederationConfigMapName, Namespace: r.ApplicationsNamespace}}
+		if err := r.Delete(ctx, configMap); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("deleting MaaS Consumer Portal federation ConfigMap: %w", err)
+		}
+		return nil
+	}
+	configMap, err := r.buildMaasConsumerPortalFederationConfigMap(statuses)
+	if err != nil {
+		return err
+	}
+	resource, err := configMapToUnstructured(configMap)
+	if err != nil {
+		return fmt.Errorf("converting MaaS Consumer Portal federation ConfigMap: %w", err)
+	}
+	deployer := deploy.NewDeployer(deploy.WithFieldOwner("dashboard-operator"),
+		deploy.WithLabel(labels.PlatformPartOf, "maas-consumer-portal"),
+		deploy.WithLabel("app.kubernetes.io/part-of", "maas-consumer-portal"),
+		deploy.WithLabel(moduleComponentLabel, "maas-consumer-portal"))
+	if err := deployer.Deploy(ctx, deploy.DeployInput{Client: r.Client, Owner: dashboard,
+		Release: deploy.ReleaseInfo{Type: string(r.Platform)}, Resources: []unstructured.Unstructured{resource}}); err != nil {
+		return fmt.Errorf("deploying MaaS Consumer Portal federation ConfigMap: %w", err)
+	}
+	if err := r.patchMaasConsumerPortalDeploymentFederationHash(ctx, configMap.Data[federationConfigKey]); err != nil {
+		return err
+	}
+	return nil
+}

--- a/dashboard-operator/internal/controller/maas_consumer_portal_integration_test.go
+++ b/dashboard-operator/internal/controller/maas_consumer_portal_integration_test.go
@@ -1,0 +1,351 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+)
+
+// writeMaasConsumerPortalManifest writes the portal ConsoleLink kustomize bundle
+// into base/maas-consumer-portal-consolelink/rhoai so the reconciler can render it.
+func writeMaasConsumerPortalManifest(t *testing.T, base string) {
+	t.Helper()
+
+	dir := filepath.Join(base, "maas-consumer-portal-consolelink", "rhoai")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - consolelink.yaml
+configMapGenerator:
+  - name: maas-consumer-portal-params
+    env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+replacements:
+  - source:
+      kind: ConfigMap
+      name: maas-consumer-portal-params
+      fieldPath: data.section-title
+    targets:
+      - select:
+          kind: ConsoleLink
+          name: maas-consumer-portal-link
+        fieldPaths:
+          - spec.applicationMenu.section
+  - source:
+      kind: ConfigMap
+      name: maas-consumer-portal-params
+      fieldPath: data.maas-consumer-portal-url
+    targets:
+      - select:
+          kind: ConsoleLink
+          name: maas-consumer-portal-link
+        fieldPaths:
+          - spec.href
+`), 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "consolelink.yaml"), []byte(`apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: maas-consumer-portal-link
+spec:
+  applicationMenu:
+    section: section-title
+    imageURL: data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=
+  href: maas-consumer-portal-url
+  location: ApplicationMenu
+  text: MaaS Consumer Portal
+`), 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "params.env"), []byte("maas-consumer-portal-url=\nsection-title=\n"), 0644))
+}
+
+// getConsoleLink fetches a cluster-scoped ConsoleLink by name, returning nil
+// when it does not exist.
+func getConsoleLink(t *testing.T, name string) *unstructured.Unstructured {
+	t.Helper()
+
+	cl := &unstructured.Unstructured{}
+	cl.SetGroupVersionKind(ctrlpkg.ConsoleLinkGVK)
+	err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, cl)
+	if err != nil {
+		return nil
+	}
+
+	return cl
+}
+
+func deleteConsoleLinkIfExists(t *testing.T, name string) {
+	t.Helper()
+
+	cl := &unstructured.Unstructured{}
+	cl.SetGroupVersionKind(ctrlpkg.ConsoleLinkGVK)
+	cl.SetName(name)
+	_ = k8sClient.Delete(context.Background(), cl)
+}
+
+// conditionStatus returns the status of the named condition on the Dashboard,
+// or an empty string when the condition is absent.
+func conditionStatus(dashboard *v1alpha1.Dashboard, conditionType string) metav1.ConditionStatus {
+	for i := range dashboard.Status.Conditions {
+		if dashboard.Status.Conditions[i].Type == conditionType {
+			return dashboard.Status.Conditions[i].Status
+		}
+	}
+
+	return ""
+}
+
+func conditionReason(dashboard *v1alpha1.Dashboard, conditionType string) string {
+	for i := range dashboard.Status.Conditions {
+		if dashboard.Status.Conditions[i].Type == conditionType {
+			return dashboard.Status.Conditions[i].Reason
+		}
+	}
+
+	return ""
+}
+
+func TestIntegration_MaasConsumerPortalConsoleLink(t *testing.T) {
+	base := createIntegrationManifests(t, []string{"model-registry"})
+	writeMaasConsumerPortalManifest(t, base)
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                k8sClient,
+		Scheme:                k8sClient.Scheme(),
+		ManifestsBasePath:     base,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             integrationNamespace,
+		ApplicationsNamespace: integrationNamespace,
+	}
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway:            &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules:            disableAllModulesExcept("modelRegistry"),
+		MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"},
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+		deleteConsoleLinkIfExists(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	// ConsoleLink is created with the derived href.
+	cl := getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
+	require.NotNil(t, cl, "maas-consumer-portal-link ConsoleLink should be created when enabled")
+
+	href, found, err := unstructured.NestedString(cl.Object, "spec", "href")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "https://maas-consumer-portal.test.example.com/", href)
+
+	// ownerReference points to the Dashboard CR (for GC on CR deletion).
+	owners := cl.GetOwnerReferences()
+	require.Len(t, owners, 1, "ConsoleLink should have exactly one owner reference")
+	assert.Equal(t, v1alpha1.DashboardKind, owners[0].Kind)
+	assert.Equal(t, v1alpha1.DashboardInstanceName, owners[0].Name)
+
+	// The portal carries a distinct part-of label so the core dashboard teardown
+	// (which selects part-of=dashboard) never touches it. This makes the portal
+	// an independent operand — see TestIntegration_MaasConsumerPortalConsoleLinkPreservedWhenCoreRemoved.
+	assert.Equal(t, "maas-consumer-portal", cl.GetLabels()[labels.PlatformPartOf],
+		"portal ConsoleLink must carry part-of=maas-consumer-portal, not part-of=dashboard")
+
+	// Disable the portal — the ConsoleLink is removed.
+	dashboard = getDashboard(t)
+	dashboard.Spec.MaasConsumerPortal = &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Removed"}
+	require.NoError(t, k8sClient.Update(ctx, dashboard))
+
+	reconcile(t, r)
+
+	cl = getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
+	assert.Nil(t, cl, "maas-consumer-portal-link ConsoleLink should be deleted when disabled")
+}
+
+// TestIntegration_MaasConsumerPortalConsoleLinkPreservedWhenCoreRemoved verifies
+// that the portal ConsoleLink survives a core-dashboard teardown while the
+// portal itself stays enabled — the portal is independent of the core
+// dashboard's managementState, so core `managementState: Removed` with
+// `maasConsumerPortal.managementState: Managed` must keep the link visible.
+func TestIntegration_MaasConsumerPortalConsoleLinkPreservedWhenCoreRemoved(t *testing.T) {
+	base := createIntegrationManifests(t, []string{"model-registry"})
+	writeMaasConsumerPortalManifest(t, base)
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                k8sClient,
+		Scheme:                k8sClient.Scheme(),
+		ManifestsBasePath:     base,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             integrationNamespace,
+		ApplicationsNamespace: integrationNamespace,
+	}
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway:            &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules:            disableAllModulesExcept("modelRegistry"),
+		MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"},
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+		deleteConsoleLinkIfExists(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	require.NotNil(t, getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName),
+		"ConsoleLink should exist before Removed")
+
+	// Core dashboard is torn down but the portal stays enabled, so its
+	// ConsoleLink must be preserved.
+	dashboard = getDashboard(t)
+	dashboard.Spec.ManagementState = "Removed"
+	require.NoError(t, k8sClient.Update(ctx, dashboard))
+
+	reconcile(t, r)
+
+	assert.NotNil(t, getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName),
+		"ConsoleLink should be preserved when core is Removed but portal stays enabled")
+
+	updated := getDashboard(t)
+	assert.Equal(t, metav1.ConditionFalse, conditionStatus(updated, "MaasConsumerPortalAvailable"),
+		"MaaS Consumer Portal must report unavailable when its explicitly disabled MaaS/GenAI dependencies are missing")
+	assert.Equal(t, "RequiredModuleUnavailable", conditionReason(updated, "MaasConsumerPortalAvailable"))
+}
+
+// TestIntegration_MaasConsumerPortalConsoleLinkRemovedWhenDisabled verifies that a
+// core-dashboard teardown with the portal disabled removes the portal
+// ConsoleLink along with the rest of the managed resources.
+func TestIntegration_MaasConsumerPortalConsoleLinkRemovedWhenDisabled(t *testing.T) {
+	base := createIntegrationManifests(t, []string{"model-registry"})
+	writeMaasConsumerPortalManifest(t, base)
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                k8sClient,
+		Scheme:                k8sClient.Scheme(),
+		ManifestsBasePath:     base,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             integrationNamespace,
+		ApplicationsNamespace: integrationNamespace,
+	}
+
+	dashboard := newDashboard(v1alpha1.DashboardSpec{
+		Gateway:            &v1alpha1.GatewaySpec{Domain: "test.example.com"},
+		Modules:            disableAllModulesExcept("modelRegistry"),
+		MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"},
+	})
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	t.Cleanup(func() {
+		deleteDashboard(t)
+		cleanupModuleResources(t)
+		deleteConsoleLinkIfExists(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
+	})
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	require.NotNil(t, getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName),
+		"ConsoleLink should exist before Removed")
+
+	// Portal disabled AND core Removed: nothing should keep the link alive.
+	dashboard = getDashboard(t)
+	dashboard.Spec.ManagementState = "Removed"
+	dashboard.Spec.MaasConsumerPortal = &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Removed"}
+	require.NoError(t, k8sClient.Update(ctx, dashboard))
+
+	reconcile(t, r)
+
+	assert.Nil(t, getConsoleLink(t, ctrlpkg.MaasConsumerPortalConsoleLinkName),
+		"ConsoleLink should be removed when managementState is Removed and portal is disabled")
+}
+
+func TestIntegration_MaasConsumerPortalModuleDemandMatrix(t *testing.T) {
+	tests := []struct {
+		name                         string
+		coreState                    string
+		maasConsumerPortalState      string
+		wantSharedBFFs               bool
+		wantMaasConsumerPortalConfig bool
+	}{
+		{name: "Core Dashboard only", coreState: "Managed", maasConsumerPortalState: "Removed", wantSharedBFFs: true},
+		{name: "Core Dashboard and MaaS Consumer Portal", coreState: "Managed", maasConsumerPortalState: "Managed", wantSharedBFFs: true, wantMaasConsumerPortalConfig: true},
+		{name: "MaaS Consumer Portal only", coreState: "Removed", maasConsumerPortalState: "Managed", wantSharedBFFs: true, wantMaasConsumerPortalConfig: true},
+		{name: "both operands removed", coreState: "Removed", maasConsumerPortalState: "Removed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := createIntegrationManifests(t, []string{"maas", "gen-ai"})
+			writeMaasConsumerPortalManifest(t, base)
+			r := &ctrlpkg.DashboardReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), ManifestsBasePath: base, Platform: cluster.OpenDataHub, Namespace: integrationNamespace, ApplicationsNamespace: integrationNamespace}
+			dashboard := newDashboard(v1alpha1.DashboardSpec{ManagementSpec: common.ManagementSpec{ManagementState: common.ManagementState(tt.coreState)}, Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"}, Modules: disableAllModulesExcept("maas", "genAi"), MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: tt.maasConsumerPortalState}})
+			require.NoError(t, k8sClient.Create(context.Background(), dashboard))
+			t.Cleanup(func() {
+				deleteDashboard(t)
+				cleanupModuleResources(t)
+				deleteConsoleLinkIfExists(t, ctrlpkg.MaasConsumerPortalConsoleLinkName)
+				_ = k8sClient.Delete(context.Background(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "maas-consumer-portal-federation-config", Namespace: integrationNamespace}})
+			})
+			reconcile(t, r)
+			reconcile(t, r)
+
+			if tt.wantSharedBFFs {
+				assert.Len(t, listDeployments(t, "maas"), 1, "one MaaS BFF Deployment")
+				assert.Len(t, listServices(t, "maas"), 1, "one MaaS BFF Service")
+				assert.Len(t, listDeployments(t, "gen-ai"), 1, "one GenAI BFF Deployment")
+				assert.Len(t, listServices(t, "gen-ai"), 1, "one GenAI BFF Service")
+			} else {
+				assert.Empty(t, listDeployments(t, "maas"))
+				assert.Empty(t, listServices(t, "maas"))
+				assert.Empty(t, listDeployments(t, "gen-ai"))
+				assert.Empty(t, listServices(t, "gen-ai"))
+			}
+
+			maasConsumerPortalConfig := getConfigMap(t, "maas-consumer-portal-federation-config")
+			if !tt.wantMaasConsumerPortalConfig {
+				assert.Nil(t, maasConsumerPortalConfig)
+				return
+			}
+			require.NotNil(t, maasConsumerPortalConfig)
+			assert.Equal(t, "maas-consumer-portal", maasConsumerPortalConfig.Labels[labels.PlatformPartOf])
+			entries := parseFederationEntries(t, maasConsumerPortalConfig)
+			require.Len(t, entries, 2)
+			assert.NotNil(t, findFederationEntry(entries, "maas"))
+			assert.NotNil(t, findFederationEntry(entries, "genAi"))
+		})
+	}
+}

--- a/dashboard-operator/internal/controller/maas_consumer_portal_module_deploy_test.go
+++ b/dashboard-operator/internal/controller/maas_consumer_portal_module_deploy_test.go
@@ -1,0 +1,100 @@
+package controller_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+)
+
+func TestBuildMaasConsumerPortalFederationConfigMap(t *testing.T) {
+	scheme := testScheme(t)
+	reconciler := &ctrlpkg.DashboardReconciler{
+		Client:                fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme:                scheme,
+		Platform:              cluster.OpenDataHub,
+		ApplicationsNamespace: testNamespace,
+	}
+	statuses := allDeployedStatuses()
+	statuses["maas"] = v1alpha1.ModuleStatus{Phase: v1alpha1.ModulePhaseDegraded}
+	statuses["genAi"] = v1alpha1.ModuleStatus{Phase: v1alpha1.ModulePhaseDisabled}
+
+	configMap, err := ctrlpkg.BuildMaasConsumerPortalFederationConfigMap(reconciler, statuses)
+	require.NoError(t, err)
+	assert.Equal(t, "maas-consumer-portal-federation-config", configMap.Name)
+	assert.Equal(t, "maas-consumer-portal", configMap.Labels["platform.opendatahub.io/part-of"])
+	assert.Equal(t, "maas-consumer-portal", configMap.Labels["app.kubernetes.io/part-of"])
+	assert.Equal(t, "maas-consumer-portal", configMap.Labels["app.kubernetes.io/component"])
+
+	var entries []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(configMap.Data["module-federation-config.json"]), &entries))
+	require.Len(t, entries, 1)
+	assert.Equal(t, "maas", entries[0]["name"])
+	assert.Equal(t, "/maas/api", entries[0]["proxy"].([]any)[0].(map[string]any)["path"])
+}
+
+func TestBuildMaasConsumerPortalFederationConfigMap_IncludesHealthyDependencies(t *testing.T) {
+	scheme := testScheme(t)
+	reconciler := &ctrlpkg.DashboardReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).Build(), Scheme: scheme, Platform: cluster.OpenDataHub, ApplicationsNamespace: testNamespace}
+	configMap, err := ctrlpkg.BuildMaasConsumerPortalFederationConfigMap(reconciler, allDeployedStatuses())
+	require.NoError(t, err)
+	var entries []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(configMap.Data["module-federation-config.json"]), &entries))
+	require.Len(t, entries, 2)
+	assert.Equal(t, "genAi", entries[0]["name"])
+	assert.Equal(t, "maas", entries[1]["name"])
+	assert.Equal(t, float64(8143), entries[0]["service"].(map[string]any)["port"])
+	assert.Equal(t, float64(8243), entries[1]["service"].(map[string]any)["port"])
+}
+
+func TestDeployMaasConsumerPortalFederationConfigMap_RemovedDeletesConfigMap(t *testing.T) {
+	scheme := testScheme(t)
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "maas-consumer-portal-federation-config", Namespace: testNamespace}}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	reconciler := &ctrlpkg.DashboardReconciler{Client: client, Scheme: scheme, ApplicationsNamespace: testNamespace}
+	dashboard := &v1alpha1.Dashboard{Spec: v1alpha1.DashboardSpec{MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Removed"}}}
+	require.NoError(t, reconciler.DeployMaasConsumerPortalFederationConfigMap(context.Background(), dashboard, nil))
+	assert.Error(t, client.Get(context.Background(), types.NamespacedName{Name: configMap.Name, Namespace: testNamespace}, &corev1.ConfigMap{}))
+}
+
+func TestPatchMaasConsumerPortalDeploymentFederationHash(t *testing.T) {
+	const annotation = "dashboard.opendatahub.io/maas-consumer-portal-federation-config-hash"
+	newDeployment := func(annotations map[string]string) *appsv1.Deployment {
+		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "maas-consumer-portal", Namespace: testNamespace}, Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}}}
+	}
+	tests := []struct{ name, oldHash, data string }{
+		{name: "creates annotation", data: `[{"name":"maas"}]`},
+		{name: "updates changed annotation", oldHash: "old", data: `[{"name":"genAi"}]`},
+		{name: "does not fail when deployment is absent", data: `[]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := testScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.name != "does not fail when deployment is absent" {
+				builder = builder.WithObjects(newDeployment(map[string]string{annotation: tt.oldHash}))
+			}
+			client := builder.Build()
+			reconciler := &ctrlpkg.DashboardReconciler{Client: client, Scheme: scheme, ApplicationsNamespace: testNamespace}
+			require.NoError(t, reconciler.PatchMaasConsumerPortalDeploymentFederationHash(context.Background(), tt.data))
+			if tt.name == "does not fail when deployment is absent" {
+				return
+			}
+			updated := &appsv1.Deployment{}
+			require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "maas-consumer-portal", Namespace: testNamespace}, updated))
+			assert.Equal(t, ctrlpkg.ComputeFederationConfigHash(tt.data), updated.Spec.Template.Annotations[annotation])
+		})
+	}
+}

--- a/dashboard-operator/internal/controller/maas_consumer_portal_modules_test.go
+++ b/dashboard-operator/internal/controller/maas_consumer_portal_modules_test.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+func TestResolveModuleStatuses_MaasConsumerPortalDemand(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       v1alpha1.DashboardSpec
+		wantPhases map[string]v1alpha1.ModulePhase
+		wantReason map[string]string
+	}{
+		{
+			name:       "MaaS Consumer Portal only requires MaaS and GenAI",
+			spec:       v1alpha1.DashboardSpec{ManagementSpec: common.ManagementSpec{ManagementState: "Removed"}, MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"}},
+			wantPhases: map[string]v1alpha1.ModulePhase{"maas": v1alpha1.ModulePhaseDeployed, "genAi": v1alpha1.ModulePhaseDeployed, "mlflow": v1alpha1.ModulePhaseNotDeployed},
+		},
+		{
+			name:       "Core Dashboard and MaaS Consumer Portal share MaaS and GenAI demand",
+			spec:       v1alpha1.DashboardSpec{ManagementSpec: common.ManagementSpec{ManagementState: "Managed"}, MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"}},
+			wantPhases: map[string]v1alpha1.ModulePhase{"maas": v1alpha1.ModulePhaseDeployed, "genAi": v1alpha1.ModulePhaseDeployed, "mlflow": v1alpha1.ModulePhaseDeployed},
+		},
+		{
+			name:       "explicit disable overrides MaaS Consumer Portal demand",
+			spec:       v1alpha1.DashboardSpec{ManagementSpec: common.ManagementSpec{ManagementState: "Removed"}, MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"}, Modules: map[string]v1alpha1.ModuleOverride{"maas": {State: v1alpha1.ModuleDisabled}}},
+			wantPhases: map[string]v1alpha1.ModulePhase{"maas": v1alpha1.ModulePhaseDisabled, "genAi": v1alpha1.ModulePhaseDeployed},
+			wantReason: map[string]string{"maas": "ExplicitOverride"},
+		},
+		{
+			name:       "neither operand requires modules",
+			spec:       v1alpha1.DashboardSpec{ManagementSpec: common.ManagementSpec{ManagementState: "Removed"}},
+			wantPhases: map[string]v1alpha1.ModulePhase{"maas": v1alpha1.ModulePhaseNotDeployed, "genAi": v1alpha1.ModulePhaseNotDeployed},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statuses := resolveModuleStatuses(&tt.spec)
+			for module, phase := range tt.wantPhases {
+				require.Contains(t, statuses, module)
+				assert.Equal(t, phase, statuses[module].Phase)
+			}
+			for module, reason := range tt.wantReason {
+				assert.Equal(t, reason, statuses[module].Reason)
+			}
+		})
+	}
+}

--- a/dashboard-operator/internal/controller/maas_consumer_portal_test.go
+++ b/dashboard-operator/internal/controller/maas_consumer_portal_test.go
@@ -150,3 +150,107 @@ func TestReconcileMaasConsumerPortalConsoleLink_DisabledDeleteFails(t *testing.T
 	assert.Equal(t, common.ConditionSeverityInfo, maasConsumerPortalCond.Severity)
 	assert.True(t, cm.IsHappy(), "Ready must remain True even when the portal delete fails (Info severity)")
 }
+
+func TestSetMaasConsumerPortalModuleCondition(t *testing.T) {
+	newDashboard := func(state string) *v1alpha1.Dashboard {
+		return &v1alpha1.Dashboard{Spec: v1alpha1.DashboardSpec{
+			MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: state},
+		}}
+	}
+	deployed := map[string]v1alpha1.ModuleStatus{
+		"maas":  {Phase: v1alpha1.ModulePhaseDeployed},
+		"genAi": {Phase: v1alpha1.ModulePhaseDeployed},
+	}
+
+	t.Run("healthy dependencies leave the condition unchanged", func(t *testing.T) {
+		dashboard := newDashboard("Managed")
+		cm := maasConsumerPortalTestManager(t, dashboard)
+		(&DashboardReconciler{}).setMaasConsumerPortalModuleCondition(cm, dashboard, deployed)
+		assert.Equal(t, metav1.ConditionUnknown, cm.GetCondition(conditionMaasConsumerPortalAvailable).Status)
+	})
+
+	for _, phase := range []v1alpha1.ModulePhase{
+		v1alpha1.ModulePhaseDisabled,
+		v1alpha1.ModulePhaseNotDeployed,
+		v1alpha1.ModulePhaseDegraded,
+	} {
+		t.Run(string(phase)+" dependency reports unavailable", func(t *testing.T) {
+			dashboard := newDashboard("Managed")
+			cm := maasConsumerPortalTestManager(t, dashboard)
+			statuses := map[string]v1alpha1.ModuleStatus{
+				"maas":  {Phase: phase, Message: "dependency is unavailable"},
+				"genAi": {Phase: v1alpha1.ModulePhaseDeployed},
+			}
+			(&DashboardReconciler{}).setMaasConsumerPortalModuleCondition(cm, dashboard, statuses)
+			condition := cm.GetCondition(conditionMaasConsumerPortalAvailable)
+			require.NotNil(t, condition)
+			assert.Equal(t, metav1.ConditionFalse, condition.Status)
+			assert.Equal(t, "RequiredModuleUnavailable", condition.Reason)
+			assert.Equal(t, common.ConditionSeverityInfo, condition.Severity)
+		})
+	}
+
+	t.Run("preserves an earlier portal failure", func(t *testing.T) {
+		dashboard := newDashboard("Managed")
+		cm := maasConsumerPortalTestManager(t, dashboard)
+		cm.MarkFalse(conditionMaasConsumerPortalAvailable,
+			conditions.WithReason("MaasConsumerPortalDomainRequired"),
+			conditions.WithMessage("gateway domain is not set"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+
+		(&DashboardReconciler{}).setMaasConsumerPortalModuleCondition(cm, dashboard, map[string]v1alpha1.ModuleStatus{
+			"maas":  {Phase: v1alpha1.ModulePhaseDisabled, Message: "disabled"},
+			"genAi": {Phase: v1alpha1.ModulePhaseDeployed},
+		})
+
+		assert.Equal(t, "MaasConsumerPortalDomainRequired", cm.GetCondition(conditionMaasConsumerPortalAvailable).Reason)
+	})
+
+	for _, state := range []string{"Removed", ""} {
+		t.Run("portal "+state+" is a no-op", func(t *testing.T) {
+			dashboard := newDashboard(state)
+			cm := maasConsumerPortalTestManager(t, dashboard)
+			(&DashboardReconciler{}).setMaasConsumerPortalModuleCondition(cm, dashboard, map[string]v1alpha1.ModuleStatus{
+				"maas": {Phase: v1alpha1.ModulePhaseDisabled},
+			})
+			assert.Equal(t, metav1.ConditionUnknown, cm.GetCondition(conditionMaasConsumerPortalAvailable).Status)
+		})
+	}
+}
+
+func TestMaasConsumerPortalRequiredModuleSlugs(t *testing.T) {
+	spec := &v1alpha1.DashboardSpec{
+		ManagementSpec:     common.ManagementSpec{ManagementState: "Removed"},
+		MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Managed"},
+	}
+	assert.Equal(t, map[string]bool{"maas": true, "gen-ai": true}, maasConsumerPortalRequiredModuleSlugs(spec, resolveModuleStatuses(spec)))
+
+	spec.Modules = map[string]v1alpha1.ModuleOverride{"maas": {State: v1alpha1.ModuleDisabled}}
+	assert.Equal(t, map[string]bool{"gen-ai": true}, maasConsumerPortalRequiredModuleSlugs(spec, resolveModuleStatuses(spec)))
+
+	spec.MaasConsumerPortal.ManagementState = "Removed"
+	assert.Empty(t, maasConsumerPortalRequiredModuleSlugs(spec, resolveModuleStatuses(spec)))
+}
+
+func TestMarkMaasConsumerPortalFederationConfigMapFailed(t *testing.T) {
+	dashboard := &v1alpha1.Dashboard{}
+	cm := maasConsumerPortalTestManager(t, dashboard)
+	(&DashboardReconciler{}).markMaasConsumerPortalFederationConfigMapFailed(cm, errors.New("apply failed"))
+	condition := cm.GetCondition(conditionMaasConsumerPortalAvailable)
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, "MaasConsumerPortalFederationConfigMapFailed", condition.Reason)
+	assert.Equal(t, common.ConditionSeverityInfo, condition.Severity)
+
+	t.Run("preserves an earlier portal failure", func(t *testing.T) {
+		dashboard := &v1alpha1.Dashboard{}
+		cm := maasConsumerPortalTestManager(t, dashboard)
+		cm.MarkFalse(conditionMaasConsumerPortalAvailable,
+			conditions.WithReason("MaasConsumerPortalDomainRequired"),
+			conditions.WithMessage("gateway domain is not set"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+
+		(&DashboardReconciler{}).markMaasConsumerPortalFederationConfigMapFailed(cm, errors.New("apply failed"))
+		assert.Equal(t, "MaasConsumerPortalDomainRequired", cm.GetCondition(conditionMaasConsumerPortalAvailable).Reason)
+	})
+}

--- a/dashboard-operator/internal/controller/managementstate_integration_test.go
+++ b/dashboard-operator/internal/controller/managementstate_integration_test.go
@@ -84,7 +84,9 @@ func TestIntegration_ManagementStateRemoved_TeardownResources(t *testing.T) {
 	dashboard = getDashboard(t)
 	assert.Equal(t, common.PhaseNotReady, dashboard.Status.Phase)
 	assert.Empty(t, dashboard.Status.URL)
-	assert.Nil(t, dashboard.Status.ModuleStatuses)
+	require.NotNil(t, dashboard.Status.ModuleStatuses)
+	assert.Equal(t, v1alpha1.ModulePhaseNotDeployed, dashboard.Status.ModuleStatuses["modelRegistry"].Phase)
+	assert.Equal(t, "NotRequired", dashboard.Status.ModuleStatuses["modelRegistry"].Reason)
 
 	cond := conditions.FindStatusCondition(dashboard, string(common.ConditionTypeProvisioningSucceeded))
 	require.NotNil(t, cond, "ProvisioningSucceeded condition should be present")
@@ -131,7 +133,9 @@ func TestIntegration_ManagementStateRemoved_IdempotentRereconcile(t *testing.T) 
 
 	dashboard = getDashboard(t)
 	assert.Equal(t, common.PhaseNotReady, dashboard.Status.Phase)
-	assert.Nil(t, dashboard.Status.ModuleStatuses)
+	require.NotNil(t, dashboard.Status.ModuleStatuses)
+	assert.Equal(t, v1alpha1.ModulePhaseNotDeployed, dashboard.Status.ModuleStatuses["modelRegistry"].Phase)
+	assert.Equal(t, "NotRequired", dashboard.Status.ModuleStatuses["modelRegistry"].Reason)
 
 	// Operator-owned resources remain intact across repeated teardowns.
 	assertExists(t, &appsv1.Deployment{}, types.NamespacedName{Name: "dashboard-operator", Namespace: integrationNamespace})

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -610,6 +610,7 @@ func (r *DashboardReconciler) reconcileModuleDemand(ctx context.Context, dashboa
 	}
 	if err := r.deleteModuleResources(ctx, statuses); err != nil {
 		log.FromContext(ctx).Error(err, "Failed to clean up disabled module resources")
+		return nil, err
 	}
 	r.overlayStandaloneReadiness(ctx, statuses)
 	return statuses, nil

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -89,6 +89,24 @@ func proxyPathsFor(mod ModuleDefinition) []proxyRoute {
 	}}
 }
 
+// moduleFederationEntry builds the common remote-module entry used by each
+// federation ConfigMap. The module registry is the source of service, TLS, and
+// proxy-route configuration for every consumer.
+func (r *DashboardReconciler) moduleFederationEntry(name string, mod ModuleDefinition) federationEntry {
+	return federationEntry{
+		Name:        name,
+		RemoteEntry: "/remoteEntry.js",
+		Authorize:   true,
+		TLS:         mod.TLS,
+		Proxy:       proxyPathsFor(mod),
+		Service: &serviceRef{
+			Name:      standaloneServiceName(r.Platform, mod.ManifestSlug),
+			Namespace: r.ApplicationsNamespace,
+			Port:      mod.Port,
+		},
+	}
+}
+
 // coreBffPort is the port core-bff listens on within the main dashboard pod/service.
 const coreBffPort = 8943
 
@@ -394,21 +412,7 @@ func (r *DashboardReconciler) buildFederationConfigMap(
 			continue
 		}
 
-		svcName := standaloneServiceName(r.Platform, mod.ManifestSlug)
-
-		entry := federationEntry{
-			Name:        name,
-			RemoteEntry: "/remoteEntry.js",
-			Authorize:   true,
-			TLS:         mod.TLS,
-			Proxy:       proxyPathsFor(mod),
-			Service: &serviceRef{
-				Name:      svcName,
-				Namespace: r.ApplicationsNamespace,
-				Port:      mod.Port,
-			},
-		}
-		entries = append(entries, entry)
+		entries = append(entries, r.moduleFederationEntry(name, mod))
 	}
 
 	// Add coreBff entry — core-bff is always present when the dashboard is deployed
@@ -594,6 +598,21 @@ func (r *DashboardReconciler) deployFederationConfigMap(
 	}
 
 	return fedCM.Data[federationConfigKey], nil
+}
+
+// reconcileModuleDemand deploys and removes shared BFFs based on both operand
+// lifecycles. Shared modules retain the dashboard ownership label because they
+// are common dependencies rather than resources owned by a single operand.
+func (r *DashboardReconciler) reconcileModuleDemand(ctx context.Context, dashboard *v1alpha1.Dashboard) (map[string]v1alpha1.ModuleStatus, error) {
+	statuses := resolveModuleStatuses(&dashboard.Spec)
+	if err := r.deployModuleManifests(ctx, dashboard, statuses); err != nil {
+		return nil, err
+	}
+	if err := r.deleteModuleResources(ctx, statuses); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to clean up disabled module resources")
+	}
+	r.overlayStandaloneReadiness(ctx, statuses)
+	return statuses, nil
 }
 
 // --- Helper: ConfigMap to Unstructured ---

--- a/dashboard-operator/internal/controller/module_deploy_test.go
+++ b/dashboard-operator/internal/controller/module_deploy_test.go
@@ -3,6 +3,7 @@ package controller_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -12,7 +13,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/opendatahub-io/odh-platform-utilities/api/common"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
@@ -104,6 +107,25 @@ func TestReconcileModuleDemand_ExplicitDisableRemovesExistingResources(t *testin
 	assert.Equal(t, "ExplicitOverride", statuses["maas"].Reason)
 	assert.Error(t, reconciler.Get(context.Background(), types.NamespacedName{Name: "maas-ui", Namespace: testNamespace}, &appsv1.Deployment{}))
 	assert.Error(t, reconciler.Get(context.Background(), types.NamespacedName{Name: "maas-ui", Namespace: testNamespace}, &corev1.Service{}))
+}
+
+func TestReconcileModuleDemand_ReturnsCleanupError(t *testing.T) {
+	scheme := testScheme(t)
+	resourceLabels := map[string]string{labels.PlatformPartOf: "dashboard", "app.kubernetes.io/component": "maas"}
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "maas-ui", Namespace: testNamespace, Labels: resourceLabels}}
+	reconciler := &ctrlpkg.DashboardReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+				return errors.New("simulated delete failure")
+			},
+		}).Build(),
+		Scheme: scheme, ManifestsBasePath: t.TempDir(), Platform: cluster.OpenDataHub, ApplicationsNamespace: testNamespace,
+	}
+	dashboard := &v1alpha1.Dashboard{Spec: v1alpha1.DashboardSpec{Modules: map[string]v1alpha1.ModuleOverride{"maas": {State: v1alpha1.ModuleDisabled}}}}
+
+	statuses, err := reconciler.ReconcileModuleDemand(context.Background(), dashboard)
+	assert.Nil(t, statuses)
+	require.ErrorContains(t, err, "deleting deployment for module maas: simulated delete failure")
 }
 
 func TestReconcileModuleDemand_OverlaysStandaloneReadiness(t *testing.T) {

--- a/dashboard-operator/internal/controller/module_deploy_test.go
+++ b/dashboard-operator/internal/controller/module_deploy_test.go
@@ -14,7 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
@@ -64,6 +66,58 @@ func allDeployedStatuses() map[string]v1alpha1.ModuleStatus {
 		}
 	}
 	return statuses
+}
+
+func TestReconcileModuleDemand_WhenNeitherOperandRequiresModules(t *testing.T) {
+	scheme := testScheme(t)
+	reconciler := &ctrlpkg.DashboardReconciler{
+		Client:                fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme:                scheme,
+		ManifestsBasePath:     t.TempDir(),
+		Platform:              cluster.OpenDataHub,
+		ApplicationsNamespace: testNamespace,
+	}
+	dashboard := &v1alpha1.Dashboard{Spec: v1alpha1.DashboardSpec{
+		ManagementSpec:     common.ManagementSpec{ManagementState: "Removed"},
+		MaasConsumerPortal: &v1alpha1.MaasConsumerPortalSpec{ManagementState: "Removed"},
+	}}
+
+	statuses, err := reconciler.ReconcileModuleDemand(context.Background(), dashboard)
+	require.NoError(t, err)
+	for module, status := range statuses {
+		assert.Equalf(t, v1alpha1.ModulePhaseNotDeployed, status.Phase, "%s should not be deployed", module)
+		assert.Equalf(t, "NotRequired", status.Reason, "%s should be marked not required", module)
+	}
+}
+
+func TestReconcileModuleDemand_ExplicitDisableRemovesExistingResources(t *testing.T) {
+	scheme := testScheme(t)
+	resourceLabels := map[string]string{labels.PlatformPartOf: "dashboard", "app.kubernetes.io/component": "maas"}
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "maas-ui", Namespace: testNamespace, Labels: resourceLabels}}
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "maas-ui", Namespace: testNamespace, Labels: resourceLabels}}
+	reconciler := &ctrlpkg.DashboardReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, service).Build(), Scheme: scheme, ManifestsBasePath: t.TempDir(), Platform: cluster.OpenDataHub, ApplicationsNamespace: testNamespace}
+	dashboard := &v1alpha1.Dashboard{Spec: v1alpha1.DashboardSpec{Modules: map[string]v1alpha1.ModuleOverride{"maas": {State: v1alpha1.ModuleDisabled}}}}
+
+	statuses, err := reconciler.ReconcileModuleDemand(context.Background(), dashboard)
+	require.NoError(t, err)
+	assert.Equal(t, v1alpha1.ModulePhaseDisabled, statuses["maas"].Phase)
+	assert.Equal(t, "ExplicitOverride", statuses["maas"].Reason)
+	assert.Error(t, reconciler.Get(context.Background(), types.NamespacedName{Name: "maas-ui", Namespace: testNamespace}, &appsv1.Deployment{}))
+	assert.Error(t, reconciler.Get(context.Background(), types.NamespacedName{Name: "maas-ui", Namespace: testNamespace}, &corev1.Service{}))
+}
+
+func TestReconcileModuleDemand_OverlaysStandaloneReadiness(t *testing.T) {
+	scheme := testScheme(t)
+	resourceLabels := map[string]string{labels.PlatformPartOf: "dashboard", "app.kubernetes.io/component": "maas"}
+	replicas := int32(1)
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "maas-ui", Namespace: testNamespace, Labels: resourceLabels}, Spec: appsv1.DeploymentSpec{Replicas: &replicas}}
+	reconciler := &ctrlpkg.DashboardReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build(), Scheme: scheme, ManifestsBasePath: t.TempDir(), Platform: cluster.OpenDataHub, ApplicationsNamespace: testNamespace}
+	dashboard := &v1alpha1.Dashboard{Spec: v1alpha1.DashboardSpec{Modules: map[string]v1alpha1.ModuleOverride{"modelRegistry": {State: v1alpha1.ModuleDisabled}, "genAi": {State: v1alpha1.ModuleDisabled}, "mlflow": {State: v1alpha1.ModuleDisabled}, "evalHub": {State: v1alpha1.ModuleDisabled}, "automl": {State: v1alpha1.ModuleDisabled}, "autorag": {State: v1alpha1.ModuleDisabled}, "agentOps": {State: v1alpha1.ModuleDisabled}, "notebooks": {State: v1alpha1.ModuleDisabled}}}}
+
+	statuses, err := reconciler.ReconcileModuleDemand(context.Background(), dashboard)
+	require.NoError(t, err)
+	assert.Equal(t, v1alpha1.ModulePhaseDegraded, statuses["maas"].Phase)
+	assert.Equal(t, "ReplicasNotReady", statuses["maas"].Reason)
 }
 
 func TestBuildFederationConfigMap_ExcludesDisabledModules(t *testing.T) {

--- a/dashboard-operator/internal/controller/modules.go
+++ b/dashboard-operator/internal/controller/modules.go
@@ -28,6 +28,9 @@ type ModuleDefinition struct {
 	ProxyPaths              []proxyRoute
 	// InterBFFDeps injects service-discovery env vars into this module's container.
 	InterBFFDeps []interBFFDependency
+	// RequiredByMaasConsumerPortal identifies the modules required when the
+	// MaaS Consumer Portal operand is managed independently of the dashboard.
+	RequiredByMaasConsumerPortal bool
 }
 
 var moduleRegistry = map[string]ModuleDefinition{
@@ -41,12 +44,13 @@ var moduleRegistry = map[string]ModuleDefinition{
 		RequiredDSCComponents: []string{"modelregistry"},
 	},
 	"genAi": {
-		Name:          "genAi",
-		ContainerName: "gen-ai-ui",
-		Port:          8143,
-		ImageEnvVar:   "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
-		ManifestSlug:  "gen-ai",
-		TLS:           true,
+		Name:                         "genAi",
+		ContainerName:                "gen-ai-ui",
+		Port:                         8143,
+		ImageEnvVar:                  "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
+		ManifestSlug:                 "gen-ai",
+		TLS:                          true,
+		RequiredByMaasConsumerPortal: true,
 		InterBFFDeps: []interBFFDependency{{
 			EnvServiceName: "BFF_MAAS_SERVICE_NAME",
 			EnvServicePort: "BFF_MAAS_SERVICE_PORT",
@@ -64,12 +68,13 @@ var moduleRegistry = map[string]ModuleDefinition{
 		ProxyPaths:            []proxyRoute{{Path: "/_bff/mlflow/api", PathRewrite: "/api"}},
 	},
 	"maas": {
-		Name:          "maas",
-		ContainerName: "maas-ui",
-		Port:          8243,
-		ImageEnvVar:   "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
-		ManifestSlug:  "maas",
-		TLS:           true,
+		Name:                         "maas",
+		ContainerName:                "maas-ui",
+		Port:                         8243,
+		ImageEnvVar:                  "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
+		ManifestSlug:                 "maas",
+		TLS:                          true,
+		RequiredByMaasConsumerPortal: true,
 	},
 	"evalHub": {
 		Name:                  "evalHub",
@@ -122,18 +127,45 @@ var moduleRegistry = map[string]ModuleDefinition{
 }
 
 // resolveModuleStatuses determines the status of each module based on
-// DSC component availability, spec overrides, and inter-module dependencies.
+// aggregate operand demand, DSC component availability, spec overrides, and
+// inter-module dependencies.
 // It uses a three-pass algorithm:
 //
-//	Pass 1: DSC component gate + explicit CR overrides
+//	Pass 1: aggregate demand + DSC component gate + explicit CR overrides
 //	Pass 2: Inter-module dependency resolution (transitive propagation)
 //	Pass 3: Unknown module detection
 func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.ModuleStatus {
 	now := metav1.Now()
 	result := make(map[string]v1alpha1.ModuleStatus, len(moduleRegistry))
 
-	// Pass 1: DSC component gate + explicit CR overrides
+	coreRequiresModules := spec.ManagementState != "Removed"
+	maasConsumerPortalRequiresModules := spec.MaasConsumerPortal != nil &&
+		spec.MaasConsumerPortal.ManagementState == "Managed"
+
+	// Pass 1: aggregate demand + DSC component gate + explicit CR overrides
 	for name, mod := range moduleRegistry {
+		// Explicit user configuration takes precedence over either operand's
+		// demand and must retain the ExplicitOverride status reason.
+		if override, ok := spec.Modules[name]; ok && override.State == v1alpha1.ModuleDisabled {
+			result[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseDisabled,
+				Reason:             "ExplicitOverride",
+				Message:            "Module explicitly disabled via spec.modules override",
+				LastTransitionTime: now,
+			}
+			continue
+		}
+
+		if !coreRequiresModules && (!maasConsumerPortalRequiresModules || !mod.RequiredByMaasConsumerPortal) {
+			result[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseNotDeployed,
+				Reason:             "NotRequired",
+				Message:            "Module is not required by a managed operand",
+				LastTransitionTime: now,
+			}
+			continue
+		}
+
 		// Check DSC component dependencies (only when Components map is non-nil)
 		if len(mod.RequiredDSCComponents) > 0 && spec.Components != nil {
 			disabled := false
@@ -155,18 +187,6 @@ func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.Mod
 			if disabled {
 				continue
 			}
-		}
-
-		// Check explicit CR override
-		if override, ok := spec.Modules[name]; ok && override.State == v1alpha1.ModuleDisabled {
-			result[name] = v1alpha1.ModuleStatus{
-				Phase:              v1alpha1.ModulePhaseDisabled,
-				Reason:             "ExplicitOverride",
-				Message:            "Module explicitly disabled via spec.modules override",
-				LastTransitionTime: now,
-			}
-
-			continue
 		}
 
 		// Tentatively enabled
@@ -219,6 +239,15 @@ func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.Mod
 	}
 
 	return result
+}
+
+func preserveModuleStatusTransitionTimes(previous, next map[string]v1alpha1.ModuleStatus) {
+	for name, status := range next {
+		if prior, ok := previous[name]; ok && prior.Phase == status.Phase && prior.Reason == status.Reason && prior.Message == status.Message {
+			status.LastTransitionTime = prior.LastTransitionTime
+			next[name] = status
+		}
+	}
 }
 
 // overlayContainerReadiness inspects the pods backing the dashboard

--- a/dashboard-operator/internal/controller/support.go
+++ b/dashboard-operator/internal/controller/support.go
@@ -67,33 +67,6 @@ func observabilityManifestInfo(basePath string, platform cluster.Platform) rende
 	}
 }
 
-// maasConsumerPortalHostPrefix is prepended to Gateway.Domain to derive the
-// MaaS Consumer Portal host (e.g. maas-consumer-portal.<domain>).
-const maasConsumerPortalHostPrefix = "maas-consumer-portal"
-
-// maasConsumerPortalConsoleLinkManifestInfo points at the portal ConsoleLink
-// bundle. It always uses the /rhoai source: the portal is an RHOAI feature
-// and deploys on both self-managed and managed RHOAI when enabled, so it is
-// intentionally not gated by the platformPaths /not-supported overlay.
-func maasConsumerPortalConsoleLinkManifestInfo(basePath string) render.ManifestInfo {
-	return render.ManifestInfo{
-		Path:       basePath,
-		ContextDir: "maas-consumer-portal-consolelink",
-		SourcePath: "/rhoai",
-	}
-}
-
-// maasConsumerPortalURL derives the portal URL from the gateway domain. The
-// second return value is false when the domain is empty, meaning the URL
-// cannot be derived and the ConsoleLink must not be deployed.
-func maasConsumerPortalURL(domain string) (string, bool) {
-	if domain == "" {
-		return "", false
-	}
-
-	return fmt.Sprintf("https://%s.%s/", maasConsumerPortalHostPrefix, domain), true
-}
-
 func computeKustomizeVariables(dashboard *v1alpha1.Dashboard, platform cluster.Platform) map[string]string {
 	params := map[string]string{}
 

--- a/manifests/modules/gen-ai/networkpolicy.yaml
+++ b/manifests/modules/gen-ai/networkpolicy.yaml
@@ -17,6 +17,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               network.openshift.io/policy-group: ingress
+        - podSelector:
+            matchLabels:
+              deployment: maas-consumer-portal
   egress:
     - to:
         - namespaceSelector:

--- a/manifests/modules/maas/networkpolicy.yaml
+++ b/manifests/modules/maas/networkpolicy.yaml
@@ -20,6 +20,9 @@ spec:
         - podSelector:
             matchLabels:
               deployment: gen-ai-ui
+        - podSelector:
+            matchLabels:
+              deployment: maas-consumer-portal
   egress:
     - to:
         - namespaceSelector:


### PR DESCRIPTION
[https://redhat.atlassian.net/browse/RHOAIENG-90166](https://redhat.atlassian.net/browse/RHOAIENG-90166)

Depends on:

- [https://github.com/opendatahub-io/odh-dashboard/pull/9562](https://github.com/opendatahub-io/odh-dashboard/pull/9562)
- [https://github.com/opendatahub-io/odh-dashboard/pull/9581](https://github.com/opendatahub-io/odh-dashboard/pull/9581)

## Description

Implements operand-aware, aggregate-demand orchestration for the shared MaaS and GenAI BFFs used by the core dashboard and MaaS Consumer Portal.

- Resolve module demand from both the core dashboard and MaaS Consumer Portal management states. MaaS and GenAI run when either operand requires them; no other module is enabled by the portal alone.
- Preserve explicit `spec.modules.<module>.state=Disabled` overrides and report `MaasConsumerPortalAvailable=False` with an actionable dependency reason when a portal-required module is unavailable.
- Keep shared MaaS and GenAI Deployments and Services during core-dashboard-only, portal-only, and dual-managed operation; remove them only when neither operand needs them.
- Generate and reconcile `maas-consumer-portal-federation-config`, containing deterministic MaaS and GenAI federation entries derived from the module registry. The ConfigMap uses MaaS Consumer Portal ownership labels and changes trigger a portal Deployment rollout through a configuration-hash annotation.
- Allow ingress from Pods labeled `deployment: maas-consumer-portal` to the MaaS and GenAI NetworkPolicies on ports 8243 and 8143.
- Preserve a primary MaaS Consumer Portal availability failure reason rather than allowing later dependency or ConfigMap checks to mask it.



### File Restructuring

MaaS Consumer Portal-specific controller code and tests were extracted from the general controller files into focused files:

- `maas_consumer_portal.go` for portal availability conditions and lifecycle state.
- `maas_consumer_portal_consolelink.go` for ConsoleLink reconciliation.
- `maas_consumer_portal_federation.go` for portal federation ConfigMap generation, reconciliation, and rollout hashing.
- Dedicated MaaS Consumer Portal unit, module-deploy, export, and envtest integration test files.

The shared module-demand and federation-entry logic remains in the general module controller code because it is intentionally consumed by both operands.

> **Note**: This PR produces the portal federation ConfigMap. The MaaS Consumer Portal Deployment manifest must mount `maas-consumer-portal-federation-config` so Core-BFF can consume its JSON.



## How Has This Been Tested?

  - make -C dashboard-operator fmt
  - make -C dashboard-operator vet
  - make -C dashboard-operator lint
  - make -C dashboard-operator test
  - make -C dashboard-operator test-integration
  - make -C dashboard-operator build
  - make -C dashboard-operator chart-lint

## Test Impact

- Added unit coverage for portal module availability, explicit overrides, ConfigMap contents, hash rollout behavior, condition precedence, and shared module-demand reconciliation.
- Added envtest coverage for all four core-dashboard/MaaS Consumer Portal Managed/Removed state combinations, including validation that both operands share a single MaaS and GenAI BFF deployment/service pair.



## Request Review Criteria

- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body
- [x] The developer has added tests for the related changes
- [x] The code follows repository best practices
- [ ] The developer has tested the PR image on a cluster before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MaaS Consumer Portal integration, including ConsoleLink provisioning and federation configuration.
  * Added portal availability reporting when required modules or federation configuration are unavailable.
  * Enabled MaaS Consumer Portal traffic to required GenAI and MaaS services.

* **Bug Fixes**
  * Preserved module status details and transition times during resource teardown.
  * Improved handling of shared modules required by multiple dashboard components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->