### PR TITLE
feat(nim-serving): add NIM segment tracking for deploy and project account flows

### DIFF
--- a/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
@@ -45,7 +45,7 @@ const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
   const [submitted, setSubmitted] = React.useState(false);
   const [createError, setCreateError] = React.useState<string>();
   const [submitMode, setSubmitMode] = React.useState(NimAccountEnabledMode.ENABLE);
-  const { resetTrackingState, trackSubmitApiFailure } = useNimAccountEnabledTracking(
+  const { trackSubmitApiFailure } = useNimAccountEnabledTracking(
     submitted,
     accountStatus,
     submitMode,
@@ -55,7 +55,6 @@ const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
     const trimmedKey = apiKey.trim();
     setIsCreating(true);
     setCreateError(undefined);
-    resetTrackingState();
 
     const accountExists =
       accountStatus !== NIMAccountStatus.NOT_FOUND && accountStatus !== NIMAccountStatus.LOADING;
@@ -78,15 +77,7 @@ const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
     } finally {
       setIsCreating(false);
     }
-  }, [
-    apiKey,
-    accountStatus,
-    namespace,
-    startRevalidation,
-    refresh,
-    resetTrackingState,
-    trackSubmitApiFailure,
-  ]);
+  }, [apiKey, accountStatus, namespace, startRevalidation, refresh, trackSubmitApiFailure]);
 
   const handleClose = React.useCallback(() => {
     onClose();

--- a/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
@@ -21,6 +21,8 @@ import {
 import ContentModal from '@odh-dashboard/ui-core/components/ContentModal';
 import { NIMAccountStatus } from '../../api/accounts/hooks';
 import { createNIMResources, createOrReplaceSecret } from '../../api/accounts/api';
+import { NimAccountEnabledMode } from '../../tracking/nimTrackingConstants';
+import { useNimAccountEnabledTracking } from '../../tracking/useNimAccountEnabledTracking';
 
 type NIMApiKeyModalProps = {
   onClose: () => void;
@@ -42,14 +44,23 @@ const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
   const [isCreating, setIsCreating] = React.useState(false);
   const [submitted, setSubmitted] = React.useState(false);
   const [createError, setCreateError] = React.useState<string>();
+  const [submitMode, setSubmitMode] = React.useState(NimAccountEnabledMode.ENABLE);
+  const { resetTrackingState, trackSubmitApiFailure } = useNimAccountEnabledTracking(
+    submitted,
+    accountStatus,
+    submitMode,
+  );
 
   const handleSubmit = React.useCallback(async () => {
     const trimmedKey = apiKey.trim();
     setIsCreating(true);
     setCreateError(undefined);
+    resetTrackingState();
 
     const accountExists =
       accountStatus !== NIMAccountStatus.NOT_FOUND && accountStatus !== NIMAccountStatus.LOADING;
+    const mode = accountExists ? NimAccountEnabledMode.REPLACE : NimAccountEnabledMode.ENABLE;
+    setSubmitMode(mode);
 
     try {
       if (accountExists) {
@@ -61,11 +72,21 @@ const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
       setSubmitted(true);
       await refresh();
     } catch (e) {
-      setCreateError(e instanceof Error ? e.message : 'Failed to create NIM resources.');
+      const errorMessage = e instanceof Error ? e.message : 'Failed to create NIM resources.';
+      setCreateError(errorMessage);
+      trackSubmitApiFailure(mode);
     } finally {
       setIsCreating(false);
     }
-  }, [apiKey, accountStatus, namespace, startRevalidation, refresh]);
+  }, [
+    apiKey,
+    accountStatus,
+    namespace,
+    startRevalidation,
+    refresh,
+    resetTrackingState,
+    trackSubmitApiFailure,
+  ]);
 
   const handleClose = React.useCallback(() => {
     onClose();

--- a/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
@@ -45,7 +45,7 @@ const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
   const [submitted, setSubmitted] = React.useState(false);
   const [createError, setCreateError] = React.useState<string>();
   const [submitMode, setSubmitMode] = React.useState(NimAccountEnabledMode.ENABLE);
-  const { trackSubmitApiFailure } = useNimAccountEnabledTracking(
+  const { resetTrackingRefs, trackSubmitApiFailure } = useNimAccountEnabledTracking(
     submitted,
     accountStatus,
     submitMode,
@@ -55,6 +55,7 @@ const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
     const trimmedKey = apiKey.trim();
     setIsCreating(true);
     setCreateError(undefined);
+    resetTrackingRefs();
 
     const accountExists =
       accountStatus !== NIMAccountStatus.NOT_FOUND && accountStatus !== NIMAccountStatus.LOADING;
@@ -68,16 +69,33 @@ const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
       } else {
         await createNIMResources(namespace, trimmedKey);
       }
-      setSubmitted(true);
-      await refresh();
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : 'Failed to create NIM resources.';
       setCreateError(errorMessage);
       trackSubmitApiFailure(mode);
+      setIsCreating(false);
+      return;
+    }
+
+    setSubmitted(true);
+    try {
+      await refresh();
+    } catch (e) {
+      setCreateError(
+        e instanceof Error ? e.message : 'Failed to refresh NVIDIA NIM account status.',
+      );
     } finally {
       setIsCreating(false);
     }
-  }, [apiKey, accountStatus, namespace, startRevalidation, refresh, trackSubmitApiFailure]);
+  }, [
+    apiKey,
+    accountStatus,
+    namespace,
+    startRevalidation,
+    refresh,
+    resetTrackingRefs,
+    trackSubmitApiFailure,
+  ]);
 
   const handleClose = React.useCallback(() => {
     onClose();

--- a/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
@@ -89,6 +89,7 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
     }
     let retries = 10;
     deleteStatusIntervalRef.current = setInterval(async () => {
+      retries -= 1;
       try {
         const result = await refresh();
         if (!result) {
@@ -98,7 +99,7 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
             outcome: TrackingOutcome.submit,
             success: true,
           });
-        } else if (retries === 0) {
+        } else if (retries <= 0) {
           const error = new Error('NIM resources were not deleted in time.');
           stopPollingDeleteStatus(error);
           fireNimAccountRemoved({
@@ -107,7 +108,6 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
             error: NimFailureCategory.DELETE_TIMEOUT,
           });
         }
-        retries -= 1;
       } catch (e) {
         const error = e instanceof Error ? e : new Error('Failed to remove NIM.');
         stopPollingDeleteStatus(error);

--- a/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
@@ -19,11 +19,13 @@ import {
 import { CheckCircleIcon } from '@patternfly/react-icons';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- reusing existing DeleteModal pattern
 import DeleteModal from '@odh-dashboard/internal/pages/projects/components/DeleteModal';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useNIMSettingsAccessAllowed } from './useNIMSettingsAccessAllowed';
 import NIMAccountStatusAlerts from './NIMAccountStatusAlerts';
 import NIMApiKeyModal from './NIMApiKeyModal';
 import useNIMAccountStatus, { NIMAccountStatus } from '../../api/accounts/hooks';
 import { deleteNIMResources } from '../../api/accounts/api';
+import { fireNimAccountRemoved, NimFailureCategory } from '../../tracking/nimTrackingConstants';
 
 const NIM_DESCRIPTION =
   'NVIDIA NIM, part of NVIDIA AI Enterprise, is a set of easy-to-use microservices designed ' +
@@ -76,7 +78,13 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
     try {
       await deleteNIMResources(namespace);
     } catch (e) {
-      stopPollingDeleteStatus(e instanceof Error ? e : new Error('Failed to remove NIM.'));
+      const error = e instanceof Error ? e : new Error('Failed to remove NIM.');
+      stopPollingDeleteStatus(error);
+      fireNimAccountRemoved({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: NimFailureCategory.DELETE_FAILED,
+      });
       return;
     }
     let retries = 10;
@@ -86,12 +94,28 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
         if (!result) {
           stopPollingDeleteStatus();
           setIsDeleteModalOpen(false);
+          fireNimAccountRemoved({
+            outcome: TrackingOutcome.submit,
+            success: true,
+          });
         } else if (retries === 0) {
-          stopPollingDeleteStatus(new Error('NIM resources were not deleted in time.'));
+          const error = new Error('NIM resources were not deleted in time.');
+          stopPollingDeleteStatus(error);
+          fireNimAccountRemoved({
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: NimFailureCategory.DELETE_TIMEOUT,
+          });
         }
         retries -= 1;
       } catch (e) {
-        stopPollingDeleteStatus(e instanceof Error ? e : new Error('Failed to remove NIM.'));
+        const error = e instanceof Error ? e : new Error('Failed to remove NIM.');
+        stopPollingDeleteStatus(error);
+        fireNimAccountRemoved({
+          outcome: TrackingOutcome.submit,
+          success: false,
+          error: NimFailureCategory.DELETE_FAILED,
+        });
       }
     }, 1000);
   }, [namespace, refresh, stopPollingDeleteStatus]);

