### PR TITLE
fix(RHOAIENG-90811): clean up disabled module ConfigMaps

### DIFF
--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -33,6 +33,10 @@ func (r *DashboardReconciler) PatchDeploymentFederationHash(ctx context.Context,
 	return r.patchDeploymentFederationHash(ctx, configData)
 }
 
+func (r *DashboardReconciler) DeleteModuleResources(ctx context.Context, statuses map[string]v1alpha1.ModuleStatus) error {
+	return r.deleteModuleResources(ctx, statuses)
+}
+
 func (r *DashboardReconciler) CleanupLegacySidecarResources(ctx context.Context) error {
 	return r.cleanupLegacySidecarResources(ctx)
 }

--- a/dashboard-operator/internal/controller/integration_test.go
+++ b/dashboard-operator/internal/controller/integration_test.go
@@ -132,12 +132,18 @@ data:
 		moduleDir := filepath.Join(base, "modules", slug)
 		require.NoError(t, os.MkdirAll(moduleDir, 0755))
 
-		require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+		kustomization := fmt.Sprintf(`apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
-`), 0644))
+configMapGenerator:
+  - name: %[1]s-params
+    env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+`, slug)
+		require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "kustomization.yaml"), []byte(kustomization), 0644))
 
 		deployment := fmt.Sprintf(`apiVersion: apps/v1
 kind: Deployment
@@ -297,6 +303,21 @@ func listServices(t *testing.T, componentLabel string) []corev1.Service {
 	require.NoError(t, err)
 
 	return services.Items
+}
+
+func listConfigMaps(t *testing.T, componentLabel string) []corev1.ConfigMap {
+	t.Helper()
+	var configMaps corev1.ConfigMapList
+	err := k8sClient.List(context.Background(), &configMaps,
+		client.InNamespace(integrationNamespace),
+		client.MatchingLabels{
+			labels.PlatformPartOf:         "dashboard",
+			"app.kubernetes.io/component": componentLabel,
+		},
+	)
+	require.NoError(t, err)
+
+	return configMaps.Items
 }
 
 func getFederationConfigMap(t *testing.T) *corev1.ConfigMap {
@@ -905,16 +926,33 @@ func TestIntegration_DSCComponentGate(t *testing.T) {
 		cleanupModuleResources(t)
 	})
 
-	// Create Dashboard with DSC Components map that does NOT include
-	// "modelregistry" — the component required by the modelRegistry module.
+	// Start with the modelregistry component available so the module and all of
+	// its resources are deployed before exercising the disabled-module cleanup.
 	dashboard := newDashboard(v1alpha1.DashboardSpec{
 		Gateway: &v1alpha1.GatewaySpec{Domain: "test.example.com"},
 		Modules: disableAllModulesExcept("modelRegistry"),
 		Components: map[string]v1alpha1.ComponentAvailability{
-			"kserve": {ManagementState: "Managed"},
+			"modelregistry": {ManagementState: "Managed"},
 		},
 	})
 	require.NoError(t, k8sClient.Create(ctx, dashboard))
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	assert.Len(t, listDeployments(t, "model-registry"), 1)
+	assert.Len(t, listServices(t, "model-registry"), 1)
+	configMaps := listConfigMaps(t, "model-registry")
+	require.Len(t, configMaps, 1)
+	paramsUID := configMaps[0].UID
+
+	// Remove the component required by modelRegistry. This transition must
+	// remove every module-scoped resource, including its generated ConfigMap.
+	dashboard = getDashboard(t)
+	dashboard.Spec.Components = map[string]v1alpha1.ComponentAvailability{
+		"kserve": {ManagementState: "Managed"},
+	}
+	require.NoError(t, k8sClient.Update(ctx, dashboard))
 
 	reconcile(t, r)
 	reconcile(t, r)
