### PR TITLE
fix(e2e): harden manifest URL timeouts and MaaS overview phase waits

### DIFF
--- a/packages/cypress/cypress/tests/e2e/maas/testOverviewTab.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/maas/testOverviewTab.cy.ts
@@ -1,4 +1,6 @@
 import {
+  checkMaaSAuthPolicyState,
+  checkMaaSSubscriptionState,
   cleanupAuthPolicy,
   cleanupSubscription,
   createLLMInferenceServiceWithMaaSEnabled,
@@ -206,6 +208,15 @@ describe('MaaS Governance Overview tab', () => {
       overviewTabPage.findTable().should('exist');
       overviewRow.findModelAuthorizationPolicies().should('contain.text', '1');
       overviewRow.findModelPoliciesWarning().should('not.exist');
+
+      cy.step('Wait for subscription and auth policy CRs to reach Active');
+      ensureAdminOcSession();
+      checkMaaSSubscriptionState(subscriptionName, modelsAsAServiceNamespace, {
+        phase: PhaseStatus.ACTIVE,
+      });
+      checkMaaSAuthPolicyState(policyName, modelsAsAServiceNamespace, {
+        phase: PhaseStatus.ACTIVE,
+      });
 
       cy.step('Verify the Model is Ready Status after creating the subscription and policy');
       overviewRow.findModelPhase().should('contain.text', PhaseStatus.READY);

--- a/packages/cypress/cypress/utils/oc_commands/maas.ts
+++ b/packages/cypress/cypress/utils/oc_commands/maas.ts
@@ -186,8 +186,8 @@ export type CheckMaaSOptions = {
   retryIntervalMs?: number;
 };
 
-/** Default poll budget for MaaS subscription/policy phase checks (6 attempts × 5s ≈ 30s). */
-export const MAAS_STATE_DEFAULT_MAX_ATTEMPTS = 6;
+/** Default poll budget for MaaS subscription/policy phase checks (24 attempts × 5s ≈ 2 min). */
+export const MAAS_STATE_DEFAULT_MAX_ATTEMPTS = 24;
 export const MAAS_STATE_DEFAULT_RETRY_INTERVAL_MS = 5000;
 
 type MaaSOptionsCheckResult = { met: true } | { met: false; reason: string; retryable: boolean };
@@ -587,49 +587,70 @@ const authPolicyOptionsMet = (
 const shouldPollMaaSState = (options: CheckMaaSOptions): boolean =>
   !!(options.phase || options.models || options.groups);
 
-const getMaaSPollBudget = (
-  options: CheckMaaSOptions,
-  pollForState: boolean,
-): { maxAttempts: number; retryIntervalMs: number } => ({
-  maxAttempts: pollForState ? options.maxAttempts ?? MAAS_STATE_DEFAULT_MAX_ATTEMPTS : 1,
-  retryIntervalMs: options.retryIntervalMs ?? MAAS_STATE_DEFAULT_RETRY_INTERVAL_MS,
-});
+const getMaaSWaitTimeoutSeconds = (options: CheckMaaSOptions, pollForState: boolean): number => {
+  const maxAttempts = pollForState ? options.maxAttempts ?? MAAS_STATE_DEFAULT_MAX_ATTEMPTS : 1;
+  const retryIntervalMs = options.retryIntervalMs ?? MAAS_STATE_DEFAULT_RETRY_INTERVAL_MS;
+  return Math.max(1, Math.ceil((maxAttempts * retryIntervalMs) / 1000));
+};
+
+const waitForMaaSPhase = (
+  kind: string,
+  name: string,
+  namespace: string,
+  phase: string,
+  timeoutSeconds: number,
+): Cypress.Chainable<CommandLineResult> => {
+  const resource = `${kind}/${name}`;
+  const command = `oc wait --for=jsonpath='{.status.phase}'=${phase} ${resource} -n ${namespace} --timeout=${timeoutSeconds}s`;
+  cy.log(`⏳ oc wait ${resource} phase=${phase} (timeout ${timeoutSeconds}s)`);
+  return cy
+    .exec(command, { failOnNonZeroExit: false, timeout: (timeoutSeconds + 15) * 1000 })
+    .then((result) => {
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `${resource} in namespace ${namespace} did not reach phase ${phase}: ${
+            result.stderr || result.stdout
+          }`,
+        );
+      }
+      cy.log(`✅ ${resource} reached phase ${phase}`);
+      return cy.wrap(result);
+    });
+};
 
 const pollMaaSResourceState = <T>(
   resourceLabel: string,
+  kind: string,
+  name: string,
+  namespace: string,
   ocCommand: string,
   parseDoc: (stdout: string) => T,
   optionsMet: (doc: T, options: CheckMaaSOptions) => MaaSOptionsCheckResult,
   options: CheckMaaSOptions,
   pollForState: boolean,
 ): Cypress.Chainable<CommandLineResult> => {
-  const { maxAttempts, retryIntervalMs } = getMaaSPollBudget(options, pollForState);
-  let attempts = 0;
-
-  const checkState = (): Cypress.Chainable<CommandLineResult> =>
+  const getAndCheck = (): Cypress.Chainable<CommandLineResult> =>
     cy.exec(ocCommand, { failOnNonZeroExit: true }).then((result) => {
-      attempts++;
       const doc = parseDoc(result.stdout);
       const checkResult = optionsMet(doc, options);
-
-      if (checkResult.met) {
-        cy.log(`✅ ${resourceLabel} conditions met after ${attempts} attempt(s)`);
-        return cy.wrap(result);
+      if (!checkResult.met) {
+        throw new Error(`${resourceLabel} did not meet expected state. ${checkResult.reason}`);
       }
-
-      if (checkResult.retryable && attempts < maxAttempts) {
-        cy.log(
-          `⏳ ${resourceLabel}: ${checkResult.reason}, retrying in ${
-            retryIntervalMs / 1000
-          }s (attempt ${attempts}/${maxAttempts})`,
-        );
-        return cy.wait(retryIntervalMs).then(() => checkState());
-      }
-
-      throw new Error(`${resourceLabel} did not meet expected state. ${checkResult.reason}`);
+      cy.log(`✅ ${resourceLabel} conditions met`);
+      return cy.wrap(result);
     });
 
-  return checkState();
+  if (options.phase && pollForState) {
+    return waitForMaaSPhase(
+      kind,
+      name,
+      namespace,
+      options.phase,
+      getMaaSWaitTimeoutSeconds(options, pollForState),
+    ).then(() => getAndCheck());
+  }
+
+  return getAndCheck();
 };
 
 const getAuthPolicyGroupNames = (doc: MaaSAuthPolicyState): string[] => {
@@ -699,6 +720,9 @@ export const checkMaaSSubscriptionState = (
 
   return pollMaaSResourceState(
     resourceLabel,
+    'MaaSSubscription',
+    subscriptionName,
+    namespace,
     ocCommand,
     (stdout) => parseMaaSSubscriptionDoc(subscriptionName, stdout),
     subscriptionOptionsMet,
@@ -746,6 +770,9 @@ export const checkMaaSAuthPolicyState = (
 
   return pollMaaSResourceState(
     resourceLabel,
+    'MaaSAuthPolicy',
+    policyName,
+    namespace,
     ocCommand,
     (stdout) => parseMaaSAuthPolicyDoc(policyName, stdout),
     authPolicyOptionsMet,

--- a/packages/cypress/cypress/utils/urlValidator.ts
+++ b/packages/cypress/cypress/utils/urlValidator.ts
@@ -37,8 +37,8 @@ const maxRedirects = 5;
 
 // Tiered timeout strategy for different URL types
 const TIMEOUT_TIERS = {
-  INTERNAL: 5000, // Internal Red Hat domains (*.redhat.com, *.openshift.com)
-  NORMAL: 15000, // Most external URLs
+  INTERNAL: 10000, // Cluster-adjacent Red Hat domains (*.redhat.com, *.openshift.com)
+  NORMAL: 15000, // Most external URLs, including public docs CDNs
   SLOW: 30000, // Known slow services (catalogs, CDNs, etc.)
 };
 
@@ -49,6 +49,10 @@ const SLOW_DOMAINS = [
   'registry.redhat.io', // Red Hat registry - can be slow
 ];
 
+// Public CDN-backed docs hosts. These match INTERNAL_DOMAINS suffixes but are not
+// fast internal endpoints; CI 5s INTERNAL timeouts flake on docs.redhat.com.
+const EXTERNAL_REDHAT_DOMAINS = ['docs.redhat.com'];
+
 // Internal/fast domains
 const INTERNAL_DOMAINS = ['.redhat.com', '.openshift.com', 'redhat.com', 'openshift.com'];
 
@@ -57,6 +61,11 @@ const getTimeoutForUrl = (url: string): number => {
   // Check if it's a known slow domain
   if (SLOW_DOMAINS.some((domain) => url.includes(domain))) {
     return TIMEOUT_TIERS.SLOW;
+  }
+
+  // Public docs.redhat.com is a large external CDN, not an internal service
+  if (EXTERNAL_REDHAT_DOMAINS.some((domain) => url.includes(domain))) {
+    return TIMEOUT_TIERS.NORMAL;
   }
 
   // Check if it's an internal domain


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-93084

## Description
Harden two Cypress E2E flakes that fail in CI under load but pass on rerun. These are test timing gaps, not product regressions.

- **testManifestLinks.cy.ts:** `docs.redhat.com` was classified as an INTERNAL URL with a 5s timeout. Treat it as a normal external CDN (15s) and raise the remaining `*.redhat.com` / `*.openshift.com` INTERNAL timeout to 10s.
- **maas/testOverviewTab.cy.ts:** Auth-policy/subscription phase labels could still show Unknown when the 10s Cypress command timeout elapsed. Wait for `status.phase=Active` with `oc wait` (up to 2 minutes) before asserting Ready in the UI.

## How Has This Been Tested?
On cluster `dash-e2e-rhoai` with `CY_TEST_CONFIG=packages/cypress/test-variables.yml` (equivalent change; overview spec path is `modelsAsAService/` on the 3.6 branch and `maas/` here):

- `testManifestLinks.cy.ts` — 2 passing (59s); all 87 manifest URLs reachable, including docs.redhat.com.
- `testOverviewTab.cy.ts` — 1 passing (9m 41s); subscription and auth-policy CRs reached Active via `oc wait`, then UI Ready assertions succeeded.

<img width="1600" height="690" alt="image" src="https://github.com/user-attachments/assets/d6d0794a-f005-4da2-ae1e-f7922275ee37" />
<img width="1714" height="393" alt="image" src="https://github.com/user-attachments/assets/2ab96609-0714-48a7-b622-6747f272669f" />
/dashboard-e2e-tests/2754/Test_20Reports/

Lint-staged passed on commit (`eslint --max-warnings 0` on the changed files).

## Test Impact
No new specs. Existing E2E specs above were updated. Timeout-tier logic is Cypress-task-only and is covered by `testManifestLinks.cy.ts`.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)