### PR TITLE
chore(data-registry): sync API contract to 0.7.6

### DIFF
--- a/packages/data-registry/bff/openapi/src/data-registry-api.yaml
+++ b/packages/data-registry/bff/openapi/src/data-registry-api.yaml
@@ -5,7 +5,7 @@
 openapi: 3.1.0
 info:
   title: RHOAI Data Registry API
-  version: 0.7.4
+  version: 0.7.6
   description: |
     The RHOAI Data Registry exposes an **Iceberg REST Catalog-compatible API** for
     registering, discovering, and managing data assets across OpenShift AI projects.
@@ -1312,6 +1312,11 @@ components:
         updated-at:
           type: ['string', 'null']
           description: Last update timestamp in ISO 8601 format
+        labels:
+          type: ['array', 'null']
+          items:
+            type: string
+          description: Labels assigned to this volume for grouping and filtering
         properties:
           type: object
           additionalProperties:
@@ -1363,6 +1368,16 @@ components:
           type: string
         storage_location:
           type: string
+        add_labels:
+          type: array
+          items:
+            type: string
+          description: Labels to add to this volume. Existing labels are preserved.
+        remove_labels:
+          type: array
+          items:
+            type: string
+          description: Remove these labels from the volume. Other labels are preserved.
         properties:
           type: object
           additionalProperties:


### PR DESCRIPTION
## Summary
- sync the vendored Data Registry API contract from 0.7.4 to 0.7.6
- document volume labels and volume label update fields

## Validation
- `go test ./...` in `packages/data-registry/bff`
- OpenAPI YAML parsing and contract field verification

No BFF runtime changes are required because the Data Registry surface uses a transparent catch-all reverse proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Volume information can now include optional labels.
  * Volume updates support adding or removing labels while preserving existing labels.

* **Documentation**
  * Updated the API specification to reflect the latest volume-label capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->