### PR TITLE
fix(eval-hub): add Open-Telco benchmark dataset links

### DIFF
--- a/packages/eval-hub/frontend/src/app/utilities/__tests__/benchmarkDatasetUrls.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utilities/__tests__/benchmarkDatasetUrls.spec.ts
@@ -19,6 +19,15 @@ describe('getBenchmarkDatasetUrl', () => {
         'https://huggingface.co/datasets/tinyBenchmarks/tinyTruthfulQA',
       );
     });
+
+    it.each([
+      ['inspect/telemath', 'https://huggingface.co/datasets/netop/TeleMath'],
+      ['inspect/teleqna', 'https://huggingface.co/datasets/netop/TeleQnA'],
+      ['inspect/telelogs', 'https://huggingface.co/datasets/netop/TeleLogs'],
+      ['inspect/3gpp-tsg', 'https://huggingface.co/datasets/GSMA/ot-lite'],
+    ])('should return the URL for the Open-Telco benchmark %s', (id, url) => {
+      expect(getBenchmarkDatasetUrl(id)).toBe(url);
+    });
   });
 
   describe('prefix matches', () => {

--- a/packages/eval-hub/frontend/src/app/utilities/benchmarkDatasetUrls.ts
+++ b/packages/eval-hub/frontend/src/app/utilities/benchmarkDatasetUrls.ts
@@ -103,6 +103,13 @@ const EXACT_BENCHMARK_DATASETS: Record<string, string> = {
   // Winogender: Gender bias in coreference
   winogender: 'https://huggingface.co/datasets/oskarvanderwal/winogender',
 
+  // Open-Telco v1 benchmarks
+  'inspect/telemath': 'https://huggingface.co/datasets/netop/TeleMath',
+  'inspect/teleqna': 'https://huggingface.co/datasets/netop/TeleQnA',
+  'inspect/telelogs': 'https://huggingface.co/datasets/netop/TeleLogs',
+  // 3GPP-TSG is the `3gpp_tsg` configuration in the shared GSMA/ot-lite dataset.
+  'inspect/3gpp-tsg': 'https://huggingface.co/datasets/GSMA/ot-lite',
+
   // --- Open LLM Leaderboard task wrappers ---
   leaderboard_bbh: 'https://huggingface.co/datasets/lukaemon/bbh',
   leaderboard_bbh_salient_translation_error_detection:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-90311

## Description

Fixes the missing dataset links for the Open-Telco benchmark entries in EvalHub.

Added exact benchmark mappings for TeleMath, TeleQnA, TeleLogs, and 3GPP-TSG. The 3GPP-TSG entry links to the shared `GSMA/ot-lite` dataset, where the benchmark is provided as the `3gpp_tsg` configuration.

<img width="832" height="629" alt="image" src="https://github.com/user-attachments/assets/94f512b3-135d-42d0-b0f7-cf58d5cf0bd5" />


## How Has This Been Tested?

<img width="257" height="175" alt="image" src="https://github.com/user-attachments/assets/1d512989-e098-48e8-a71d-901f98b18063" />

From `packages/eval-hub/frontend`:

```bash
npm run test:jest -- --runInBand src/app/utilities/__tests__/benchmarkDatasetUrls.spec.ts
npm run test:type-check
npm run lint
npm run test:unit
```

Results:

- Focused Jest suite: 17 tests passed
- Full unit suite: 878 tests passed
- Type-check passed
- Lint passed

This change does not modify the UI layout, so no screenshots are required.

## Test Impact

Added parameterized Jest unit coverage for all four Open-Telco benchmark dataset mappings in `benchmarkDatasetUrls.spec.ts`.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-90311]: https://redhat.atlassian.net/browse/RHOAIENG-90311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resolving Open-Telco benchmark identifiers—including namespaced forms—to their corresponding Hugging Face dataset URLs.
  - Added mappings for TeleMath, TeleQnA, TeleLogs, and 3GPP-TSG datasets.

- **Tests**
  - Added coverage for URL resolution across bare and namespaced benchmark identifiers, confirming links to the appropriate Hugging Face datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->