### PR TITLE
fix(ci): sync-stable on dispatch only with Jenkins target SHA

### DIFF
--- a/.github/workflows/sync-stable.yml
+++ b/.github/workflows/sync-stable.yml
@@ -7,9 +7,10 @@ on:
         description: 'Type SYNC_STABLE to confirm manual fast-forward of main to stable'
         required: true
         type: string
-  push:
-    branches:
-      - main
+      target_commit:
+        description: 'Commit SHA on main to fast-forward stable to (from Jenkins)'
+        required: true
+        type: string
 
 concurrency:
   group: stable-ff-${{ github.workflow }}
@@ -23,9 +24,8 @@ jobs:
   fast-forward:
     name: Fast-forward main to stable
     if: >-
-      github.event_name == 'push' ||
-      (github.ref == 'refs/heads/main' &&
-       github.event.inputs.SYNC_STABLE == 'SYNC_STABLE')
+      github.ref == 'refs/heads/main' &&
+      github.event.inputs.SYNC_STABLE == 'SYNC_STABLE'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -49,26 +49,45 @@ jobs:
           # Uses automatic GITHUB_TOKEN - no manual secrets needed!
 
       - name: Fast-forward main to stable
+        env:
+          TARGET_COMMIT: ${{ github.event.inputs.target_commit }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
+
+          if [[ ! "$TARGET_COMMIT" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "ERROR: target_commit must be a full 40-character SHA, got: $TARGET_COMMIT"
+            exit 1
+          fi
+
+          git fetch origin main "$TARGET_COMMIT"
+
+          if ! git cat-file -e "$TARGET_COMMIT^{commit}" 2>/dev/null; then
+            echo "ERROR: target_commit $TARGET_COMMIT not found after fetch"
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$TARGET_COMMIT" origin/main; then
+            echo "ERROR: target_commit $TARGET_COMMIT is not on main"
+            exit 1
+          fi
 
           echo "stable before: $(git rev-parse HEAD)"
-          echo "main target:   $(git rev-parse origin/main)"
+          echo "main target:   $TARGET_COMMIT"
 
-          if [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]]; then
-            echo "No changes — stable is already up to date with main"
+          if [[ "$(git rev-parse HEAD)" == "$(git rev-parse "$TARGET_COMMIT")" ]]; then
+            echo "No changes — stable is already at target commit"
             exit 0
           fi
 
-          if ! git merge-base --is-ancestor HEAD origin/main; then
-            echo "ERROR: Cannot fast-forward. stable has diverged from main."
+          if ! git merge-base --is-ancestor HEAD "$TARGET_COMMIT"; then
+            echo "ERROR: Cannot fast-forward. stable has diverged from target commit or target is behind stable."
             echo "Manual intervention required."
             exit 1
           fi
 
-          git merge --ff-only origin/main
+          git merge --ff-only "$TARGET_COMMIT"
           echo "stable after:  $(git rev-parse HEAD)"
           git push origin stable
-          echo "Fast-forwarded main to stable"
+          echo "Fast-forwarded stable to $TARGET_COMMIT"

--- a/.github/workflows/sync-stable.yml
+++ b/.github/workflows/sync-stable.yml
@@ -16,16 +16,40 @@ concurrency:
   group: stable-ff-${{ github.workflow }}
   cancel-in-progress: false
 
-# Read-only default; the fast-forward job escalates to contents:write only for git push.
+# Read-only default; sync jobs escalate to contents:write only for git push.
 permissions:
   contents: read
 
 jobs:
+  validate:
+    name: Validate dispatch inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate workflow dispatch inputs
+        env:
+          SYNC_STABLE_INPUT: ${{ github.event.inputs.SYNC_STABLE }}
+          TARGET_COMMIT: ${{ github.event.inputs.target_commit }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "ERROR: workflow must be dispatched from main, got: ${{ github.ref }}"
+            exit 1
+          fi
+
+          if [[ "$SYNC_STABLE_INPUT" != "SYNC_STABLE" ]]; then
+            echo "ERROR: SYNC_STABLE must be 'SYNC_STABLE', got: $SYNC_STABLE_INPUT"
+            exit 1
+          fi
+
+          if [[ ! "$TARGET_COMMIT" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "ERROR: target_commit must be a full 40-character SHA, got: $TARGET_COMMIT"
+            exit 1
+          fi
+
   fast-forward:
     name: Fast-forward main to stable
-    if: >-
-      github.ref == 'refs/heads/main' &&
-      github.event.inputs.SYNC_STABLE == 'SYNC_STABLE'
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -55,21 +79,15 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if [[ ! "$TARGET_COMMIT" =~ ^[a-f0-9]{40}$ ]]; then
-            echo "ERROR: target_commit must be a full 40-character SHA, got: $TARGET_COMMIT"
-            exit 1
-          fi
-
-          git fetch origin main "$TARGET_COMMIT"
+          git fetch origin main
 
           if ! git cat-file -e "$TARGET_COMMIT^{commit}" 2>/dev/null; then
             echo "ERROR: target_commit $TARGET_COMMIT not found after fetch"
             exit 1
           fi
 
-          if ! git merge-base --is-ancestor "$TARGET_COMMIT" origin/main; then
-            echo "ERROR: target_commit $TARGET_COMMIT is not on main"
+          if ! git rev-list --first-parent origin/main | grep -Fxq "$TARGET_COMMIT"; then
+            echo "ERROR: target_commit $TARGET_COMMIT is not on main's first-parent history"
             exit 1
           fi
 

--- a/.github/workflows/sync-stable.yml
+++ b/.github/workflows/sync-stable.yml
@@ -16,24 +16,22 @@ concurrency:
   group: stable-ff-${{ github.workflow }}
   cancel-in-progress: false
 
-# Read-only default; sync jobs escalate to contents:write only for git push.
-permissions:
-  contents: read
-
 jobs:
   validate:
     name: Validate dispatch inputs
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Validate workflow dispatch inputs
         env:
           SYNC_STABLE_INPUT: ${{ github.event.inputs.SYNC_STABLE }}
           TARGET_COMMIT: ${{ github.event.inputs.target_commit }}
+          WORKFLOW_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
 
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "ERROR: workflow must be dispatched from main, got: ${{ github.ref }}"
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "ERROR: workflow must be dispatched from main, got: $WORKFLOW_REF"
             exit 1
           fi
 


### PR DESCRIPTION
## Description

The **Fast-forward main to stable** workflow currently runs on every push to `main`, which fast-forwards `stable` to `origin/main` HEAD. Release sync should run only when Jenkins dispatches the workflow after a validated build, and `stable` should advance to the **exact commit** Jenkins passed—not whatever is latest on `main` at run time.

Changes:

- **Remove** `on: push` to `main` — workflow runs only via `workflow_dispatch`
- **Add** required `target_commit` input (40-char SHA on `main`)
- **Fast-forward** `stable` to that SHA (`git merge --ff-only "$TARGET_COMMIT"`)
- **Validate** the SHA exists, is on `main`, and is a fast-forward from current `stable`

Jenkins dispatch example:

```bash
gh workflow run sync-stable.yml \
  --ref main \
  -f SYNC_STABLE=SYNC_STABLE \
  -f target_commit=<full-sha-from-build>
```

## How Has This Been Tested?

Workflow YAML only. After merge:

1. Confirm merges to `main` no longer trigger **Fast-forward main to stable**.
2. Dispatch manually with a known `main` SHA and confirm `stable` moves to that commit.
3. Wire Jenkins to pass the built/tested commit SHA as `target_commit`.

## Test Impact

No unit or Cypress coverage. GitHub Actions workflow change only.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our Best Practices (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stable branch synchronization now requires explicit manual confirmation from the main branch.
  * Synchronization targets a specified commit and verifies that it belongs to the main branch history.
  * Added safeguards to prevent synchronization when the selected commit cannot be safely fast-forwarded.
  * Stable is updated only to the exact validated commit, improving synchronization accuracy and predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->