### PR TITLE
Add NIM properties to model deployment tracking events

### DIFF
--- a/packages/model-serving/extension-points/deployment-wizard.ts
+++ b/packages/model-serving/extension-points/deployment-wizard.ts
@@ -319,6 +319,7 @@ export type WizardTrackingPropertiesExtension<D extends Deployment = Deployment>
     getProperties: CodeRef<
       (
         wizardState: WizardFormData['state'],
+        externalData?: ExternalDataMap,
       ) => Record<string, string | number | boolean | undefined>
     >;
   }

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -45,6 +45,7 @@ export const useModelDeploymentSubmit = (
     initialWizardData,
     deployMethod?.properties.platform,
     !!existingDeployment,
+    externalData,
   );
   const { applyAllFieldDataFn, applyExtensionsLoaded } = useWizardFieldApply(
     formState,

--- a/packages/model-serving/src/shared/tracking/__tests__/useWizardTrackingProperties.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/useWizardTrackingProperties.spec.ts
@@ -60,14 +60,17 @@ describe('useWizardTrackingProperties', () => {
       },
     ] as never);
 
+    const externalData = {
+      'nim-serving/nimImage': { data: { nimImages: [] }, loaded: true },
+    };
     const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'nvidia-nim');
-    const result = await renderResult.result.current.getTrackingProperties();
+    const result = await renderResult.result.current.getTrackingProperties(externalData);
 
     expect(result).toEqual({
       nimModelId: 'meta/llama3-8b',
       nimImageVersion: '1.0.0',
     });
