### PR TITLE
Add tokenreview and access token fowarding to notebooks module

### DIFF
--- a/manifests/modules/notebooks/cluster-role.yaml
+++ b/manifests/modules/notebooks/cluster-role.yaml
@@ -63,3 +63,9 @@ rules:
       - create
     resources:
       - subjectaccessreviews
+  - apiGroups:
+      - authentication.k8s.io
+    verbs:
+      - create
+    resources:
+      - tokenreviews

--- a/manifests/modules/notebooks/deployment.yaml
+++ b/manifests/modules/notebooks/deployment.yaml
@@ -80,6 +80,13 @@ spec:
         - name: notebooks-ui
           image: notebooks-ui-image
           imagePullPolicy: Always
+          env:
+            - name: AUTH_METHOD
+              value: user_token
+            - name: AUTH_TOKEN_HEADER
+              value: x-forwarded-access-token
+            - name: AUTH_TOKEN_PREFIX
+              value: ""
           livenessProbe:
             httpGet:
               path: /api/v1/healthcheck


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-90228

Notebooks-ui's authorization model is authenticate → resolve user.Info{Name,Groups} → SAR pre-check (internal/auth/authorization.go, using the SA's own privileged client) → then perform the actual Workspace/WorkspaceKind/PVC read-write through a single shared, SA-privileged controller-runtime manager client set up once at startup — not a fresh per-request client scoped to the caller's own token. 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Solution: Add TokenReviews to notebooks role and headers in deployment

## How Has This Been Tested?

- Auth fix: Rebuilt and redeployed notebooks-ui with AUTH_METHOD=user_token, AUTH_TOKEN_HEADER=x-forwarded-access-token, AUTH_TOKEN_PREFIX="", and granted the tokenreviews RBAC permission the new authenticator requires. Confirmed via notebooks-ui pod logs that requests progressed from a hard 401 ("authentication is required to access this resource") to a SAR-based 403 ("authorization was denied for user \"ldap-user1\"") — proving identity is now correctly resolved via TokenReview off the header the dashboard proxy actually forwards.
- Namespace-propagation fixes: After granting the missing namespace-scoped RBAC, exercised the full create-workspace flow through the UI: Data Science Project → "Workbenches v2" tab → Create Workspace → attach/create volume modals. Confirmed the namespace now resolves correctly end-to-end (previously: WorkspaceForm's namespace was empty, VolumesAttachModal was stuck on a permanent loading spinner, and VolumesCreateModal's Create button 404'd — all three now work).
- Static checks: go build ./..., go vet ./..., gofmt -l . pass clean on the Go changes; tsc --noEmit and eslint pass clean on the frontend changes.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