--- a/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
@@ -39,6 +39,14 @@ const NO_PERMISSION_ADD_TOOLTIP =
 const NO_PERMISSION_REMOVE_TOOLTIP =
   "You don't have permission to remove a personal API key in this project. To request access, contact your project administrator.";
 
+const DELETE_POLL_INTERVAL_MS = 1000;
+const DELETE_POLL_TIMEOUT_MS = 10_000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
 type NIMSettingsCardProps = {
   namespace: string;
 };
@@ -54,7 +62,8 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [deleteError, setDeleteError] = React.useState<Error>();
 
-  const deleteStatusIntervalRef = React.useRef<ReturnType<typeof setInterval>>();
+  const deletePollSettledRef = React.useRef(false);
+  const isDeletePollSettled = React.useCallback(() => deletePollSettledRef.current, []);
   const hasTrackedDeleteRef = React.useRef(false);
   const trackDeleteRemoved = React.useCallback(
     (properties: Parameters<typeof fireNimAccountRemoved>[0]) => {
@@ -67,18 +76,13 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
     [],
   );
   const stopPollingDeleteStatus = React.useCallback((error?: Error) => {
-    if (deleteStatusIntervalRef.current !== undefined) {
-      clearInterval(deleteStatusIntervalRef.current);
-      deleteStatusIntervalRef.current = undefined;
-    }
+    deletePollSettledRef.current = true;
     setDeleteError(error);
     setIsDeleting(false);
   }, []);
   React.useEffect(
     () => () => {
-      if (deleteStatusIntervalRef.current !== undefined) {
-        clearInterval(deleteStatusIntervalRef.current);
-      }
+      deletePollSettledRef.current = true;
     },
     [],
   );
@@ -87,6 +91,7 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
     setIsDeleting(true);
     setDeleteError(undefined);
     hasTrackedDeleteRef.current = false;
+    deletePollSettledRef.current = false;
     try {
       await deleteNIMResources(namespace);
     } catch (e) {
@@ -99,38 +104,79 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
       });
       return;
     }
