### PR TITLE
Fix NIM deployment wizard review details

### DIFF
--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -1010,10 +1010,6 @@ class ModelServingWizard extends Wizard {
     return this.findStep('summary-step');
   }
 
-  findReviewModelDetails() {
-    return cy.findByTestId('review-step-model-details');
-  }
-
   findModelTypeSelect() {
     return cy.findByTestId('model-type-select');
   }

--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -1006,6 +1006,14 @@ class ModelServingWizard extends Wizard {
     return this.findStep('advanced-options-step');
   }
 
+  findReviewStep() {
+    return this.findStep('summary-step');
+  }
+
+  findReviewModelDetails() {
+    return cy.findByTestId('review-step-model-details');
+  }
+
   findModelTypeSelect() {
     return cy.findByTestId('model-type-select');
   }

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -188,7 +188,13 @@ describe('NIM Models Deployments', () => {
     modelServingWizard.findTokenAuthenticationCheckbox().should('be.checked');
     modelServingWizard.findNextButton().should('be.enabled').click();
 
-    // Step 4: Summary
+    // Step 4: Review
+    modelServingWizard.findReviewStep().should('be.enabled');
+    modelServingWizard
+      .findReviewModelDetails()
+      .should('contain.text', ModelTypeLabel.NIM)
+      .and('contain.text', 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1')
+      .and('not.contain.text', 'Model location');
     modelServingWizard.findSubmitButton().should('be.enabled').click();
 
     // PVC creation — dry-run validates the PVC can be created

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -191,7 +191,7 @@ describe('NIM Models Deployments', () => {
     // Step 4: Review
     modelServingWizard.findReviewStep().should('be.enabled');
     modelServingWizard
-      .findReviewModelDetails()
+      .findReviewStepModelDetailsSection()
       .should('contain.text', ModelTypeLabel.NIM)
       .and('contain.text', 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1')
       .and('not.contain.text', 'Model location');

--- a/packages/model-serving/src/components/deploymentWizard/steps/ReviewStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ReviewStep.tsx
@@ -41,6 +41,7 @@ type StatusItemKey = WizardStateKey | `${WizardStateKey}-${string}` | 'projectNa
 
 type StatusItem<K extends StatusItemKey = StatusItemKey> = {
   key: K;
+  replaces?: string;
   label: string;
   comp: (state: WizardState) => React.ReactNode;
   optional?: boolean;
@@ -60,13 +61,37 @@ const getExtensionItems = (
     ?.filter((section) => section.title === title)
     .flatMap((section) => section.items) ?? [];
 
+export const mergeReviewItems = (
+  baseItems: StatusItem[],
+  extensionItems: StatusItem[],
+): StatusItem[] =>
+  extensionItems.reduce<StatusItem[]>((items, extensionItem) => {
+    if (extensionItem.replaces) {
+      const replacementIndex = items.findIndex((item) => item.key === extensionItem.replaces);
+      if (replacementIndex >= 0) {
+        return [
+          ...items.slice(0, replacementIndex),
+          extensionItem,
+          ...items.slice(replacementIndex + 1),
+        ];
+      }
+    }
+    return [...items, extensionItem];
+  }, baseItems);
+
+const mergeSectionItems = (
+  title: WizardStepTitle,
+  baseItems: StatusItem[],
+  extensionStatusSections?: StatusSection[],
+): StatusItem[] => mergeReviewItems(baseItems, getExtensionItems(title, extensionStatusSections));
+
 const getStatusSections = (
   projectName: string | undefined,
   extensionStatusSections: StatusSection[] | undefined,
   isGenAiEnabled: boolean,
   hasModelServerExtension: boolean,
 ): StatusSection[] => {
-  return [
+  const statusSections: StatusSection[] = [
     {
       title: WizardStepTitle.MODEL_DETAILS,
       items: [
@@ -213,7 +238,6 @@ const getStatusSections = (
           isVisible: (wizardState) =>
             wizardState.state.modelLocationData.data?.type === ModelLocationType.PVC,
         },
-        ...getExtensionItems(WizardStepTitle.MODEL_DETAILS, extensionStatusSections),
       ],
     },
     {
@@ -268,7 +292,6 @@ const getStatusSections = (
           label: 'Replicas',
           comp: (state) => state.numReplicas.data ?? 1,
         },
-        ...getExtensionItems(WizardStepTitle.MODEL_DEPLOYMENT, extensionStatusSections),
       ],
     },
     {
@@ -370,11 +393,20 @@ const getStatusSections = (
             return wizardState.state.deploymentStrategy.isVisible;
           },
         },
-        ...getExtensionItems(WizardStepTitle.ADVANCED_SETTINGS, extensionStatusSections),
       ],
     },
     ...(extensionStatusSections?.filter((section) => !isWizardStepTitle(section.title)) ?? []),
   ];
+
+  return statusSections.map((section) => {
+    if (!isWizardStepTitle(section.title)) {
+      return section;
+    }
+    return {
+      ...section,
+      items: mergeSectionItems(section.title, section.items, extensionStatusSections),
+    };
+  });
 };
 
 export const ReviewStepContent: React.FC<ReviewStepContentProps> = ({
@@ -408,6 +440,7 @@ export const ReviewStepContent: React.FC<ReviewStepContentProps> = ({
       title: section.title ?? '',
       items: section.items.map((item) => ({
         key: item.key,
+        replaces: item.replaces,
         label: item.label,
         comp: (state) => item.value(state),
         optional: item.optional,

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ReviewStep.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ReviewStep.spec.ts
@@ -1,0 +1,34 @@
+import { mergeReviewItems } from '../ReviewStep';
+
+describe('mergeReviewItems', () => {
+  const createItem = (key: string, replaces?: string) => ({
+    key,
+    ...(replaces ? { replaces } : {}),
+    label: key,
+    comp: () => key,
+  });
+
+  it('should replace a matching base item in place', () => {
+    const result = mergeReviewItems(
+      [createItem('modelType'), createItem('modelLocation'), createItem('image')],
+      [createItem('nimModelType', 'modelType')],
+    );
+
+    expect(result.map((item) => item.key)).toEqual(['nimModelType', 'modelLocation', 'image']);
+  });
+
+  it('should append extension items without a replacement target', () => {
+    const result = mergeReviewItems([createItem('modelType')], [createItem('nimImage')]);
+
+    expect(result.map((item) => item.key)).toEqual(['modelType', 'nimImage']);
+  });
+
+  it('should append an extension item when its replacement target is not present', () => {
+    const result = mergeReviewItems(
+      [createItem('modelType')],
+      [createItem('nimLocation', 'modelLocation')],
+    );
+
+    expect(result.map((item) => item.key)).toEqual(['modelType', 'nimLocation']);
+  });
+});

--- a/packages/model-serving/src/shared/types/form-data.ts
+++ b/packages/model-serving/src/shared/types/form-data.ts
@@ -189,6 +189,8 @@ export type WizardFormData = {
 
 export type WizardReviewItem = {
   key: string;
+  /** Optional key of an existing review item to replace within the same section. */
+  replaces?: string;
   label: string;
   value: (wizardState: WizardFormData['state']) => React.ReactNode;
   optional?: boolean;

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -5,7 +5,10 @@ import TypeaheadSelect, {
   TypeaheadSelectOption,
 } from '@odh-dashboard/ui-core/components/TypeaheadSelect';
 import type { ProjectSectionType } from '@odh-dashboard/model-serving/shared/wizard-fields';
-import type { WizardField } from '@odh-dashboard/model-serving/shared/types/form-data';
+import {
+  WizardStepTitle,
+  type WizardField,
+} from '@odh-dashboard/model-serving/shared/types/form-data';
 import { NIMModelLocationKey } from '@odh-dashboard/model-serving/shared/wizard-fields';
 import { TemplateKind } from '@odh-dashboard/k8s-core';
 import { getNIMHardwareProfileFieldOverrides } from './nimHardwareProfileOverrides';
@@ -13,6 +16,7 @@ import useNIMAccountStatus, { NIMAccountStatus } from '../../../api/accounts/hoo
 import NIMSettingsLink from '../../projectSettings/NIMSettingsLink';
 import { useNIMImages, type NIMImagesData } from '../../../api/images/hooks';
 import type { NIMImage } from '../../../api/images/types';
+import { NIM_MODEL_TYPE } from '../../../constants';
 import {
   formatImageString,
   getImageRepository,
@@ -373,4 +377,28 @@ export const NIMImageFieldWizardField: NIMImageFieldType = {
   },
   component: NIMImageFieldComponent,
   externalDataHook: useNIMImageFieldExternalData,
+  getReviewSections: (value) => [
+    {
+      title: WizardStepTitle.MODEL_DETAILS,
+      items: [
+        {
+          key: 'nimModelType',
+          replaces: 'modelType',
+          label: 'Model type',
+          value: () => NIM_MODEL_TYPE,
+        },
+        {
+          key: 'nimModelLocation',
+          replaces: 'modelLocationData-locationType',
+          label: 'Model location',
+          value: () => 'NVIDIA NIM',
+        },
+        {
+          key: 'nimImage',
+          label: 'NIM image',
+          value: () => (value.repository && value.tag ? `${value.repository}:${value.tag}` : '--'),
+        },
+      ],
+    },
+  ],
 };

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -387,6 +387,8 @@ export const NIMImageFieldWizardField: NIMImageFieldType = {
           label: 'Model type',
           value: () => NIM_MODEL_TYPE,
         },
+        // Use replaces with isVisible returning false to hide the existing model location row,
+        // since it is redundant with the model type for NIM models.
         {
           key: 'nimModelLocation',
           replaces: 'modelLocationData-locationType',

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMImageField.tsx
@@ -391,7 +391,8 @@ export const NIMImageFieldWizardField: NIMImageFieldType = {
           key: 'nimModelLocation',
           replaces: 'modelLocationData-locationType',
           label: 'Model location',
-          value: () => 'NVIDIA NIM',
+          value: () => undefined,
+          isVisible: () => false,
         },
         {
           key: 'nimImage',

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
@@ -51,6 +51,44 @@ describe('NIMImageFieldComponent', () => {
     mockUseAccessReview.mockReturnValue([true, true]);
   });
 
+  it('should provide NIM-specific review details', () => {
+    const { NIMImageFieldWizardField } = require('../NIMImageField');
+    const sections = NIMImageFieldWizardField.getReviewSections?.({
+      repository: 'nvcr.io/nim/meta/llama-3.2-1b-instruct',
+      tag: '1.8',
+    });
+
+    expect(sections).toEqual([
+      {
+        title: 'Model details',
+        items: [
+          {
+            key: 'nimModelType',
+            replaces: 'modelType',
+            label: 'Model type',
+            value: expect.any(Function),
+          },
+          {
+            key: 'nimModelLocation',
+            replaces: 'modelLocationData-locationType',
+            label: 'Model location',
+            value: expect.any(Function),
+          },
+          {
+            key: 'nimImage',
+            label: 'NIM image',
+            value: expect.any(Function),
+          },
+        ],
+      },
+    ]);
+
+    const items = sections?.[0].items ?? [];
+    expect(items[0].value({} as never)).toBe('NVIDIA NIM');
+    expect(items[1].value({} as never)).toBe('NVIDIA NIM');
+    expect(items[2].value({} as never)).toBe('nvcr.io/nim/meta/llama-3.2-1b-instruct:1.8');
+  });
+
   it('should show info alert when no project is selected', () => {
     renderComponent({
       externalData: {

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/NIMImageField.spec.tsx
@@ -73,6 +73,7 @@ describe('NIMImageFieldComponent', () => {
             replaces: 'modelLocationData-locationType',
             label: 'Model location',
             value: expect.any(Function),
+            isVisible: expect.any(Function),
           },
           {
             key: 'nimImage',
@@ -85,7 +86,7 @@ describe('NIMImageFieldComponent', () => {
 
     const items = sections?.[0].items ?? [];
     expect(items[0].value({} as never)).toBe('NVIDIA NIM');
-    expect(items[1].value({} as never)).toBe('NVIDIA NIM');
+    expect(items[1].isVisible?.({} as never)).toBe(false);
     expect(items[2].value({} as never)).toBe('nvcr.io/nim/meta/llama-3.2-1b-instruct:1.8');
   });
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-90938

## Description

When the `nimWizard` feature flag was enabled, the model deployment wizard Review page displayed generic values for NVIDIA NIM deployments:

- Model type was shown as `Generative AI model (Example, LLM)`.
- Model location was shown as `New connection`.
- The selected NIM image was not shown.

This change adds a generic review-item replacement capability to the deployment wizard extension contract. NIM uses that capability to provide its own Model type review value and selected image while hiding the redundant Model location row. The shared Model Serving review component remains platform-agnostic.

## Screenshots

NIM deployment review step:

<img width="918" height="972" alt="Screenshot 2026-09-04 at 4 32 20 PM" src="https://github.com/user-attachments/assets/39b6e87b-fdeb-412e-a593-230e8cca145b" />

Non-NIM review step:

<img width="919" height="966" alt="Screenshot 2026-09-04 at 4 34 49 PM" src="https://github.com/user-attachments/assets/40ec39c0-b4fa-450d-82ec-77b9307aabd7" />

## How Has This Been Tested?

Automated validation:

- `npm run type-check`
- `npm run lint`
- Model Serving unit tests: 59 suites / 569 tests passed
- NIM Serving unit tests: 26 suites / 252 tests passed
- Commit-time lint-staged checks passed

Manual browser validation used the dashboard with `?devFeatureFlags=nimWizard=true`:

- NIM flow reached Review with Model type `NVIDIA NIM`, the selected image `nvcr.io/nim/meta/llama3-70b-instruct:1.0.0`, no Model location row, and the existing NIM Storage section.
- Non-NIM regression flow reached Review with Predictive model and Cluster storage values, and no NIM image row.
- No deployment was submitted.

## Test Impact

- Added unit coverage for generic review-item replacement and fallback append behavior.
- Added NIM review-section coverage for the NIM model type, hidden Model location row, and selected image value.
- Existing Model Serving and NIM Serving unit suites passed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change. Manual validation was performed, but screenshots are not included in this draft.
- [ ] Included tags to the UX team if it was a UI/UX change. No UX review tag is proposed.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-90938]: https://redhat.atlassian.net/browse/RHOAIENG-90938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