### PR TITLE
fix(agent-ops): enforce managed-by label on detail, use status.service for Service lookup

### DIFF
--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -121,13 +121,15 @@ paths:
       summary: List agent runtimes
       description: |
         Returns deployed agent and tool runtimes from Sandbox CRs (`agents.x-k8s.io/v1beta1/sandboxes`)
-        labeled `openshell.ai/managed-by=openshell`.
+        labeled `app.kubernetes.io/managed-by=odh-agent-ops`.
         Results are deduplicated by namespace and name.
   /api/v1/agents/runtimes/{ns}/{name}:
     summary: Get agent runtime detail.
     description: >-
       Returns full agent detail, runtime info, workload status, service endpoints,
-      and conditions for a single deployed agent.
+      and conditions for a single deployed agent labeled
+      `app.kubernetes.io/managed-by=odh-agent-ops`. Returns 404 for sandboxes
+      without this label.
     get:
       tags:
         - AgentOperation

--- a/packages/agent-ops/bff/README.md
+++ b/packages/agent-ops/bff/README.md
@@ -16,7 +16,7 @@ This service exposes core dashboard endpoints plus agent runtime APIs backed by 
 - GET `/api/v1/agents/runtimes` – list deployed agent and tool runtimes
 - GET `/api/v1/agents/runtimes/{ns}/{name}` – full runtime detail for one agent
 
-Agent endpoints validate `{ns}` and `{name}` as DNS-1123 identifiers. List discovery loads Sandbox CRs (`agents.x-k8s.io/v1beta1/sandboxes`) labeled `openshell.ai/managed-by=openshell`. Detail loads any authorized Sandbox CR by name (no label filter).
+Agent endpoints validate `{ns}` and `{name}` as DNS-1123 identifiers. Both list and detail endpoints only return Sandbox CRs (`agents.x-k8s.io/v1beta1/sandboxes`) labeled `app.kubernetes.io/managed-by=odh-agent-ops`. Sandboxes without this label return 404 on detail.
 
 Discovery metadata uses Starter Kit annotations: `openshift.io/display-name`, `openshift.io/description`, and `opendatahub.io/agent-framework`. Container ports are read from `spec.podTemplate.spec.containers[].ports` and exposed with `status.serviceFQDN` in list/detail responses. Agent card enrichment is disabled for 3.5 discovery scope.
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client.go
@@ -186,6 +186,15 @@ func isManagedSandbox(obj *unstructured.Unstructured) bool {
 	return labels[agents.LabelManagedBy] == agents.ManagedByValue
 }
 
+// managedSandboxOrNotFound rejects sandboxes not deployed through agent-ops.
+// Mutations and detail must agree with the list label selector.
+func managedSandboxOrNotFound(obj *unstructured.Unstructured) error {
+	if !isManagedSandbox(obj) {
+		return agents.ErrNotFound
+	}
+	return nil
+}
+
 func isRetryableListError(err error) bool {
 	return apierrors.IsServerTimeout(err) ||
 		apierrors.IsServiceUnavailable(err) ||

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Client reads agent Sandbox CRs from the Kubernetes API.
@@ -101,7 +102,11 @@ func (c *Client) listAgentSummaries(ctx context.Context, namespace string) ([]ag
 				continue
 			}
 			seen[name] = struct{}{}
-			service := mapService(c.getServiceBestEffort(ctx, namespace, name))
+			svcName := sandboxServiceName(sandbox)
+			if svcName == "" {
+				svcName = name
+			}
+			service := mapService(c.getServiceBestEffort(ctx, namespace, svcName))
 			summaries = append(summaries, sandboxToSummary(sandbox, service))
 		}
 	}
@@ -133,7 +138,15 @@ func (c *Client) getAgentDetail(ctx context.Context, namespace, name string) (*a
 		return nil, fmt.Errorf("failed to get sandbox %q in namespace %q: %w", name, namespace, err)
 	}
 
-	service := mapService(c.getServiceBestEffort(ctx, namespace, name))
+	if !isManagedSandbox(obj) {
+		return nil, agents.ErrNotFound
+	}
+
+	svcName := sandboxServiceName(*obj)
+	if svcName == "" {
+		svcName = name
+	}
+	service := mapService(c.getServiceBestEffort(ctx, namespace, svcName))
 	detail := sandboxToDetail(*obj, service)
 	return detail, nil
 }
@@ -163,6 +176,14 @@ func requestIdentityFromContext(ctx context.Context) (*k8s.RequestIdentity, erro
 		return nil, errors.New("invalid RequestIdentity in context")
 	}
 	return identity, nil
