### PR TITLE
fix(core-bff): forward x-forwarded-access-token for federated authorize entries

### DIFF
--- a/distributions/core-bff/bff/internal/api/module_proxy.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy.go
@@ -160,11 +160,11 @@ func normalizeFederationEntries(entries []moduleFederationEntry) ([]normalizedPr
 }
 
 // validateProxyEntries rejects duplicate paths, reserved-route collisions, and invalid service refs.
-func validateProxyEntries(entries []normalizedProxyEntry) error {
+func validateProxyEntries(entries []normalizedProxyEntry, authTokenHeader string) error {
 	if err := validateProxyPaths(entries); err != nil {
 		return err
 	}
-	return validateServiceRefs(entries)
+	return validateServiceRefs(entries, authTokenHeader)
 }
 
 func validateProxyPaths(entries []normalizedProxyEntry) error {
@@ -218,7 +218,7 @@ func proxyPathsOverlap(a, b string) bool {
 	return a == b || strings.HasPrefix(a, b+"/") || strings.HasPrefix(b, a+"/")
 }
 
-func validateServiceRefs(entries []normalizedProxyEntry) error {
+func validateServiceRefs(entries []normalizedProxyEntry, authTokenHeader string) error {
 	for _, e := range entries {
 		if e.service.Service.Name == "" {
 			return fmt.Errorf("entry %s has empty service name", e.entryName)
@@ -240,6 +240,9 @@ func validateServiceRefs(entries []normalizedProxyEntry) error {
 			for k := range e.service.Headers {
 				if strings.EqualFold(k, constants.HeaderAuthorization) {
 					return fmt.Errorf("entry %s sets a custom Authorization header while authorize is enabled; these conflict", e.entryName)
+				}
+				if authTokenHeader != "" && strings.EqualFold(k, authTokenHeader) {
+					return fmt.Errorf("entry %s sets a custom %s header while authorize is enabled; the server-resolved token takes precedence", e.entryName, authTokenHeader)
 				}
 			}
 		}
@@ -290,17 +293,26 @@ func (app *App) buildModuleProxyConfig(entry normalizedProxyEntry, targetURL *ur
 		// SetOutboundHeadersFn runs after stripping (see proxy.rewriteFunc), so
 		// the value set here is the trusted, server-resolved token. Both headers
 		// are forwarded so upstreams reading either convention authenticate.
+		//
+		// When the ingress auth header is the standard Authorization header, the
+		// "Bearer <token>" value from AuthHeaderFn is already correct, so we skip
+		// raw-token injection to avoid clobbering it with the unprefixed token.
 		authTokenHeader := app.config.AuthTokenHeader
-		cfg.SetOutboundHeadersFn = func(r *http.Request, outH http.Header) {
-			if authTokenHeader != "" {
-				if identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity); ok && identity != nil {
-					if token := identity.ResolveToken(app.devFallbackToken); token != "" {
-						outH.Set(authTokenHeader, token)
+		injectAuthToken := authTokenHeader != "" && !strings.EqualFold(authTokenHeader, constants.HeaderAuthorization)
+		if injectAuthToken || len(customHeaders) > 0 {
+			cfg.SetOutboundHeadersFn = func(r *http.Request, outH http.Header) {
+				// Apply custom headers first so the server-resolved token set below
+				// is authoritative and cannot be overridden by a static config value.
+				for k, v := range customHeaders {
+					outH.Set(k, v)
+				}
+				if injectAuthToken {
+					if identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity); ok && identity != nil {
+						if token := identity.ResolveToken(app.devFallbackToken); token != "" {
+							outH.Set(authTokenHeader, token)
+						}
 					}
 				}
-			}
-			for k, v := range customHeaders {
-				outH.Set(k, v)
 			}
 		}
 	} else if len(customHeaders) > 0 {
@@ -331,7 +343,7 @@ func (app *App) initModuleProxies() error {
 		return nil
 	}
 
-	if err := validateProxyEntries(normalized); err != nil {
+	if err := validateProxyEntries(normalized, app.config.AuthTokenHeader); err != nil {
 		return err
 	}
 

--- a/distributions/core-bff/bff/internal/api/module_proxy.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy.go
@@ -294,22 +294,30 @@ func (app *App) buildModuleProxyConfig(entry normalizedProxyEntry, targetURL *ur
 		// the value set here is the trusted, server-resolved token. Both headers
 		// are forwarded so upstreams reading either convention authenticate.
 		//
-		// When the ingress auth header is the standard Authorization header, the
-		// "Bearer <token>" value from AuthHeaderFn is already correct, so we skip
-		// raw-token injection to avoid clobbering it with the unprefixed token.
+		// This injection also covers the case where the configured auth header IS
+		// the standard Authorization header: SensitiveIngressHeaders appends the
+		// configured header to StripHeaders, so the "Bearer <token>" value set by
+		// AuthHeaderFn would otherwise be stripped and never reach the upstream.
+		// Because SetOutboundHeadersFn runs after stripping, re-injecting here (with
+		// the "Bearer " prefix for the Authorization header, raw otherwise) restores
+		// the trusted token regardless of which header is configured.
 		authTokenHeader := app.config.AuthTokenHeader
-		injectAuthToken := authTokenHeader != "" && !strings.EqualFold(authTokenHeader, constants.HeaderAuthorization)
-		if injectAuthToken || len(customHeaders) > 0 {
+		if authTokenHeader != "" || len(customHeaders) > 0 {
+			isAuthorizationHeader := strings.EqualFold(authTokenHeader, constants.HeaderAuthorization)
 			cfg.SetOutboundHeadersFn = func(r *http.Request, outH http.Header) {
 				// Apply custom headers first so the server-resolved token set below
 				// is authoritative and cannot be overridden by a static config value.
 				for k, v := range customHeaders {
 					outH.Set(k, v)
 				}
-				if injectAuthToken {
+				if authTokenHeader != "" {
 					if identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity); ok && identity != nil {
 						if token := identity.ResolveToken(app.devFallbackToken); token != "" {
-							outH.Set(authTokenHeader, token)
+							if isAuthorizationHeader {
+								outH.Set(authTokenHeader, k8s.BearerTokenPrefix+token)
+							} else {
+								outH.Set(authTokenHeader, token)
+							}
 						}
 					}
 				}

--- a/distributions/core-bff/bff/internal/api/module_proxy.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy.go
@@ -271,6 +271,8 @@ func (app *App) buildModuleProxyConfig(entry normalizedProxyEntry, targetURL *ur
 		cfg.SSRFAllowedHosts = []string{targetURL.Hostname()}
 	}
 
+	customHeaders := entry.service.Headers
+
 	if entry.service.Authorize {
 		cfg.AuthHeaderFn = func(r *http.Request) string {
 			identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
@@ -279,12 +281,31 @@ func (app *App) buildModuleProxyConfig(entry normalizedProxyEntry, targetURL *ur
 			}
 			return k8s.BearerTokenPrefix + identity.ResolveToken(app.devFallbackToken)
 		}
-	}
 
-	if len(entry.service.Headers) > 0 {
-		headers := entry.service.Headers
+		// Re-inject the validated user token in the ingress auth header
+		// (default: x-forwarded-access-token). mod-arch BFFs (maas, gen-ai, ...)
+		// read the token from this header, not the Kubernetes-style Authorization
+		// header that AuthHeaderFn sets. The inbound value is stripped by
+		// SensitiveIngressHeaders (StripHeaders) so a client cannot spoof it;
+		// SetOutboundHeadersFn runs after stripping (see proxy.rewriteFunc), so
+		// the value set here is the trusted, server-resolved token. Both headers
+		// are forwarded so upstreams reading either convention authenticate.
+		authTokenHeader := app.config.AuthTokenHeader
+		cfg.SetOutboundHeadersFn = func(r *http.Request, outH http.Header) {
+			if authTokenHeader != "" {
+				if identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity); ok && identity != nil {
+					if token := identity.ResolveToken(app.devFallbackToken); token != "" {
+						outH.Set(authTokenHeader, token)
+					}
+				}
+			}
+			for k, v := range customHeaders {
+				outH.Set(k, v)
+			}
+		}
+	} else if len(customHeaders) > 0 {
 		cfg.SetOutboundHeadersFn = func(_ *http.Request, outH http.Header) {
-			for k, v := range headers {
+			for k, v := range customHeaders {
 				outH.Set(k, v)
 			}
 		}

--- a/distributions/core-bff/bff/internal/api/module_proxy_test.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy_test.go
@@ -920,6 +920,47 @@ func TestInitModuleProxies_AuthorizeEmptyAuthTokenHeader(t *testing.T) {
 	assert.Empty(t, receivedTokenHeader)
 }
 
+// TestInitModuleProxies_AuthorizeWithAuthorizationHeader verifies that when the
+// configured ingress auth header IS the standard Authorization header, the
+// server-resolved token still reaches the upstream. SensitiveIngressHeaders
+// appends the configured header to StripHeaders, so the value AuthHeaderFn sets
+// is stripped before the request goes out; SetOutboundHeadersFn (which runs after
+// stripping) must re-inject it as "Bearer <token>". Regression test for the
+// AuthTokenHeader == "Authorization" configuration.
+func TestInitModuleProxies_AuthorizeWithAuthorizationHeader(t *testing.T) {
+	var receivedAuthHeader string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	app := newTestApp(func(a *App) {
+		a.config.DevMode = true
+		a.config.AuthTokenHeader = "Authorization"
+	})
+	proxyHandler := createTestProxy(t, app, backend.URL, "/auth-header/api", "/api", true, false, nil)
+
+	admin := k8mocks.DefaultTestUsers[0]
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth-header/api/v1/items", nil)
+	// A client attempts to spoof the Authorization header. It must be stripped
+	// and overwritten by the server-resolved token, never forwarded as-is.
+	req.Header.Set("Authorization", "Bearer attacker-token")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken("test-token-123"),
+	})
+	proxyHandler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	// The trusted token is forwarded with the "Bearer " prefix (not a raw,
+	// unprefixed token, and not the spoofed inbound value).
+	assert.Equal(t, "Bearer test-token-123", receivedAuthHeader)
+	assert.NotContains(t, receivedAuthHeader, "attacker-token")
+}
+
 func TestInitModuleProxies_PathRewrite(t *testing.T) {
 	var receivedPath string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/distributions/core-bff/bff/internal/api/module_proxy_test.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy_test.go
@@ -360,10 +360,11 @@ func TestNormalizeFederationEntries(t *testing.T) {
 
 func TestValidateProxyEntries(t *testing.T) {
 	tests := []struct {
-		name      string
-		entries   []normalizedProxyEntry
-		wantErr   bool
-		errSubstr string
+		name       string
+		entries    []normalizedProxyEntry
+		authHeader string
+		wantErr    bool
+		errSubstr  string
 	}{
 		{
 			name: "empty proxy path rejected",
@@ -527,6 +528,44 @@ func TestValidateProxyEntries(t *testing.T) {
 			errSubstr: "custom Authorization header while authorize is enabled",
 		},
 		{
+			name:       "authorize with custom auth-token header rejected",
+			authHeader: "x-forwarded-access-token",
+			entries: []normalizedProxyEntry{
+				{entryName: "tokenConflict", service: moduleProxyServiceEntry{
+					Authorize: true, Path: "/ok/api",
+					Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443},
+					Headers: map[string]string{"x-forwarded-access-token": "spoofed-token"}, //nolint:gosec // G101 false positive: HTTP header name, not a credential
+				}},
+			},
+			wantErr:   true,
+			errSubstr: "custom x-forwarded-access-token header while authorize is enabled",
+		},
+		{
+			name:       "authorize with custom auth-token header case-insensitive",
+			authHeader: "x-forwarded-access-token",
+			entries: []normalizedProxyEntry{
+				{entryName: "tokenConflict", service: moduleProxyServiceEntry{
+					Authorize: true, Path: "/ok/api",
+					Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443},
+					Headers: map[string]string{"X-Forwarded-Access-Token": "spoofed-token"}, //nolint:gosec // G101 false positive: HTTP header name, not a credential
+				}},
+			},
+			wantErr:   true,
+			errSubstr: "custom x-forwarded-access-token header while authorize is enabled",
+		},
+		{
+			name:       "non-authorized route with auth-token header allowed",
+			authHeader: "x-forwarded-access-token",
+			entries: []normalizedProxyEntry{
+				{entryName: "staticToken", service: moduleProxyServiceEntry{
+					Authorize: false, Path: "/ok/api",
+					Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443},
+					Headers: map[string]string{"x-forwarded-access-token": "static-token"},
+				}},
+			},
+			wantErr: false,
+		},
+		{
 			name: "non-authorized route with Authorization header allowed",
 			entries: []normalizedProxyEntry{
 				{entryName: "staticAuth", service: moduleProxyServiceEntry{
@@ -549,7 +588,7 @@ func TestValidateProxyEntries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateProxyEntries(tt.entries)
+			err := validateProxyEntries(tt.entries, tt.authHeader)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errSubstr != "" {
@@ -610,7 +649,7 @@ func TestReservedPathCollisionBothDirections(t *testing.T) {
 			entries := []normalizedProxyEntry{
 				{entryName: "collision", service: moduleProxyServiceEntry{Path: tt.path, Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
 			}
-			err := validateProxyEntries(entries)
+			err := validateProxyEntries(entries, "")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "collides with reserved BFF route")
 		})
@@ -632,7 +671,7 @@ func TestReservedPathCollisionUsesPathSegmentBoundaries(t *testing.T) {
 			entries := []normalizedProxyEntry{
 				{entryName: "nonCollision", service: moduleProxyServiceEntry{Path: tt.path, Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
 			}
-			require.NoError(t, validateProxyEntries(entries))
+			require.NoError(t, validateProxyEntries(entries, ""))
 		})
 	}
 }
@@ -658,7 +697,7 @@ func TestReservedPathCollisionViaPathPrefix(t *testing.T) {
 			entries := []normalizedProxyEntry{
 				{entryName: "sneaky", service: moduleProxyServiceEntry{Path: tt.path, Service: moduleServiceRef{Name: "svc", Namespace: "ns", Port: 443}}},
 			}
-			err := validateProxyEntries(entries)
+			err := validateProxyEntries(entries, "")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "collides with reserved BFF route")
 			assert.Contains(t, err.Error(), "sneaky")
@@ -722,6 +761,9 @@ func TestInitModuleProxies_AuthorizeTrue(t *testing.T) {
 	proxyHandler := createTestProxy(t, appDirect, backend.URL, "/auth-mod/api", "/api", true, false, nil)
 	rr := httptest.NewRecorder()
 	req2 := httptest.NewRequest(http.MethodGet, "/auth-mod/api/v1/items", nil)
+	// A client attempts to spoof the ingress auth header. It must be stripped
+	// and overwritten by the server-resolved token, never forwarded as-is.
+	req2.Header.Set("x-forwarded-access-token", "attacker-token")
 	req2 = reqWithIdentity(req2, &k8s.RequestIdentity{
 		UserID: admin.UserName,
 		Groups: admin.Groups,
@@ -731,9 +773,11 @@ func TestInitModuleProxies_AuthorizeTrue(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	// K8s-style Authorization header is forwarded (Bearer <token>) ...
 	assert.Contains(t, receivedAuthHeader, "Bearer test-token-123")
-	// ... and the ingress auth header is re-injected with the raw token so
-	// mod-arch BFFs (which read x-forwarded-access-token) authenticate too.
+	// ... and the ingress auth header is re-injected with the raw server-resolved
+	// token so mod-arch BFFs (which read x-forwarded-access-token) authenticate
+	// too. The spoofed inbound value must not survive.
 	assert.Equal(t, "test-token-123", receivedTokenHeader)
+	assert.NotContains(t, receivedTokenHeader, "attacker-token")
 }
 
 func TestInitModuleProxies_AuthorizeFalse(t *testing.T) {
@@ -805,6 +849,75 @@ func TestInitModuleProxies_CustomHeaders(t *testing.T) {
 	require.NotNil(t, receivedHeaders)
 	assert.Equal(t, "custom-value", receivedHeaders.Get("X-Custom-Header"))
 	assert.Equal(t, "another-value", receivedHeaders.Get("X-Another"))
+}
+
+// TestInitModuleProxies_AuthorizeWithCustomHeaders verifies that an authorize:true
+// entry forwards both static custom headers AND the server-resolved auth token,
+// and that the token injection is authoritative (custom headers cannot shadow it).
+func TestInitModuleProxies_AuthorizeWithCustomHeaders(t *testing.T) {
+	var receivedHeaders http.Header
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	app := newTestApp(func(a *App) {
+		a.config.DevMode = true
+		a.config.AuthTokenHeader = "x-forwarded-access-token"
+	})
+	headers := map[string]string{"X-Custom-Header": "custom-value"}
+	proxyHandler := createTestProxy(t, app, backend.URL, "/auth-custom/api", "/api", true, false, headers)
+
+	admin := k8mocks.DefaultTestUsers[0]
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth-custom/api/v1/data", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken("test-token-123"),
+	})
+	proxyHandler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, receivedHeaders)
+	assert.Equal(t, "custom-value", receivedHeaders.Get("X-Custom-Header"))
+	assert.Contains(t, receivedHeaders.Get("Authorization"), "Bearer test-token-123")
+	assert.Equal(t, "test-token-123", receivedHeaders.Get("x-forwarded-access-token"))
+}
+
+// TestInitModuleProxies_AuthorizeEmptyAuthTokenHeader verifies that when no
+// ingress auth header is configured, only the K8s-style Authorization header is
+// forwarded (no raw-token injection).
+func TestInitModuleProxies_AuthorizeEmptyAuthTokenHeader(t *testing.T) {
+	var receivedAuthHeader string
+	var receivedTokenHeader string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		receivedTokenHeader = r.Header.Get("x-forwarded-access-token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	app := newTestApp(func(a *App) {
+		a.config.DevMode = true
+		a.config.AuthTokenHeader = ""
+	})
+	proxyHandler := createTestProxy(t, app, backend.URL, "/auth-empty/api", "/api", true, false, nil)
+
+	admin := k8mocks.DefaultTestUsers[0]
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth-empty/api/v1/items", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken("test-token-123"),
+	})
+	proxyHandler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, receivedAuthHeader, "Bearer test-token-123")
+	assert.Empty(t, receivedTokenHeader)
 }
 
 func TestInitModuleProxies_PathRewrite(t *testing.T) {

--- a/distributions/core-bff/bff/internal/api/module_proxy_test.go
+++ b/distributions/core-bff/bff/internal/api/module_proxy_test.go
@@ -677,8 +677,10 @@ func TestInitModuleProxies_EmptyConfig(t *testing.T) {
 
 func TestInitModuleProxies_AuthorizeTrue(t *testing.T) {
 	var receivedAuthHeader string
+	var receivedTokenHeader string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuthHeader = r.Header.Get("Authorization")
+		receivedTokenHeader = r.Header.Get("x-forwarded-access-token")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer backend.Close()
@@ -715,6 +717,7 @@ func TestInitModuleProxies_AuthorizeTrue(t *testing.T) {
 
 	appDirect := newTestApp(func(a *App) {
 		a.config.DevMode = true
+		a.config.AuthTokenHeader = "x-forwarded-access-token"
 	})
 	proxyHandler := createTestProxy(t, appDirect, backend.URL, "/auth-mod/api", "/api", true, false, nil)
 	rr := httptest.NewRecorder()
@@ -726,7 +729,11 @@ func TestInitModuleProxies_AuthorizeTrue(t *testing.T) {
 	})
 	proxyHandler.ServeHTTP(rr, req2)
 	assert.Equal(t, http.StatusOK, rr.Code)
+	// K8s-style Authorization header is forwarded (Bearer <token>) ...
 	assert.Contains(t, receivedAuthHeader, "Bearer test-token-123")
+	// ... and the ingress auth header is re-injected with the raw token so
+	// mod-arch BFFs (which read x-forwarded-access-token) authenticate too.
+	assert.Equal(t, "test-token-123", receivedTokenHeader)
 }
 
 func TestInitModuleProxies_AuthorizeFalse(t *testing.T) {


### PR DESCRIPTION
<!--- https://issues.redhat.com/browse/RHOAIENG-93083 -->

## Description

The core-bff module-federation reverse proxy did not forward the ingress auth header (`x-forwarded-access-token`) to federated `authorize: true` upstreams, which broke authentication against mod-arch BFFs (`maas`, `gen-ai`) — the ones the MaaS Consumer Portal federates.

**Root cause (header-contract mismatch):**
- The shared `maas-ui` / `gen-ai-ui` BFFs read the user token **only** from `--auth-token-header=x-forwarded-access-token` (no `Authorization` fallback).
- core-bff's federation proxy (`distributions/core-bff/bff/internal/api/module_proxy.go`), for `authorize: true` entries, **strips** the inbound `x-forwarded-access-token` (via `SensitiveIngressHeaders`) and re-injected the token only as `Authorization: Bearer <token>` (the Kubernetes-API convention).
- Downstream the mod-arch BFFs saw no `x-forwarded-access-token` and returned **400** (`missing required Header: x-forwarded-access-token`, maas) / **401** (gen-ai). The legacy Node.js dashboard is unaffected because its proxy forwards the header unchanged; the portal is the first core-bff federation consumer, so it surfaced the gap.

**Fix:** for `authorize: true` entries, in addition to the existing `Authorization: Bearer` header, re-inject the validated, server-resolved token into the configured ingress auth header (`app.config.AuthTokenHeader`, default `x-forwarded-access-token`) as the **raw** token via `SetOutboundHeadersFn`. Security is preserved: the inbound client value is still stripped by `SensitiveIngressHeaders`, and `SetOutboundHeadersFn` runs *after* stripping (per `proxy.rewriteFunc` ordering), so only the trusted, server-resolved token is forwarded. Both conventions are now sent, so upstreams reading either `Authorization: Bearer` (k8s style) or `x-forwarded-access-token` (mod-arch style) authenticate.

Jira: https://issues.redhat.com/browse/RHOAIENG-93083

## How Has This Been Tested?

- **Unit tests:** `KUBEBUILDER_ASSETS=... go test ./internal/api/ ./internal/proxy/` — pass. `TestInitModuleProxies_AuthorizeTrue` now asserts both `Authorization: Bearer <token>` and `x-forwarded-access-token: <token>` arrive at the upstream.
- **Lint:** `make lint` (golangci-lint) — 0 issues.
- **Verified live on a ROSA cluster (`ui-monarch-rosa`, ODH):** built a core-bff image with this fix, deployed it to the MaaS Consumer Portal, and pointed the portal's federation config at the **unmodified** shared `odh-dashboard-maas-ui:8243` / `odh-dashboard-gen-ai-ui:8143` (which accept only `x-forwarded-access-token`). Through the portal proxy: `/maas/api/v1/user` → **200**, `/maas/api/v1/is-maas-admin` → **200**, `/gen-ai/api/v1/config` → **200** (all previously **400/401**). The stuck portal data panels loaded.

## Test Impact

Extended the existing `TestInitModuleProxies_AuthorizeTrue` unit test to assert the ingress auth header (`x-forwarded-access-token`) is forwarded alongside `Authorization: Bearer`. No new test files required — this is a Go BFF proxy change covered by the existing api/proxy test packages.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authenticated module proxy requests so the resolved user token is correctly forwarded through the configured authentication header.
  * Prevented custom headers from overriding the authentication token on authorized routes.
  * Preserved custom headers when authorization forwarding is disabled.
  * Improved compatibility with backends that rely on raw token headers for authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->