### PR TITLE
Flake fix - add try catch to useNIMPVC

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMPVC.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMPVC.ts
@@ -25,11 +25,15 @@ export const useNIMPVC = (
           (vol) => vol.persistentVolumeClaim?.claimName,
         )?.persistentVolumeClaim?.claimName;
         if (pvcName) {
-          const pvcData = await getPvc(namespace, pvcName);
-          setPvc(pvcData);
-          const size = pvcData.spec.resources.requests.storage;
-          if (size) {
-            setPvcSize(size);
+          try {
+            const pvcData = await getPvc(namespace, pvcName);
+            setPvc(pvcData);
+            const size = pvcData.spec.resources.requests.storage;
+            if (size) {
+              setPvcSize(size);
+            }
+          } catch {
+            // PVC fetch failed — keep the default size rather than leaking an unhandled rejection.
           }
         }
       }

--- a/packages/cypress/cypress/utils/servingUtils.ts
+++ b/packages/cypress/cypress/utils/servingUtils.ts
@@ -118,7 +118,7 @@ export const initInterceptsForAllProjects = (): void => {
   // fetches the PVC. Without this stub the request falls through and, if it resolves at test
   // teardown, throws an unhandled "Unexpected end of JSON input" from an empty body.
   cy.interceptK8s(
-    { model: PVCModel, ns: 'nim-project', name: 'nim-pvc' },
-    mockPVCK8sResource({ name: 'nim-pvc', namespace: 'nim-project' }),
+    { model: PVCModel, ns: 'nim-project', name: 'my-nim-pvc' },
+    mockPVCK8sResource({ name: 'my-nim-pvc', namespace: 'nim-project' }),
   );
 };

--- a/packages/cypress/cypress/utils/servingUtils.ts
+++ b/packages/cypress/cypress/utils/servingUtils.ts
@@ -1,6 +1,7 @@
 import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { mockSecretK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockSecretK8sResource';
+import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
 import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
 import { mockServingRuntimeK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockServingRuntimeK8sResource';
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
@@ -22,6 +23,7 @@ import {
   InferenceServiceModel,
   NIMAccountModel,
   ProjectModel,
+  PVCModel,
   ServingRuntimeModel,
 } from './models';
 
@@ -111,4 +113,12 @@ export const initInterceptsForAllProjects = (): void => {
   );
 
   cy.interceptK8sList(NIMAccountModel, mockK8sResourceList([mockNimAccount({})]));
+
+  // The NIM edit modal reads the runtime's `nim-pvc` volume (see mockNimServingRuntime) and
+  // fetches the PVC. Without this stub the request falls through and, if it resolves at test
+  // teardown, throws an unhandled "Unexpected end of JSON input" from an empty body.
+  cy.interceptK8s(
+    { model: PVCModel, ns: 'nim-project', name: 'nim-pvc' },
+    mockPVCK8sResource({ name: 'nim-pvc', namespace: 'nim-project' }),
+  );
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Hopefully resolves https://redhat.atlassian.net/browse/RHOAIENG-91619

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Recently I had added a new parameter to `mockNimServingRuntime` to add a pvcName to the servingRuntime, since all nims have this. This might have caused this flake to occur. During the teardown of the `All projects with every type of serving listed` there was a non-mocked PVC fetch happening on the edit of the NIM model, this was because there was a PVC now it was trying to fetch

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I'll try running it a bunch of times in the CI

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Mock intercept added to the potentially failing api call

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved reliability when retrieving NIM persistent volume information. If the request fails, the default 30 GiB storage value is retained instead of surfacing an unhandled error.
* Prevented errors during NIM project editing flows when persistent volume data is temporarily unavailable.
* NIM project workflows now continue more smoothly when storage information cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->