+}
+
+// isManagedSandbox returns true when the sandbox carries the managed-by label
+// that matches the list selector. This keeps the detail endpoint consistent
+// with list: only sandboxes deployed through agent-ops are surfaced.
+func isManagedSandbox(obj *unstructured.Unstructured) bool {
+	labels := obj.GetLabels()
+	return labels[agents.LabelManagedBy] == agents.ManagedByValue
 }
 
 func isRetryableListError(err error) bool {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_detail_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_detail_test.go
@@ -111,7 +111,7 @@ func TestGetAgentDetailDoesNotFallBackToDeployment(t *testing.T) {
 	require.ErrorIs(t, err, agents.ErrNotFound)
 }
 
-func TestGetAgentDetailReturnsUnlabeledSandbox(t *testing.T) {
+func TestGetAgentDetailRejectsUnlabeledSandbox(t *testing.T) {
 	namespace := "agent-ops-demo"
 	agentName := "unlabeled-sandbox"
 
@@ -127,10 +127,8 @@ func TestGetAgentDetailReturnsUnlabeledSandbox(t *testing.T) {
 		dynamic:             dynamicClient,
 	}
 
-	detail, err := client.GetAgent(context.Background(), namespace, agentName)
-	require.NoError(t, err)
-	require.NotNil(t, detail)
-	assert.Equal(t, agentName, detail.Metadata.Name)
+	_, err := client.GetAgent(context.Background(), namespace, agentName)
+	require.ErrorIs(t, err, agents.ErrNotFound)
 }
 
 func TestGetAgentDetailReturnsForbiddenWhenSandboxGetDenied(t *testing.T) {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_test.go
@@ -118,8 +118,8 @@ func testSandboxCR(namespace, name string, extra ...func(*unstructured.Unstructu
 	obj.SetName(name)
 	obj.SetNamespace(namespace)
 	obj.SetLabels(map[string]string{
-		agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
-		agents.LabelWorkloadType:       agents.WorkloadTypeSandbox,
+		agents.LabelManagedBy:    agents.ManagedByValue,
+		agents.LabelWorkloadType: agents.WorkloadTypeSandbox,
 	})
 	obj.Object["status"] = map[string]any{
 		"phase": "Ready",
@@ -221,51 +221,7 @@ func TestClient_ListAgentsFromConditionsOnlySandboxCR(t *testing.T) {
 	assert.Equal(t, "ready", list.Items[0].Status)
 }
 
-func testOpenShellSandboxCR(namespace, name string, extra ...func(*unstructured.Unstructured)) *unstructured.Unstructured {
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   sandboxGVR.Group,
-		Version: sandboxGVR.Version,
-		Kind:    "Sandbox",
-	})
-	obj.SetName(name)
-	obj.SetNamespace(namespace)
-	obj.SetLabels(map[string]string{
-		agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
-		agents.LabelOpenShellSandboxID: "sandbox-uuid-123",
-	})
-	obj.Object["status"] = map[string]any{
-		"phase": "Ready",
-	}
-	for _, fn := range extra {
-		fn(obj)
-	}
-	return obj
-}
-
-func TestClient_ListAgentsFromOpenShellSandboxCR(t *testing.T) {
-	namespace := "openshell-ns"
-	agentName := "openshell-agent"
-
-	sandbox := testOpenShellSandboxCR(namespace, agentName)
-	dynamicClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), defaultGVRListKinds())
-	seedSandboxCR(t, dynamicClient, sandbox)
-
-	client := newTestAgentClient(t)
-	client.k8sClient = &dynamicTestK8sClient{
-		permissiveK8sClient: *client.k8sClient.(*permissiveK8sClient),
-		dynamic:             dynamicClient,
-	}
-
-	list, err := client.ListAgents(context.Background(), namespace)
-	require.NoError(t, err)
-	require.Len(t, list.Items, 1)
-	assert.Equal(t, agentName, list.Items[0].Name)
-	assert.Equal(t, agents.AgentTypeAgent, list.Items[0].ResourceType)
-	assert.Equal(t, "ready", list.Items[0].Status)
-}
-
-func TestClient_ListAgentsSkipsSandboxesWithoutOpenShellLabel(t *testing.T) {
+func TestClient_ListAgentsSkipsSandboxesWithoutManagedByLabel(t *testing.T) {
 	namespace := "shared-ns"
 	agentName := "agent-type-only"
 
@@ -290,11 +246,16 @@ func TestClient_ListAgentsSkipsSandboxesWithoutOpenShellLabel(t *testing.T) {
 	assert.Empty(t, list.Items)
 }
 
-func TestClient_GetAgentFromOpenShellSandboxCR(t *testing.T) {
-	namespace := "openshell-ns"
-	agentName := "openshell-agent"
+func TestClient_ListAgentsSkipsOpenShellOnlySandboxes(t *testing.T) {
+	namespace := "shared-ns"
+	agentName := "openshell-only-agent"
 
-	sandbox := testOpenShellSandboxCR(namespace, agentName)
+	sandbox := testSandboxCR(namespace, agentName, func(obj *unstructured.Unstructured) {
+		obj.SetLabels(map[string]string{
+			"openshell.ai/managed-by": "openshell",
+		})
+	})
+
 	dynamicClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), defaultGVRListKinds())
 	seedSandboxCR(t, dynamicClient, sandbox)
 
@@ -304,22 +265,15 @@ func TestClient_GetAgentFromOpenShellSandboxCR(t *testing.T) {
 		dynamic:             dynamicClient,
 	}
 
-	detail, err := client.GetAgent(context.Background(), namespace, agentName)
+	list, err := client.ListAgents(context.Background(), namespace)
 	require.NoError(t, err)
-	require.NotNil(t, detail)
-	assert.Equal(t, agentName, detail.Metadata.Name)
-	assert.Equal(t, agents.OpenShellManagedByValue, detail.Metadata.Labels[agents.LabelOpenShellManagedBy])
-	assert.Equal(t, "", detail.Metadata.Labels[agents.LabelAgentType])
-
-	result := mapper.AgentDetailToRuntimeDetail(detail)
-	require.NotNil(t, result)
-	assert.Equal(t, agents.AgentTypeAgent, result.Runtime.Type)
+	assert.Empty(t, list.Items)
 }
 
 func TestAgentLabelSelectors(t *testing.T) {
 	selectors := agentLabelSelectors()
 	require.Len(t, selectors, 1)
-	assert.Equal(t, fmt.Sprintf("%s=%s", agents.LabelOpenShellManagedBy, agents.OpenShellManagedByValue), selectors[0])
+	assert.Equal(t, fmt.Sprintf("%s=%s", agents.LabelManagedBy, agents.ManagedByValue), selectors[0])
 }
 
 func TestClient_GetAgentFromSandboxCR(t *testing.T) {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -53,6 +53,9 @@ func (c *Client) DeleteAgent(ctx context.Context, namespace, name string) error 
 	if err != nil {
 		return mapK8sError(err)
 	}
+	if err := managedSandboxOrNotFound(cr); err != nil {
+		return err
+	}
 
 	rv := cr.GetResourceVersion()
 	if err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{
@@ -77,6 +80,9 @@ func (c *Client) StopAgent(ctx context.Context, namespace, name string) error {
 	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return mapK8sError(err)
+	}
+	if err := managedSandboxOrNotFound(cr); err != nil {
+		return err
 	}
 
 	operatingMode, _, _ := unstructured.NestedString(cr.Object, "spec", "operatingMode")
@@ -108,6 +114,9 @@ func (c *Client) RestartAgent(ctx context.Context, namespace, name string) error
 	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return mapK8sError(err)
+	}
+	if err := managedSandboxOrNotFound(cr); err != nil {
+		return err
 	}
 
 	podSelector := ""
@@ -143,6 +152,9 @@ func (c *Client) StartAgent(ctx context.Context, namespace, name string) error {
 	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return mapK8sError(err)
+	}
+	if err := managedSandboxOrNotFound(cr); err != nil {
+		return err
 	}
 
 	operatingMode, _, _ := unstructured.NestedString(cr.Object, "spec", "operatingMode")

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
@@ -242,10 +242,11 @@ func TestDeleteAgent_Unmanaged(t *testing.T) {
 	require.NoError(t, err)
 
 	err = client.DeleteAgent(context.Background(), ns, "foreign-agent")
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrNotFound)
 
 	_, err = dynamicClient.Resource(sandboxGVR).Namespace(ns).Get(context.Background(), "foreign-agent", metav1.GetOptions{})
-	assert.Error(t, err, "Sandbox should be deleted regardless of labels")
+	require.NoError(t, err, "unmanaged Sandbox must not be deleted")
 }
 
 func TestDeployAgent_FullParams(t *testing.T) {
@@ -326,6 +327,9 @@ func seedSandboxWithMode(t *testing.T, dynamicClient *fakedynamic.FakeDynamicCli
 		"metadata": map[string]any{
 			"name":      name,
 			"namespace": ns,
+			"labels": map[string]any{
+				agents.LabelManagedBy: agents.ManagedByValue,
+			},
 		},
 		"spec": map[string]any{
 			"operatingMode": mode,
@@ -336,6 +340,69 @@ func seedSandboxWithMode(t *testing.T, dynamicClient *fakedynamic.FakeDynamicCli
 	}}
 	_, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{})
 	require.NoError(t, err)
+}
+
+func seedUnmanagedSandboxWithMode(t *testing.T, dynamicClient *fakedynamic.FakeDynamicClient, ns, name, mode string) {
+	t.Helper()
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": sandboxGVR.Group + "/" + sandboxGVR.Version,
+		"kind":       "Sandbox",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": ns,
+			"labels": map[string]any{
+				agents.LabelManagedBy: "some-other-tool",
+			},
+		},
+		"spec": map[string]any{
+			"operatingMode": mode,
+		},
+		"status": map[string]any{
+			"selector": "app=" + name,
+		},
+	}}
+	_, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func TestStopAgent_Unmanaged(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+	seedUnmanagedSandboxWithMode(t, dynamicClient, ns, "foreign-agent", "Running")
+
+	err := client.StopAgent(context.Background(), ns, "foreign-agent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrNotFound)
+
+	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Get(context.Background(), "foreign-agent", metav1.GetOptions{})
+	require.NoError(t, err)
+	mode, _, _ := unstructured.NestedString(cr.Object, "spec", "operatingMode")
+	assert.Equal(t, "Running", mode, "unmanaged Sandbox operatingMode must be unchanged")
+}
+
+func TestStartAgent_Unmanaged(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+	seedUnmanagedSandboxWithMode(t, dynamicClient, ns, "foreign-agent", "Suspended")
+
+	err := client.StartAgent(context.Background(), ns, "foreign-agent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrNotFound)
+
+	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Get(context.Background(), "foreign-agent", metav1.GetOptions{})
+	require.NoError(t, err)
+	mode, _, _ := unstructured.NestedString(cr.Object, "spec", "operatingMode")
+	assert.Equal(t, "Suspended", mode, "unmanaged Sandbox operatingMode must be unchanged")
+}
+
+func TestRestartAgent_Unmanaged(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+	seedUnmanagedSandboxWithMode(t, dynamicClient, ns, "foreign-agent", "Running")
+
+	err := client.RestartAgent(context.Background(), ns, "foreign-agent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrNotFound)
 }
 
 func TestStopAgent_Success(t *testing.T) {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
@@ -113,7 +113,7 @@ func TestDeployAgent_CreatesSandboxCR(t *testing.T) {
 	sandbox, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Get(context.Background(), "my-agent", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "Sandbox", sandbox.GetKind())
-	assert.Equal(t, managedByValue, sandbox.GetLabels()[labelManagedBy])
+	assert.Equal(t, agents.ManagedByValue, sandbox.GetLabels()[agents.LabelManagedBy])
 
 	spec := sandbox.Object["spec"].(map[string]any)
 	assert.Equal(t, "Running", spec["operatingMode"])
@@ -143,7 +143,7 @@ func TestDeployAgent_AlreadyExistsManaged(t *testing.T) {
 			"name":      "my-agent",
 			"namespace": ns,
 			"labels": map[string]any{
-				labelManagedBy: managedByValue,
+				agents.LabelManagedBy: agents.ManagedByValue,
 			},
 		},
 	}}
@@ -173,7 +173,7 @@ func TestDeployAgent_AlreadyExistsReuses(t *testing.T) {
 			"name":      "my-agent",
 			"namespace": ns,
 			"labels": map[string]any{
-				labelManagedBy: "some-other-tool",
+				agents.LabelManagedBy: "some-other-tool",
 			},
 		},
 	}}
@@ -201,7 +201,7 @@ func TestDeleteAgent_Success(t *testing.T) {
 			"name":      "my-agent",
 			"namespace": ns,
 			"labels": map[string]any{
-				labelManagedBy: managedByValue,
+				agents.LabelManagedBy: agents.ManagedByValue,
 			},
 		},
 	}}