@@ -927,6 +965,33 @@ func TestIntegration_DSCComponentGate(t *testing.T) {
 	assert.Equal(t, v1alpha1.ModulePhaseDisabled, status.Phase)
 	assert.Equal(t, "ComponentNotAvailable", status.Reason)
 
-	deps := listDeployments(t, "model-registry")
-	assert.Empty(t, deps, "model-registry Deployment should not exist without DSC component")
+	assert.Empty(t, listDeployments(t, "model-registry"), "model-registry Deployment should be removed")
+	assert.Empty(t, listServices(t, "model-registry"), "model-registry Service should be removed")
+	assert.Empty(t, listConfigMaps(t, "model-registry"), "model-registry ConfigMap should be removed")
+
+	var coreConfigMap corev1.ConfigMap
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+		Name: "dashboard-core-config", Namespace: integrationNamespace,
+	}, &coreConfigMap), "core ConfigMap should not be removed with module resources")
+
+	// A repeated reconcile must remain a no-op while the module is disabled.
+	reconcile(t, r)
+	assert.Empty(t, listConfigMaps(t, "model-registry"))
+
+	// Re-enable the component and verify that the full module resource set is
+	// recreated rather than relying on stale resources from its prior state.
+	dashboard = getDashboard(t)
+	dashboard.Spec.Components = map[string]v1alpha1.ComponentAvailability{
+		"modelregistry": {ManagementState: "Managed"},
+	}
+	require.NoError(t, k8sClient.Update(ctx, dashboard))
+
+	reconcile(t, r)
+	reconcile(t, r)
+
+	assert.Len(t, listDeployments(t, "model-registry"), 1)
+	assert.Len(t, listServices(t, "model-registry"), 1)
+	configMaps = listConfigMaps(t, "model-registry")
+	require.Len(t, configMaps, 1)
+	assert.NotEqual(t, paramsUID, configMaps[0].UID, "module ConfigMap should be recreated after re-enabling")
 }

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -264,6 +264,19 @@ func (r *DashboardReconciler) deleteModuleResources(
 			}
 		}
 