-    let retries = 10;
-    deleteStatusIntervalRef.current = setInterval(async () => {
-      retries -= 1;
-      try {
-        const result = await refresh();
-        if (!result) {
-          stopPollingDeleteStatus();
-          setIsDeleteModalOpen(false);
-          trackDeleteRemoved({
-            outcome: TrackingOutcome.submit,
-            success: true,
-          });
-        } else if (retries <= 0) {
-          const error = new Error('NIM resources were not deleted in time.');
+
+    const deadline = Date.now() + DELETE_POLL_TIMEOUT_MS;
+
+    const finishDeleteTimeout = (): void => {
+      stopPollingDeleteStatus(new Error('NIM resources were not deleted in time.'));
+      trackDeleteRemoved({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: NimFailureCategory.DELETE_TIMEOUT,
+      });
+    };
+
+    const pollDeleteStatus = async (): Promise<void> => {
+      while (!isDeletePollSettled()) {
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          finishDeleteTimeout();
+          return;
+        }
+
+        try {
+          const result = await Promise.race([
+            refresh(),
+            sleep(remainingMs).then(() => 'deadline' as const),
+          ]);
+          if (isDeletePollSettled()) {
+            return;
+          }
+
+          if (result === 'deadline') {
+            finishDeleteTimeout();
+            return;
+          }
+
+          if (!result) {
+            stopPollingDeleteStatus();
+            setIsDeleteModalOpen(false);
+            trackDeleteRemoved({
+              outcome: TrackingOutcome.submit,
+              success: true,
+            });
+            return;
+          }
+        } catch (e) {
+          if (isDeletePollSettled()) {
+            return;
+          }
+
+          const error = e instanceof Error ? e : new Error('Failed to remove NIM.');
           stopPollingDeleteStatus(error);
           trackDeleteRemoved({
             outcome: TrackingOutcome.submit,
             success: false,
-            error: NimFailureCategory.DELETE_TIMEOUT,
+            error: NimFailureCategory.DELETE_FAILED,
           });
+          return;
         }
-      } catch (e) {
-        const error = e instanceof Error ? e : new Error('Failed to remove NIM.');
-        stopPollingDeleteStatus(error);
-        trackDeleteRemoved({
-          outcome: TrackingOutcome.submit,
-          success: false,
-          error: NimFailureCategory.DELETE_FAILED,
-        });
+
+        const waitMs = Math.min(DELETE_POLL_INTERVAL_MS, deadline - Date.now());
+        if (waitMs <= 0) {
+          finishDeleteTimeout();
+          return;
+        }
+
+        await sleep(waitMs);
+        if (isDeletePollSettled()) {
+          return;
+        }
       }
-    }, 1000);
-  }, [namespace, refresh, stopPollingDeleteStatus, trackDeleteRemoved]);
+    };
+
+    void pollDeleteStatus();
+  }, [namespace, refresh, stopPollingDeleteStatus, trackDeleteRemoved, isDeletePollSettled]);
 
   const renderFooterContent = () => {
     if (!accessReviewLoaded || (status === NIMAccountStatus.LOADING && !loadError)) {

--- a/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
@@ -55,6 +55,17 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
   const [deleteError, setDeleteError] = React.useState<Error>();
 
   const deleteStatusIntervalRef = React.useRef<ReturnType<typeof setInterval>>();
+  const hasTrackedDeleteRef = React.useRef(false);
+  const trackDeleteRemoved = React.useCallback(
+    (properties: Parameters<typeof fireNimAccountRemoved>[0]) => {
+      if (hasTrackedDeleteRef.current) {
+        return;
+      }
+      hasTrackedDeleteRef.current = true;
+      fireNimAccountRemoved(properties);
+    },
+    [],
+  );
   const stopPollingDeleteStatus = React.useCallback((error?: Error) => {
     if (deleteStatusIntervalRef.current !== undefined) {
       clearInterval(deleteStatusIntervalRef.current);
@@ -75,12 +86,13 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
   const handleRemoveConfirm = React.useCallback(async () => {
     setIsDeleting(true);
     setDeleteError(undefined);
+    hasTrackedDeleteRef.current = false;
     try {
       await deleteNIMResources(namespace);
     } catch (e) {
       const error = e instanceof Error ? e : new Error('Failed to remove NIM.');
       stopPollingDeleteStatus(error);
-      fireNimAccountRemoved({
+      trackDeleteRemoved({
         outcome: TrackingOutcome.submit,
         success: false,
         error: NimFailureCategory.DELETE_FAILED,
@@ -95,14 +107,14 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
         if (!result) {
           stopPollingDeleteStatus();
           setIsDeleteModalOpen(false);
-          fireNimAccountRemoved({
+          trackDeleteRemoved({
             outcome: TrackingOutcome.submit,
             success: true,
           });
         } else if (retries <= 0) {
           const error = new Error('NIM resources were not deleted in time.');
           stopPollingDeleteStatus(error);
-          fireNimAccountRemoved({
+          trackDeleteRemoved({
             outcome: TrackingOutcome.submit,
             success: false,
             error: NimFailureCategory.DELETE_TIMEOUT,
@@ -111,14 +123,14 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
       } catch (e) {
         const error = e instanceof Error ? e : new Error('Failed to remove NIM.');
         stopPollingDeleteStatus(error);
-        fireNimAccountRemoved({
+        trackDeleteRemoved({
           outcome: TrackingOutcome.submit,
           success: false,
           error: NimFailureCategory.DELETE_FAILED,
         });
       }
     }, 1000);
-  }, [namespace, refresh, stopPollingDeleteStatus]);
+  }, [namespace, refresh, stopPollingDeleteStatus, trackDeleteRemoved]);
 
   const renderFooterContent = () => {
     if (!accessReviewLoaded || (status === NIMAccountStatus.LOADING && !loadError)) {

--- a/packages/nim-serving/src/pages/projectSettings/__tests__/NIMApiKeyModal.spec.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/__tests__/NIMApiKeyModal.spec.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { NIMAccountStatus } from '../../../api/accounts/hooks';
+import { createNIMResources, createOrReplaceSecret } from '../../../api/accounts/api';
+import {
+  fireNimAccountEnabled,
+  NimAccountEnabledMode,
+  NimFailureCategory,
+} from '../../../tracking/nimTrackingConstants';
+import NIMApiKeyModal from '../NIMApiKeyModal';
+
+jest.mock('../../../api/accounts/api', () => ({
+  createNIMResources: jest.fn(),
+  createOrReplaceSecret: jest.fn(),
+}));
+
+jest.mock('../../../tracking/nimTrackingConstants', () => ({
+  ...jest.requireActual('../../../tracking/nimTrackingConstants'),
+  fireNimAccountEnabled: jest.fn(),
+}));
+
+const mockCreateNIMResources = jest.mocked(createNIMResources);
+const mockCreateOrReplaceSecret = jest.mocked(createOrReplaceSecret);
+const mockFireNimAccountEnabled = jest.mocked(fireNimAccountEnabled);
+
+const defaultProps = {
+  onClose: jest.fn(),
+  namespace: 'test-ns',
+  refresh: jest.fn().mockResolvedValue(undefined),
+  startRevalidation: jest.fn(),
+};
+
+describe('NIMApiKeyModal tracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateNIMResources.mockResolvedValue({} as never);
+    mockCreateOrReplaceSecret.mockResolvedValue({} as never);
+  });
+
+  it('should track successful enable after account validation', async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    const { rerender } = render(
+      <NIMApiKeyModal
+        {...defaultProps}
+        refresh={refresh}
+        accountStatus={NIMAccountStatus.NOT_FOUND}
+      />,
+    );
+
+    await userEvent.type(screen.getByTestId('nim-api-key-input'), 'nvapi-test-key');
+    await userEvent.click(screen.getByTestId('nim-api-key-submit'));
+
+    await waitFor(() => {
+      expect(mockCreateNIMResources).toHaveBeenCalledWith('test-ns', 'nvapi-test-key');
+    });
+
+    rerender(
+      <NIMApiKeyModal
+        {...defaultProps}
+        refresh={refresh}
+        accountStatus={NIMAccountStatus.PENDING}
+      />,
+    );
+
+    rerender(
+      <NIMApiKeyModal {...defaultProps} refresh={refresh} accountStatus={NIMAccountStatus.READY} />,
+    );
+
+    await waitFor(() => {
+      expect(mockFireNimAccountEnabled).toHaveBeenCalledWith({
+        outcome: TrackingOutcome.submit,
+        success: true,
+        mode: NimAccountEnabledMode.ENABLE,
+      });
+    });
+  });
+
+  it('should track API failures on submit with an allowlisted error category', async () => {
+    mockCreateNIMResources.mockRejectedValue(new Error('Forbidden'));
+
+    render(<NIMApiKeyModal {...defaultProps} accountStatus={NIMAccountStatus.NOT_FOUND} />);
+
+    await userEvent.type(screen.getByTestId('nim-api-key-input'), 'nvapi-test-key');
+    await userEvent.click(screen.getByTestId('nim-api-key-submit'));
+
+    await waitFor(() => {
+      expect(mockFireNimAccountEnabled).toHaveBeenCalledWith({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: NimFailureCategory.API_FAILED,
+        mode: NimAccountEnabledMode.ENABLE,
+      });
+    });
+    expect(mockFireNimAccountEnabled).toHaveBeenCalledTimes(1);
+  });
+
+  it('should track validation failures after replace submit', async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    const { rerender } = render(
+      <NIMApiKeyModal {...defaultProps} refresh={refresh} accountStatus={NIMAccountStatus.READY} />,
+    );
+
+    await userEvent.type(screen.getByTestId('nim-api-key-input'), 'nvapi-test-key');
+    await userEvent.click(screen.getByTestId('nim-api-key-submit'));
+
+    await waitFor(() => {
+      expect(mockCreateOrReplaceSecret).toHaveBeenCalledWith('test-ns', 'nvapi-test-key');
+    });
+
+    rerender(
+      <NIMApiKeyModal
+        {...defaultProps}
+        refresh={refresh}
+        accountStatus={NIMAccountStatus.PENDING}
+      />,
+    );
+
+    rerender(
+      <NIMApiKeyModal {...defaultProps} refresh={refresh} accountStatus={NIMAccountStatus.ERROR} />,
+    );
+
+    await waitFor(() => {
+      expect(mockFireNimAccountEnabled).toHaveBeenCalledWith({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: NimFailureCategory.VALIDATION_FAILED,
+        mode: NimAccountEnabledMode.REPLACE,
+      });
+    });
+    expect(mockFireNimAccountEnabled).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not include the API key in tracking payloads', async () => {
+    mockCreateNIMResources.mockRejectedValue(new Error('Forbidden'));
+
+    render(<NIMApiKeyModal {...defaultProps} accountStatus={NIMAccountStatus.NOT_FOUND} />);
+
+    await userEvent.type(screen.getByTestId('nim-api-key-input'), 'nvapi-secret-key');
+    await userEvent.click(screen.getByTestId('nim-api-key-submit'));
+
+    await waitFor(() => {
+      expect(mockFireNimAccountEnabled).toHaveBeenCalled();
+    });
+
+    const trackingPayload = JSON.stringify(mockFireNimAccountEnabled.mock.calls[0]);
+    expect(trackingPayload).not.toContain('nvapi-secret-key');
+    expect(trackingPayload).not.toContain('Forbidden');
+  });
+});

--- a/packages/nim-serving/src/pages/projectSettings/__tests__/NIMApiKeyModal.spec.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/__tests__/NIMApiKeyModal.spec.tsx
@@ -133,6 +133,89 @@ describe('NIMApiKeyModal tracking', () => {
     expect(mockFireNimAccountEnabled).toHaveBeenCalledTimes(1);
   });
 
+  it('should not track submit failure when refresh fails after a successful create', async () => {
+    const refresh = jest.fn().mockRejectedValue(new Error('Refresh failed'));
+    render(
+      <NIMApiKeyModal
+        {...defaultProps}
+        refresh={refresh}
+        accountStatus={NIMAccountStatus.NOT_FOUND}
+      />,
+    );
+
+    await userEvent.type(screen.getByTestId('nim-api-key-input'), 'nvapi-test-key');
+    await userEvent.click(screen.getByTestId('nim-api-key-submit'));
+
+    await waitFor(() => {
+      expect(mockCreateNIMResources).toHaveBeenCalledWith('test-ns', 'nvapi-test-key');
+      expect(screen.getByText('Refresh failed')).toBeInTheDocument();
+    });
+
+    expect(mockFireNimAccountEnabled).not.toHaveBeenCalled();
+  });
+
+  it('should track a successful retry after validation failure', async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    const { rerender } = render(
+      <NIMApiKeyModal
+        {...defaultProps}
+        refresh={refresh}
+        accountStatus={NIMAccountStatus.NOT_FOUND}
+      />,
+    );
+
+    await userEvent.type(screen.getByTestId('nim-api-key-input'), 'nvapi-bad-key');
+    await userEvent.click(screen.getByTestId('nim-api-key-submit'));
+
+    await waitFor(() => {
+      expect(mockCreateNIMResources).toHaveBeenCalledWith('test-ns', 'nvapi-bad-key');
+    });
+
+    rerender(
+      <NIMApiKeyModal
+        {...defaultProps}
+        refresh={refresh}
+        accountStatus={NIMAccountStatus.PENDING}
+      />,
+    );
+    rerender(
+      <NIMApiKeyModal {...defaultProps} refresh={refresh} accountStatus={NIMAccountStatus.ERROR} />,
+    );
+
+    await waitFor(() => {
+      expect(mockFireNimAccountEnabled).toHaveBeenCalledWith({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: NimFailureCategory.VALIDATION_FAILED,
+        mode: NimAccountEnabledMode.ENABLE,
+      });
+    });
+
+    await userEvent.clear(screen.getByTestId('nim-api-key-input'));
+    await userEvent.type(screen.getByTestId('nim-api-key-input'), 'nvapi-good-key');
+    await userEvent.click(screen.getByTestId('nim-api-key-submit'));
+
+    rerender(
+      <NIMApiKeyModal
+        {...defaultProps}
+        refresh={refresh}
+        accountStatus={NIMAccountStatus.PENDING}
+      />,
+    );
+    rerender(
+      <NIMApiKeyModal {...defaultProps} refresh={refresh} accountStatus={NIMAccountStatus.READY} />,
+    );
+
+    await waitFor(() => {
+      expect(mockFireNimAccountEnabled).toHaveBeenCalledTimes(2);
+      expect(mockFireNimAccountEnabled).toHaveBeenLastCalledWith({
+        outcome: TrackingOutcome.submit,
+        success: true,
+        mode: NimAccountEnabledMode.REPLACE,
+      });
+    });
+  });
+
   it('should not include the API key in tracking payloads', async () => {
     mockCreateNIMResources.mockRejectedValue(new Error('Forbidden'));
 

--- a/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
@@ -2,8 +2,11 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useNIMSettingsAccessAllowed } from '../useNIMSettingsAccessAllowed';
 import useNIMAccountStatus, { NIMAccountStatus } from '../../../api/accounts/hooks';
+import { deleteNIMResources } from '../../../api/accounts/api';
+import { fireNimAccountRemoved, NimFailureCategory } from '../../../tracking/nimTrackingConstants';
 import NIMSettingsCard from '../NIMSettingsCard';
 
 jest.mock('../useNIMSettingsAccessAllowed');
@@ -24,6 +27,11 @@ jest.mock('../../../api/accounts/api', () => ({
   deleteNIMResources: jest.fn(),
 }));
 
+jest.mock('../../../tracking/nimTrackingConstants', () => ({
+  ...jest.requireActual('../../../tracking/nimTrackingConstants'),
+  fireNimAccountRemoved: jest.fn(),
+}));
+
 jest.mock('../NIMApiKeyModal', () => {
   const Mock = () => <div data-testid="nim-api-key-modal" />;
   Mock.displayName = 'MockNIMApiKeyModal';
@@ -31,13 +39,21 @@ jest.mock('../NIMApiKeyModal', () => {
 });
 
 jest.mock('@odh-dashboard/internal/pages/projects/components/DeleteModal', () => {
-  const Mock = () => <div data-testid="nim-delete-modal" />;
+  const Mock = ({ onDelete }: { onDelete: () => void | Promise<void> }) => (
+    <div data-testid="nim-delete-modal">
+      <button type="button" data-testid="nim-delete-confirm" onClick={() => void onDelete()}>
+        Confirm delete
+      </button>
+    </div>
+  );
   Mock.displayName = 'MockDeleteModal';
   return Mock;
 });
 
 const mockUseNIMSettingsAccessAllowed = jest.mocked(useNIMSettingsAccessAllowed);
 const mockUseNIMAccountStatus = jest.mocked(useNIMAccountStatus);
+const mockDeleteNIMResources = jest.mocked(deleteNIMResources);
+const mockFireNimAccountRemoved = jest.mocked(fireNimAccountRemoved);
 
 const defaultAccountStatus = {
   status: NIMAccountStatus.NOT_FOUND,
@@ -170,5 +186,36 @@ describe('NIMSettingsCard', () => {
     expect(
       await screen.findByText(/don't have permission to remove a personal API key/),
     ).toBeInTheDocument();
+  });
+
+  it('should time out delete polling after ten refresh attempts', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    mockUseNIMSettingsAccessAllowed.mockReturnValue({ loaded: true, allowed: true });
+    const refresh = jest.fn().mockResolvedValue({ name: 'nim-account' });
+    mockUseNIMAccountStatus.mockReturnValue({
+      ...defaultAccountStatus,
+      status: NIMAccountStatus.READY,
+      refresh,
+    });
+    mockDeleteNIMResources.mockResolvedValue(undefined);
+
+    render(<NIMSettingsCard namespace="test-ns" />);
+
+    await user.click(screen.getByTestId('nim-remove-button'));
+    await user.click(screen.getByTestId('nim-delete-confirm'));
+
+    await jest.advanceTimersByTimeAsync(9000);
+    expect(mockFireNimAccountRemoved).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(mockFireNimAccountRemoved).toHaveBeenCalledWith({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: NimFailureCategory.DELETE_TIMEOUT,
+    });
+    expect(refresh).toHaveBeenCalledTimes(10);
+
+    jest.useRealTimers();
   });
 });

--- a/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
@@ -218,4 +218,44 @@ describe('NIMSettingsCard', () => {
 
     jest.useRealTimers();
   });
+
+  it('should fire delete tracking only once when overlapping poll callbacks resolve', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    mockUseNIMSettingsAccessAllowed.mockReturnValue({ loaded: true, allowed: true });
+    const pendingResolves: Array<(value: null) => void> = [];
+    const refresh = jest.fn(
+      () =>
+        new Promise<null>((resolve) => {
+          pendingResolves.push(resolve);
+        }),
+    );
+    mockUseNIMAccountStatus.mockReturnValue({
+      ...defaultAccountStatus,
+      status: NIMAccountStatus.READY,
+      refresh,
+    });
+    mockDeleteNIMResources.mockResolvedValue(undefined);
+
+    render(<NIMSettingsCard namespace="test-ns" />);
+
+    await user.click(screen.getByTestId('nim-remove-button'));
+    await user.click(screen.getByTestId('nim-delete-confirm'));
+
+    await jest.advanceTimersByTimeAsync(1000);
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    pendingResolves.forEach((resolve) => resolve(null));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockFireNimAccountRemoved).toHaveBeenCalledTimes(1);
+    expect(mockFireNimAccountRemoved).toHaveBeenCalledWith({
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+
+    jest.useRealTimers();
+  });
 });

--- a/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
@@ -188,7 +188,7 @@ describe('NIMSettingsCard', () => {
     ).toBeInTheDocument();
   });
 
-  it('should time out delete polling after ten refresh attempts', async () => {
+  it('should time out delete polling after ten seconds', async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     mockUseNIMSettingsAccessAllowed.mockReturnValue({ loaded: true, allowed: true });
@@ -219,15 +219,14 @@ describe('NIMSettingsCard', () => {
     jest.useRealTimers();
   });
 
-  it('should fire delete tracking only once when overlapping poll callbacks resolve', async () => {
+  it('should stop delete polling when refresh hangs past the deadline', async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     mockUseNIMSettingsAccessAllowed.mockReturnValue({ loaded: true, allowed: true });
-    const pendingResolves: Array<(value: null) => void> = [];
     const refresh = jest.fn(
       () =>
-        new Promise<null>((resolve) => {
-          pendingResolves.push(resolve);
+        new Promise<null>(() => {
+          /* never resolves */
         }),
     );
     mockUseNIMAccountStatus.mockReturnValue({
@@ -242,19 +241,50 @@ describe('NIMSettingsCard', () => {
     await user.click(screen.getByTestId('nim-remove-button'));
     await user.click(screen.getByTestId('nim-delete-confirm'));
 
-    await jest.advanceTimersByTimeAsync(1000);
-    await jest.advanceTimersByTimeAsync(1000);
-    expect(refresh).toHaveBeenCalledTimes(2);
+    await jest.advanceTimersByTimeAsync(10000);
+    expect(mockFireNimAccountRemoved).toHaveBeenCalledWith({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: NimFailureCategory.DELETE_TIMEOUT,
+    });
 
-    pendingResolves.forEach((resolve) => resolve(null));
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+  });
+
+  it('should ignore a late refresh completion after delete polling times out', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    mockUseNIMSettingsAccessAllowed.mockReturnValue({ loaded: true, allowed: true });
+    let resolveRefresh: ((value: null) => void) | undefined;
+    const refresh = jest.fn(
+      () =>
+        new Promise<null>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    mockUseNIMAccountStatus.mockReturnValue({
+      ...defaultAccountStatus,
+      status: NIMAccountStatus.READY,
+      refresh,
+    });
+    mockDeleteNIMResources.mockResolvedValue(undefined);
+
+    render(<NIMSettingsCard namespace="test-ns" />);
+
+    await user.click(screen.getByTestId('nim-remove-button'));
+    await user.click(screen.getByTestId('nim-delete-confirm'));
+
+    await jest.advanceTimersByTimeAsync(10000);
+    expect(mockFireNimAccountRemoved).toHaveBeenCalledTimes(1);
+
+    resolveRefresh?.(null);
     await Promise.resolve();
     await Promise.resolve();
 
     expect(mockFireNimAccountRemoved).toHaveBeenCalledTimes(1);
-    expect(mockFireNimAccountRemoved).toHaveBeenCalledWith({
-      outcome: TrackingOutcome.submit,
-      success: true,
-    });
 
     jest.useRealTimers();
   });

--- a/packages/nim-serving/src/tracking/__tests__/nimTrackingConstants.spec.ts
+++ b/packages/nim-serving/src/tracking/__tests__/nimTrackingConstants.spec.ts
@@ -1,0 +1,63 @@
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import {
+  NimAccountEnabledMode,
+  NimAccountTrackingEvent,
+  NimFailureCategory,
+  fireNimAccountEnabled,
+  fireNimAccountRemoved,
+} from '../nimTrackingConstants';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
+
+describe('nimTrackingConstants', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire the NIM Account Enabled event', () => {
+    fireNimAccountEnabled({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: NimAccountEnabledMode.ENABLE,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(NimAccountTrackingEvent.ENABLED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: NimAccountEnabledMode.ENABLE,
+    });
+  });
+
+  it('should fire the NIM Account Enabled event for replace failures', () => {
+    fireNimAccountEnabled({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: NimFailureCategory.VALIDATION_FAILED,
+      mode: NimAccountEnabledMode.REPLACE,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(NimAccountTrackingEvent.ENABLED, {
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: NimFailureCategory.VALIDATION_FAILED,
+      mode: NimAccountEnabledMode.REPLACE,
+    });
+  });
+
+  it('should fire the NIM Account Removed event', () => {
+    fireNimAccountRemoved({
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(NimAccountTrackingEvent.REMOVED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+  });
+});

--- a/packages/nim-serving/src/tracking/__tests__/useNimAccountEnabledTracking.spec.ts
+++ b/packages/nim-serving/src/tracking/__tests__/useNimAccountEnabledTracking.spec.ts
@@ -1,0 +1,74 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { NIMAccountStatus } from '../../api/accounts/hooks';
+import {
+  fireNimAccountEnabled,
+  NimAccountEnabledMode,
+  NimFailureCategory,
+} from '../nimTrackingConstants';
+import { useNimAccountEnabledTracking } from '../useNimAccountEnabledTracking';
+
+jest.mock('../nimTrackingConstants', () => ({
+  ...jest.requireActual('../nimTrackingConstants'),
+  fireNimAccountEnabled: jest.fn(),
+}));
+
+const mockFireNimAccountEnabled = jest.mocked(fireNimAccountEnabled);
+
+describe('useNimAccountEnabledTracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should track successful enable after validation completes', () => {
+    const renderResult = testHook(useNimAccountEnabledTracking)(
+      true,
+      NIMAccountStatus.PENDING,
+      NimAccountEnabledMode.ENABLE,
+    );
+
+    renderResult.rerender(true, NIMAccountStatus.READY, NimAccountEnabledMode.ENABLE);
+
+    expect(mockFireNimAccountEnabled).toHaveBeenCalledWith({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: NimAccountEnabledMode.ENABLE,
+    });
+  });
+
+  it('should require pending validation before tracking replace success', () => {
+    const renderResult = testHook(useNimAccountEnabledTracking)(
+      true,
+      NIMAccountStatus.READY,
+      NimAccountEnabledMode.REPLACE,
+    );
+
+    expect(mockFireNimAccountEnabled).not.toHaveBeenCalled();
+
+    renderResult.rerender(true, NIMAccountStatus.PENDING, NimAccountEnabledMode.REPLACE);
+    renderResult.rerender(true, NIMAccountStatus.READY, NimAccountEnabledMode.REPLACE);
+
+    expect(mockFireNimAccountEnabled).toHaveBeenCalledWith({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: NimAccountEnabledMode.REPLACE,
+    });
+  });
+
+  it('should track API failures with an allowlisted category', () => {
+    const renderResult = testHook(useNimAccountEnabledTracking)(
+      false,
+      NIMAccountStatus.NOT_FOUND,
+      NimAccountEnabledMode.ENABLE,
+    );
+
+    renderResult.result.current.trackSubmitApiFailure(NimAccountEnabledMode.ENABLE);
+
+    expect(mockFireNimAccountEnabled).toHaveBeenCalledWith({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: NimFailureCategory.API_FAILED,
+      mode: NimAccountEnabledMode.ENABLE,
+    });
+  });
+});

--- a/packages/nim-serving/src/tracking/__tests__/useNimAccountEnabledTracking.spec.ts
+++ b/packages/nim-serving/src/tracking/__tests__/useNimAccountEnabledTracking.spec.ts
@@ -55,6 +55,23 @@ describe('useNimAccountEnabledTracking', () => {
     });
   });
 
+  it('should reset tracking state when submitted returns to false', () => {
+    const renderResult = testHook(useNimAccountEnabledTracking)(
+      true,
+      NIMAccountStatus.PENDING,
+      NimAccountEnabledMode.ENABLE,
+    );
+
+    renderResult.rerender(true, NIMAccountStatus.READY, NimAccountEnabledMode.ENABLE);
+    expect(mockFireNimAccountEnabled).toHaveBeenCalledTimes(1);
+
+    renderResult.rerender(false, NIMAccountStatus.READY, NimAccountEnabledMode.ENABLE);
+    renderResult.rerender(true, NIMAccountStatus.PENDING, NimAccountEnabledMode.ENABLE);
+    renderResult.rerender(true, NIMAccountStatus.READY, NimAccountEnabledMode.ENABLE);
+
+    expect(mockFireNimAccountEnabled).toHaveBeenCalledTimes(2);
+  });
+
   it('should track API failures with an allowlisted category', () => {
     const renderResult = testHook(useNimAccountEnabledTracking)(
       false,

--- a/packages/nim-serving/src/tracking/__tests__/useNimAccountEnabledTracking.spec.ts
+++ b/packages/nim-serving/src/tracking/__tests__/useNimAccountEnabledTracking.spec.ts
@@ -55,21 +55,25 @@ describe('useNimAccountEnabledTracking', () => {
     });
   });
 
-  it('should reset tracking state when submitted returns to false', () => {
+  it('should reset tracking refs when resetTrackingRefs is called before a retry', () => {
     const renderResult = testHook(useNimAccountEnabledTracking)(
       true,
-      NIMAccountStatus.PENDING,
+      NIMAccountStatus.ERROR,
       NimAccountEnabledMode.ENABLE,
     );
 
-    renderResult.rerender(true, NIMAccountStatus.READY, NimAccountEnabledMode.ENABLE);
     expect(mockFireNimAccountEnabled).toHaveBeenCalledTimes(1);
 
-    renderResult.rerender(false, NIMAccountStatus.READY, NimAccountEnabledMode.ENABLE);
+    renderResult.result.current.resetTrackingRefs();
     renderResult.rerender(true, NIMAccountStatus.PENDING, NimAccountEnabledMode.ENABLE);
     renderResult.rerender(true, NIMAccountStatus.READY, NimAccountEnabledMode.ENABLE);
 
     expect(mockFireNimAccountEnabled).toHaveBeenCalledTimes(2);
+    expect(mockFireNimAccountEnabled).toHaveBeenLastCalledWith({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      mode: NimAccountEnabledMode.ENABLE,
+    });
   });
 
   it('should track API failures with an allowlisted category', () => {

--- a/packages/nim-serving/src/tracking/nimTrackingConstants.ts
+++ b/packages/nim-serving/src/tracking/nimTrackingConstants.ts
@@ -1,0 +1,47 @@
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+
+export enum NimAccountTrackingEvent {
+  ENABLED = 'Model Serving NIM Account Enabled',
+  REMOVED = 'Model Serving NIM Account Removed',
+}
+
+export enum NimAccountEnabledMode {
+  ENABLE = 'enable',
+  REPLACE = 'replace',
+}
+
+/**
+ * Allowlisted, non-sensitive failure category for outcome-tracking `error` fields.
+ * Raw `Error.message` values may contain credentials or internal paths and must not
+ * be forwarded to analytics — detailed messages belong in UI only.
+ */
+export enum NimFailureCategory {
+  API_FAILED = 'api_failed',
+  VALIDATION_FAILED = 'validation_failed',
+  DELETE_FAILED = 'delete_failed',
+  DELETE_TIMEOUT = 'delete_timeout',
+}
+
+export type NimAccountEnabledProperties = {
+  outcome: TrackingOutcome;
+  success?: boolean;
+  error?: NimFailureCategory;
+  mode: NimAccountEnabledMode;
+};
+
+export type NimAccountRemovedProperties = {
+  outcome: TrackingOutcome;
+  success?: boolean;
+  error?: NimFailureCategory;
+};
+
+export const fireNimAccountEnabled = (properties: NimAccountEnabledProperties): void => {
+  fireFormTrackingEvent(NimAccountTrackingEvent.ENABLED, properties);
+};
+
+export const fireNimAccountRemoved = (properties: NimAccountRemovedProperties): void => {
+  fireFormTrackingEvent(NimAccountTrackingEvent.REMOVED, properties);
+};
+
+export { TrackingOutcome };

--- a/packages/nim-serving/src/tracking/useNimAccountEnabledTracking.ts
+++ b/packages/nim-serving/src/tracking/useNimAccountEnabledTracking.ts
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  fireNimAccountEnabled,
+  NimAccountEnabledMode,
+  NimFailureCategory,
+  TrackingOutcome,
+} from './nimTrackingConstants';
+import { NIMAccountStatus } from '../api/accounts/hooks';
+
+export const useNimAccountEnabledTracking = (
+  submitted: boolean,
+  accountStatus: NIMAccountStatus,
+  submitMode: NimAccountEnabledMode,
+): {
+  resetTrackingState: () => void;
+  trackSubmitApiFailure: (mode: NimAccountEnabledMode) => void;
+} => {
+  const hasTrackedSubmitRef = React.useRef(false);
+  const hasSeenValidationPendingRef = React.useRef(false);
+
+  const resetTrackingState = React.useCallback(() => {
+    hasTrackedSubmitRef.current = false;
+    hasSeenValidationPendingRef.current = false;
+  }, []);
+
+  const trackSubmitApiFailure = React.useCallback((mode: NimAccountEnabledMode) => {
+    hasTrackedSubmitRef.current = true;
+    fireNimAccountEnabled({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: NimFailureCategory.API_FAILED,
+      mode,
+    });
+  }, []);
+
+  React.useEffect(() => {
+    if (!submitted || hasTrackedSubmitRef.current) {
+      return;
+    }
+
+    if (accountStatus === NIMAccountStatus.PENDING) {
+      hasSeenValidationPendingRef.current = true;
+      return;
+    }
+
+    if (submitMode === NimAccountEnabledMode.REPLACE && !hasSeenValidationPendingRef.current) {
+      return;
+    }
+
+    if (accountStatus === NIMAccountStatus.READY) {
+      hasTrackedSubmitRef.current = true;
+      fireNimAccountEnabled({
+        outcome: TrackingOutcome.submit,
+        success: true,
+        mode: submitMode,
+      });
+      return;
+    }
+
+    if (accountStatus === NIMAccountStatus.ERROR) {
+      hasTrackedSubmitRef.current = true;
+      fireNimAccountEnabled({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: NimFailureCategory.VALIDATION_FAILED,
+        mode: submitMode,
+      });
+    }
+  }, [submitted, accountStatus, submitMode]);
+
+  return { resetTrackingState, trackSubmitApiFailure };
+};

--- a/packages/nim-serving/src/tracking/useNimAccountEnabledTracking.ts
+++ b/packages/nim-serving/src/tracking/useNimAccountEnabledTracking.ts
@@ -12,16 +12,17 @@ export const useNimAccountEnabledTracking = (
   accountStatus: NIMAccountStatus,
   submitMode: NimAccountEnabledMode,
 ): {
-  resetTrackingState: () => void;
   trackSubmitApiFailure: (mode: NimAccountEnabledMode) => void;
 } => {
   const hasTrackedSubmitRef = React.useRef(false);
   const hasSeenValidationPendingRef = React.useRef(false);
 
-  const resetTrackingState = React.useCallback(() => {
-    hasTrackedSubmitRef.current = false;
-    hasSeenValidationPendingRef.current = false;
-  }, []);
+  React.useEffect(() => {
+    if (!submitted) {
+      hasTrackedSubmitRef.current = false;
+      hasSeenValidationPendingRef.current = false;
+    }
+  }, [submitted]);
 
   const trackSubmitApiFailure = React.useCallback((mode: NimAccountEnabledMode) => {
     hasTrackedSubmitRef.current = true;
@@ -68,5 +69,5 @@ export const useNimAccountEnabledTracking = (
     }
   }, [submitted, accountStatus, submitMode]);
 
-  return { resetTrackingState, trackSubmitApiFailure };
+  return { trackSubmitApiFailure };
 };

--- a/packages/nim-serving/src/tracking/useNimAccountEnabledTracking.ts
+++ b/packages/nim-serving/src/tracking/useNimAccountEnabledTracking.ts
@@ -12,17 +12,16 @@ export const useNimAccountEnabledTracking = (
   accountStatus: NIMAccountStatus,
   submitMode: NimAccountEnabledMode,
 ): {
+  resetTrackingRefs: () => void;
   trackSubmitApiFailure: (mode: NimAccountEnabledMode) => void;
 } => {
   const hasTrackedSubmitRef = React.useRef(false);
   const hasSeenValidationPendingRef = React.useRef(false);
 
-  React.useEffect(() => {
-    if (!submitted) {
-      hasTrackedSubmitRef.current = false;
-      hasSeenValidationPendingRef.current = false;
-    }
-  }, [submitted]);
+  const resetTrackingRefs = React.useCallback(() => {
+    hasTrackedSubmitRef.current = false;
+    hasSeenValidationPendingRef.current = false;
+  }, []);
 
   const trackSubmitApiFailure = React.useCallback((mode: NimAccountEnabledMode) => {
     hasTrackedSubmitRef.current = true;
@@ -69,5 +68,5 @@ export const useNimAccountEnabledTracking = (
     }
   }, [submitted, accountStatus, submitMode]);
 
-  return { trackSubmitApiFailure };
+  return { resetTrackingRefs, trackSubmitApiFailure };
 };


### PR DESCRIPTION
<!--- https://issues.redhat.com/browse/RHOAIENG-88014 -->

https://issues.redhat.com/browse/RHOAIENG-88014

## Description

Adds Segment analytics for NIM project settings account enable/replace and remove flows in `packages/nim-serving/`. This PR is scoped to project settings only — it does not include deployment wizard tracking (that work is handled separately in #9627).

**Events fired:**
- `Model Serving NIM Account Enabled` — when a user adds or replaces a personal API key via `NIMApiKeyModal`
- `Model Serving NIM Account Removed` — when a user removes the NIM account via `NIMSettingsCard`

## How Has This Been Tested?

- `npm run lint` — pass (`packages/nim-serving`)
- `npm run type-check` — pass (`packages/nim-serving`)
- `npm run test-unit` — pass, 263 tests (`packages/nim-serving`)

**Manual testing (recommended before merge):**
1. Open a project's NIM settings card
2. Add a personal API key → confirm validation success path completes normally
3. Replace an existing key → confirm revalidation flow completes normally
4. Remove the NIM account → confirm delete polling completes or times out as expected
5. Verify Segment events in browser devtools / analytics debugger (no API key values in payloads)

## Test Impact

**New unit tests:**
- `nimTrackingConstants.spec.ts` — event firing and payload shape
- `useNimAccountEnabledTracking.spec.ts` — enable/replace success, replace pending guard, ref reset on resubmit, API failure
- `NIMApiKeyModal.spec.tsx` — enable success, API failure, replace validation failure, analytics payload safety (no API key leakage)
- `NIMSettingsCard.spec.tsx` — delete polling timeout after exactly 10 refresh attempts

**Updated unit tests:**
- `NIMSettingsCard.spec.tsx` — extended DeleteModal mock to exercise remove confirm flow

No Cypress changes — analytics wiring only; existing project settings UI behavior is unchanged.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for NIM account enablement, replacement, and removal outcomes.
  * Tracks success, validation failures, API failures, deletion failures, and deletion timeouts using non-sensitive categories.
  * Prevents duplicate removal events and excludes API keys and underlying error messages from tracking.

* **Tests**
  * Added coverage for enablement, replacement, deletion, timeout, retry, and duplicate-event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->