-    expect(mockGetProperties).toHaveBeenCalledWith(mockWizardState);
+    expect(mockGetProperties).toHaveBeenCalledWith(mockWizardState, externalData);
   });
 
   it('should only use the first matching extension for the platform', async () => {

--- a/packages/model-serving/src/shared/tracking/useModelDeployedTracking.ts
+++ b/packages/model-serving/src/shared/tracking/useModelDeployedTracking.ts
@@ -19,6 +19,7 @@ import {
 import { MODEL_CAPABILITIES_FIELD_ID } from '../../components/deploymentWizard/fields/modelCapabilities/ModelCapabilitiesField';
 import type { WizardFormState } from '../../components/deploymentWizard/useDeploymentWizardReducer';
 import type { InitialWizardFormData } from '../types/form-data';
+import type { ExternalDataMap } from '../../components/deploymentWizard/ExternalDataLoader';
 
 export const getBaseModelDeployedTrackingProperties = (
   formState: WizardFormState,
@@ -67,6 +68,7 @@ export const useModelDeployedTracking = (
   initialWizardData?: InitialWizardFormData,
   platformId?: string,
   isEdit?: boolean,
+  externalData?: ExternalDataMap,
 ): {
   fireModelDeployedTracking: (
     outcome: 'submit' | 'cancel',
@@ -80,7 +82,7 @@ export const useModelDeployedTracking = (
 
   const fireModelDeployedTracking = React.useCallback(
     async (outcome: 'submit' | 'cancel', success?: boolean, errorMessage?: string) => {
-      const platformTrackingProperties = await getTrackingProperties();
+      const platformTrackingProperties = await getTrackingProperties(externalData);
       const wizardProperties = getModelDeployedTrackingProperties({
         navState: getDeployWizardNavState(location.state),
         validatedConfigurations: initialWizardData?.validatedConfigurations,
@@ -110,6 +112,7 @@ export const useModelDeployedTracking = (
       getTrackingProperties,
       trackEvent,
       isEdit,
+      externalData,
     ],
   );
 

--- a/packages/model-serving/src/shared/tracking/useWizardTrackingProperties.ts
+++ b/packages/model-serving/src/shared/tracking/useWizardTrackingProperties.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useExtensions } from '@odh-dashboard/plugin-core';
 import { isWizardTrackingPropertiesExtension } from '../../../extension-points/deployment-wizard';
+import type { ExternalDataMap } from '../../components/deploymentWizard/ExternalDataLoader';
 import type { WizardFormData } from '../types/form-data';
 
 /**
@@ -12,30 +13,35 @@ export const useWizardTrackingProperties = (
   wizardState: WizardFormData['state'],
   platformId?: string,
 ): {
-  getTrackingProperties: () => Promise<Record<string, string | number | boolean | undefined>>;
+  getTrackingProperties: (
+    externalData?: ExternalDataMap,
+  ) => Promise<Record<string, string | number | boolean | undefined>>;
 } => {
   const extensions = useExtensions(isWizardTrackingPropertiesExtension);
 
-  const getTrackingProperties = React.useCallback(async (): Promise<
-    Record<string, string | number | boolean | undefined>
-  > => {
-    if (!platformId) {
-      return {};
-    }
+  const getTrackingProperties = React.useCallback(
+    async (
+      externalData?: ExternalDataMap,
+    ): Promise<Record<string, string | number | boolean | undefined>> => {
+      if (!platformId) {
+        return {};
+      }
 
-    const matchingExtension = extensions.find((ext) => ext.properties.platform === platformId);
+      const matchingExtension = extensions.find((ext) => ext.properties.platform === platformId);
 
-    if (!matchingExtension) {
-      return {};
-    }
+      if (!matchingExtension) {
+        return {};
+      }
 
-    try {
-      const resolvedFn = await matchingExtension.properties.getProperties();
-      return resolvedFn(wizardState);
-    } catch {
-      return {};
-    }
-  }, [extensions, platformId, wizardState]);
+      try {
+        const resolvedFn = await matchingExtension.properties.getProperties();
+        return resolvedFn(wizardState, externalData);
+      } catch {
+        return {};
+      }
+    },
+    [extensions, platformId, wizardState],
+  );
 
   return { getTrackingProperties };
 };

--- a/packages/nim-serving/extensions/nim-kserve.ts
+++ b/packages/nim-serving/extensions/nim-kserve.ts
@@ -12,14 +12,14 @@ import type {
 // eslint-disable-next-line no-restricted-syntax
 import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
 // eslint-disable-next-line no-restricted-syntax
-import { NIM_LEGACY_ID } from '../src/constants';
+import { NIM_IMAGE_FIELD_ID, NIM_LEGACY_ID, NIM_PVC_STORAGE_FIELD_ID } from '../src/constants';
 import type { NIMImageFieldValue } from '../src/pages/deploymentWizard/fields/NIMImageField';
 import type { NIMPVCFieldValue } from '../src/pages/deploymentWizard/fields/NIMPVCField';
 
 const nimPVCApplyExtension: WizardFieldApplyExtension<NIMPVCFieldValue, KServeDeployment> = {
   type: 'model-serving.deployment/wizard-field-apply',
   properties: {
-    fieldId: 'nim-serving/pvcStorage',
+    fieldId: NIM_PVC_STORAGE_FIELD_ID,
     platform: NIM_LEGACY_ID,
     apply: () =>
       import('../src/nimKServe/fields/nimPVCApplyExtract').then((m) => m.applyNIMPVCFieldData),
@@ -33,7 +33,7 @@ const nimPVCExtractorExtension: WizardFieldExtractorExtension<NIMPVCFieldValue, 
   {
     type: 'model-serving.deployment/wizard-field-extractor',
     properties: {
-      fieldId: 'nim-serving/pvcStorage',
+      fieldId: NIM_PVC_STORAGE_FIELD_ID,
       platform: KSERVE_ID,
       extract: () =>
         import('../src/nimKServe/fields/nimPVCApplyExtract').then((m) => m.extractNIMPVCFieldData),
@@ -61,7 +61,7 @@ const nimPVCDeployFunctionsExtension: WizardFieldDeploymentFunctionsExtension<
 > = {
   type: 'model-serving.deployment/wizard-field-deployment-functions',
   properties: {
-    fieldId: 'nim-serving/pvcStorage',
+    fieldId: NIM_PVC_STORAGE_FIELD_ID,
     platform: NIM_LEGACY_ID,
     preDeploy: () =>
       import('../src/nimKServe/fields/nimPVCDeployFunctions').then((m) => m.nimPVCPreDeploy),
@@ -75,7 +75,7 @@ const nimPVCDeployFunctionsExtension: WizardFieldDeploymentFunctionsExtension<
 const nimImageApplyExtension: WizardFieldApplyExtension<NIMImageFieldValue, KServeDeployment> = {
   type: 'model-serving.deployment/wizard-field-apply',
   properties: {
-    fieldId: 'nim-serving/nimImage',
+    fieldId: NIM_IMAGE_FIELD_ID,
     platform: NIM_LEGACY_ID,
     apply: () =>
       import('../src/nimKServe/fields/nimImageApplyExtract').then((m) => m.applyNIMImageFieldData),
@@ -94,7 +94,7 @@ const nimImageExtractExtension: WizardFieldExtractorExtension<
   // undefined for non-NIM deployments so plain KServe edits are unaffected.
   type: 'model-serving.deployment/wizard-field-extractor',
   properties: {
-    fieldId: 'nim-serving/nimImage',
+    fieldId: NIM_IMAGE_FIELD_ID,
     platform: KSERVE_ID,
     extract: () =>
       import('../src/nimKServe/fields/nimImageApplyExtract').then(

--- a/packages/nim-serving/extensions/nim-kserve.ts
+++ b/packages/nim-serving/extensions/nim-kserve.ts
@@ -7,6 +7,7 @@ import type {
   WizardFieldApplyExtension,
   WizardFieldDeploymentFunctionsExtension,
   WizardFieldExtractorExtension,
+  WizardTrackingPropertiesExtension,
 } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
 // eslint-disable-next-line no-restricted-syntax
 import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
@@ -41,6 +42,18 @@ const nimPVCExtractorExtension: WizardFieldExtractorExtension<NIMPVCFieldValue, 
       required: [SupportedArea.NIM_WIZARD],
     },
   };
+
+const nimTrackingPropertiesExtension: WizardTrackingPropertiesExtension<KServeDeployment> = {
+  type: 'model-serving.deployment/tracking-properties',
+  properties: {
+    platform: NIM_LEGACY_ID,
+    getProperties: () =>
+      import('../src/tracking/nimWizardTracking').then((m) => m.getNIMWizardTrackingProperties),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
 
 const nimPVCDeployFunctionsExtension: WizardFieldDeploymentFunctionsExtension<
   NIMPVCFieldValue,
@@ -118,6 +131,7 @@ const extensions: (
   | WizardFieldApplyExtension<NIMImageFieldValue, KServeDeployment>
   | WizardFieldApplyExtension<NIMPVCFieldValue, KServeDeployment>
   | WizardFieldDeploymentFunctionsExtension<NIMPVCFieldValue, KServeDeployment>
+  | WizardTrackingPropertiesExtension<KServeDeployment>
 )[] = [
   nimKServeFormDataExtension,
   {
@@ -138,6 +152,7 @@ const extensions: (
   nimPVCExtractorExtension,
   nimPVCDeployFunctionsExtension,
   nimImageExtractExtension,
+  nimTrackingPropertiesExtension,
 ];
 
 export default extensions;

--- a/packages/nim-serving/extensions/nim-service.ts
+++ b/packages/nim-serving/extensions/nim-service.ts
@@ -21,12 +21,12 @@ import type { NIMImageFieldValue } from '../src/pages/deploymentWizard/fields/NI
 import type { NIMPVCFieldValue } from '../src/pages/deploymentWizard/fields/NIMPVCField';
 // Allow this import as it consists of constants only.
 // eslint-disable-next-line no-restricted-syntax
-import { NIM_SERVICE_ID } from '../src/constants';
+import { NIM_IMAGE_FIELD_ID, NIM_PVC_STORAGE_FIELD_ID, NIM_SERVICE_ID } from '../src/constants';
 
 const nimImageApplyExtension: WizardFieldApplyExtension<NIMImageFieldValue, NIMDeployment> = {
   type: 'model-serving.deployment/wizard-field-apply',
   properties: {
-    fieldId: 'nim-serving/nimImage',
+    fieldId: NIM_IMAGE_FIELD_ID,
     platform: NIM_SERVICE_ID,
     apply: () =>
       import('../src/pages/deploymentWizard/fields/nimImageApplyExtract').then(
@@ -42,7 +42,7 @@ const nimImageExtractorExtension: WizardFieldExtractorExtension<NIMImageFieldVal
   {
     type: 'model-serving.deployment/wizard-field-extractor',
     properties: {
-      fieldId: 'nim-serving/nimImage',
+      fieldId: NIM_IMAGE_FIELD_ID,
       platform: NIM_SERVICE_ID,
       extract: () =>
         import('../src/pages/deploymentWizard/fields/nimImageApplyExtract').then(
@@ -57,7 +57,7 @@ const nimImageExtractorExtension: WizardFieldExtractorExtension<NIMImageFieldVal
 const nimPVCApplyExtension: WizardFieldApplyExtension<NIMPVCFieldValue, NIMDeployment> = {
   type: 'model-serving.deployment/wizard-field-apply',
   properties: {
-    fieldId: 'nim-serving/pvcStorage',
+    fieldId: NIM_PVC_STORAGE_FIELD_ID,
     platform: NIM_SERVICE_ID,
     apply: () =>
       import('../src/pages/deploymentWizard/fields/nimPVCApplyExtract').then(
@@ -72,7 +72,7 @@ const nimPVCApplyExtension: WizardFieldApplyExtension<NIMPVCFieldValue, NIMDeplo
 const nimPVCExtractorExtension: WizardFieldExtractorExtension<NIMPVCFieldValue, NIMDeployment> = {
   type: 'model-serving.deployment/wizard-field-extractor',
   properties: {
-    fieldId: 'nim-serving/pvcStorage',
+    fieldId: NIM_PVC_STORAGE_FIELD_ID,
     platform: NIM_SERVICE_ID,
     extract: () =>
       import('../src/pages/deploymentWizard/fields/nimPVCApplyExtract').then(
@@ -90,7 +90,7 @@ const nimPVCDeployFunctionsExtension: WizardFieldDeploymentFunctionsExtension<
 > = {
   type: 'model-serving.deployment/wizard-field-deployment-functions',
   properties: {
-    fieldId: 'nim-serving/pvcStorage',
+    fieldId: NIM_PVC_STORAGE_FIELD_ID,
     platform: NIM_SERVICE_ID,
     preDeploy: () =>
       import('../src/pages/deploymentWizard/fields/nimPVCDeployFunctions').then(

--- a/packages/nim-serving/src/constants.ts
+++ b/packages/nim-serving/src/constants.ts
@@ -1,5 +1,8 @@
 export const NIM_OPERATOR_MANAGED_BY = 'k8s-nim-operator';
 
+export const NIM_IMAGE_FIELD_ID = 'nim-serving/nimImage';
+export const NIM_PVC_STORAGE_FIELD_ID = 'nim-serving/pvcStorage';
+
 /** Platform id for the legacy NIM UI (KServe-backed NIM serving). */
 export const NIM_LEGACY_ID = 'nvidia-nim';
 

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -20,6 +20,7 @@ import {
   parseImageString,
 } from '../../../api/images/utils';
 import { useFetchNIMTemplate } from '../../../api/servingruntime/useFetchNIMTemplate';
+import { NIM_IMAGE_FIELD_ID } from '../../../constants';
 
 export const isNIMImageFieldExternalData = (data: unknown): data is NIMImageFieldExternalData =>
   !!data && typeof data === 'object' && 'nimImages' in data && 'accountStatus' in data;
@@ -355,7 +356,7 @@ export type NIMImageFieldType = WizardField<
 >;
 
 export const NIMImageFieldWizardField: NIMImageFieldType = {
-  id: 'nim-serving/nimImage',
+  id: NIM_IMAGE_FIELD_ID,
   step: 'modelSource',
   type: 'addition',
   isActive: (wizardFormData) =>

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -24,14 +24,13 @@ import useFetch, {
 } from '@odh-dashboard/ui-core/hooks/useFetch';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { useDefaultStorageClass } from '@odh-dashboard/internal/pages/projects/screens/spawner/storage/useDefaultStorageClass';
-import { isNIMPVC, NIM_PVC_SUBPATH_ANNOTATION } from '../../clusterStorage/clusterStorage';
 import { categorizePVCs, type ExistingPVCOption } from './nimPVCUtils';
+import { NIM_PVC_STORAGE_FIELD_ID } from '../../../constants';
 
 export {
   NIM_PVC_ANNOTATION,
   NIM_PVC_SUBPATH_ANNOTATION,
 } from '../../clusterStorage/clusterStorage';
-import { NIM_PVC_STORAGE_FIELD_ID } from '../../../constants';
 
 export enum NIMPVCStorageMode {
   NEW = 'new',

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -24,12 +24,14 @@ import useFetch, {
 } from '@odh-dashboard/ui-core/hooks/useFetch';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { useDefaultStorageClass } from '@odh-dashboard/internal/pages/projects/screens/spawner/storage/useDefaultStorageClass';
+import { isNIMPVC, NIM_PVC_SUBPATH_ANNOTATION } from '../../clusterStorage/clusterStorage';
 import { categorizePVCs, type ExistingPVCOption } from './nimPVCUtils';
 
 export {
   NIM_PVC_ANNOTATION,
   NIM_PVC_SUBPATH_ANNOTATION,
 } from '../../clusterStorage/clusterStorage';
+import { NIM_PVC_STORAGE_FIELD_ID } from '../../../constants';
 
 export enum NIMPVCStorageMode {
   NEW = 'new',
@@ -379,7 +381,7 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
 export type NIMPVCFieldType = WizardField<NIMPVCFieldValue, NIMPVCExternalData, NIMPVCDependencies>;
 
 export const NIMPVCFieldWizardField: NIMPVCFieldType = {
-  id: 'nim-serving/pvcStorage',
+  id: NIM_PVC_STORAGE_FIELD_ID,
   step: 'modelDeployment',
   type: 'addition',
   isActive: (wizardFormData) =>

--- a/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
+++ b/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
@@ -113,6 +113,41 @@ describe('getNIMWizardTrackingProperties', () => {
     });
   });
 
+  it('should fall back to the catalog image name when the display name is empty', () => {
+    expect(
+      getNIMWizardTrackingProperties(
+        wizardState({
+          [NIM_IMAGE_FIELD_ID]: imageValue,
+          [NIM_PVC_STORAGE_FIELD_ID]: {
+            storageMode: NIMPVCStorageMode.EXISTING,
+            storageClassName: '',
+            storageSizeGi: 75,
+          },
+        }),
+        {
+          [NIM_IMAGE_FIELD_ID]: {
+            data: {
+              nimImages: {
+                images: [
+                  {
+                    name: 'arctic-embed-l',
+                    displayName: '',
+                    namespace: 'nim/snowflake',
+                    tags: ['1.0.1'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ),
+    ).toEqual({
+      nimImage: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',
+      nimImageName: 'arctic-embed-l',
+      nimPvcType: 'existing',
+    });
+  });
+
   it('should omit the display name when the catalog image is unavailable', () => {
     expect(
       getNIMWizardTrackingProperties(

--- a/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
+++ b/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
@@ -75,6 +75,44 @@ describe('getNIMWizardTrackingProperties', () => {
     });
   });
 
+  it('should match catalog tags when the selected tag needs normalization', () => {
+    expect(
+      getNIMWizardTrackingProperties(
+        wizardState({
+          [NIM_IMAGE_FIELD_ID]: {
+            repository: 'nvcr.io/nim/snowflake/arctic-embed-l',
+            tag: '1.0',
+          },
+          [NIM_PVC_STORAGE_FIELD_ID]: {
+            storageMode: NIMPVCStorageMode.EXISTING,
+            storageClassName: '',
+            storageSizeGi: 75,
+          },
+        }),
+        {
+          [NIM_IMAGE_FIELD_ID]: {
+            data: {
+              nimImages: {
+                images: [
+                  {
+                    name: 'arctic-embed-l',
+                    displayName: 'Snowflake Arctic Embed Large Embedding',
+                    namespace: 'nim/snowflake',
+                    tags: ['1.0'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ),
+    ).toEqual({
+      nimImage: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0',
+      nimImageName: 'Snowflake Arctic Embed Large Embedding',
+      nimPvcType: 'existing',
+    });
+  });
+
   it('should omit the display name when the catalog image is unavailable', () => {
     expect(
       getNIMWizardTrackingProperties(

--- a/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
+++ b/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
@@ -1,0 +1,94 @@
+import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import { NIMPVCStorageMode } from '../../pages/deploymentWizard/fields/NIMPVCField';
+import { getNIMWizardTrackingProperties } from '../nimWizardTracking';
+
+const wizardState = (fields: Record<string, unknown>): WizardFormData['state'] =>
+  fields as WizardFormData['state'];
+
+const imageValue = {
+  repository: 'nvcr.io/nim/snowflake/arctic-embed-l',
+  tag: '1.0.1',
+};
+
+const imageExternalData = {
+  'nim-serving/nimImage': {
+    data: {
+      nimImages: [
+        {
+          name: 'arctic-embed-l',
+          displayName: 'Snowflake Arctic Embed Large Embedding',
+          namespace: 'nim/snowflake',
+          tags: ['1.0.1'],
+        },
+      ],
+    },
+  },
+};
+
+describe('getNIMWizardTrackingProperties', () => {
+  it('should track the catalog image display name and new storage choices', () => {
+    expect(
+      getNIMWizardTrackingProperties(
+        wizardState({
+          'nim-serving/nimImage': imageValue,
+          'nim-serving/pvcStorage': {
+            storageMode: NIMPVCStorageMode.NEW,
+            pvcName: 'user-pvc',
+            subPath: 'private-path',
+            storageClassName: 'gp3-csi',
+            storageSizeGi: 75,
+          },
+        }),
+        imageExternalData,
+      ),
+    ).toEqual({
+      nimImage: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',
+      nimImageName: 'Snowflake Arctic Embed Large Embedding',
+      nimPvcType: 'new',
+      nimStorageSizeGi: 75,
+      nimStorageClassName: 'gp3-csi',
+    });
+  });
+
+  it('should track existing storage without new-storage properties or names', () => {
+    expect(
+      getNIMWizardTrackingProperties(
+        wizardState({
+          'nim-serving/nimImage': imageValue,
+          'nim-serving/pvcStorage': {
+            storageMode: NIMPVCStorageMode.EXISTING,
+            pvcName: 'user-pvc',
+            subPath: 'private-path',
+            storageClassName: '',
+            storageSizeGi: 75,
+          },
+        }),
+        imageExternalData,
+      ),
+    ).toEqual({
+      nimImage: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',
+      nimImageName: 'Snowflake Arctic Embed Large Embedding',
+      nimPvcType: 'existing',
+    });
+  });
+
+  it('should omit the display name when the catalog image is unavailable', () => {
+    expect(
+      getNIMWizardTrackingProperties(
+        wizardState({
+          'nim-serving/nimImage': imageValue,
+          'nim-serving/pvcStorage': {
+            storageMode: NIMPVCStorageMode.NEW,
+            storageClassName: '',
+            storageSizeGi: 50,
+          },
+        }),
+        { 'nim-serving/nimImage': { data: { nimImages: [] } } },
+      ),
+    ).toEqual({
+      nimImage: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',
+      nimPvcType: 'new',
+      nimStorageSizeGi: 50,
+    });
+  });
+});

--- a/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
+++ b/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
@@ -1,6 +1,7 @@
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
 import { NIMPVCStorageMode } from '../../pages/deploymentWizard/fields/NIMPVCField';
 import { getNIMWizardTrackingProperties } from '../nimWizardTracking';
+import { NIM_IMAGE_FIELD_ID, NIM_PVC_STORAGE_FIELD_ID } from '../../constants';
 
 const wizardState = (fields: Record<string, unknown>): WizardFormData['state'] =>
   fields as WizardFormData['state'];
@@ -11,7 +12,7 @@ const imageValue = {
 };
 
 const imageExternalData = {
-  'nim-serving/nimImage': {
+  [NIM_IMAGE_FIELD_ID]: {
     data: {
       nimImages: [
         {
@@ -30,8 +31,8 @@ describe('getNIMWizardTrackingProperties', () => {
     expect(
       getNIMWizardTrackingProperties(
         wizardState({
-          'nim-serving/nimImage': imageValue,
-          'nim-serving/pvcStorage': {
+          [NIM_IMAGE_FIELD_ID]: imageValue,
+          [NIM_PVC_STORAGE_FIELD_ID]: {
             storageMode: NIMPVCStorageMode.NEW,
             pvcName: 'user-pvc',
             subPath: 'private-path',
@@ -54,8 +55,8 @@ describe('getNIMWizardTrackingProperties', () => {
     expect(
       getNIMWizardTrackingProperties(
         wizardState({
-          'nim-serving/nimImage': imageValue,
-          'nim-serving/pvcStorage': {
+          [NIM_IMAGE_FIELD_ID]: imageValue,
+          [NIM_PVC_STORAGE_FIELD_ID]: {
             storageMode: NIMPVCStorageMode.EXISTING,
             pvcName: 'user-pvc',
             subPath: 'private-path',
@@ -76,14 +77,14 @@ describe('getNIMWizardTrackingProperties', () => {
     expect(
       getNIMWizardTrackingProperties(
         wizardState({
-          'nim-serving/nimImage': imageValue,
-          'nim-serving/pvcStorage': {
+          [NIM_IMAGE_FIELD_ID]: imageValue,
+          [NIM_PVC_STORAGE_FIELD_ID]: {
             storageMode: NIMPVCStorageMode.NEW,
             storageClassName: '',
             storageSizeGi: 50,
           },
         }),
-        { 'nim-serving/nimImage': { data: { nimImages: [] } } },
+        { [NIM_IMAGE_FIELD_ID]: { data: { nimImages: [] } } },
       ),
     ).toEqual({
       nimImage: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',

--- a/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
+++ b/packages/nim-serving/src/tracking/__tests__/nimWizardTracking.spec.ts
@@ -14,14 +14,16 @@ const imageValue = {
 const imageExternalData = {
   [NIM_IMAGE_FIELD_ID]: {
     data: {
-      nimImages: [
-        {
-          name: 'arctic-embed-l',
-          displayName: 'Snowflake Arctic Embed Large Embedding',
-          namespace: 'nim/snowflake',
-          tags: ['1.0.1'],
-        },
-      ],
+      nimImages: {
+        images: [
+          {
+            name: 'arctic-embed-l',
+            displayName: 'Snowflake Arctic Embed Large Embedding',
+            namespace: 'nim/snowflake',
+            tags: ['1.0.1'],
+          },
+        ],
+      },
     },
   },
 };
@@ -84,7 +86,7 @@ describe('getNIMWizardTrackingProperties', () => {
             storageSizeGi: 50,
           },
         }),
-        { [NIM_IMAGE_FIELD_ID]: { data: { nimImages: [] } } },
+        { [NIM_IMAGE_FIELD_ID]: { data: { nimImages: { images: [] } } } },
       ),
     ).toEqual({
       nimImage: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',

--- a/packages/nim-serving/src/tracking/nimWizardTracking.ts
+++ b/packages/nim-serving/src/tracking/nimWizardTracking.ts
@@ -6,9 +6,7 @@ import {
   NIMPVCStorageMode,
   type NIMPVCFieldValue,
 } from '../pages/deploymentWizard/fields/NIMPVCField';
-
-const NIM_IMAGE_FIELD_ID = 'nim-serving/nimImage';
-const NIM_PVC_FIELD_ID = 'nim-serving/pvcStorage';
+import { NIM_IMAGE_FIELD_ID, NIM_PVC_STORAGE_FIELD_ID } from '../constants';
 
 type TrackingProperties = Record<string, string | number | boolean | undefined>;
 
@@ -81,7 +79,7 @@ export const getNIMWizardTrackingProperties = (
       : undefined,
     externalData,
   );
-  const pvcValue = wizardState[NIM_PVC_FIELD_ID];
+  const pvcValue = wizardState[NIM_PVC_STORAGE_FIELD_ID];
 
   if (!isNIMPVCFieldValue(pvcValue)) {
     return properties;

--- a/packages/nim-serving/src/tracking/nimWizardTracking.ts
+++ b/packages/nim-serving/src/tracking/nimWizardTracking.ts
@@ -1,0 +1,99 @@
+import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import type { NIMImage } from '../api/images/types';
+import { getImageRepository, normalizeVersion } from '../api/images/utils';
+import type { NIMImageFieldValue } from '../pages/deploymentWizard/fields/NIMImageField';
+import {
+  NIMPVCStorageMode,
+  type NIMPVCFieldValue,
+} from '../pages/deploymentWizard/fields/NIMPVCField';
+
+const NIM_IMAGE_FIELD_ID = 'nim-serving/nimImage';
+const NIM_PVC_FIELD_ID = 'nim-serving/pvcStorage';
+
+type TrackingProperties = Record<string, string | number | boolean | undefined>;
+
+type ExternalDataMap = Record<string, { data: unknown }>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isNIMImageFieldValue = (value: unknown): value is NIMImageFieldValue =>
+  isRecord(value) && typeof value.repository === 'string' && typeof value.tag === 'string';
+
+const isNIMPVCFieldValue = (value: unknown): value is NIMPVCFieldValue =>
+  isRecord(value) &&
+  (value.storageMode === NIMPVCStorageMode.NEW ||
+    value.storageMode === NIMPVCStorageMode.EXISTING) &&
+  typeof value.storageSizeGi === 'number' &&
+  typeof value.storageClassName === 'string';
+
+const isNIMImage = (
+  value: unknown,
+): value is NIMImage & {
+  namespace: string;
+  tags: string[];
+} =>
+  isRecord(value) &&
+  typeof value.name === 'string' &&
+  typeof value.namespace === 'string' &&
+  (value.displayName === undefined || typeof value.displayName === 'string') &&
+  Array.isArray(value.tags) &&
+  value.tags.every((tag) => typeof tag === 'string');
+
+const getNIMImageProperties = (
+  imageValue: NIMImageFieldValue | undefined,
+  externalData?: ExternalDataMap,
+): TrackingProperties => {
+  if (!imageValue?.repository || !imageValue.tag) {
+    return {};
+  }
+
+  const properties: TrackingProperties = {
+    nimImage: `${imageValue.repository}:${imageValue.tag}`,
+  };
+  const imageData = externalData?.[NIM_IMAGE_FIELD_ID]?.data;
+
+  if (!isRecord(imageData) || !Array.isArray(imageData.nimImages)) {
+    return properties;
+  }
+
+  const image = imageData.nimImages.find(
+    (candidate): candidate is NIMImage & { namespace: string; tags: string[] } =>
+      isNIMImage(candidate) &&
+      getImageRepository(candidate.namespace, candidate.name) === imageValue.repository &&
+      candidate.tags.some((tag) => normalizeVersion(tag) === imageValue.tag),
+  );
+
+  if (image) {
+    properties.nimImageName = image.displayName ?? image.name;
+  }
+
+  return properties;
+};
+
+export const getNIMWizardTrackingProperties = (
+  wizardState: WizardFormData['state'],
+  externalData?: ExternalDataMap,
+): TrackingProperties => {
+  const properties = getNIMImageProperties(
+    isNIMImageFieldValue(wizardState[NIM_IMAGE_FIELD_ID])
+      ? wizardState[NIM_IMAGE_FIELD_ID]
+      : undefined,
+    externalData,
+  );
+  const pvcValue = wizardState[NIM_PVC_FIELD_ID];
+
+  if (!isNIMPVCFieldValue(pvcValue)) {
+    return properties;
+  }
+
+  properties.nimPvcType = pvcValue.storageMode;
+  if (pvcValue.storageMode === NIMPVCStorageMode.NEW) {
+    properties.nimStorageSizeGi = pvcValue.storageSizeGi;
+    if (pvcValue.storageClassName) {
+      properties.nimStorageClassName = pvcValue.storageClassName;
+    }
+  }
+
+  return properties;
+};

--- a/packages/nim-serving/src/tracking/nimWizardTracking.ts
+++ b/packages/nim-serving/src/tracking/nimWizardTracking.ts
@@ -63,7 +63,7 @@ const getNIMImageProperties = (
     (candidate): candidate is NIMImage & { namespace: string; tags: string[] } =>
       isNIMImage(candidate) &&
       getImageRepository(candidate.namespace, candidate.name) === imageValue.repository &&
-      candidate.tags.some((tag) => normalizeVersion(tag) === imageValue.tag),
+      candidate.tags.some((tag) => normalizeVersion(tag) === normalizeVersion(imageValue.tag)),
   );
 
   if (image) {

--- a/packages/nim-serving/src/tracking/nimWizardTracking.ts
+++ b/packages/nim-serving/src/tracking/nimWizardTracking.ts
@@ -51,11 +51,15 @@ const getNIMImageProperties = (
   };
   const imageData = externalData?.[NIM_IMAGE_FIELD_ID]?.data;
 
-  if (!isRecord(imageData) || !Array.isArray(imageData.nimImages)) {
+  if (
+    !isRecord(imageData) ||
+    !isRecord(imageData.nimImages) ||
+    !Array.isArray(imageData.nimImages.images)
+  ) {
     return properties;
   }
 
-  const image = imageData.nimImages.find(
+  const image = imageData.nimImages.images.find(
     (candidate): candidate is NIMImage & { namespace: string; tags: string[] } =>
       isNIMImage(candidate) &&
       getImageRepository(candidate.namespace, candidate.name) === imageValue.repository &&

--- a/packages/nim-serving/src/tracking/nimWizardTracking.ts
+++ b/packages/nim-serving/src/tracking/nimWizardTracking.ts
@@ -67,7 +67,7 @@ const getNIMImageProperties = (
   );
 
   if (image) {
-    properties.nimImageName = image.displayName ?? image.name;
+    properties.nimImageName = image.displayName || image.name;
   }
 
   return properties;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-88015

## Description

Adds NIM-specific properties to the model deployment analytics events and fixes catalog image-name lookup.

The `Model Deployed` and `Model Updated` events now include the NIM image repository/tag, catalog image display name when available, PVC storage mode, and new-storage size/class properties. User-entered deployment names, PVC names, subpaths, and credentials are not included.

`externalData` was added to the tracking-property extension contract and passed through the model-serving tracking collection path because the catalog display name is available only in the NIM wizard field's external data. The wizard state contains the selected repository and tag, but not the catalog metadata needed to derive the safe display name. Passing the existing external-data map keeps the model-serving hub independent of the NIM package while allowing the NIM extension to resolve the catalog entry. The implementation validates the nested `nimImages.images` shape and omits `nimImageName` when the catalog entry is unavailable.

The edit flow emits `Model Updated` rather than `Model Deployed`, including for existing-storage NIM deployments.

## How Has This Been Tested?

- Ran the targeted NIM tracking unit tests:
  - `npm run test-unit --workspace=@odh-dashboard/nim-serving -- --runInBand src/tracking/__tests__/nimWizardTracking.spec.ts`
- Ran ESLint on the changed implementation and test files.
- Ran the NIM package type check:
  - `npm run type-check --workspace=@odh-dashboard/nim-serving`
- Manually validated in the local dashboard with `nimWizard=true` using Playwright:
  - Created a NIM deployment with new storage (`75 GiB`, `gp3-csi`).
  - Edited a deployment using a catalog image that exists.
  - Edited `nim-bad-image` using an image absent from the catalog.
  - Captured all three console telemetry payloads.
  - Confirmed catalog-backed events include `nimImageName: "Active Speaker Detection"`.
  - Confirmed the unavailable-image event omits `nimImageName` while retaining the safe raw image value.
  - Confirmed user-entered deployment/PVC names and subpaths were absent.

Captured browser console output:

```text
[LOG] Telemetry event triggered: Model Deployed - {"outcome":"submit","success":true,"modelType":"NVIDIA NIM","numReplicas":1,"modelLocationType":"nvidia-nim","countOfSuggestedCapabilities":0,"countOfCustomCapabilities":0,"nimImage":"nvcr.io/nim/nvidia/active-speaker-detection:1.1.0","nimImageName":"Active Speaker Detection","nimPvcType":"new","nimStorageSizeGi":75,"nimStorageClassName":"gp3-csi","enableToolCalling":false,"validatedConfigurationCount":0,"validatedConfigurationNames":"","hasValidatedArgumentsSection":false,"entryPoint":"project_deployments","hasInjectedValidatedArgs":false} for version v3.4.0 @ webpack-internal:///../packages/analytics/src/segmentUtils.ts:208

[LOG] Telemetry event triggered: Model Updated - {"outcome":"submit","success":true,"modelType":"NVIDIA NIM","servingRuntimeFormat":"active-speaker-detection","numReplicas":1,"modelLocationType":"nvidia-nim","countOfSuggestedCapabilities":0,"countOfCustomCapabilities":0,"nimImage":"nvcr.io/nim/nvidia/active-speaker-detection:1.1.0","nimImageName":"Active Speaker Detection","nimPvcType":"existing","enableToolCalling":false,"validatedConfigurationCount":0,"validatedConfigurationNames":"","hasValidatedArgumentsSection":false,"entryPoint":"edit","hasInjectedValidatedArgs":false} for version v3.4.0 @ webpack-internal:///../packages/analytics/src/segmentUtils.ts:208

[LOG] Telemetry event triggered: Model Updated - {"outcome":"submit","success":true,"modelType":"NVIDIA NIM","servingRuntimeFormat":"nonexistent-model","numReplicas":1,"modelLocationType":"nvidia-nim","countOfSuggestedCapabilities":0,"countOfCustomCapabilities":0,"nimImage":"nvcr.io/nim/fake/nonexistent-model:99.99.99","nimPvcType":"existing","enableToolCalling":false,"validatedConfigurationCount":0,"validatedConfigurationNames":"","hasValidatedArgumentsSection":false,"entryPoint":"edit","hasInjectedValidatedArgs":false} for version v3.4.0 @ webpack-internal:///../packages/analytics/src/segmentUtils.ts:208
```

## Test Impact

- Updated unit-test fixtures to match the actual `NIMImageFieldExternalData` shape (`nimImages.images`).
- Existing-storage behavior remains unchanged: `nimStorageSizeGi` and `nimStorageClassName` are omitted.
- Catalog lookup failures or unavailable images do not prevent safe telemetry emission.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Deployment wizard analytics now capture NIM image details, including the selected image and display name when available.
  - Tracking now records storage configuration, including whether new or existing storage is used and relevant storage settings.
  - Analytics extensions can use additional deployment data to provide more complete platform-specific tracking.

- **Improvements**
  - NIM deployment fields now use consistent identifiers across the wizard and deployment workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->