+		var configMaps corev1.ConfigMapList
+		if err := r.List(ctx, &configMaps, matchLabels, inNamespace); err != nil {
+			errs = append(errs, fmt.Errorf("listing configmaps for module %s: %w", name, err))
+		} else {
+			for i := range configMaps.Items {
+				if err := r.Delete(ctx, &configMaps.Items[i]); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("deleting configmap for module %s: %w", name, err))
+				} else {
+					deleted = true
+				}
+			}
+		}
+
 		var services corev1.ServiceList
 		if err := r.List(ctx, &services, matchLabels, inNamespace); err != nil {
 			errs = append(errs, fmt.Errorf("listing services for module %s: %w", name, err))

--- a/dashboard-operator/internal/controller/module_deploy_test.go
+++ b/dashboard-operator/internal/controller/module_deploy_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
@@ -412,4 +414,87 @@ func TestPatchDeploymentFederationHash_DeploymentNotFound(t *testing.T) {
 
 	err := r.PatchDeploymentFederationHash(context.Background(), `[{"name":"genAi"}]`)
 	require.NoError(t, err, "NotFound should be a no-op, not an error")
+}
+
+func TestDeleteModuleResources_ConfigMaps(t *testing.T) {
+	tests := []struct {
+		name       string
+		phase      v1alpha1.ModulePhase
+		wantDelete bool
+	}{
+		{name: "disabled module", phase: v1alpha1.ModulePhaseDisabled, wantDelete: true},
+		{name: "not-deployed module", phase: v1alpha1.ModulePhaseNotDeployed, wantDelete: true},
+		{name: "deployed module", phase: v1alpha1.ModulePhaseDeployed, wantDelete: false},
+		{name: "degraded module", phase: v1alpha1.ModulePhaseDegraded, wantDelete: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := testScheme(t)
+			moduleConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      "mlflow-params",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					labels.PlatformPartOf:         "dashboard",
+					"app.kubernetes.io/component": "mlflow",
+				},
+			}}
+			coreConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      "dashboard-core-config",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					labels.PlatformPartOf: "dashboard",
+				},
+			}}
+			otherModuleConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      "gen-ai-params",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					labels.PlatformPartOf:         "dashboard",
+					"app.kubernetes.io/component": "gen-ai",
+				},
+			}}
+			otherNamespaceConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      "mlflow-params",
+				Namespace: "other-ns",
+				Labels: map[string]string{
+					labels.PlatformPartOf:         "dashboard",
+					"app.kubernetes.io/component": "mlflow",
+				},
+			}}
+
+			cli := fake.NewClientBuilder().WithScheme(s).WithObjects(
+				moduleConfigMap,
+				coreConfigMap,
+				otherModuleConfigMap,
+				otherNamespaceConfigMap,
+			).Build()
+			r := &ctrlpkg.DashboardReconciler{
+				Client:                cli,
+				Scheme:                s,
+				ApplicationsNamespace: testNamespace,
+			}
+
+			statuses := allDeployedStatuses()
+			statuses["mlflow"] = v1alpha1.ModuleStatus{Phase: tt.phase}
+			require.NoError(t, r.DeleteModuleResources(context.Background(), statuses))
+
+			err := cli.Get(context.Background(), types.NamespacedName{
+				Name: moduleConfigMap.Name, Namespace: moduleConfigMap.Namespace,
+			}, &corev1.ConfigMap{})
+			if tt.wantDelete {
+				assert.True(t, apierrors.IsNotFound(err), "module ConfigMap should be deleted")
+				require.NoError(t, r.DeleteModuleResources(context.Background(), statuses), "cleanup should be idempotent")
+			} else {
+				require.NoError(t, err, "module ConfigMap should be retained")
+			}
+
+			for _, retained := range []*corev1.ConfigMap{coreConfigMap, otherModuleConfigMap, otherNamespaceConfigMap} {
+				err := cli.Get(context.Background(), types.NamespacedName{
+					Name: retained.Name, Namespace: retained.Namespace,
+				}, &corev1.ConfigMap{})
+				require.NoErrorf(t, err, "ConfigMap %s/%s should be retained", retained.Namespace, retained.Name)
+			}
+		})
+	}
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-90811

## Description

Clean up generated module ConfigMaps when a dashboard module transitions to `Disabled` or `NotDeployed`.

Module cleanup already removed Deployments, Services, ServiceAccounts, NetworkPolicies, ClusterRoles, and ClusterRoleBindings using the dashboard and module-component labels. This change applies the same label and namespace scoping to ConfigMaps so generated resources such as `mlflow-params` do not remain after their module is disabled.

The change does not alter the deployer's getter implementation or controller watches.

## How Has This Been Tested?

From `dashboard-operator/`:

```sh
make test
make test-integration
make lint
make build
```

The integration coverage exercises the full module lifecycle: deploy while the required DSC component is available, remove all module-scoped resources when the component becomes unavailable, reconcile again to verify idempotence, and recreate the resources when the component is restored.

## Test Impact

- Added unit coverage for ConfigMap cleanup in `Disabled` and `NotDeployed` phases.
- Added retention coverage for `Deployed` and `Degraded` phases.
- Added checks that core, other-module, and other-namespace ConfigMaps are not deleted.
- Extended the envtest module manifests to generate module params ConfigMaps.
- Extended `TestIntegration_DSCComponentGate` to validate enable, disable, idempotent cleanup, and re-enable behavior.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Module-specific configuration resources are now removed when a module is disabled or no longer deployed.
  - Core dashboard configuration and resources belonging to other modules or namespaces remain unaffected.
  - Reconciliation is idempotent, preventing unnecessary changes during repeated updates.
  - Re-enabling a module recreates its complete resource set, including its configuration resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->