### PR TITLE
Persist NIM wizard ServingRuntime edits

### DIFF
--- a/packages/cypress/cypress/pages/modelServing/NIMWizardFields.ts
+++ b/packages/cypress/cypress/pages/modelServing/NIMWizardFields.ts
@@ -54,4 +54,9 @@ export class NIMWizardFields extends SubComponentBase {
   findExistingPVCInput(): Cypress.Chainable<JQuery<HTMLInputElement>> {
     return this.findExistingPVCSelect().find('input');
   }
+
+  selectExistingPVC(name: string): void {
+    this.findExistingPVCInput().click();
+    cy.findByRole('option', { name }).click();
+  }
 }

--- a/packages/kserve/src/__tests__/deploy.spec.ts
+++ b/packages/kserve/src/__tests__/deploy.spec.ts
@@ -2,13 +2,14 @@ import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/f
 import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
 import { mockServingRuntimeK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockServingRuntimeK8sResource';
 import { deployKServeDeployment } from '../deploy';
-import { createServingRuntime } from '../deployServer';
+import { createServingRuntime, updateServingRuntime } from '../deployServer';
 import { deployInferenceService } from '../deployModel';
 import type { KServeDeployment } from '../types';
 
 jest.mock('../deployServer', () => ({
   ...jest.requireActual('../deployServer'),
   createServingRuntime: jest.fn(),
+  updateServingRuntime: jest.fn(),
 }));
 jest.mock('../deployModel', () => ({
   ...jest.requireActual('../deployModel'),
@@ -16,6 +17,7 @@ jest.mock('../deployModel', () => ({
 }));
 
 const mockCreateServingRuntime = jest.mocked(createServingRuntime);
+const mockUpdateServingRuntime = jest.mocked(updateServingRuntime);
 const mockDeployInferenceService = jest.mocked(deployInferenceService);
 
 const WIZARD_DATA = {
@@ -56,8 +58,47 @@ describe('deployKServeDeployment', () => {
     );
 
     expect(mockCreateServingRuntime).not.toHaveBeenCalled();
+    expect(mockUpdateServingRuntime).not.toHaveBeenCalled();
     expect(mockDeployInferenceService).toHaveBeenCalledTimes(1);
     expect(result.server).toBe(existingDeployment.server);
+  });
+
+  it('should update an existing serving runtime when explicitly requested', async () => {
+    const existingServer = mockServingRuntimeK8sResource({ name: 'existing-runtime' });
+    const updatedServer = {
+      ...existingServer,
+      spec: {
+        ...existingServer.spec,
+        containers: existingServer.spec.containers.map((container) => ({
+          ...container,
+          image: 'updated-image',
+        })),
+      },
+    };
+    mockUpdateServingRuntime.mockResolvedValue(updatedServer);
+
+    const result = await deployKServeDeployment(
+      WIZARD_DATA,
+      {},
+      'test-project',
+      {
+        modelServingPlatformId: 'kserve',
+        model: mockInferenceServiceK8sResource({}),
+        server: existingServer,
+      },
+      undefined,
+      existingServer,
+      undefined,
+      true,
+      undefined,
+      undefined,
+      undefined,
+      (deployment) => ({ ...deployment, server: updatedServer }),
+      true,
+    );
+
+    expect(mockUpdateServingRuntime).toHaveBeenCalledWith(updatedServer, { dryRun: true });
+    expect(result.server).toBe(updatedServer);
   });
 
   it('should create a serving runtime for a new deployment', async () => {

--- a/packages/kserve/src/__tests__/deploy.spec.ts
+++ b/packages/kserve/src/__tests__/deploy.spec.ts
@@ -63,6 +63,44 @@ describe('deployKServeDeployment', () => {
     expect(result.server).toBe(existingDeployment.server);
   });
 
+  it('should preserve the existing serving runtime template name when updating without a template name', async () => {
+    const existingServer = mockServingRuntimeK8sResource({
+      name: 'existing-runtime',
+      templateName: 'nim-template',
+    });
+
+    await deployKServeDeployment(
+      WIZARD_DATA,
+      {},
+      'test-project',
+      {
+        modelServingPlatformId: 'kserve',
+        model: mockInferenceServiceK8sResource({}),
+        server: existingServer,
+      },
+      undefined,
+      existingServer,
+      undefined,
+      true,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(mockUpdateServingRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          annotations: expect.objectContaining({
+            'opendatahub.io/template-name': 'nim-template',
+          }),
+        }),
+      }),
+      { dryRun: true },
+    );
+  });
+
   it('should update an existing serving runtime when explicitly requested', async () => {
     const existingServer = mockServingRuntimeK8sResource({ name: 'existing-runtime' });
     const updatedServer = {

--- a/packages/kserve/src/deploy.ts
+++ b/packages/kserve/src/deploy.ts
@@ -5,7 +5,7 @@ import type {
 import { DeploymentAssemblyFn } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
 import { setUpTokenAuth } from '@odh-dashboard/model-serving/concepts/auth';
 import { KServeDeployment } from './types';
-import { assembleServingRuntime, createServingRuntime } from './deployServer';
+import { assembleServingRuntime, createServingRuntime, updateServingRuntime } from './deployServer';
 import {
   assembleInferenceService,
   deployInferenceService,
@@ -26,6 +26,7 @@ export const deployKServeDeployment = async (
   overwrite?: boolean,
   initialWizardData?: InitialWizardFormData,
   applyFieldData?: DeploymentAssemblyFn<KServeDeployment>,
+  updateExistingServingRuntime?: boolean,
 ): Promise<KServeDeployment> => {
   const inferenceServiceData: CreatingInferenceServiceObject = {
     project: projectName,
@@ -70,11 +71,11 @@ export const deployKServeDeployment = async (
     assembledDeployment = applyFieldData(assembledDeployment);
   }
 
-  // Only newly assembled servers are created; editing leaves the existing runtime alone and
-  // updates the inference service only.
   let servingRuntimeResult = existingDeployment?.server;
   if (!servingRuntimeResult && assembledDeployment.server) {
     servingRuntimeResult = await createServingRuntime(assembledDeployment.server, { dryRun });
+  } else if (updateExistingServingRuntime && assembledDeployment.server) {
+    servingRuntimeResult = await updateServingRuntime(assembledDeployment.server, { dryRun });
   }
 
   const inferenceServiceResult = await deployInferenceService(

--- a/packages/kserve/src/deploy.ts
+++ b/packages/kserve/src/deploy.ts
@@ -62,7 +62,9 @@ export const deployKServeDeployment = async (
           name: wizardData.k8sNameDesc.data.k8sName.value,
           servingRuntime,
           scope: wizardData.modelServer?.data?.selection?.scope,
-          templateName: serverResourceTemplateName,
+          templateName:
+            serverResourceTemplateName ||
+            existingDeployment?.server?.metadata.annotations?.['opendatahub.io/template-name'],
         })
       : undefined,
   };

--- a/packages/kserve/src/deployServer.ts
+++ b/packages/kserve/src/deployServer.ts
@@ -6,7 +6,7 @@ import {
 import { ServingRuntimeModel } from '@odh-dashboard/internal/api/index';
 import { type InferenceServiceKind, ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
 import type { ModelServerSelectFieldData } from '@odh-dashboard/model-serving/shared/wizard-fields';
-import { k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sCreateResource, k8sUpdateResource } from '@openshift/dynamic-plugin-sdk-utils';
 import type { KServeDeployment } from './types';
 
 type CreatingServingRuntimeObject = {
@@ -51,6 +51,20 @@ export const createServingRuntime = (
     ),
   );
 };
+
+export const updateServingRuntime = (
+  servingRuntime: ServingRuntimeKind,
+  opts?: K8sAPIOptions,
+): Promise<ServingRuntimeKind> =>
+  k8sUpdateResource<ServingRuntimeKind>(
+    applyK8sAPIOptions(
+      {
+        model: ServingRuntimeModel,
+        resource: servingRuntime,
+      },
+      opts,
+    ),
+  );
 
 export const applyModelRuntime = (
   inferenceService: InferenceServiceKind,

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -490,8 +490,7 @@ describe('NIM Models Deployments', () => {
       .should('contain.text', 'Deploy the NIM image from an existing cluster storage');
     modelServingWizardEdit.nim.findExistingPVCInput().should('have.value', 'my-nim-wizard-pvc');
     modelServingWizardEdit.nim.findSubPathInput().should('have.value', 'arctic-embed-l');
-    modelServingWizardEdit.nim.findExistingPVCInput().click();
-    cy.findByRole('option', { name: 'updated-nim-wizard-pvc' }).click();
+    modelServingWizardEdit.nim.selectExistingPVC('updated-nim-wizard-pvc');
     modelServingWizardEdit.nim
       .findSubPathInput()
       .type('{selectall}updated-cache-path')
@@ -515,10 +514,16 @@ describe('NIM Models Deployments', () => {
     modelServingWizardEdit.findDeployButton().should('be.enabled').click();
 
     cy.wait('@updateServingRuntime').then((interception) => {
-      expect(interception.request.body.spec.volumes).to.deep.include({
-        persistentVolumeClaim: { claimName: 'updated-nim-wizard-pvc' },
-      });
-      expect(interception.request.body.spec.containers[0].volumeMounts).to.deep.include({
+      const pvcVolume = interception.request.body.spec.volumes.find(
+        (volume: { persistentVolumeClaim?: { claimName: string } }) =>
+          volume.persistentVolumeClaim?.claimName === 'updated-nim-wizard-pvc',
+      );
+      const cacheVolumeMount = interception.request.body.spec.containers[0].volumeMounts.find(
+        (volumeMount: { mountPath: string }) => volumeMount.mountPath === '/mnt/models/cache',
+      );
+
+      expect(pvcVolume?.persistentVolumeClaim?.claimName).to.equal('updated-nim-wizard-pvc');
+      expect(cacheVolumeMount).to.containSubset({
         mountPath: '/mnt/models/cache',
         subPath: 'updated-cache-path',
       });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -524,6 +524,7 @@ describe('NIM Models Deployments', () => {
 
       expect(pvcVolume?.persistentVolumeClaim?.claimName).to.equal('updated-nim-wizard-pvc');
       expect(cacheVolumeMount).to.containSubset({
+        name: 'updated-nim-wizard-pvc',
         mountPath: '/mnt/models/cache',
         subPath: 'updated-cache-path',
       });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -412,8 +412,25 @@ describe('NIM Models Deployments', () => {
     // The PVC must be in the fetched list for the existing-storage select to render its name
     cy.interceptK8sList(
       { model: PVCModel, ns: 'test-project' },
-      mockK8sResourceList([mockNimModelPVC({ name: 'my-nim-wizard-pvc' })]),
+      mockK8sResourceList([
+        mockNimModelPVC({ name: 'my-nim-wizard-pvc' }),
+        mockNimModelPVC({ name: 'updated-nim-wizard-pvc' }),
+      ]),
     );
+    cy.interceptK8s(
+      'PUT',
+      { model: ServingRuntimeModel, ns: 'test-project', name: 'test-name' },
+      mockNimServingRuntime({
+        image: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',
+        pvcName: 'updated-nim-wizard-pvc',
+        subPath: 'updated-cache-path',
+      }),
+    ).as('updateServingRuntime');
+    cy.interceptK8s(
+      'PUT',
+      { model: InferenceServiceModel, ns: 'test-project', name: 'test-name' },
+      mockNimInferenceService(),
+    ).as('updateInferenceService');
     // Auth is enabled by default on the NIM deployment (no enable-auth=false annotation), so the
     // token auth field reads the deployment's service-account token secret ("<deployment-name>-sa")
     // and prefills the existing service account name from the secret's display name.
@@ -473,6 +490,12 @@ describe('NIM Models Deployments', () => {
       .should('contain.text', 'Deploy the NIM image from an existing cluster storage');
     modelServingWizardEdit.nim.findExistingPVCInput().should('have.value', 'my-nim-wizard-pvc');
     modelServingWizardEdit.nim.findSubPathInput().should('have.value', 'arctic-embed-l');
+    modelServingWizardEdit.nim.findExistingPVCInput().click();
+    cy.findByRole('option', { name: 'updated-nim-wizard-pvc' }).click();
+    modelServingWizardEdit.nim
+      .findSubPathInput()
+      .type('{selectall}updated-cache-path')
+      .should('have.value', 'updated-cache-path');
 
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
 
@@ -489,6 +512,18 @@ describe('NIM Models Deployments', () => {
     modelServingWizardEdit.findEnvVariableName('0').should('have.value', 'CUSTOM_VAR');
     modelServingWizardEdit.findEnvVariableValue('0').should('have.value', 'custom-value');
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
+    modelServingWizardEdit.findDeployButton().should('be.enabled').click();
+
+    cy.wait('@updateServingRuntime').then((interception) => {
+      expect(interception.request.body.spec.volumes).to.deep.include({
+        persistentVolumeClaim: { claimName: 'updated-nim-wizard-pvc' },
+      });
+      expect(interception.request.body.spec.containers[0].volumeMounts).to.deep.include({
+        mountPath: '/mnt/models/cache',
+        subPath: 'updated-cache-path',
+      });
+    });
+    cy.wait('@updateInferenceService');
   });
 
   it('should NOT manage NIM PVCs in cluster storage tab NIM is disabled', () => {

--- a/packages/nim-serving/src/nimKServe/__tests__/deploy.spec.ts
+++ b/packages/nim-serving/src/nimKServe/__tests__/deploy.spec.ts
@@ -213,6 +213,7 @@ describe('deployNIMKServeDeployment', () => {
     );
 
     expect(getDeployedRuntime()).toBe(existingServer);
+    expect(mockDeployKServeDeployment.mock.calls[0][12]).toBe(true);
     expect(mockGetNIMAccount).not.toHaveBeenCalled();
   });
 

--- a/packages/nim-serving/src/nimKServe/deploy.ts
+++ b/packages/nim-serving/src/nimKServe/deploy.ts
@@ -88,5 +88,6 @@ export const deployNIMKServeDeployment = async (
     overwrite,
     initialWizardData,
     applyFieldData,
+    true,
   );
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-90939

## Description

When the NIM deployment wizard edits an existing KServe deployment, it now updates the associated `ServingRuntime` after applying wizard field data. This persists NIM cache PVC and subpath changes that are stored on the `ServingRuntime`.

The generic KServe deployment path retains its current behavior unless a caller explicitly opts in. The NIM KServe deploy wrapper owns that opt-in, so other KServe-based deployments do not begin updating existing `ServingRuntime` resources.

## How Has This Been Tested?

- Ran `npm run test-unit --workspace=@odh-dashboard/kserve -- --runInBand` — 105 tests passed.
- Ran `npm run test-unit --workspace=@odh-dashboard/nim-serving -- --runInBand` — 251 tests passed.
- Ran `npm run type-check`.
- Ran `npm run lint`.
- Ran `npm run test:cypress-ci --prefix frontend -- --spec '../packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts'` — 7 tests passed.
- Manually tested the NIM wizard with `nimWizard=true` in the `mturley-nim` project: updated the cache subpath of `test-new-nim`, saved, reopened the wizard to confirm the value was prefilled, and verified the persisted `ServingRuntime` volume mount through `oc`.

## Test Impact

- Added KServe unit coverage for the default no-update behavior and the explicit existing-`ServingRuntime` update path.
- Added NIM KServe unit coverage confirming the NIM wrapper opts in to the update path.
- Extended the mocked NIM wizard Cypress edit test to change cache PVC and subpath, then assert the `ServingRuntime` update request contains the new values.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Editing an existing NIM deployment now correctly updates its serving runtime when requested.
  - Persistent volume claim and cache subpath changes are now applied during deployment edits.
  - Existing serving runtimes and their templates are preserved when no runtime update is requested.

- **Improvements**
  - The deployment wizard now supports selecting an existing persistent volume claim during edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->