### PR TITLE
feat(eval-hub): display collection version metadata

### DIFF
--- a/packages/eval-hub/api/openapi/eval-hub.yaml
+++ b/packages/eval-hub/api/openapi/eval-hub.yaml
@@ -1335,6 +1335,26 @@ components:
         owner:
           type: string
           nullable: true
+        version_counter:
+          type: integer
+          nullable: true
+          description: Monotonic version counter for custom collections
+        state:
+          $ref: '#/components/schemas/CollectionState'
+
+    CollectionState:
+      type: object
+      description: Server-managed state present only for custom tenant collections
+      properties:
+        derived_from:
+          type: string
+          nullable: true
+        run_count:
+          type: integer
+          nullable: true
+        pinned_order:
+          type: integer
+          nullable: true
 
     CollectionPrimaryScore:
       type: object

--- a/packages/eval-hub/bff/internal/integrations/evalhub/evalhub_client.go
+++ b/packages/eval-hub/bff/internal/integrations/evalhub/evalhub_client.go
@@ -325,12 +325,21 @@ type Collection struct {
 
 // CollectionResource holds the resource metadata for a collection.
 type CollectionResource struct {
-	ID        string `json:"id"`
-	Tenant    string `json:"tenant,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
-	ReadOnly  bool   `json:"read_only,omitempty"`
-	Owner     string `json:"owner,omitempty"`
+	ID             string           `json:"id"`
+	Tenant         string           `json:"tenant,omitempty"`
+	CreatedAt      string           `json:"created_at,omitempty"`
+	UpdatedAt      string           `json:"updated_at,omitempty"`
+	ReadOnly       bool             `json:"read_only,omitempty"`
+	Owner          string           `json:"owner,omitempty"`
+	VersionCounter *int             `json:"version_counter,omitempty"`
+	State          *CollectionState `json:"state,omitempty"`
+}
+
+// CollectionState is present only for custom tenant collections.
+type CollectionState struct {
+	DerivedFrom string `json:"derived_from,omitempty"`
+	RunCount    int    `json:"run_count,omitempty"`
+	PinnedOrder int    `json:"pinned_order,omitempty"`
 }
 
 // CollectionBenchmark represents a BenchmarkConfig entry within a collection.

--- a/packages/eval-hub/bff/openapi/src/eval-hub.yaml
+++ b/packages/eval-hub/bff/openapi/src/eval-hub.yaml
@@ -1335,6 +1335,26 @@ components:
         owner:
           type: string
           nullable: true
+        version_counter:
+          type: integer
+          nullable: true
+          description: Monotonic version counter for custom collections
+        state:
+          $ref: '#/components/schemas/CollectionState'
+
+    CollectionState:
+      type: object
+      description: Server-managed state present only for custom tenant collections
+      properties:
+        derived_from:
+          type: string
+          nullable: true
+        run_count:
+          type: integer
+          nullable: true
+        pinned_order:
+          type: integer
+          nullable: true
 
     CollectionPrimaryScore:
       type: object

--- a/packages/eval-hub/frontend/src/__mocks__/mockCollection.ts
+++ b/packages/eval-hub/frontend/src/__mocks__/mockCollection.ts
@@ -9,6 +9,8 @@ type MockCollectionOptions = Partial<{
   tags: string[];
   benchmarkIds: string[];
   threshold: number;
+  versionCounter: number;
+  isCustom: boolean;
 }>;
 
 export const mockCollection = (options: MockCollectionOptions = {}): Collection => ({
@@ -16,6 +18,7 @@ export const mockCollection = (options: MockCollectionOptions = {}): Collection 
     id: options.id ?? 'collection-001',
     created_at: '2026-02-01T12:00:00Z',
     updated_at: '2026-02-01T12:00:00Z',
+    ...(options.isCustom ? { version_counter: options.versionCounter ?? 3, state: {} } : {}),
   },
   name: options.name ?? 'Safety Suite',
   category: options.category ?? 'Safety',

--- a/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/chooseCollection.cy.ts
+++ b/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/chooseCollection.cy.ts
@@ -62,9 +62,16 @@ const accuracySuite = mockCollection({
   benchmarkIds: ['truthfulqa_mc1'],
 });
 
+const customSuite = mockCollection({
+  id: 'col-custom',
+  name: 'Custom Suite',
+  category: 'Custom',
+  isCustom: true,
+});
+
 describe('Choose Collection Page', () => {
   beforeEach(() => {
-    initIntercepts({ collections: [safetySuite, reasoningSuite, accuracySuite] });
+    initIntercepts({ collections: [safetySuite, reasoningSuite, accuracySuite, customSuite] });
   });
 
   it('should display collection cards in the gallery', () => {
@@ -117,6 +124,21 @@ describe('Choose Collection Page', () => {
       .findByRole('button', { name: 'Close drawer panel' })
       .click();
     chooseCollectionPage.findCollectionDrawerPanel().should('not.exist');
+  });
+
+  it('should show version metadata for custom collections', () => {
+    chooseCollectionPage.visit(NAMESPACE);
+
+    chooseCollectionPage.findCollectionCard('col-custom').findByText('Custom Suite').click();
+
+    chooseCollectionPage
+      .findCollectionDrawerPanel()
+      .findByTestId('collection-version')
+      .should('contain.text', 'v3');
+    chooseCollectionPage
+      .findCollectionDrawerPanel()
+      .findByTestId('collection-last-modified')
+      .should('contain.text', '02/01/2026');
   });
 
   it('should navigate to start page when clicking "Select benchmark suite"', () => {

--- a/packages/eval-hub/frontend/src/app/components/CollectionDrawerPanel.tsx
+++ b/packages/eval-hub/frontend/src/app/components/CollectionDrawerPanel.tsx
@@ -4,6 +4,10 @@ import {
   Card,
   CardBody,
   Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
   DrawerActions,
   DrawerCloseButton,
   DrawerHead,
@@ -26,6 +30,7 @@ import {
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { Collection, ProviderAgentMetadata, ProviderBenchmark } from '~/app/types';
+import { formatDate } from '~/app/utilities/evaluationUtils';
 import BenchmarkDrawerTileContent from './BenchmarkDrawerTileContent';
 import SearchableMultiSelectFilter from './SearchableMultiSelectFilter';
 import { capitalizeFirst, getCategoryColor, getMetricDisplayName } from './benchmarkUtils';
@@ -119,6 +124,29 @@ const CollectionDrawerPanel: React.FC<CollectionDrawerPanelProps> = ({
           {collection.description && (
             <StackItem>
               <Content component="p">{collection.description}</Content>
+            </StackItem>
+          )}
+
+          {collection.resource.state && (
+            <StackItem>
+              <DescriptionList isHorizontal>
+                {collection.resource.version_counter != null && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Version</DescriptionListTerm>
+                    <DescriptionListDescription data-testid="collection-version">
+                      v{collection.resource.version_counter}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+                {collection.resource.updated_at && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Last modified</DescriptionListTerm>
+                    <DescriptionListDescription data-testid="collection-last-modified">
+                      {formatDate(collection.resource.updated_at)}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+              </DescriptionList>
             </StackItem>
           )}
 

--- a/packages/eval-hub/frontend/src/app/components/__tests__/CollectionDrawerPanel.spec.tsx
+++ b/packages/eval-hub/frontend/src/app/components/__tests__/CollectionDrawerPanel.spec.tsx
@@ -122,6 +122,35 @@ describe('CollectionDrawerPanel', () => {
     expect(screen.getByTestId('benchmark-search-input').querySelector('input')).toHaveValue('');
   });
 
+  it('should show version and last modified for custom collections', () => {
+    renderPanel({
+      collection: makeCollection({
+        resource: {
+          id: 'custom-collection',
+          state: {},
+          version_counter: 3,
+          updated_at: '2026-08-25T10:00:00Z',
+        },
+      }),
+      benchmarkDetailsMap: new Map(),
+    });
+
+    expect(screen.getByTestId('collection-version')).toHaveTextContent('v3');
+    expect(screen.getByTestId('collection-last-modified')).toHaveTextContent('08/25/2026');
+  });
+
+  it('should not show version or last modified for curated collections', () => {
+    renderPanel({
+      collection: makeCollection({
+        resource: { id: 'curated-collection', updated_at: '2026-08-25T10:00:00Z' },
+      }),
+      benchmarkDetailsMap: new Map(),
+    });
+
+    expect(screen.queryByTestId('collection-version')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('collection-last-modified')).not.toBeInTheDocument();
+  });
+
   it('should preserve search when the same collection remains open', () => {
     const detailsMap = new Map<string, BenchmarkWithProvider>([
       ['prov:bench-a', makeBenchmark('bench-a', 'prov', ['accuracy'])],

--- a/packages/eval-hub/frontend/src/app/types.ts
+++ b/packages/eval-hub/frontend/src/app/types.ts
@@ -274,6 +274,14 @@ export type CollectionResource = {
   updated_at?: string;
   read_only?: boolean;
   owner?: string;
+  version_counter?: number;
+  state?: CollectionState;
+};
+
+export type CollectionState = {
+  derived_from?: string;
+  run_count?: number;
+  pinned_order?: number;
 };
 
 export type CollectionPrimaryScore = {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAI-239
https://redhat.atlassian.net/browse/RHOAIENG-90973

## Description

Display version and last-modified metadata for custom EvalHub collections in the collection detail drawer.

The EvalHub API now exposes `resource.version_counter` and `resource.state` for tenant-scoped custom collections. This change:

- Documents the new collection resource fields in both EvalHub OpenAPI specs.
- Passes the fields through the EvalHub BFF and frontend models.
- Displays `v{version_counter}` and a formatted `updated_at` timestamp in `CollectionDrawerPanel` only when `resource.state` is present.
- Leaves curated collections unchanged because they do not include `resource.state`.

Pagination is already implemented on the base branch and is not changed by this PR.

## How Has This Been Tested?

From `packages/eval-hub/frontend`:

```bash
npm run test:unit -- --runInBand src/app/components/__tests__/CollectionDrawerPanel.spec.tsx
npm run test:type-check
npm run lint
npm run test:cypress-ci -- --spec "src/__tests__/cypress/cypress/tests/mocked/createFlow/chooseCollection.cy.ts"
```

From `packages/eval-hub/bff`:

```bash
go test ./internal/integrations/evalhub/... ./internal/api/...
```

From the repository root or `packages/eval-hub`:

```bash
npm run test:contract --prefix packages/eval-hub
```

Results:

- Collection drawer unit tests: 7 passed
- EvalHub collection Cypress spec: 18 passed, including pagination and custom metadata coverage
- EvalHub contract tests: 4 passed
- BFF Go tests: passed
- Frontend type-check: passed
- Frontend lint: passed

The Cypress build emitted only existing asset-size warnings. No cluster-based manual verification was performed.

## Test Impact

Added unit coverage for custom collection metadata visibility and curated collection omission. Added Cypress coverage that verifies version and last-modified metadata in the collection drawer. Existing collection gallery filtering and pagination tests continue to pass.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change. Automated Cypress coverage was run, but no screenshot was captured.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHAI-239]: https://redhat.atlassian.net/browse/RHAI-239
[RHOAIENG-90973]: https://redhat.atlassian.net/browse/RHOAIENG-90973
