### PR TITLE
fix(manifests): tune dashboard probes to improve startup time (RHOAIENG-15122)

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -47,6 +47,22 @@ spec:
               ephemeral-storage: 50Mi
             limits:
               memory: 1Gi
+          # The dashboard app binds to 127.0.0.1 (loopback) only and is reached
+          # in-pod via the kube-rbac-proxy sidecar, so probes MUST use `exec: curl`
+          # against loopback — a tcpSocket/httpGet probe on the pod IP is refused.
+          startupProbe:
+            exec:
+              command:
+                - curl
+                - -f
+                - -s
+                - --max-time
+                - '10'
+                - http://127.0.0.1:8080/api/health
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 3
+            failureThreshold: 20
           livenessProbe:
             exec:
               command:
@@ -56,9 +72,8 @@ spec:
                 - --max-time
                 - '10'
                 - http://127.0.0.1:8080/
-            initialDelaySeconds: 30
-            timeoutSeconds: 15
-            periodSeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
@@ -70,9 +85,8 @@ spec:
                 - --max-time
                 - '10'
                 - http://127.0.0.1:8080/api/health
-            initialDelaySeconds: 30
-            timeoutSeconds: 15
-            periodSeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           volumeMounts:
@@ -107,14 +121,22 @@ spec:
               name: dashboard-ui
             - containerPort: 8444
               name: proxy-health
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8444
+              scheme: HTTPS
+            initialDelaySeconds: 1
+            timeoutSeconds: 1
+            periodSeconds: 2
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /healthz
               port: 8444
               scheme: HTTPS
-            initialDelaySeconds: 30
             timeoutSeconds: 1
-            periodSeconds: 5
+            periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
@@ -122,7 +144,6 @@ spec:
               path: /healthz
               port: 8444
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 1
             periodSeconds: 5
             successThreshold: 1
@@ -169,14 +190,22 @@ spec:
               ephemeral-storage: 10Mi
             limits:
               memory: 256Mi
+          startupProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8943
+              scheme: HTTPS
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            periodSeconds: 2
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /healthcheck
               port: 8943
               scheme: HTTPS
-            initialDelaySeconds: 30
-            timeoutSeconds: 15
-            periodSeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
@@ -184,9 +213,8 @@ spec:
               path: /healthcheck
               port: 8943
               scheme: HTTPS
-            initialDelaySeconds: 15
-            timeoutSeconds: 15
-            periodSeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           volumeMounts:


### PR DESCRIPTION
<!-- https://issues.redhat.com/browse/RHOAIENG-15122 -->

## Description

The dashboard deployment took ~30–40s to become `Ready` on startup. The liveness and readiness probes for all three containers used `initialDelaySeconds: 30` combined with `periodSeconds: 30`, so a pod could not become ready before 30s — and a single missed check pushed that toward a full minute. This intermittently caused the odh-operator dashboard availability tests to flake (see [RHOAIENG-15122](https://redhat.atlassian.net/browse/RHOAIENG-15122)).

This PR tunes the probes on the three containers of the `odh-dashboard` deployment (`manifests/base/deployment.yaml`):

- **Adds a `startupProbe`** to each container so the gating happens quickly and repeatedly during boot instead of a fixed 30s wait.
- **Removes `initialDelaySeconds`** from liveness/readiness (the `startupProbe` now gates them) and **shortens `periodSeconds`** (readiness `30s → 5s`, liveness `30s → 10s`).

### Key finding / gotcha

The original ticket suggested a `tcpSocket: port: 8080` startup probe. That does **not** work for the `odh-dashboard` container: the app binds to **`127.0.0.1` (loopback) only** and is reached in-pod through the `kube-rbac-proxy` sidecar (`--upstream=http://localhost:8080`). A `tcpSocket`/`httpGet` probe connects to the **pod IP**, which the app is not listening on, so it returns `connection refused` and crash-loops the container (observed: `Startup probe failed: dial tcp <podIP>:8080: connect: connection refused` → `exitCode 137`). The `startupProbe` for `odh-dashboard` therefore uses `exec: curl http://127.0.0.1:8080/api/health`, matching the existing liveness/readiness probes. The `kube-rbac-proxy` and `core-bff` sidecars bind to `0.0.0.0`, so they keep their `httpGet` probes.

## How Has This Been Tested?

Tested on a live RHOAI cluster (ROSA, `ui-monarch-rosa`) running the `dashboard-operator`. Startup time was measured as the delta between container start (`.status.containerStatuses[].state.running.startedAt`) and the pod `Ready` condition transition, over multiple pod restarts.

**Baseline (current `main` probes):**

| Run | created → ready | container up → ready |
|-----|-----------------|----------------------|
| 1 | 38s | 34s |
| 2 | 39s | 38s |
| 3 | 38s | 36s |

**Tuned probes (this PR):**

| Run | created → ready | container up → ready |
|-----|-----------------|----------------------|
| 1 | 7s | 5s |
| 2 | 6s | 5s |
| 3 | 6s | 5s |

Result: **~38s → ~6–9s** pod readiness (~5–6x faster; container-up→ready as low as 2s), matching the ~8s the reporter observed.

The change was validated end-to-end through the operator, not just as a live patch:
1. Built a `dashboard-operator` image with the updated manifest baked in (`quay.io/lferrnan/odh-dashboard-operator:rhoaieng-15122`, `linux/amd64`).
2. Deployed it to the cluster and let it reconcile the `odh-dashboard` deployment.
3. Re-measured startup (operator-driven): **6–9s** created → ready, **0 container restarts**.

**Side-effect investigation (no negative effects found):**
- 0 restarts across all pods with the tuned config (vs. crash-loop with the ticket's proposed `tcpSocket` probe).
- Liveness stable over a 60s soak — no probe flapping / restarts.
- Dashboard `Route` serves normally (`HTTP 302` → auth redirect, expected for unauthenticated request).
- `Dashboard` CR reports `phase: Ready`, `Ready=True`, `AllDependentsHealthy`.
- The cluster was restored to its managed state after testing.

## Test Impact

No automated tests are added — this is a manifest-only (probe timing) change with no application-logic or API surface to unit/cypress test. The change was validated on a live cluster as described above. It should also reduce flakiness in the odh-operator dashboard availability integration tests, which motivated the ticket.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-15122]: https://redhat.atlassian.net/browse/RHOAIENG-15122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application health monitoring during startup to ensure services are marked ready only after they are fully operational.
  * Updated health-check timing to detect unavailable or recovered services more promptly.
  * Improved deployment reliability by applying consistent startup, readiness, and liveness checks across dashboard services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->