### PR TITLE
update node, npm, go versions in documentation

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -80,7 +80,7 @@ These packages export extensions but have **no** `module-federation` config. The
 
 A standalone Kubernetes operator that manages the full lifecycle of the Dashboard application. Co-located in the monorepo (not a separate repository) because the controller is tightly coupled to Dashboard frontend/backend versions and manifest layouts.
 
-- **Language**: Go 1.25+ with controller-runtime v0.23
+- **Language**: Go 1.26+ with controller-runtime v0.23
 - **CRD**: `Dashboard` (cluster-scoped, singleton `default-dashboard`) in group `dashboard.opendatahub.io`
 - **Key dependencies**: `odh-platform-utilities` (Tier 1 packages for manifest rendering, SSA deployment, platform detection, status conditions)
 - **CI**: `.github/workflows/dashboard-operator-tests.yml` — lint, build, test on `dashboard-operator/**` changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@ odh-dashboard/
 
 ## Development Requirements
 
-- **Node.js**: >= 22.0.0
-- **npm**: >= 10.0.0
-- **Go**: >= 1.26 (for packages with BFF), >= 1.25 (for dashboard-operator)
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0
+- **Go**: >= 1.26 (for packages with BFF and dashboard-operator; see each package's `go.mod`)
 
 ## Key Technologies
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ A dashboard for Open Data Hub components, featuring user flows to navigate and i
 
 Before you begin, ensure you have the following installed:
 
-- **Node.js**: >= 22.0.0
-- **npm**: >= 10.9.2
-- **Go**: >= 1.26 (for packages with Backend-for-Frontend services)
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0 (pinned in `package.json` `packageManager`)
+- **Go**: >= 1.26 (for packages with Backend-for-Frontend services; see each package's `go.mod`)
 
 For detailed development setup requirements, see [Dev setup & Requirements].
 

--- a/dashboard-operator/AGENTS.md
+++ b/dashboard-operator/AGENTS.md
@@ -55,7 +55,7 @@ dashboard-operator/
 
 ## Development Requirements
 
-- **Go**: >= 1.25 (see `go.mod` for exact toolchain version)
+- **Go**: >= 1.26 (see `go.mod` for exact toolchain version)
 - **controller-gen**: v0.17.2 (auto-installed by Makefile)
 - **golangci-lint**: v2.1.0 (auto-installed by Makefile)
 

--- a/distributions/core-bff/AGENTS.md
+++ b/distributions/core-bff/AGENTS.md
@@ -100,8 +100,8 @@ core-bff/
 
 ### Frontend
 
-- **Node.js**: >= 22.0.0
-- **npm**: >= 10.8.2
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0
 
 ### BFF
 
@@ -394,7 +394,7 @@ npm run test:contract:xks         # foundation + xks tests
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.25+** for the BFF and **Node 22+** for the frontend
+1. Use **Go 1.25+** for the BFF and **Node 22.18+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Use **PatternFly components** for all federated-mode UI
 4. Run tests before pushing:

--- a/distributions/core-bff/frontend/docs/dev-setup.md
+++ b/distributions/core-bff/frontend/docs/dev-setup.md
@@ -5,8 +5,8 @@
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `22.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,7 @@ These all share the same underlying proxy to an endpoint call, they just structu
 
 The Dashboard Module Controller (`dashboard-operator/`) is a standalone Kubernetes operator that manages the full lifecycle of the Dashboard application. It is co-located in the monorepo because the controller is tightly coupled to Dashboard frontend/backend versions and manifest layouts.
 
-- **Language**: Go 1.25+ with controller-runtime v0.23
+- **Language**: Go 1.26+ with controller-runtime v0.23
 - **CRD**: `Dashboard` (cluster-scoped, singleton) in group `components.platform.opendatahub.io`
 - **Key dependencies**: `odh-platform-utilities` for manifest rendering, SSA deployment, platform detection, status conditions
 - **Reconciliation**: Kustomize rendering -> SSA deploy -> URL extraction -> module dependency resolution -> status update

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -419,7 +419,7 @@ Each certificate includes DNS names for in-cluster service discovery:
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| Go | >= 1.25 | Build and test |
+| Go | >= 1.26 | Build and test |
 | controller-gen | (via Makefile) | CRD/RBAC generation from markers |
 | golangci-lint | v2 | Linting (downloaded by `make lint`) |
 | Helm | >= 3.x | Chart validation and local rendering |

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -5,8 +5,8 @@
 ODH requires the following to run:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `22.5.1`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 - [OpenShift CLI](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/cli_tools/openshift-cli-oc)
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) (if you need to do deployment)
 

--- a/docs/multi-agent-local.md
+++ b/docs/multi-agent-local.md
@@ -7,7 +7,7 @@ For foundational concepts (worktrees, conflict avoidance, best practices), see [
 ## Prerequisites
 
 - Claude Code CLI installed and authenticated
-- Node.js >= 22.0.0, npm >= 10.0.0
+- Node.js >= 22.18.0, npm 11.8.0
 - Git configured with remote access to the repository
 - Terminal emulator supporting split panes (built-in in most modern terminals)
 

--- a/packages/agent-ops/AGENTS.md
+++ b/packages/agent-ops/AGENTS.md
@@ -96,8 +96,8 @@ mod-arch-starter/
 
 ### Frontend
 
-- **Node.js**: >= 22.0.0
-- **npm**: >= 10.8.2
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0
 
 ### BFF
 
@@ -381,7 +381,7 @@ make test   # Run tests
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.24+** for the BFF and **Node 22+** for the frontend
+1. Use **Go 1.24+** for the BFF and **Node 22.18+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Stick to **PatternFly components** and utilities; Material UI appears only when Kubeflow flavor
    explicitly requires it

--- a/packages/agent-ops/frontend/docs/dev-setup.md
+++ b/packages/agent-ops/frontend/docs/dev-setup.md
@@ -5,8 +5,8 @@
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `22.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 

--- a/packages/automl/AGENTS.md
+++ b/packages/automl/AGENTS.md
@@ -93,8 +93,8 @@ mod-arch-starter/
 
 ### Frontend
 
-- **Node.js**: >= 22.0.0
-- **npm**: >= 10.8.2
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0
 
 ### BFF
 
@@ -371,7 +371,7 @@ make test   # Run tests
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.26+** for the BFF and **Node 22+** for the frontend
+1. Use **Go 1.26+** for the BFF and **Node 22.18+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Stick to **PatternFly components** and utilities; Material UI appears only when Kubeflow flavor explicitly requires it
 4. Run tests before pushing:

--- a/packages/automl/README.md
+++ b/packages/automl/README.md
@@ -30,7 +30,7 @@ For general ODH Dashboard contribution guidelines, refer to [ODH CONTRIBUTING.md
 
 ## Prerequisites
 
-- **[Node.js](https://nodejs.org/)**: v22.0.0 or later
+- **[Node.js](https://nodejs.org/)**: v22.18.0 or later
 - **[Go](https://go.dev/)**: v1.26 or later
 - **[Docker](https://www.docker.com/)**/**[Podman](https://podman.io/)**: For containerized deployment
 

--- a/packages/automl/frontend/docs/dev-setup.md
+++ b/packages/automl/frontend/docs/dev-setup.md
@@ -5,8 +5,8 @@
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `22.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 

--- a/packages/autorag/AGENTS.md
+++ b/packages/autorag/AGENTS.md
@@ -93,8 +93,8 @@ mod-arch-starter/
 
 ### Frontend
 
-- **Node.js**: >= 22.0.0
-- **npm**: >= 10.8.2
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0
 
 ### BFF
 
@@ -371,7 +371,7 @@ make test   # Run tests
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.26+** for the BFF and **Node 22+** for the frontend
+1. Use **Go 1.26+** for the BFF and **Node 22.18+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Stick to **PatternFly components** and utilities; Material UI appears only when Kubeflow flavor explicitly requires it
 4. Run tests before pushing:

--- a/packages/autorag/README.md
+++ b/packages/autorag/README.md
@@ -30,7 +30,7 @@ For general ODH Dashboard contribution guidelines, refer to [ODH CONTRIBUTING.md
 
 ## Prerequisites
 
-- **[Node.js](https://nodejs.org/)**: v22.0.0 or later
+- **[Node.js](https://nodejs.org/)**: v22.18.0 or later
 - **[Go](https://go.dev/)**: v1.26 or later
 - **[Docker](https://www.docker.com/)**/**[Podman](https://podman.io/)**: For containerized deployment
 

--- a/packages/autorag/frontend/docs/dev-setup.md
+++ b/packages/autorag/frontend/docs/dev-setup.md
@@ -5,8 +5,8 @@
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `22.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 

--- a/packages/autox-core/ui/package.json
+++ b/packages/autox-core/ui/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.18.0"
   },
   "scripts": {
     "test": "run-s test:lint test:type-check test:unit",

--- a/packages/data-registry/AGENTS.md
+++ b/packages/data-registry/AGENTS.md
@@ -97,8 +97,8 @@ mod-arch-starter/
 
 ### Frontend
 
-- **Node.js**: >= 22.0.0
-- **npm**: >= 10.8.2
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0
 
 ### BFF
 
@@ -397,7 +397,7 @@ make test   # Run tests
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.24+** for the BFF and **Node 22+** for the frontend
+1. Use **Go 1.24+** for the BFF and **Node 22.18+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Stick to **PatternFly components** and utilities; Material UI appears only when Kubeflow flavor
    explicitly requires it

--- a/packages/data-registry/frontend/docs/dev-setup.md
+++ b/packages/data-registry/frontend/docs/dev-setup.md
@@ -5,8 +5,8 @@
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `22.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 

--- a/packages/eval-hub/AGENTS.md
+++ b/packages/eval-hub/AGENTS.md
@@ -96,8 +96,8 @@ mod-arch-starter/
 
 ### Frontend
 
-- **Node.js**: >= 22.0.0
-- **npm**: >= 10.8.2
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0
 
 ### BFF
 
@@ -381,7 +381,7 @@ make test   # Run tests
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.26+** for the BFF and **Node 22+** for the frontend
+1. Use **Go 1.26+** for the BFF and **Node 22.18+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Stick to **PatternFly components** and utilities; Material UI appears only when Kubeflow flavor
    explicitly requires it

--- a/packages/eval-hub/frontend/docs/dev-setup.md
+++ b/packages/eval-hub/frontend/docs/dev-setup.md
@@ -5,8 +5,8 @@
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `22.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 

--- a/packages/feature-store/README.md
+++ b/packages/feature-store/README.md
@@ -47,7 +47,7 @@ No separate dev server is needed. Feature Store code is compiled into the host d
 
 ### Prerequisites
 
-- Node.js >= 22, npm >= 10
+- Node.js >= 22.18.0, npm 11.8.0
 - A cluster with a Feast service deployed (`FeatureStore` CR with label `feature-store-ui=enabled`)
 
 ### Running locally

--- a/packages/gen-ai/.claude/skills/cluster-deploy-genai/SKILL.md
+++ b/packages/gen-ai/.claude/skills/cluster-deploy-genai/SKILL.md
@@ -81,10 +81,10 @@ oc whoami --show-server
 # jq (required for JSON patching)
 jq --version
 
-# Go >= 1.24
+# Go >= 1.26
 go version
 
-# Node >= 22
+# Node >= 22.18.0
 node --version
 
 # npm deps installed (check for node_modules at repo root)

--- a/packages/gen-ai/README.md
+++ b/packages/gen-ai/README.md
@@ -22,7 +22,7 @@ This project is a web application built with a modular architecture. It consists
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) (v20 or later)
+- [Node.js](https://nodejs.org/) (v22.18.0 or later)
 - [Go](https://golang.org/) (v1.26 or later)
 - [Docker](https://www.docker.com/) (for containerized deployment)
 

--- a/packages/maas/AGENTS.md
+++ b/packages/maas/AGENTS.md
@@ -100,8 +100,8 @@ maas/
 
 ### Frontend
 
-- **Node.js**: >= 20.0.0
-- **npm**: >= 10.0.0
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0
 
 ### BFF
 
@@ -326,7 +326,7 @@ DEPLOYMENT_MODE=federated STYLE_THEME=patternfly-theme make dev-start
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.26+** for the BFF and **Node 20+** for the frontend
+1. Use **Go 1.26+** for the BFF and **Node 22.18+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Stick to **PatternFly components** and utilities; Material UI appears only when Kubeflow flavor
    explicitly requires it

--- a/packages/maas/frontend/docs/dev-setup.md
+++ b/packages/maas/frontend/docs/dev-setup.md
@@ -5,8 +5,8 @@
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `22.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 

--- a/packages/mlflow/AGENTS.md
+++ b/packages/mlflow/AGENTS.md
@@ -94,8 +94,8 @@ mlflow/
 
 ### Frontend
 
-- **Node.js**: >= 22.0.0
-- **npm**: >= 10.8.2
+- **Node.js**: >= 22.18.0
+- **npm**: 11.8.0
 
 ### BFF
 
@@ -408,7 +408,7 @@ make test   # Run tests
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.26+** for the BFF and **Node 22+** for the frontend
+1. Use **Go 1.26+** for the BFF and **Node 22.18+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Use **PatternFly components** for all federated-mode UI
 4. Run tests before pushing:

--- a/packages/mlflow/frontend/docs/dev-setup.md
+++ b/packages/mlflow/frontend/docs/dev-setup.md
@@ -5,8 +5,8 @@
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `22.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 

--- a/packages/model-registry/upstream/frontend/docs/dev-setup.md
+++ b/packages/model-registry/upstream/frontend/docs/dev-setup.md
@@ -5,8 +5,8 @@
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `20.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 

--- a/packages/notebooks/upstream/workspaces/frontend/README.md
+++ b/packages/notebooks/upstream/workspaces/frontend/README.md
@@ -13,8 +13,8 @@ The Kubeflow Workspaces Frontend is the web user interface used to monitor and m
 This project requires the following tools to be installed on your system:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `20.17.0`
-  - NPM recommended version -> `10.8.2`
+  - Node recommended version -> `22.18.0`
+  - NPM recommended version -> `11.8.0`
 
 ## Development
 


### PR DESCRIPTION
## Description

Documentation and one `engines` field were out of sync with the versions the monorepo actually enforces.

**Source of truth**
- **Node.js**: `>= 22.18.0` (`engines` in root `package.json`, `frontend/`, `backend/`, and most packages)
- **npm**: `11.8.0` (`packageManager` in root `package.json`; CI pins it via `.github/actions/module-caches`)
- **Go**: per-package `go.mod` (most BFFs `1.26`; `dashboard-operator` `1.26.5`; `core-bff` `1.25`; `agent-ops` / `data-registry` `1.24.3`)

**What was wrong**
- Root `README.md` listed Node `>= 22.0.0` and npm `>= 10.9.2`
- `AGENTS.md`, `docs/dev-setup.md`, package `AGENTS.md` files, and `*/docs/dev-setup.md` files still referenced Node 22.0 / 22.5 / 22.17 and npm 10.x
- `dashboard-operator` docs still said Go `>= 1.25` while `go.mod` is `1.26.5`
- `packages/maas/AGENTS.md` still listed Node `>= 20.0.0`
- `packages/autox-core/ui/package.json` had `engines.node: ">=22.0.0"` while the rest of the repo requires `>= 22.18.0`

**Why Node 22.18.0 (not 22.0)**
`@odh-dashboard/app-config` exports TypeScript source (no build step). Rspack/webpack configs `require('@odh-dashboard/app-config/rspack')` at Node runtime. Native type stripping is enabled by default starting in Node **22.18.0**; earlier 22.x releases need `--experimental-strip-types`. See `docs/module-federation.md`.

**Changes (32 files)**
- Updated root and package docs to Node `>= 22.18.0` and npm `11.8.0`
- Updated `dashboard-operator` / architecture docs to Go `>= 1.26`
- Left package-specific Go minimums where they differ (`core-bff` 1.25, `agent-ops` / `data-registry` 1.24.3)
- Aligned upstream vendored dev-setup docs (`model-registry`, `notebooks`) with their `package.json` engines
- Fixed `packages/autox-core/ui/package.json` `engines.node` to `>= 22.18.0`

No runtime, build, or CI behavior changes — documentation and one `engines` alignment only.

## How Has This Been Tested?

- Compared all updated values against root `package.json` (`engines`, `packageManager`), per-package `go.mod` files, and `.github/actions/module-caches` (npm pin).
- Verified `docs/module-federation.md` rationale for the Node 22.18 floor.
- No application code paths changed; no local `npm run dev` / build run required for doc-only updates.

## Test Impact

Not applicable — documentation and a single `engines` field update only. No new unit or Cypress tests.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- N/A — no UI changes

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
  - N/A — documentation-only change; cluster validation not required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated development prerequisites across the project to Node.js 22.18.0 or newer and npm 11.8.0.
  - Updated applicable Go requirements to Go 1.26 or newer.
  - Aligned package-specific setup, README, and deployment guidance with the updated tool versions.
  - Updated package support requirements to reflect the newer Node.js minimum.
  - Retained controller-runtime version 0.23 in architecture documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->