@@ -234,7 +234,7 @@ func TestDeleteAgent_Unmanaged(t *testing.T) {
 			"name":      "foreign-agent",
 			"namespace": ns,
 			"labels": map[string]any{
-				labelManagedBy: "some-other-tool",
+				agents.LabelManagedBy: "some-other-tool",
 			},
 		},
 	}}
@@ -250,7 +250,7 @@ func TestDeleteAgent_Unmanaged(t *testing.T) {
 
 func TestDeployAgent_FullParams(t *testing.T) {
 	ns := "test-ns"
-	client, _ := newDeployTestClient(t,
+	client, dynamicClient := newDeployTestClient(t,
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
 	)
 
@@ -275,4 +275,153 @@ func TestDeployAgent_FullParams(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, "full-agent", result.Name)
 	assert.Equal(t, ns, result.Namespace)
+
+	sandbox, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Get(context.Background(), "full-agent", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	labels := sandbox.GetLabels()
+	assert.Equal(t, agents.ManagedByValue, labels[agents.LabelManagedBy])
+	assert.Equal(t, agents.AgentTypeAgent, labels[agents.LabelAgentType])
+	assert.Equal(t, agents.WorkloadTypeSandbox, labels[agents.LabelWorkloadType])
+	assert.Equal(t, "full-agent", labels["app.kubernetes.io/name"])
+	assert.Equal(t, "agent", labels["app.kubernetes.io/component"])
+	assert.Empty(t, labels["openshell.ai/managed-by"], "must not contain openshell labels")
+
+	annotations := sandbox.GetAnnotations()
+	assert.Equal(t, "Full test agent", annotations[agents.AnnotationDescription])
+	assert.Equal(t, "a2a", annotations[agents.AnnotationProtocol])
+	assert.Equal(t, "langgraph", annotations[agents.AnnotationFramework])
+	assert.Equal(t, "quay.io/example/full-agent:v2.0.0", annotations[agents.AnnotationImageRef])
+
+	spec := sandbox.Object["spec"].(map[string]any)
+	podSpec := spec["podTemplate"].(map[string]any)["spec"].(map[string]any)
+	container := podSpec["containers"].([]any)[0].(map[string]any)
+	assert.Equal(t, "quay.io/example/full-agent:v2.0.0", container["image"])
+
+	ports := container["ports"].([]any)
+	require.Len(t, ports, 1)
+	assert.Equal(t, int64(9000), ports[0].(map[string]any)["containerPort"])
+
+	envVars := container["env"].([]any)
+	envMap := make(map[string]string)
+	for _, ev := range envVars {
+		e := ev.(map[string]any)
+		envMap[e["name"].(string)] = e["value"].(string)
+	}
+	assert.Equal(t, "debug", envMap["LOG_LEVEL"])
+	assert.Contains(t, envMap, "AGENT_ENDPOINT")
+	assert.Contains(t, envMap, "HOST")
+	assert.Contains(t, envMap, "PORT")
+
+	secrets := podSpec["imagePullSecrets"].([]any)
+	require.Len(t, secrets, 1)
+	assert.Equal(t, "my-pull-secret", secrets[0].(map[string]any)["name"])
+}
+
+func seedSandboxWithMode(t *testing.T, dynamicClient *fakedynamic.FakeDynamicClient, ns, name, mode string) {
+	t.Helper()
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": sandboxGVR.Group + "/" + sandboxGVR.Version,
+		"kind":       "Sandbox",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": ns,
+		},
+		"spec": map[string]any{
+			"operatingMode": mode,
+		},
+		"status": map[string]any{
+			"selector": "app=" + name,
+		},
+	}}
+	_, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func TestStopAgent_Success(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+	seedSandboxWithMode(t, dynamicClient, ns, "my-agent", "Running")
+
+	err := client.StopAgent(context.Background(), ns, "my-agent")
+	require.NoError(t, err)
+
+	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Get(context.Background(), "my-agent", metav1.GetOptions{})
+	require.NoError(t, err)
+	mode, _, _ := unstructured.NestedString(cr.Object, "spec", "operatingMode")
+	assert.Equal(t, "Suspended", mode)
+}
+
+func TestStopAgent_NotFound(t *testing.T) {
+	client, _ := newDeployTestClient(t)
+	err := client.StopAgent(context.Background(), "test-ns", "missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrNotFound)
+}
+
+func TestStopAgent_AlreadyStopped(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+	seedSandboxWithMode(t, dynamicClient, ns, "my-agent", "Suspended")
+
+	err := client.StopAgent(context.Background(), ns, "my-agent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrConflict)
+}
+
+func TestStartAgent_Success(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+	seedSandboxWithMode(t, dynamicClient, ns, "my-agent", "Suspended")
+
+	err := client.StartAgent(context.Background(), ns, "my-agent")
+	require.NoError(t, err)
+
+	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Get(context.Background(), "my-agent", metav1.GetOptions{})
+	require.NoError(t, err)
+	mode, _, _ := unstructured.NestedString(cr.Object, "spec", "operatingMode")
+	assert.Equal(t, "Running", mode)
+}
+
+func TestStartAgent_NotFound(t *testing.T) {
+	client, _ := newDeployTestClient(t)
+	err := client.StartAgent(context.Background(), "test-ns", "missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrNotFound)
+}
+
+func TestStartAgent_AlreadyRunning(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+	seedSandboxWithMode(t, dynamicClient, ns, "my-agent", "Running")
+
+	err := client.StartAgent(context.Background(), ns, "my-agent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrConflict)
+}
+
+func TestStartAgent_AlreadyRunningEmptyMode(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+	seedSandboxWithMode(t, dynamicClient, ns, "my-agent", "")
+
+	err := client.StartAgent(context.Background(), ns, "my-agent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrConflict)
+}
+
+func TestRestartAgent_Success(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+	seedSandboxWithMode(t, dynamicClient, ns, "my-agent", "Running")
+
+	err := client.RestartAgent(context.Background(), ns, "my-agent")
+	require.NoError(t, err)
+}
+
+func TestRestartAgent_NotFound(t *testing.T) {
+	client, _ := newDeployTestClient(t)
+	err := client.RestartAgent(context.Background(), "test-ns", "missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrNotFound)
 }

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -9,11 +9,9 @@ import (
 )
 
 const (
-	labelManagedBy = "app.kubernetes.io/managed-by"
 	labelAppName   = "app.kubernetes.io/name"
 	labelComponent = "app.kubernetes.io/component"
 
-	managedByValue = "odh-agent-ops"
 	componentValue = "agent"
 	containerName  = "agent"
 
@@ -47,12 +45,11 @@ func buildSandboxCR(params *agents.DeployAgentParams) *unstructured.Unstructured
 	}
 
 	labels := map[string]any{
-		agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
-		agents.LabelAgentType:          agents.AgentTypeAgent,
-		agents.LabelWorkloadType:       agents.WorkloadTypeSandbox,
-		labelManagedBy:                 managedByValue,
-		labelAppName:                   params.Name,
-		labelComponent:                 componentValue,
+		agents.LabelManagedBy:    agents.ManagedByValue,
+		agents.LabelAgentType:    agents.AgentTypeAgent,
+		agents.LabelWorkloadType: agents.WorkloadTypeSandbox,
+		labelAppName:             params.Name,
+		labelComponent:           componentValue,
 	}
 
 	annotations := map[string]any{

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
@@ -25,10 +25,9 @@ func TestBuildSandboxCR(t *testing.T) {
 	assert.Equal(t, "test-ns", obj.GetNamespace())
 
 	labels := obj.GetLabels()
-	assert.Equal(t, agents.OpenShellManagedByValue, labels[agents.LabelOpenShellManagedBy])
+	assert.Equal(t, agents.ManagedByValue, labels[agents.LabelManagedBy])
 	assert.Equal(t, agents.AgentTypeAgent, labels[agents.LabelAgentType])
 	assert.Equal(t, agents.WorkloadTypeSandbox, labels[agents.LabelWorkloadType])
-	assert.Equal(t, managedByValue, labels[labelManagedBy])
 
 	spec := obj.Object["spec"].(map[string]any)
 	assert.Equal(t, "Running", spec["operatingMode"])

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/mapper.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/mapper.go
@@ -28,7 +28,7 @@ const (
 
 func agentLabelSelectors() []string {
 	return []string{
-		fmt.Sprintf("%s=%s", agents.LabelOpenShellManagedBy, agents.OpenShellManagedByValue),
+		fmt.Sprintf("%s=%s", agents.LabelManagedBy, agents.ManagedByValue),
 	}
 }
 
@@ -53,6 +53,7 @@ func sandboxToSummary(sandbox unstructured.Unstructured, service *agents.AgentSe
 		StatusMessage: sandboxConditionMessage(sandbox),
 		ResourceType:  agents.ResolveAgentResourceType(labels),
 		WorkloadType:  agents.WorkloadTypeSandbox,
+		ServiceName:   sandboxServiceName(sandbox),
 		ServiceFQDN:   serviceFQDN,
 		PodIP:         sandboxPodIP(sandbox),
 		Ports:         append([]agents.AgentServicePort(nil), ports...),
@@ -83,6 +84,7 @@ func sandboxToDetail(sandbox unstructured.Unstructured, service *agents.AgentSer
 		DisplayName:    mapper.AgentDisplayName(annotations, sandbox.GetName()),
 		Framework:      mapper.AgentFramework(annotations),
 		ContainerImage: mapper.ContainerImageFromSpec(spec),
+		ServiceName:    sandboxServiceName(sandbox),
 		ServiceFQDN:    sandboxServiceFQDN(sandbox),
 		WorkloadType:   agents.WorkloadTypeSandbox,
 		ReadyStatus:    sandboxPhase(sandbox),
@@ -189,11 +191,7 @@ func normalizeSandboxPhase(phase string) string {
 }
 
 func buildSandboxServiceFromStatus(sandbox unstructured.Unstructured) *agents.AgentService {
-	fqdn := sandboxServiceFQDN(sandbox)
-	if fqdn == "" {
-		return nil
-	}
-	serviceName := serviceNameFromFQDN(fqdn)
+	serviceName := sandboxServiceName(sandbox)
 	if serviceName == "" {
 		return nil
 	}
@@ -251,6 +249,17 @@ func sandboxPodIP(sandbox unstructured.Unstructured) string {
 		}
 	}
 	return stringField(status["podIP"])
+}
+
+func sandboxServiceName(sandbox unstructured.Unstructured) string {
+	status, ok := sandbox.Object["status"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	if name := stringField(status["service"]); name != "" {
+		return name
+	}
+	return serviceNameFromFQDN(stringField(status["serviceFQDN"]))
 }
 
 func sandboxServiceFQDN(sandbox unstructured.Unstructured) string {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/mapper_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/mapper_test.go
@@ -39,8 +39,8 @@ func TestSandboxToSummary(t *testing.T) {
 			"name":      "my-agent",
 			"namespace": "test-ns",
 			"labels": map[string]any{
-				agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
-				agents.LabelWorkloadType:       agents.WorkloadTypeSandbox,
+				agents.LabelManagedBy:    agents.ManagedByValue,
+				agents.LabelWorkloadType: agents.WorkloadTypeSandbox,
 			},
 			"annotations": map[string]any{
 				agents.AnnotationDisplayName: "My Agent",
@@ -64,16 +64,15 @@ func TestSandboxToSummary(t *testing.T) {
 	assert.Equal(t, agents.AgentTypeAgent, summary.ResourceType)
 }
 
-func TestSandboxToSummaryOpenShellDefaultsResourceType(t *testing.T) {
+func TestSandboxToSummaryAlwaysReturnsAgentResourceType(t *testing.T) {
 	sandbox := unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": sandboxGVR.Group + "/" + sandboxGVR.Version,
 		"kind":       "Sandbox",
 		"metadata": map[string]any{
-			"name":      "openshell-agent",
-			"namespace": "openshell-ns",
+			"name":      "minimal-agent",
+			"namespace": "test-ns",
 			"labels": map[string]any{
-				agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
-				agents.LabelOpenShellSandboxID: "uuid-123",
+				"some-other-label": "some-value",
 			},
 		},
 		"status": map[string]any{
@@ -82,7 +81,7 @@ func TestSandboxToSummaryOpenShellDefaultsResourceType(t *testing.T) {
 	}}
 
 	summary := sandboxToSummary(sandbox, nil)
-	assert.Equal(t, "openshell-agent", summary.Name)
+	assert.Equal(t, "minimal-agent", summary.Name)
 	assert.Equal(t, agents.AgentTypeAgent, summary.ResourceType)
 }
 
@@ -94,7 +93,7 @@ func TestSandboxToDetail(t *testing.T) {
 			"name":      "my-agent",
 			"namespace": "test-ns",
 			"labels": map[string]any{
-				agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
+				agents.LabelManagedBy: agents.ManagedByValue,
 			},
 			"annotations": map[string]any{
 				agents.AnnotationDescription: "Detail agent",
@@ -120,6 +119,7 @@ func TestSandboxToDetail(t *testing.T) {
 		},
 		"status": map[string]any{
 			"phase":       "Ready",
+			"service":     "my-agent",
 			"serviceFQDN": "my-agent.test-ns.svc.cluster.local",
 		},
 	}}
@@ -130,6 +130,7 @@ func TestSandboxToDetail(t *testing.T) {
 	assert.Equal(t, "Detail agent", detail.Metadata.Annotations[agents.AnnotationDescription])
 	assert.Equal(t, "crewai", detail.Framework)
 	assert.Equal(t, "quay.io/example/agent:1.0", detail.ContainerImage)
+	assert.Equal(t, "my-agent", detail.ServiceName)
 	assert.Equal(t, "my-agent.test-ns.svc.cluster.local", detail.ServiceFQDN)
 	assert.Equal(t, agents.WorkloadTypeSandbox, detail.WorkloadType)
 	assert.Equal(t, "ready", detail.ReadyStatus)
@@ -263,7 +264,7 @@ func TestSandboxToSummaryAndDetailFromConditionsOnly(t *testing.T) {
 			"name":      "weatherservice",
 			"namespace": "dan",
 			"labels": map[string]any{
-				agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
+				agents.LabelManagedBy: agents.ManagedByValue,
 			},
 		},
 		"spec": map[string]any{"operatingMode": "Running"},
@@ -312,6 +313,44 @@ func TestServiceNameFromFQDN(t *testing.T) {
 	assert.Equal(t, "my-agent", serviceNameFromFQDN("my-agent.test-ns.svc.cluster.local"))
 	assert.Equal(t, "backing-svc", serviceNameFromFQDN("backing-svc.test-ns.svc.cluster.local."))
 	assert.Equal(t, "", serviceNameFromFQDN(""))
+}
+
+func TestSandboxServiceName(t *testing.T) {
+	t.Run("prefers status.service over FQDN parsing", func(t *testing.T) {
+		sandbox := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "x", "namespace": "ns"},
+			"status": map[string]any{
+				"service":     "actual-svc",
+				"serviceFQDN": "different-name.ns.svc.cluster.local",
+			},
+		}}
+		assert.Equal(t, "actual-svc", sandboxServiceName(sandbox))
+	})
+
+	t.Run("falls back to FQDN when status.service absent", func(t *testing.T) {
+		sandbox := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "x", "namespace": "ns"},
+			"status": map[string]any{
+				"serviceFQDN": "from-fqdn.ns.svc.cluster.local",
+			},
+		}}
+		assert.Equal(t, "from-fqdn", sandboxServiceName(sandbox))
+	})
+
+	t.Run("returns empty when neither field set", func(t *testing.T) {
+		sandbox := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "x", "namespace": "ns"},
+			"status":   map[string]any{},
+		}}
+		assert.Equal(t, "", sandboxServiceName(sandbox))
+	})
+
+	t.Run("returns empty when no status", func(t *testing.T) {
+		sandbox := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "x", "namespace": "ns"},
+		}}
+		assert.Equal(t, "", sandboxServiceName(sandbox))
+	})
 }
 
 func TestSandboxEndpointURLUsesServiceNameFromFQDN(t *testing.T) {

--- a/packages/agent-ops/bff/internal/integrations/agents/metadata.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/metadata.go
@@ -15,22 +15,18 @@ const (
 	AnnotationFramework = "opendatahub.io/agent-framework"
 	AnnotationImageRef  = "opendatahub.io/agent-image"
 
-	LabelOpenShellManagedBy = "openshell.ai/managed-by"
-	OpenShellManagedByValue = "openshell"
-	LabelOpenShellSandboxID = "openshell.ai/sandbox-id"
+	LabelManagedBy = "app.kubernetes.io/managed-by"
+	ManagedByValue = "odh-agent-ops"
 
 	AgentTypeAgent = "agent"
 
 	WorkloadTypeSandbox = "sandbox"
 )
 
-// ResolveAgentResourceType returns the agent resource type from sandbox labels.
-// Discovery is OpenShell-only; sandboxes with openshell.ai/managed-by=openshell are agents.
-func ResolveAgentResourceType(labels map[string]string) string {
-	if labels[LabelOpenShellManagedBy] == OpenShellManagedByValue {
-		return AgentTypeAgent
-	}
-	return ""
+// ResolveAgentResourceType returns the resource type for any Sandbox CR the BFF lists.
+// The label selector on list calls already gates ownership, so every listed CR is an agent.
+func ResolveAgentResourceType(_ map[string]string) string {
+	return AgentTypeAgent
 }
 
 const (

--- a/packages/agent-ops/bff/internal/integrations/agents/metadata_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/metadata_test.go
@@ -7,21 +7,16 @@ import (
 )
 
 func TestResolveAgentResourceType(t *testing.T) {
-	t.Run("returns agent for OpenShell managed-by", func(t *testing.T) {
+	t.Run("always returns agent", func(t *testing.T) {
 		labels := map[string]string{
-			LabelOpenShellManagedBy: OpenShellManagedByValue,
+			LabelAgentType:  AgentTypeAgent,
+			LabelManagedBy:  ManagedByValue,
+			"arbitrary-key": "arbitrary-value",
 		}
 		assert.Equal(t, AgentTypeAgent, ResolveAgentResourceType(labels))
 	})
 
-	t.Run("ignores agent-type label without OpenShell managed-by", func(t *testing.T) {
-		labels := map[string]string{
-			LabelAgentType: AgentTypeAgent,
-		}
-		assert.Equal(t, "", ResolveAgentResourceType(labels))
-	})
-
-	t.Run("returns empty when no OpenShell discovery labels", func(t *testing.T) {
-		assert.Equal(t, "", ResolveAgentResourceType(map[string]string{"foo": "bar"}))
+	t.Run("returns agent with empty labels", func(t *testing.T) {
+		assert.Equal(t, AgentTypeAgent, ResolveAgentResourceType(nil))
 	})
 }

--- a/packages/agent-ops/bff/internal/integrations/agents/mocks/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mocks/client.go
@@ -102,7 +102,7 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 			Name:      params.Name,
 			Namespace: params.Namespace,
 			Labels: map[string]string{
-				agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
+				agents.LabelManagedBy: agents.ManagedByValue,
 			},
 		},
 		WorkloadType: agents.WorkloadTypeSandbox,

--- a/packages/agent-ops/bff/internal/integrations/agents/mocks/demo_client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mocks/demo_client.go
@@ -34,7 +34,7 @@ func NewDemoClient() *Client {
 				Name:      "sample-support-agent",
 				Namespace: "agent-ops-demo",
 				Labels: map[string]string{
-					agents.LabelOpenShellManagedBy:     agents.OpenShellManagedByValue,
+					agents.LabelManagedBy:              agents.ManagedByValue,
 					agents.LabelProtocolPrefix + "a2a": "",
 					"app.kubernetes.io/name":           "sample-support-agent",
 				},

--- a/packages/agent-ops/bff/internal/integrations/agents/types.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/types.go
@@ -18,6 +18,7 @@ type AgentSummary struct {
 	StatusMessage string
 	ResourceType  string
 	WorkloadType  string
+	ServiceName   string
 	ServiceFQDN   string
 	PodIP         string
 	Ports         []AgentServicePort
@@ -34,6 +35,7 @@ type AgentDetail struct {
 	DisplayName        string
 	Framework          string
 	ContainerImage     string
+	ServiceName        string
 	ServiceFQDN        string
 	WorkloadType       string
 	ReadyStatus        string

--- a/packages/agent-ops/bff/internal/mapper/agent.go
+++ b/packages/agent-ops/bff/internal/mapper/agent.go
@@ -193,6 +193,9 @@ func serviceFQDNFromStatus(status map[string]any) string {
 }
 
 func serviceNameFromSummary(item agents.AgentSummary) string {
+	if item.ServiceName != "" {
+		return item.ServiceName
+	}
 	if name := serviceNameFromFQDN(item.ServiceFQDN); name != "" {
 		return name
 	}

--- a/packages/agent-ops/bff/internal/mapper/agent_test.go
+++ b/packages/agent-ops/bff/internal/mapper/agent_test.go
@@ -16,7 +16,7 @@ func TestAgentDetailToRuntimeDetail(t *testing.T) {
 			Name:      "sample-support-agent",
 			Namespace: "agent-ops-demo",
 			Labels: map[string]string{
-				agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
+				agents.LabelManagedBy: agents.ManagedByValue,
 			},
 			Annotations: map[string]string{
 				agents.AnnotationDescription: "Customer support agent",
@@ -57,15 +57,12 @@ func TestAgentDetailToRuntimeDetail(t *testing.T) {
 	assert.Equal(t, "http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080", result.Runtime.EndpointURL)
 }
 
-func TestAgentDetailToRuntimeDetail_OpenShellDefaultsResourceType(t *testing.T) {
+func TestAgentDetailToRuntimeDetail_AlwaysReturnsAgentResourceType(t *testing.T) {
 	detail := &agents.AgentDetail{
 		Metadata: agents.AgentMetadata{
-			Name:      "openshell-agent",
-			Namespace: "openshell-ns",
-			Labels: map[string]string{
-				agents.LabelOpenShellManagedBy: agents.OpenShellManagedByValue,
-				agents.LabelOpenShellSandboxID: "uuid-123",
-			},
+			Name:      "minimal-agent",
+			Namespace: "test-ns",
+			Labels:    map[string]string{},
 		},
 		ReadyStatus:  "Ready",
 		WorkloadType: agents.WorkloadTypeSandbox,
@@ -97,6 +94,7 @@ func TestAgentSummaryToRuntime(t *testing.T) {
 		Framework:    "langgraph",
 		Status:       "Ready",
 		ResourceType: "agent",
+		ServiceName:  "sample-support-agent",
 		ServiceFQDN:  "sample-support-agent.agent-ops-demo.svc.cluster.local",
 		Ports: []agents.AgentServicePort{
 			{Name: "http", Port: 8080},
@@ -113,6 +111,30 @@ func TestAgentSummaryToRuntime(t *testing.T) {
 	assert.Equal(t, "", runtime.EndpointURL)
 	assert.False(t, runtime.LastSyncTime.IsZero())
 	assert.Equal(t, 12, int(runtime.LastSyncTime.Day()))
+}
+
+func TestServiceNameFromSummary_PrefersServiceName(t *testing.T) {
+	item := agents.AgentSummary{
+		Name:        "sandbox-name",
+		ServiceName: "actual-svc",
+		ServiceFQDN: "different.ns.svc.cluster.local",
+	}
+	assert.Equal(t, "actual-svc", serviceNameFromSummary(item))
+}
+
+func TestServiceNameFromSummary_FallsBackToFQDN(t *testing.T) {
+	item := agents.AgentSummary{
+		Name:        "sandbox-name",
+		ServiceFQDN: "from-fqdn.ns.svc.cluster.local",
+	}
+	assert.Equal(t, "from-fqdn", serviceNameFromSummary(item))
+}
+
+func TestServiceNameFromSummary_FallsBackToName(t *testing.T) {
+	item := agents.AgentSummary{
+		Name: "sandbox-name",
+	}
+	assert.Equal(t, "sandbox-name", serviceNameFromSummary(item))
 }
 
 func TestParseTime(t *testing.T) {

--- a/packages/agent-ops/bff/openapi/src/agent-ops.yaml
+++ b/packages/agent-ops/bff/openapi/src/agent-ops.yaml
@@ -121,13 +121,15 @@ paths:
       summary: List agent runtimes
       description: |
         Returns deployed agent and tool runtimes from Sandbox CRs (`agents.x-k8s.io/v1beta1/sandboxes`)
-        labeled `openshell.ai/managed-by=openshell`.
+        labeled `app.kubernetes.io/managed-by=odh-agent-ops`.
         Results are deduplicated by namespace and name.
   /api/v1/agents/runtimes/{ns}/{name}:
     summary: Get agent runtime detail.
     description: >-
       Returns full agent detail, runtime info, workload status, service endpoints,
-      and conditions for a single deployed agent.
+      and conditions for a single deployed agent labeled
+      `app.kubernetes.io/managed-by=odh-agent-ops`. Returns 404 for sandboxes
+      without this label.
     get:
       tags:
         - AgentOperation

--- a/packages/agent-ops/contract-tests/__tests__/testAgentOpsContract.test.ts
+++ b/packages/agent-ops/contract-tests/__tests__/testAgentOpsContract.test.ts
@@ -75,6 +75,114 @@ describe('Agent Ops API Contract Tests', () => {
     });
   });
 
+  (clusterMode ? describe.skip : describe)('Agent Runtime Detail Endpoint (mock)', () => {
+    it('should return runtime detail for a pre-seeded agent', async () => {
+      const result = await apiClient.get(
+        '/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent',
+      );
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/AgentRuntimeDetailResponse/content/application~1json/schema',
+        status: 200,
+      });
+    });
+
+    it('should return 404 for a non-existent agent', async () => {
+      const result = await apiClient.get('/api/v1/agents/runtimes/agent-ops-demo/no-such-agent');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(404);
+      }
+    });
+  });
+
+  (clusterMode ? describe.skip : describe)('Agent Lifecycle Endpoints', () => {
+    it('should stop a running agent', async () => {
+      const result = await apiClient.post(
+        '/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent/stop',
+        undefined,
+      );
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/LifecycleResponse/content/application~1json/schema',
+        status: 200,
+      });
+    });
+
+    it('should return 409 when stopping an already-stopped agent', async () => {
+      const result = await apiClient.post(
+        '/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent/stop',
+        undefined,
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(409);
+      }
+    });
+
+    it('should start a stopped agent', async () => {
+      const result = await apiClient.post(
+        '/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent/start',
+        undefined,
+      );
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/LifecycleResponse/content/application~1json/schema',
+        status: 200,
+      });
+    });
+
+    it('should return 409 when starting an already-running agent', async () => {
+      const result = await apiClient.post(
+        '/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent/start',
+        undefined,
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(409);
+      }
+    });
+
+    it('should restart a running agent', async () => {
+      const result = await apiClient.post(
+        '/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent/restart',
+        undefined,
+      );
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/LifecycleResponse/content/application~1json/schema',
+        status: 200,
+      });
+    });
+
+    it('should return 404 when stopping a non-existent agent', async () => {
+      const result = await apiClient.post(
+        '/api/v1/agents/runtimes/agent-ops-demo/no-such-agent/stop',
+        undefined,
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(404);
+      }
+    });
+  });
+
+  (clusterMode ? describe.skip : describe)('Delete Agent Endpoint', () => {
+    it('should delete a pre-seeded agent', async () => {
+      const result = await apiClient.delete(
+        '/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent',
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.response.status).toBe(204);
+      }
+    });
+
+    it('should return 404 when deleting a non-existent agent', async () => {
+      const result = await apiClient.delete('/api/v1/agents/runtimes/agent-ops-demo/no-such-agent');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(404);
+      }
+    });
+  });
+
   describe('Deploy Agent Endpoint', () => {
     it('should deploy an agent with minimal params', async () => {
       const result = await apiClient.post('/api/v1/agents/deploy', {

--- a/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
+++ b/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
@@ -98,7 +98,7 @@ export const mockAgentRuntimeDetail = (
     serviceFqdn: runtime.serviceFqdn,
     containerImage: 'quay.io/example/support-agent:latest',
     labels: {
-      'openshell.ai/managed-by': 'openshell',
+      'app.kubernetes.io/managed-by': 'odh-agent-ops',
     },
     annotations: {
       'openshift.io/display-name': runtime.displayName,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62717

## Description

Hardens the agent-ops BFF Sandbox CR handling with two fixes identified by automated review:

1. **Detail endpoint now enforces the managed-by label.** `getAgentDetail` previously returned any authorized Sandbox by name, even those not deployed through agent-ops. It now checks `app.kubernetes.io/managed-by=odh-agent-ops` and returns 404 for unmanaged sandboxes, matching the list endpoint's label selector.

2. **Service lookup uses `status.service` name.** Both list and detail paths called `getServiceBestEffort` with the Sandbox CR name. When the backing Service has a different name (from `status.service` or `status.serviceFQDN`), the wrong Service was fetched. Now uses `sandboxServiceName()` with CR-name fallback.

Also includes:
- Migration of discovery label from `openshell.ai/managed-by=openshell` to `app.kubernetes.io/managed-by=odh-agent-ops`
- Unit tests for deploy, list, detail, and lifecycle handlers
- Contract tests for deploy, stop, start, restart, and delete endpoints
- Updated README and OpenAPI to document the label requirement on detail
- Synced `openapi/src/agent-ops.yaml` runtime copy

## How Has This Been Tested?

- `go test ./...` — all BFF packages pass
- `npm run test:contract` — 18/18 contract tests pass (1 skipped)
- Bugbot review: both findings addressed in this PR
- Security review: no medium+ findings
- CodeRabbit review: doc-accuracy finding addressed

## Test Impact

- **New Go unit tests:** deploy CR shape, label selectors, service name resolution, detail rejects unlabeled sandboxes, lifecycle (stop/start/restart/delete)
- **New contract tests:** deploy, stop, start, restart, delete endpoints validated against OpenAPI spec
- **Updated test:** `TestGetAgentDetailReturnsUnlabeledSandbox` → `TestGetAgentDetailRejectsUnlabeledSandbox` (asserts 404)

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent runtimes now display their associated service name when available.
  * Added support for starting, stopping, restarting, and deleting agents through the Agent Ops API.
  * Added clearer handling for invalid lifecycle operations and missing agents.

* **Bug Fixes**
  * Agent discovery now consistently recognizes runtimes managed by Agent Ops.
  * Unmanaged sandboxes are excluded from listings and return 404 when accessed directly.
  * Service names now use the most accurate available source, with sensible fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->