### PR TITLE
fix(e2e): log in as cluster admin for model deployment general settings

### DIFF
--- a/packages/cypress/cypress/tests/e2e/settings/modelDeploymentSettings/testDeploymentGeneralSettings.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/modelDeploymentSettings/testDeploymentGeneralSettings.cy.ts
@@ -1,4 +1,4 @@
-import { LDAP_CONTRIBUTOR_USER, LDAP_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
+import { LDAP_CONTRIBUTOR_USER, HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { generalSettingsPage } from '../../../../pages/modelDeploymentSettings/generalSettings';
 import { pageNotfound } from '../../../../pages/pageNotFound';
 import type { DashboardConfig } from '../../../../types';
@@ -30,7 +30,7 @@ describe('Verify Model Deployment General Settings access and model-serving cont
     },
     () => {
       cy.step('Log into the application as admin');
-      cy.visitWithLogin('/', LDAP_CLUSTER_ADMIN_USER);
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
 
       // Validate the model-serving platform switch on the General settings tab based on the
       // OpenShift 'get OdhDashboardConfig' configuration. validateModelServingPlatforms


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->

## Description
`testDeploymentGeneralSettings.cy.ts` was split out of Cluster Settings in #9378 and kept `LDAP_CLUSTER_ADMIN_USER` for the admin case. That Cypress alias maps to `TEST_USER_5` (`ldap-user10`), a regular `rhods-users` member.

The original Cluster Settings spec still works because it **creates a `cluster-admin` ClusterRoleBinding** for that user in `before` and removes it in `after`. The new spec never did that grant, so on ROSA/OSD (and any cluster where `ldap-user10` is not already an admin) the Model deployment settings page is gated by `ADMIN_USER` and Cypress sees the in-app 404 (`We can't find that page`) instead of `app-tab-page-title`.

This spec is not testing “promote a non-admin to cluster-admin.” It only needs a real admin to assert the model-serving switch against `OdhDashboardConfig`, and a contributor for the no-access case. Log in as `HTPASSWD_CLUSTER_ADMIN_USER` for the admin test, matching other settings specs. Leave the contributor case on `LDAP_CONTRIBUTOR_USER`.

## How Has This Been Tested?
Cypress E2E, Chrome headless, `CY_TEST_CONFIG=packages/cypress/test-variables.yml`:

- ROSA/AWS `mt-aws-1508-pool-qg7sk` — 2 passing (this was the failing cluster)
- PSI `dash-e2e-rhoai` — 2 passing (same result)

Admin test: switch is checked (KServe enabled). Contributor test: 404 and no nav item.

`packages/cypress` type-check and eslint on the spec passed.

## Test Impact
Updated existing Cypress E2E spec only. No product UI change.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the admin deployment settings test to use the configured HTPASSWD cluster administrator credentials.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->