### PR TITLE
fix(e2e): expect Inadmissible for zero-quota workbench Kueue lifecycle

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
@@ -1,5 +1,5 @@
 # Kueue workbench lifecycle test data
-# Uses zero quota to force Queued state, then updates quota to allow admission
+# Uses zero quota to force Inadmissible state, then updates quota to allow admission
 projectName: "kueue-lifecycle-project"
 flavorName: "lifecycle-flavor"
 clusterQueueName: "lifecycle-cluster-queue"
@@ -12,5 +12,4 @@ updatedCpuQuota: 4
 updatedMemoryQuota: 8
 sectionTab: "workbenches"
 notebookImage: "code-server-notebook"
-waitingForQuotaMessage: "Waiting for quota"
-queuePositionMarker: "(position"
+exceededQuotaMessage: "Exceeded quota"

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
@@ -59,7 +59,7 @@ describe('Workbench Kueue Lifecycle Tests', () => {
   });
 
   it(
-    'Verify workbench Kueue lifecycle: Queued → Ready after quota update',
+    'Verify workbench Kueue lifecycle: Inadmissible → Ready after quota update',
     { tags: ['@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged'] },
     () => {
       cy.step('Log into the application');
@@ -91,21 +91,16 @@ describe('Workbench Kueue Lifecycle Tests', () => {
       cy.step('Wait for notebook table to appear');
       workbenchPage.findNotebookTable(30000).should('exist');
 
-      cy.step('Verify workbench shows Queued status');
+      cy.step('Verify workbench shows Inadmissible status');
       const notebookRow = workbenchPage.getNotebookRow(workbenchName);
-      notebookRow.expectStatusLabelToBe('Queued', 120000);
+      notebookRow.expectStatusLabelToBe('Inadmissible', 120000);
 
-      cy.step('Verify status subtitle shows waiting for quota message');
+      cy.step('Verify status subtitle shows exceeded quota message');
       notebookRow
         .findNotebookStatusSubtitle()
-        .should('contain.text', fixtureData.waitingForQuotaMessage);
+        .should('contain.text', fixtureData.exceededQuotaMessage);
 
-      cy.step('Verify queue position is displayed');
-      notebookRow
-        .findNotebookStatusSubtitle()
-        .should('contain.text', fixtureData.queuePositionMarker);
-
-      cy.step('Click on the Queued status label to open the status modal');
+      cy.step('Click on the Inadmissible status label to open the status modal');
       notebookRow.findHaveNotebookStatusText().click();
 
       cy.step('Verify status modal is visible');

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -136,8 +136,7 @@ export type KueueWorkbenchTestData = {
 export type KueueWorkbenchLifecycleTestData = KueueWorkbenchTestData & {
   updatedCpuQuota: number;
   updatedMemoryQuota: number;
-  waitingForQuotaMessage: string;
-  queuePositionMarker: string;
+  exceededQuotaMessage: string;
 };
 
 export type WBControlSuiteTestData = {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-90198

## Description

Fixes `testWorkbenchKueueLifecycle.cy.ts`, which asserted **Queued** when the ClusterQueue has zero quota. The dashboard correctly maps that case to **Inadmissible** (workload exceeds max capacity), consistent with `testModelDeploymentKueueLifecycle.cy.ts` and `getKueueWorkloadStatusWithMessage`.

Updates the zero-quota assertions to expect **Inadmissible** with an "Exceeded quota" subtitle, removes the queue-position check (not shown for Inadmissible), and keeps the quota-bump path asserting **Ready**.

## How Has This Been Tested?

- Lint-staged / ESLint passed on commit
- E2E not re-run locally; Jenkins `testWorkbenchKueueLifecycle.cy.ts` should be re-run after merge

## Test Impact

- Updated `testWorkbenchKueueLifecycle.cy.ts` fixture and assertions
- Updated `testKueueWorkbenchLifecycle.yaml` and `KueueWorkbenchLifecycleTestData` type
- No product code changes

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected lifecycle validation for workbenches with zero available quota, which now appear as **Inadmissible** with an **Exceeded quota** message instead of **Queued**.
  * Confirmed that the workbench transitions to **Ready** after quota becomes available.

* **Tests**
  * Updated end-to-end coverage to verify the revised quota status and transition flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->