### PR TITLE
ci(dashboard-operator): cache envtest binaries in CI (RHOAIENG-83661)

### DIFF
--- a/.github/workflows/dashboard-operator-tests.yml
+++ b/.github/workflows/dashboard-operator-tests.yml
@@ -48,6 +48,18 @@ jobs:
         working-directory: dashboard-operator
         run: make test
 
+      # Cache the envtest Kubernetes binary assets (kube-apiserver, etcd, kubectl)
+      # downloaded by `make setup-envtest` into dashboard-operator/bin/k8s. The download
+      # is the slow part of the integration step; the tests themselves run in seconds.
+      # Keyed on the Makefile so a change to the pinned envtest/K8s version busts the cache.
+      - name: Cache envtest binaries
+        uses: actions/cache@v4
+        with:
+          path: dashboard-operator/bin/k8s
+          key: envtest-${{ runner.os }}-${{ hashFiles('dashboard-operator/Makefile') }}
+          restore-keys: |
+            envtest-${{ runner.os }}-
+
       - name: Integration tests (envtest)
         working-directory: dashboard-operator
         run: make test-integration

--- a/.github/workflows/dashboard-operator-tests.yml
+++ b/.github/workflows/dashboard-operator-tests.yml
@@ -53,7 +53,7 @@ jobs:
       # is the slow part of the integration step; the tests themselves run in seconds.
       # Keyed on the Makefile so a change to the pinned envtest/K8s version busts the cache.
       - name: Cache envtest binaries
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: dashboard-operator/bin/k8s
           key: envtest-${{ runner.os }}-${{ hashFiles('dashboard-operator/Makefile') }}

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -31,7 +31,7 @@ test: fmt vet ## Run tests.
 
 .PHONY: test-integration
 test-integration: setup-envtest ## Run integration tests with envtest.
-	KUBEBUILDER_ASSETS="$$($(ENVTEST) use 1.31.x -p path)" go test -v -race -tags=integration -count=1 ./internal/controller/...
+	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN)/k8s -p path)" go test -v -race -tags=integration -count=1 ./internal/controller/...
 
 ##@ Build
 
@@ -131,6 +131,9 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 GOLANGCI_LINT_VERSION ?= v2.1.0
 CONTROLLER_GEN_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= v0.24.1
+# Kubernetes control-plane version for envtest binaries. Pinned for reproducible
+# integration runs; bumping this busts the CI envtest binary cache.
+ENVTEST_K8S_VERSION ?= 1.31.x
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -131,9 +131,10 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 GOLANGCI_LINT_VERSION ?= v2.1.0
 CONTROLLER_GEN_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= v0.24.1
-# Kubernetes control-plane version for envtest binaries. Pinned for reproducible
-# integration runs; bumping this busts the CI envtest binary cache.
-ENVTEST_K8S_VERSION ?= 1.31.x
+# Kubernetes control-plane version for envtest binaries. Pinned to an exact
+# patch (not a 1.31.x wildcard) so setup-envtest resolves the same assets
+# regardless of cache state; bumping this busts the CI envtest binary cache.
+ENVTEST_K8S_VERSION ?= 1.31.0
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)


### PR DESCRIPTION
<!-- https://issues.redhat.com/browse/RHOAIENG-83661 -->

## Description

Completes the envtest CI integration for the dashboard-operator ([RHOAIENG-83661](https://issues.redhat.com/browse/RHOAIENG-83661)). The `make test-integration` step already runs in `dashboard-operator-tests.yml`, and the K8s control-plane version was already pinned. The only remaining acceptance criterion was **caching the envtest binary assets** so the (slow) download does not repeat on every CI run.

Changes:
- **Makefile** — `test-integration` now passes `--bin-dir $(LOCALBIN)/k8s` to `setup-envtest`, so the Kubernetes control-plane binaries (kube-apiserver, etcd, kubectl) download into `dashboard-operator/bin/k8s` instead of the OS-default data dir (`~/.local/share/io.kubebuilder.envtest`). Without this, caching `bin/k8s` would cache nothing.
- Pulled the pinned K8s version into a new `ENVTEST_K8S_VERSION ?= 1.31.x` variable (single source of truth).
- **Workflow** — added an `actions/cache@v4` step for `dashboard-operator/bin/k8s`, keyed on `hashFiles('dashboard-operator/Makefile')` so bumping the envtest or K8s version busts the cache automatically, with a `restore-keys` fallback for partial hits.

`bin/` is already gitignored, so the restored cache does not trip the workflow's "uncommitted file changes" check.

## How Has This Been Tested?

Ran the integration target locally after the Makefile change and confirmed the assets land in the cache path and all envtest integration tests pass:

```
$ make test-integration
...
ok  github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller  18.953s
$ find dashboard-operator/bin/k8s
dashboard-operator/bin/k8s/k8s/1.31.0-<os>-<arch>   # matches the cached path
```

Workflow YAML validated with `js-yaml`/`yq`.

## Test Impact

No product code changes — this is CI/build tooling only. The existing envtest integration suite (`make test-integration`) is the test coverage and continues to pass; this PR only changes where the envtest binaries are stored and adds caching around them.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-83661]: https://redhat.atlassian.net/browse/RHOAIENG-83661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated integration testing by reusing downloaded test environment tools, reducing repeated setup time in continuous integration runs.
  * Standardized the Kubernetes test environment version for more consistent integration test results.
  * Updated test setup and caching behavior to improve the reliability and efficiency of the project’s validation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->