### PR TITLE
feat(gpuaas): add cluster queue workloads table to Quota usage

### DIFF
--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -173,6 +173,38 @@ class InfrastructurePage {
     return cy.findByTestId('quota-usage-expand-all');
   }
 
+  findQuotaUsageWorkloadsSection() {
+    return cy.findByTestId('quota-usage-workloads-section');
+  }
+
+  findClusterQueueWorkloadsTable() {
+    return cy.findByTestId('cluster-queue-workloads-table');
+  }
+
+  findClusterQueueWorkloadsEmptyState() {
+    return cy.findByTestId('cluster-queue-workloads-empty-state');
+  }
+
+  findClusterQueueWorkloadsLoading() {
+    return cy.findByTestId('cluster-queue-workloads-loading');
+  }
+
+  findClusterQueueWorkloadsError() {
+    return cy.findByTestId('cluster-queue-workloads-error');
+  }
+
+  findClusterQueueWorkloadRow(namespace: string, name: string) {
+    return cy.findByTestId(`cluster-queue-workload-row-${namespace}-${name}`);
+  }
+
+  findClusterQueueWorkloadsNameFilter() {
+    return cy.findByTestId('cluster-queue-workloads-name-filter');
+  }
+
+  findClusterQueueWorkloadsStatusFilter() {
+    return cy.findByTestId('cluster-queue-workloads-status-filter');
+  }
+
   findOpenPopover() {
     return cy.findByRole('dialog');
   }

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -5,9 +5,20 @@ import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sRe
 import { mockClusterQueueK8sResource } from '@odh-dashboard/internal/__mocks__/mockClusterQueueK8sResource';
 import { mockCohortK8sResource } from '@odh-dashboard/internal/__mocks__/mockCohortK8sResource';
 import { mockResourceFlavorK8sResource } from '@odh-dashboard/internal/__mocks__/mockResourceFlavorK8sResource';
+import { mockLocalQueueK8sResource } from '@odh-dashboard/internal/__mocks__/mockLocalQueueK8sResource';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { mockWorkloadK8sResource } from '@odh-dashboard/internal/__mocks__/mockWorkloadK8sResource';
+import { WorkloadStatusType } from '@odh-dashboard/internal/concepts/distributedWorkloads/utils';
+import type { WorkloadKind, WorkloadPodSet } from '@odh-dashboard/k8s-core';
+import { WorkloadOwnerType } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
-import { ClusterQueueModel } from '@odh-dashboard/k8s-core/api/models';
-import { CohortModel, ResourceFlavorModel } from '../../../utils/models';
+import {
+  ClusterQueueModel,
+  LocalQueueModel,
+  WorkloadModel,
+} from '@odh-dashboard/k8s-core/api/models';
+import { CohortModel, PodModel, ProjectModel, ResourceFlavorModel } from '../../../utils/models';
+import { getK8sAPIResourceURL } from '../../../utils/k8s';
 import { asClusterAdminUser, asProjectAdminUser } from '../../../utils/mockUsers';
 import { infrastructurePage } from '../../../pages/infrastructure';
 
@@ -503,6 +514,207 @@ describe('GPUaaS Infrastructure Page', () => {
       infrastructurePage.findQuotaUsageNavSearch().type('prod-serving');
       infrastructurePage.findQuotaUsageTreeNode('prod-serving').should('exist');
       infrastructurePage.findQuotaUsageTreeNode('legacy-batch').should('not.exist');
+    });
+  });
+
+  describe('Cluster queue workloads section', () => {
+    const PROJECT_D = 'project-d';
+    const CLUSTER_QUEUE = 'burst-training';
+    const LOCAL_QUEUE = 'large-model-jobs';
+    const COHORT = 'ml-training';
+
+    const gpuPodSet: WorkloadPodSet = {
+      count: 1,
+      name: 'main',
+      template: {
+        metadata: {},
+        spec: {
+          containers: [
+            {
+              name: 'main',
+              image: 'test-image',
+              env: [],
+              resources: { requests: { 'nvidia.com/gpu': '2' } },
+            },
+          ],
+        },
+      },
+    };
+
+    const makeGpuWorkload = (name: string, mockStatus: WorkloadStatusType): WorkloadKind => ({
+      ...mockWorkloadK8sResource({
+        k8sName: name,
+        namespace: PROJECT_D,
+        ownerName: `${name}-owner`,
+        ownerKind: WorkloadOwnerType.Job,
+        mockStatus,
+        podSets: [gpuPodSet],
+      }),
+      spec: {
+        ...mockWorkloadK8sResource({
+          k8sName: name,
+          namespace: PROJECT_D,
+          mockStatus,
+          podSets: [gpuPodSet],
+        }).spec,
+        queueName: LOCAL_QUEUE,
+      },
+    });
+
+    const pendingWorkload = makeGpuWorkload('llm-pretrain-run', WorkloadStatusType.Pending);
+    const inadmissibleWorkload = makeGpuWorkload(
+      'multimodal-trial',
+      WorkloadStatusType.Inadmissible,
+    );
+
+    const initWorkloadIntercepts = ({
+      workloads = [pendingWorkload, inadmissibleWorkload],
+      workloadListError = false,
+    }: {
+      workloads?: WorkloadKind[];
+      workloadListError?: boolean;
+    } = {}) => {
+      initIntercepts({
+        clusterQueues: [
+          {
+            name: CLUSTER_QUEUE,
+            cohortName: COHORT,
+            gpuFlavorName: 'a100-flavor',
+            gpuNominalQuota: 8,
+          },
+        ],
+        cohortNames: ['research', { name: COHORT, parentName: 'research' }],
+        resourceFlavors: [{ name: 'a100-flavor', gpuProduct: 'NVIDIA A100' }],
+      });
+
+      cy.interceptK8sList(
+        ProjectModel,
+        mockK8sResourceList([
+          mockProjectK8sResource({
+            k8sName: PROJECT_D,
+            displayName: 'Project-D',
+            enableKueue: true,
+          }),
+        ]),
+      );
+
+      cy.interceptK8sList({ model: PodModel, ns: PROJECT_D }, mockK8sResourceList([]));
+
+      const projectDLocalQueue = {
+        ...mockLocalQueueK8sResource({
+          name: LOCAL_QUEUE,
+          namespace: PROJECT_D,
+        }),
+        spec: { clusterQueue: CLUSTER_QUEUE },
+      };
+
+      // Cluster-wide LocalQueue index (listAllLocalQueues). interceptK8sList infers ns from mock
+      // items and would register a namespaced path; listAllLocalQueues is cluster-scoped.
+      cy.intercept(
+        'GET',
+        getK8sAPIResourceURL(LocalQueueModel),
+        mockK8sResourceList([projectDLocalQueue]),
+      );
+
+      cy.interceptK8sList(
+        { model: LocalQueueModel, ns: PROJECT_D },
+        mockK8sResourceList([projectDLocalQueue]),
+      );
+
+      if (workloadListError) {
+        cy.interceptK8sList({ model: WorkloadModel, ns: PROJECT_D }, { statusCode: 500 });
+      } else {
+        cy.interceptK8sList(
+          { model: WorkloadModel, ns: PROJECT_D },
+          mockK8sResourceList(workloads),
+        );
+      }
+
+      cy.intercept(
+        'GET',
+        `/api/k8s/apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/${PROJECT_D}/localqueues/${LOCAL_QUEUE}/pendingworkloads`,
+        {
+          kind: 'PendingWorkloadsSummary',
+          apiVersion: 'visibility.kueue.x-k8s.io/v1beta2',
+          metadata: {},
+          items: [
+            {
+              metadata: { name: 'llm-pretrain-run', namespace: PROJECT_D },
+              priority: 0,
+              localQueueName: LOCAL_QUEUE,
+              positionInClusterQueue: 0,
+              positionInLocalQueue: 0,
+            },
+          ],
+        },
+      );
+    };
+
+    beforeEach(() => {
+      asClusterAdminUser();
+    });
+
+    it('should not show workloads section when a cohort is selected', () => {
+      initWorkloadIntercepts();
+      infrastructurePage.visit();
+      infrastructurePage.switchToQuotaUsageTab();
+      infrastructurePage.findQuotaUsageTreeNode(COHORT).click();
+      infrastructurePage.findQuotaUsageDetailTitle().should('contain.text', COHORT);
+      infrastructurePage.findQuotaUsageWorkloadsSection().should('not.exist');
+    });
+
+    it('should show workloads table when a cluster queue is selected', () => {
+      initWorkloadIntercepts();
+      infrastructurePage.visit();
+      infrastructurePage.switchToQuotaUsageTab();
+      infrastructurePage.findQuotaUsageTreeNode(CLUSTER_QUEUE).click();
+      infrastructurePage.findQuotaUsageWorkloadsSection().should('exist');
+      infrastructurePage.findClusterQueueWorkloadsTable().should('exist');
+      infrastructurePage
+        .findClusterQueueWorkloadRow(PROJECT_D, 'llm-pretrain-run')
+        .should('contain.text', 'Project-D')
+        .and('contain.text', 'Queued')
+        .and('contain.text', '1st');
+      infrastructurePage
+        .findClusterQueueWorkloadRow(PROJECT_D, 'multimodal-trial')
+        .should('contain.text', 'Inadmissible')
+        .and('contain.text', '--');
+    });
+
+    it('should show empty state when the cluster queue has no workloads', () => {
+      initWorkloadIntercepts({ workloads: [] });
+      infrastructurePage.visit();
+      infrastructurePage.switchToQuotaUsageTab();
+      infrastructurePage.findQuotaUsageTreeNode(CLUSTER_QUEUE).click();
+      infrastructurePage.findClusterQueueWorkloadsEmptyState().should('exist');
+      infrastructurePage.findClusterQueueWorkloadsTable().should('not.exist');
+    });
+
+    it('should filter workloads by name and status', () => {
+      initWorkloadIntercepts();
+      infrastructurePage.visit();
+      infrastructurePage.switchToQuotaUsageTab();
+      infrastructurePage.findQuotaUsageTreeNode(CLUSTER_QUEUE).click();
+      infrastructurePage.findClusterQueueWorkloadsNameFilter().type('llm-pretrain');
+      infrastructurePage.findClusterQueueWorkloadRow(PROJECT_D, 'llm-pretrain-run').should('exist');
+      infrastructurePage
+        .findClusterQueueWorkloadRow(PROJECT_D, 'multimodal-trial')
+        .should('not.exist');
+      infrastructurePage.findClusterQueueWorkloadsNameFilter().clear();
+      infrastructurePage.findClusterQueueWorkloadsStatusFilter().click();
+      cy.findByRole('option', { name: 'Queued' }).click();
+      infrastructurePage.findClusterQueueWorkloadRow(PROJECT_D, 'llm-pretrain-run').should('exist');
+      infrastructurePage
+        .findClusterQueueWorkloadRow(PROJECT_D, 'multimodal-trial')
+        .should('not.exist');
+    });
+
+    it('should show an error when namespace workload data fails to load', () => {
+      initWorkloadIntercepts({ workloadListError: true });
+      infrastructurePage.visit();
+      infrastructurePage.switchToQuotaUsageTab();
+      infrastructurePage.findQuotaUsageTreeNode(CLUSTER_QUEUE).click();
+      infrastructurePage.findClusterQueueWorkloadsError().should('exist');
     });
   });
 });

--- a/packages/gpuaas/src/components/QuotaUsageSection.scss
+++ b/packages/gpuaas/src/components/QuotaUsageSection.scss
@@ -5,3 +5,32 @@
     --pf-v6-c-tree-view__list-item--m-expanded__node-toggle-icon--Rotate: 0deg;
   }
 }
+
+// Quota usage detail sections (Summary, Accelerator usage, Workloads). PF ExpandableSection
+// renders the toggle as a link Button — match prototype heading text (see DashboardExpandableSection).
+.gpuaas-quota-usage-detail-section > .pf-v6-c-expandable-section__toggle > .pf-v6-c-button {
+  --pf-v6-c-button--m-link--Color: var(--pf-t--global--text--color--regular);
+  --pf-v6-c-button--m-link--hover--Color: var(--pf-t--global--text--color--regular);
+  --pf-v6-c-button--m-link--m-clicked--Color: var(--pf-t--global--text--color--regular);
+  --pf-v6-c-button--m-link__icon--Color: var(--pf-t--global--icon--color--regular);
+  --pf-v6-c-button--m-link--hover__icon--Color: var(--pf-t--global--icon--color--regular);
+  --pf-v6-c-button--m-link--m-clicked__icon--Color: var(--pf-t--global--icon--color--regular);
+
+  font-size: var(--pf-t--global--font--size--heading--h4) !important;
+  font-weight: var(--pf-t--global--font--weight--heading--default) !important;
+  color: var(--pf-t--global--text--color--regular) !important;
+  text-decoration: none !important;
+}
+
+.gpuaas-quota-usage-detail-section > .pf-v6-c-expandable-section__toggle > .pf-v6-c-button:hover,
+.gpuaas-quota-usage-detail-section > .pf-v6-c-expandable-section__toggle > .pf-v6-c-button:focus-visible {
+  color: var(--pf-t--global--text--color--regular) !important;
+  text-decoration: none !important;
+}
+
+.gpuaas-quota-usage-detail-section
+  > .pf-v6-c-expandable-section__toggle
+  > .pf-v6-c-button
+  .pf-v6-c-expandable-section__toggle-icon {
+  color: var(--pf-t--global--icon--color--regular) !important;
+}

--- a/packages/gpuaas/src/components/QuotaUsageSection.tsx
+++ b/packages/gpuaas/src/components/QuotaUsageSection.tsx
@@ -14,6 +14,9 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 import QuotaUsageDetailPanel from './quotaUsage/QuotaUsageDetailPanel';
 import QuotaUsageNavPanel from './quotaUsage/QuotaUsageNavPanel';
+import KueueNamespaceWorkloadCacheProvider, {
+  useKueueNamespaceWorkloadCache,
+} from '../hooks/KueueNamespaceWorkloadCacheContext';
 import './QuotaUsageSection.scss';
 import {
   QUOTA_USAGE_EMPTY_BODY,
@@ -33,9 +36,29 @@ type QuotaUsageSectionProps = {
   tree: QuotaTreeNode[];
   loaded: boolean;
   error?: Error;
+  onRegisterWorkloadRefresh?: (refresh: (() => Promise<unknown>) | undefined) => void;
 };
 
-const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({ tree, loaded, error }) => {
+/** Registers workload-cache manual refresh with the Quota usage section refresh badge. */
+const QuotaUsageWorkloadRefreshBridge: React.FC<{
+  onRegister?: QuotaUsageSectionProps['onRegisterWorkloadRefresh'];
+}> = ({ onRegister }) => {
+  const { refresh } = useKueueNamespaceWorkloadCache();
+
+  React.useEffect(() => {
+    onRegister?.(refresh);
+    return () => onRegister?.(undefined);
+  }, [onRegister, refresh]);
+
+  return null;
+};
+
+const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({
+  tree,
+  loaded,
+  error,
+  onRegisterWorkloadRefresh,
+}) => {
   const [selection, setSelection] = React.useState<QuotaSelection | undefined>();
 
   React.useEffect(() => {
@@ -83,41 +106,46 @@ const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({ tree, loaded, err
   }
 
   return (
-    <Flex
-      direction={{ default: 'column' }}
-      grow={{ default: 'grow' }}
-      className="gpuaas-quota-usage-section"
-      data-testid="quota-usage-section"
+    <KueueNamespaceWorkloadCacheProvider
+      clusterQueueNames={selection?.type === 'clusterQueue' ? [selection.clusterQueueName] : []}
     >
-      <Drawer isExpanded isInline>
-        <DrawerContent
-          panelContent={
-            <DrawerPanelContent
-              id={QUOTA_USAGE_TREE_DRAWER_PANEL_ID}
-              isResizable
-              defaultSize="75%"
-              minSize="60%"
-              maxSize="85%"
-              data-testid="quota-usage-detail-drawer"
-            >
-              <QuotaUsageDetailPanel
+      <QuotaUsageWorkloadRefreshBridge onRegister={onRegisterWorkloadRefresh} />
+      <Flex
+        direction={{ default: 'column' }}
+        grow={{ default: 'grow' }}
+        className="gpuaas-quota-usage-section"
+        data-testid="quota-usage-section"
+      >
+        <Drawer isExpanded isInline>
+          <DrawerContent
+            panelContent={
+              <DrawerPanelContent
+                id={QUOTA_USAGE_TREE_DRAWER_PANEL_ID}
+                isResizable
+                defaultSize="75%"
+                minSize="60%"
+                maxSize="85%"
+                data-testid="quota-usage-detail-drawer"
+              >
+                <QuotaUsageDetailPanel
+                  tree={tree}
+                  selection={selection}
+                  onSelectionChange={setSelection}
+                />
+              </DrawerPanelContent>
+            }
+          >
+            <DrawerContentBody style={drawerNavBodyStyle}>
+              <QuotaUsageNavPanel
                 tree={tree}
                 selection={selection}
                 onSelectionChange={setSelection}
               />
-            </DrawerPanelContent>
-          }
-        >
-          <DrawerContentBody style={drawerNavBodyStyle}>
-            <QuotaUsageNavPanel
-              tree={tree}
-              selection={selection}
-              onSelectionChange={setSelection}
-            />
-          </DrawerContentBody>
-        </DrawerContent>
-      </Drawer>
-    </Flex>
+            </DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
+      </Flex>
+    </KueueNamespaceWorkloadCacheProvider>
   );
 };
 

--- a/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadStatusLabel.scss
+++ b/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadStatusLabel.scss
@@ -1,0 +1,3 @@
+.gpuaas-cluster-queue-workload-status-label {
+  width: fit-content;
+}

--- a/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadStatusLabel.tsx
+++ b/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadStatusLabel.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Label } from '@patternfly/react-core';
+import { getQuotaUsageWorkloadStatusLabelSettings } from '../../utils/clusterQueueWorkloadStatusLabelUtils';
+import type { QuotaUsageWorkloadStatus } from '../../types';
+import './ClusterQueueWorkloadStatusLabel.scss';
+
+type ClusterQueueWorkloadStatusLabelProps = {
+  status: QuotaUsageWorkloadStatus;
+};
+
+/** Non-interactive status badge for the Quota usage workloads table. */
+const ClusterQueueWorkloadStatusLabel: React.FC<ClusterQueueWorkloadStatusLabelProps> = ({
+  status,
+}) => {
+  const labelSettings = getQuotaUsageWorkloadStatusLabelSettings(status);
+
+  return (
+    <Label
+      className="gpuaas-cluster-queue-workload-status-label"
+      variant="filled"
+      isCompact
+      color={labelSettings.color}
+      status={labelSettings.status}
+      icon={labelSettings.icon}
+      data-testid="cluster-queue-workload-status-label"
+    >
+      {labelSettings.label}
+    </Label>
+  );
+};
+
+export default ClusterQueueWorkloadStatusLabel;

--- a/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadTableRow.tsx
+++ b/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadTableRow.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable @odh-dashboard/no-restricted-imports */
+import * as React from 'react';
+import { Tr, Td } from '@patternfly/react-table';
+import { Content, ContentVariants } from '@patternfly/react-core';
+/* eslint-enable @odh-dashboard/no-restricted-imports */
+import { toOrdinal } from '@odh-dashboard/k8s-core/kueue/messageUtils';
+import ClusterQueueWorkloadStatusLabel from './ClusterQueueWorkloadStatusLabel';
+import { QUOTA_USAGE_STATUSES_PAST_ADMISSION, type ClusterQueueWorkloadRow } from '../../types';
+
+const UNAVAILABLE_VALUE = '--';
+
+const formatAccelerators = (count: number): string => (count === 1 ? '1 GPU' : `${count} GPUs`);
+
+const formatQueuePosition = (
+  position: number | undefined,
+  status: ClusterQueueWorkloadRow['status'],
+): string => {
+  if (QUOTA_USAGE_STATUSES_PAST_ADMISSION.includes(status) || position == null) {
+    return UNAVAILABLE_VALUE;
+  }
+  return toOrdinal(position);
+};
+
+const formatOptionalValue = (value: string | undefined): string => value ?? UNAVAILABLE_VALUE;
+
+const HardwareProfileCell: React.FC<{
+  hardwareProfile: string | undefined;
+  hardwareProfileResourceType: string | undefined;
+}> = ({ hardwareProfile, hardwareProfileResourceType }) => {
+  if (!hardwareProfile) {
+    return <>{UNAVAILABLE_VALUE}</>;
+  }
+  return (
+    <>
+      <Content component={ContentVariants.p}>{hardwareProfile}</Content>
+      {hardwareProfileResourceType && (
+        <Content component={ContentVariants.small}>{hardwareProfileResourceType}</Content>
+      )}
+    </>
+  );
+};
+
+type ClusterQueueWorkloadTableRowProps = {
+  workload: ClusterQueueWorkloadRow;
+  showClusterQueue?: boolean;
+};
+
+const ClusterQueueWorkloadTableRow: React.FC<ClusterQueueWorkloadTableRowProps> = ({
+  workload,
+  showClusterQueue = false,
+}) => (
+  <Tr
+    key={`${workload.namespace}/${workload.name}`}
+    data-testid={`cluster-queue-workload-row-${workload.namespace}-${workload.name}`}
+  >
+    {showClusterQueue && <Td dataLabel="Cluster queue">{workload.clusterQueue}</Td>}
+    <Td dataLabel="Name">{workload.name}</Td>
+    <Td dataLabel="Project">{workload.project}</Td>
+    <Td dataLabel="Type">{workload.type}</Td>
+    <Td dataLabel="Status">
+      <ClusterQueueWorkloadStatusLabel status={workload.status} />
+    </Td>
+    <Td dataLabel="Local queue">{workload.localQueue}</Td>
+    <Td dataLabel="Accelerators">{formatAccelerators(workload.accelerators)}</Td>
+    <Td dataLabel="Queue position">
+      {formatQueuePosition(workload.queuePosition, workload.status)}
+    </Td>
+    <Td dataLabel="Priority class">{formatOptionalValue(workload.priority)}</Td>
+    <Td dataLabel="Hardware profile">
+      <HardwareProfileCell
+        hardwareProfile={workload.hardwareProfile}
+        hardwareProfileResourceType={workload.hardwareProfileResourceType}
+      />
+    </Td>
+  </Tr>
+);
+
+export default ClusterQueueWorkloadTableRow;

--- a/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadsSection.tsx
+++ b/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadsSection.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import ClusterQueueWorkloadsTable from './ClusterQueueWorkloadsTable';
+import useClusterQueueWorkloads from '../../hooks/useClusterQueueWorkloads';
+import type { UseWorkloadRowsOptions } from '../../hooks/useWorkloadRows';
+
+type ClusterQueueWorkloadsSectionProps = {
+  clusterQueueName: string;
+  showDescription?: boolean;
+  /** Controls queue-position polling interval; workload cache stays manual-only. */
+  workloadRowsOptions?: UseWorkloadRowsOptions;
+};
+
+/**
+ * Cluster-queue-scoped workload table for the Quota usage detail panel.
+ * Cluster queue column is hidden because the panel context is already scoped to one CQ.
+ */
+const ClusterQueueWorkloadsSection: React.FC<ClusterQueueWorkloadsSectionProps> = ({
+  clusterQueueName,
+  showDescription = true,
+  workloadRowsOptions,
+}) => {
+  const { workloads, loaded, error } = useClusterQueueWorkloads(
+    clusterQueueName,
+    workloadRowsOptions,
+  );
+
+  return (
+    <ClusterQueueWorkloadsTable
+      workloads={workloads}
+      loaded={loaded}
+      error={error}
+      tableId={clusterQueueName}
+      showDescription={showDescription}
+    />
+  );
+};
+
+export default ClusterQueueWorkloadsSection;

--- a/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadsTable.tsx
+++ b/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadsTable.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import {
+  Alert,
+  Bullseye,
+  Content,
+  ContentVariants,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { DashboardEmptyTableView, Table } from '@odh-dashboard/ui-core';
+import ClusterQueueWorkloadTableRow from './ClusterQueueWorkloadTableRow';
+import ClusterQueueWorkloadsToolbar, {
+  buildWorkloadFilterOptions,
+  type ClusterQueueWorkloadsFilterDataType,
+} from './ClusterQueueWorkloadsToolbar';
+import { getClusterQueueWorkloadsTableColumns } from './clusterQueueWorkloadsTableColumns';
+import type { ClusterQueueWorkloadRow } from '../../types';
+import {
+  CLUSTER_QUEUE_WORKLOADS_EMPTY_BODY,
+  CLUSTER_QUEUE_WORKLOADS_EMPTY_TITLE,
+  CLUSTER_QUEUE_WORKLOADS_TABLE_DESCRIPTION,
+} from '../../const';
+import { filterClusterQueueWorkloads } from '../../utils/clusterQueueWorkloadsTableUtils';
+
+export type ClusterQueueWorkloadsTableProps = {
+  workloads: ClusterQueueWorkloadRow[];
+  loaded: boolean;
+  error?: Error;
+  tableId: string;
+  /** Show cluster queue column — use for namespace or cohort-wide views. */
+  showClusterQueueColumn?: boolean;
+  showDescription?: boolean;
+};
+
+const ClusterQueueWorkloadsTable: React.FC<ClusterQueueWorkloadsTableProps> = ({
+  workloads,
+  loaded,
+  error,
+  tableId,
+  showClusterQueueColumn = false,
+  showDescription = true,
+}) => {
+  const [filterData, setFilterData] = React.useState<ClusterQueueWorkloadsFilterDataType>({});
+
+  const onFilterUpdate = React.useCallback(
+    (key: string, value?: string | { label: string; value: string }) => {
+      setFilterData((current) => ({
+        ...current,
+        [key]: value,
+      }));
+    },
+    [],
+  );
+
+  const onClearFilters = React.useCallback(() => {
+    setFilterData({});
+  }, []);
+
+  const priorityFilterOptions = React.useMemo(
+    () => buildWorkloadFilterOptions(workloads.map((workload) => workload.priority)),
+    [workloads],
+  );
+  const hardwareProfileFilterOptions = React.useMemo(
+    () => buildWorkloadFilterOptions(workloads.map((workload) => workload.hardwareProfile)),
+    [workloads],
+  );
+
+  const filteredWorkloads = React.useMemo(
+    () => filterClusterQueueWorkloads(workloads, filterData),
+    [workloads, filterData],
+  );
+
+  const columns = React.useMemo(
+    () => getClusterQueueWorkloadsTableColumns({ showClusterQueue: showClusterQueueColumn }),
+    [showClusterQueueColumn],
+  );
+
+  const workloadEmptyState = (
+    <Bullseye data-testid={`cluster-queue-workloads-table-section-${tableId}`}>
+      <EmptyState
+        headingLevel="h2"
+        icon={PlusCircleIcon}
+        titleText={CLUSTER_QUEUE_WORKLOADS_EMPTY_TITLE}
+        variant={EmptyStateVariant.sm}
+        data-testid="cluster-queue-workloads-empty-state"
+      >
+        <EmptyStateBody>{CLUSTER_QUEUE_WORKLOADS_EMPTY_BODY}</EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  );
+
+  if (loaded && workloads.length === 0) {
+    if (error) {
+      return (
+        <Alert
+          className="pf-v6-u-mb-md"
+          data-testid="cluster-queue-workloads-error"
+          variant="danger"
+          isInline
+          title={error.message}
+        />
+      );
+    }
+    return workloadEmptyState;
+  }
+
+  return (
+    <Stack hasGutter data-testid={`cluster-queue-workloads-table-section-${tableId}`}>
+      {showDescription && (
+        <StackItem>
+          <Content component={ContentVariants.p}>
+            {CLUSTER_QUEUE_WORKLOADS_TABLE_DESCRIPTION}
+          </Content>
+        </StackItem>
+      )}
+      <StackItem>
+        {error && (
+          <Alert
+            className="pf-v6-u-mb-md"
+            data-testid="cluster-queue-workloads-error"
+            variant="danger"
+            isInline
+            title={error.message}
+          />
+        )}
+        {!loaded ? (
+          <Bullseye className="pf-v6-u-p-lg" data-testid="cluster-queue-workloads-loading">
+            <Spinner />
+          </Bullseye>
+        ) : (
+          <Table
+            data-testid="cluster-queue-workloads-table"
+            aria-label="Cluster queue workloads table"
+            id={`cluster-queue-workloads-table-${tableId}`}
+            variant="compact"
+            enablePagination="compact"
+            data={filteredWorkloads}
+            columns={columns}
+            toolbarContent={
+              <ClusterQueueWorkloadsToolbar
+                filterData={filterData}
+                onFilterUpdate={onFilterUpdate}
+                priorityFilterOptions={priorityFilterOptions}
+                hardwareProfileFilterOptions={hardwareProfileFilterOptions}
+              />
+            }
+            emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
+            onClearFilters={onClearFilters}
+            rowRenderer={(workload) => (
+              <ClusterQueueWorkloadTableRow
+                key={`${workload.namespace}/${workload.name}`}
+                workload={workload}
+                showClusterQueue={showClusterQueueColumn}
+              />
+            )}
+          />
+        )}
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default ClusterQueueWorkloadsTable;

--- a/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadsToolbar.tsx
+++ b/packages/gpuaas/src/components/clusterQueueWorkloads/ClusterQueueWorkloadsToolbar.tsx
@@ -1,0 +1,201 @@
+import * as React from 'react';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  SearchInput,
+  ToolbarFilter,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarToggleGroup,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+import SimpleSelect, {
+  type SimpleSelectOption,
+} from '@odh-dashboard/ui-core/components/SimpleSelect';
+import {
+  ClusterQueueWorkloadsToolbarFilterOptions,
+  clusterQueueWorkloadsFilterOptions,
+  clusterQueueWorkloadsFilterPlaceholders,
+} from '../../const';
+import { QUOTA_USAGE_WORKLOAD_STATUS_FILTER_OPTIONS } from '../../types';
+
+export type ClusterQueueWorkloadsFilterDataType = {
+  name?: string;
+  status?: string | { label: string; value: string };
+  priority?: string | { label: string; value: string };
+  hardwareProfile?: string | { label: string; value: string };
+};
+
+const statusFilterOptions: SimpleSelectOption[] = [
+  { key: '', label: 'All' },
+  ...QUOTA_USAGE_WORKLOAD_STATUS_FILTER_OPTIONS.map((status) => ({
+    key: status,
+    label: status,
+  })),
+];
+
+const attributeFilterKeys: ClusterQueueWorkloadsToolbarFilterOptions[] = [
+  ClusterQueueWorkloadsToolbarFilterOptions.status,
+  ClusterQueueWorkloadsToolbarFilterOptions.priority,
+  ClusterQueueWorkloadsToolbarFilterOptions.hardwareProfile,
+];
+
+const getFilterSelectValue = (
+  filter?: string | { label: string; value: string },
+): string | undefined => (typeof filter === 'string' ? filter : filter?.value);
+
+const buildWorkloadFilterOptions = (values: Array<string | undefined>): SimpleSelectOption[] => [
+  { key: '', label: 'All' },
+  ...[...new Set(values.filter((value): value is string => Boolean(value)))]
+    .toSorted()
+    .map((value) => ({
+      key: value,
+      label: value,
+    })),
+];
+
+type ClusterQueueWorkloadsToolbarProps = {
+  filterData: ClusterQueueWorkloadsFilterDataType;
+  onFilterUpdate: (key: string, value?: string | { label: string; value: string }) => void;
+  priorityFilterOptions: SimpleSelectOption[];
+  hardwareProfileFilterOptions: SimpleSelectOption[];
+};
+
+const ClusterQueueWorkloadsToolbar: React.FC<ClusterQueueWorkloadsToolbarProps> = ({
+  filterData,
+  onFilterUpdate,
+  priorityFilterOptions,
+  hardwareProfileFilterOptions,
+}) => {
+  const [isFilterTypeOpen, setIsFilterTypeOpen] = React.useState(false);
+  const [currentFilterType, setCurrentFilterType] =
+    React.useState<ClusterQueueWorkloadsToolbarFilterOptions>(
+      ClusterQueueWorkloadsToolbarFilterOptions.status,
+    );
+
+  const attributeFilterOptions: Record<
+    ClusterQueueWorkloadsToolbarFilterOptions,
+    SimpleSelectOption[]
+  > = {
+    [ClusterQueueWorkloadsToolbarFilterOptions.status]: statusFilterOptions,
+    [ClusterQueueWorkloadsToolbarFilterOptions.priority]: priorityFilterOptions,
+    [ClusterQueueWorkloadsToolbarFilterOptions.hardwareProfile]: hardwareProfileFilterOptions,
+  };
+
+  const renderAttributeFilter = (filterKey: ClusterQueueWorkloadsToolbarFilterOptions) => {
+    const options = attributeFilterOptions[filterKey];
+    const filterValue = filterData[filterKey];
+    const selectedValue = getFilterSelectValue(filterValue) ?? '';
+    const placeholder = clusterQueueWorkloadsFilterPlaceholders[filterKey];
+
+    return (
+      <SimpleSelect
+        dataTestId={
+          filterKey === ClusterQueueWorkloadsToolbarFilterOptions.hardwareProfile
+            ? 'cluster-queue-workloads-hardware-profile-filter'
+            : `cluster-queue-workloads-${filterKey}-filter`
+        }
+        value={selectedValue}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        options={options}
+        onChange={(selectedOptionValue) => {
+          const option = options.find((item) => item.key === selectedOptionValue);
+          onFilterUpdate(
+            filterKey,
+            option?.label && selectedOptionValue
+              ? { label: option.label, value: selectedOptionValue }
+              : '',
+          );
+        }}
+        popperProps={{ maxWidth: undefined }}
+      />
+    );
+  };
+
+  return (
+    <ToolbarToggleGroup breakpoint="md" toggleIcon={<FilterIcon />}>
+      <ToolbarGroup variant="filter-group" data-testid="cluster-queue-workloads-table-toolbar">
+        <ToolbarItem>
+          <SearchInput
+            aria-label="Filter by name"
+            placeholder="Filter by name"
+            data-testid="cluster-queue-workloads-name-filter"
+            value={filterData.name ?? ''}
+            onChange={(_event, value) => onFilterUpdate('name', value)}
+            onClear={() => onFilterUpdate('name', '')}
+          />
+        </ToolbarItem>
+        <ToolbarItem>
+          <Dropdown
+            onOpenChange={setIsFilterTypeOpen}
+            shouldFocusToggleOnSelect
+            toggle={(toggleRef) => (
+              <MenuToggle
+                data-testid="cluster-queue-workloads-table-toolbar-dropdown"
+                ref={toggleRef}
+                aria-label="Filter attribute"
+                onClick={() => setIsFilterTypeOpen((open) => !open)}
+                isExpanded={isFilterTypeOpen}
+                icon={<FilterIcon />}
+              >
+                {clusterQueueWorkloadsFilterOptions[currentFilterType]}
+              </MenuToggle>
+            )}
+            isOpen={isFilterTypeOpen}
+            popperProps={{ appendTo: 'inline' }}
+          >
+            <DropdownList>
+              {attributeFilterKeys.map((filterKey) => (
+                <DropdownItem
+                  key={filterKey}
+                  id={filterKey}
+                  data-testid={`cluster-queue-workloads-table-toolbar-option-${filterKey}`}
+                  onClick={() => {
+                    setIsFilterTypeOpen(false);
+                    setCurrentFilterType(filterKey);
+                  }}
+                >
+                  {clusterQueueWorkloadsFilterOptions[filterKey]}
+                </DropdownItem>
+              ))}
+            </DropdownList>
+          </Dropdown>
+        </ToolbarItem>
+        {attributeFilterKeys.map((filterKey) => {
+          const filterValue = filterData[filterKey];
+          const filterLabel = typeof filterValue === 'string' ? filterValue : filterValue?.label;
+          const filterSelectValue = getFilterSelectValue(filterValue);
+
+          return (
+            <ToolbarFilter
+              key={filterKey}
+              categoryName={clusterQueueWorkloadsFilterOptions[filterKey]}
+              data-testid="cluster-queue-workloads-table-toolbar-text-field"
+              labels={
+                filterSelectValue && filterLabel
+                  ? [
+                      {
+                        key: filterKey,
+                        node: <span data-testid={`${filterKey}-filter-chip`}>{filterLabel}</span>,
+                      },
+                    ]
+                  : []
+              }
+              deleteLabel={() => onFilterUpdate(filterKey, '')}
+              showToolbarItem={currentFilterType === filterKey}
+            >
+              {renderAttributeFilter(filterKey)}
+            </ToolbarFilter>
+          );
+        })}
+      </ToolbarGroup>
+    </ToolbarToggleGroup>
+  );
+};
+
+export { buildWorkloadFilterOptions };
+
+export default ClusterQueueWorkloadsToolbar;

--- a/packages/gpuaas/src/components/clusterQueueWorkloads/__tests__/ClusterQueueWorkloadStatusLabel.spec.tsx
+++ b/packages/gpuaas/src/components/clusterQueueWorkloads/__tests__/ClusterQueueWorkloadStatusLabel.spec.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ClusterQueueWorkloadStatusLabel from '../ClusterQueueWorkloadStatusLabel';
+import { QuotaUsageWorkloadStatuses } from '../../../types';
+
+describe('ClusterQueueWorkloadStatusLabel', () => {
+  it('renders Pending with the status label test id', () => {
+    render(<ClusterQueueWorkloadStatusLabel status={QuotaUsageWorkloadStatuses.Pending} />);
+
+    expect(screen.getByTestId('cluster-queue-workload-status-label')).toHaveTextContent('Pending');
+  });
+
+  it('renders Running from the Kueue status mapping', () => {
+    render(<ClusterQueueWorkloadStatusLabel status={QuotaUsageWorkloadStatuses.Running} />);
+
+    expect(screen.getByTestId('cluster-queue-workload-status-label')).toHaveTextContent('Running');
+  });
+});

--- a/packages/gpuaas/src/components/clusterQueueWorkloads/__tests__/ClusterQueueWorkloadsTable.spec.tsx
+++ b/packages/gpuaas/src/components/clusterQueueWorkloads/__tests__/ClusterQueueWorkloadsTable.spec.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ClusterQueueWorkloadsTable from '../ClusterQueueWorkloadsTable';
+import {
+  QuotaUsageWorkloadStatuses,
+  QuotaUsageWorkloadTypes,
+  type ClusterQueueWorkloadRow,
+} from '../../../types';
+
+jest.mock('@odh-dashboard/ui-core', () => {
+  const actual = jest.requireActual('@odh-dashboard/ui-core');
+  return {
+    ...actual,
+    Table: ({
+      data,
+      rowRenderer,
+      toolbarContent,
+      emptyTableView,
+      'data-testid': testId,
+    }: {
+      data: ClusterQueueWorkloadRow[];
+      rowRenderer: (row: ClusterQueueWorkloadRow) => React.ReactNode;
+      toolbarContent: React.ReactNode;
+      emptyTableView: React.ReactNode;
+      'data-testid'?: string;
+    }) => (
+      <div data-testid={testId}>
+        {toolbarContent}
+        {data.length === 0 ? emptyTableView : data.map((row) => rowRenderer(row))}
+      </div>
+    ),
+    DashboardEmptyTableView: ({ onClearFilters }: { onClearFilters: () => void }) => (
+      <button
+        type="button"
+        data-testid="cluster-queue-workloads-clear-filters"
+        onClick={onClearFilters}
+      >
+        Clear filters
+      </button>
+    ),
+  };
+});
+
+const sampleWorkloads: ClusterQueueWorkloadRow[] = [
+  {
+    name: 'wl-alpha',
+    namespace: 'dsp-1',
+    project: 'Alpha team',
+    clusterQueue: 'gpu-cq',
+    type: QuotaUsageWorkloadTypes.Workbench,
+    status: QuotaUsageWorkloadStatuses.Queued,
+    localQueue: 'user-queue',
+    accelerators: 1,
+    queuePosition: 2,
+  },
+  {
+    name: 'wl-beta',
+    namespace: 'dsp-2',
+    project: 'Beta team',
+    clusterQueue: 'gpu-cq',
+    type: QuotaUsageWorkloadTypes.Serve,
+    status: QuotaUsageWorkloadStatuses.Running,
+    localQueue: 'serve-queue',
+    accelerators: 2,
+    queuePosition: undefined,
+  },
+];
+
+describe('ClusterQueueWorkloadsTable', () => {
+  it('shows loading spinner while data is loading', () => {
+    render(<ClusterQueueWorkloadsTable workloads={[]} loaded={false} tableId="gpu-cq" />);
+
+    expect(screen.getByTestId('cluster-queue-workloads-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-queue-workloads-table')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when loaded with no workloads', () => {
+    render(<ClusterQueueWorkloadsTable workloads={[]} loaded tableId="gpu-cq" />);
+
+    expect(screen.getByTestId('cluster-queue-workloads-empty-state')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-queue-workloads-table')).not.toBeInTheDocument();
+  });
+
+  it('shows only the error state when loaded with no workloads after a load failure', () => {
+    render(
+      <ClusterQueueWorkloadsTable
+        workloads={[]}
+        loaded
+        error={new Error('namespace fetch failed')}
+        tableId="gpu-cq"
+      />,
+    );
+
+    expect(screen.getByTestId('cluster-queue-workloads-error')).toHaveTextContent(
+      'namespace fetch failed',
+    );
+    expect(screen.queryByTestId('cluster-queue-workloads-empty-state')).not.toBeInTheDocument();
+  });
+
+  it('renders workload rows and toolbar', () => {
+    render(<ClusterQueueWorkloadsTable workloads={sampleWorkloads} loaded tableId="gpu-cq" />);
+
+    expect(screen.getByTestId('cluster-queue-workloads-table')).toBeInTheDocument();
+    expect(screen.getByTestId('cluster-queue-workloads-table-toolbar')).toBeInTheDocument();
+    expect(screen.getByTestId('cluster-queue-workload-row-dsp-1-wl-alpha')).toBeInTheDocument();
+    expect(screen.getByTestId('cluster-queue-workload-row-dsp-2-wl-beta')).toBeInTheDocument();
+    expect(screen.getByText('wl-alpha')).toBeInTheDocument();
+    expect(screen.getByText('Running')).toBeInTheDocument();
+  });
+
+  it('shows inline error above the table when workloads are present', () => {
+    render(
+      <ClusterQueueWorkloadsTable
+        workloads={sampleWorkloads}
+        loaded
+        error={new Error('partial namespace failure')}
+        tableId="gpu-cq"
+      />,
+    );
+
+    expect(screen.getByTestId('cluster-queue-workloads-error')).toHaveTextContent(
+      'partial namespace failure',
+    );
+    expect(screen.getByTestId('cluster-queue-workloads-table')).toBeInTheDocument();
+  });
+});

--- a/packages/gpuaas/src/components/clusterQueueWorkloads/clusterQueueWorkloadsTableColumns.ts
+++ b/packages/gpuaas/src/components/clusterQueueWorkloads/clusterQueueWorkloadsTableColumns.ts
@@ -1,0 +1,79 @@
+import type { SortableData } from '@odh-dashboard/ui-core';
+import { CLUSTER_QUEUE_WORKLOADS_TYPE_HELP } from '../../const';
+import type { ClusterQueueWorkloadRow } from '../../types';
+
+const compareOptionalStrings = (a: string | undefined, b: string | undefined): number =>
+  (a ?? '').localeCompare(b ?? '');
+
+const clusterQueueColumn: SortableData<ClusterQueueWorkloadRow> = {
+  field: 'clusterQueue',
+  label: 'Cluster queue',
+  sortable: (a, b) => a.clusterQueue.localeCompare(b.clusterQueue),
+};
+
+const sharedColumns: SortableData<ClusterQueueWorkloadRow>[] = [
+  {
+    field: 'name',
+    label: 'Name',
+    sortable: (a, b) => a.name.localeCompare(b.name),
+  },
+  {
+    field: 'project',
+    label: 'Project',
+    sortable: (a, b) => a.project.localeCompare(b.project),
+  },
+  {
+    field: 'type',
+    label: 'Type',
+    info: {
+      popover: CLUSTER_QUEUE_WORKLOADS_TYPE_HELP,
+      popoverProps: {
+        showClose: false,
+      },
+    },
+    sortable: (a, b) => a.type.localeCompare(b.type),
+  },
+  {
+    field: 'status',
+    label: 'Status',
+    sortable: (a, b) => a.status.localeCompare(b.status),
+  },
+  {
+    field: 'localQueue',
+    label: 'Local queue',
+    sortable: (a, b) => a.localQueue.localeCompare(b.localQueue),
+  },
+  {
+    field: 'accelerators',
+    label: 'Accelerators',
+    sortable: (a, b) => a.accelerators - b.accelerators,
+  },
+  {
+    field: 'queuePosition',
+    label: 'Queue position',
+    sortable: (a, b) =>
+      (a.queuePosition ?? Number.MAX_SAFE_INTEGER) - (b.queuePosition ?? Number.MAX_SAFE_INTEGER),
+  },
+  {
+    field: 'priority',
+    label: 'Priority class',
+    sortable: (a, b) => compareOptionalStrings(a.priority, b.priority),
+  },
+  {
+    field: 'hardwareProfile',
+    label: 'Hardware profile',
+    sortable: (a, b) => compareOptionalStrings(a.hardwareProfile, b.hardwareProfile),
+  },
+];
+
+export type ClusterQueueWorkloadsTableColumnOptions = {
+  showClusterQueue?: boolean;
+};
+
+export const getClusterQueueWorkloadsTableColumns = (
+  options: ClusterQueueWorkloadsTableColumnOptions = {},
+): SortableData<ClusterQueueWorkloadRow>[] =>
+  options.showClusterQueue ? [clusterQueueColumn, ...sharedColumns] : sharedColumns;
+
+/** Default columns for per-cluster-queue cards (cluster queue implied by card context). */
+export const clusterQueueWorkloadsTableColumns = getClusterQueueWorkloadsTableColumns();

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageDetailPanel.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageDetailPanel.tsx
@@ -12,6 +12,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { InfrastructureIcon, ListIcon, ResourcesEmptyIcon } from '@patternfly/react-icons';
+import QuotaUsageWorkloadsCollapsible from './QuotaUsageWorkloadsCollapsible';
 import { QUOTA_UNASSIGNED_LABEL, QUOTA_UNASSIGNED_TOOLTIP } from '../../const';
 import { QuotaSelection, QuotaTreeNode } from '../../types';
 import { selectionFromPath } from '../../utils/quotaUsageTreeUtils';
@@ -80,6 +81,7 @@ const QuotaUsageDetailPanel: React.FC<QuotaUsageDetailPanelProps> = ({
   }
 
   const showBreadcrumb = selection.path.length > 1 && selection.path[0] !== QUOTA_UNASSIGNED_LABEL;
+  const showWorkloadsSection = selection.type === 'clusterQueue';
 
   return (
     <>
@@ -132,7 +134,11 @@ const QuotaUsageDetailPanel: React.FC<QuotaUsageDetailPanelProps> = ({
           </Content>
         </Stack>
       </DrawerHead>
-      <DrawerPanelBody className={scrollableBodyClassName} />
+      <DrawerPanelBody className={`${scrollableBodyClassName} pf-v6-u-pt-lg`}>
+        {showWorkloadsSection && (
+          <QuotaUsageWorkloadsCollapsible clusterQueueName={selection.clusterQueueName} />
+        )}
+      </DrawerPanelBody>
     </>
   );
 };

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageWorkloadsCollapsible.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageWorkloadsCollapsible.tsx
@@ -9,8 +9,6 @@ import {
 import {
   CLUSTER_QUEUE_WORKLOADS_SECTION_TITLE,
   CLUSTER_QUEUE_WORKLOADS_TABLE_DESCRIPTION,
-  INFRASTRUCTURE_MANUAL_REFRESH_ONLY,
-  INFRASTRUCTURE_REFRESH_INTERVAL,
 } from '../../const';
 import ClusterQueueWorkloadsSection from '../clusterQueueWorkloads/ClusterQueueWorkloadsSection';
 
@@ -23,14 +21,7 @@ const QuotaUsageWorkloadsCollapsible: React.FC<QuotaUsageWorkloadsCollapsiblePro
   clusterQueueName,
 }) => {
   const [isExpanded, setIsExpanded] = React.useState(true);
-  const workloadRowsOptions = React.useMemo(
-    () => ({
-      refreshRate: isExpanded
-        ? INFRASTRUCTURE_REFRESH_INTERVAL
-        : INFRASTRUCTURE_MANUAL_REFRESH_ONLY,
-    }),
-    [isExpanded],
-  );
+
   return (
     <ExpandableSection
       className="gpuaas-quota-usage-detail-section pf-v6-u-mt-xl"
@@ -50,7 +41,6 @@ const QuotaUsageWorkloadsCollapsible: React.FC<QuotaUsageWorkloadsCollapsiblePro
           <ClusterQueueWorkloadsSection
             clusterQueueName={clusterQueueName}
             showDescription={false}
-            workloadRowsOptions={workloadRowsOptions}
           />
         </StackItem>
       </Stack>

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageWorkloadsCollapsible.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageWorkloadsCollapsible.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import {
+  Content,
+  ContentVariants,
+  ExpandableSection,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import {
+  CLUSTER_QUEUE_WORKLOADS_SECTION_TITLE,
+  CLUSTER_QUEUE_WORKLOADS_TABLE_DESCRIPTION,
+  INFRASTRUCTURE_MANUAL_REFRESH_ONLY,
+  INFRASTRUCTURE_REFRESH_INTERVAL,
+} from '../../const';
+import ClusterQueueWorkloadsSection from '../clusterQueueWorkloads/ClusterQueueWorkloadsSection';
+
+type QuotaUsageWorkloadsCollapsibleProps = {
+  clusterQueueName: string;
+};
+
+/** Lightweight ExpandableSection disclosure matching the Quota usage prototype. */
+const QuotaUsageWorkloadsCollapsible: React.FC<QuotaUsageWorkloadsCollapsibleProps> = ({
+  clusterQueueName,
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(true);
+  const workloadRowsOptions = React.useMemo(
+    () => ({
+      refreshRate: isExpanded
+        ? INFRASTRUCTURE_REFRESH_INTERVAL
+        : INFRASTRUCTURE_MANUAL_REFRESH_ONLY,
+    }),
+    [isExpanded],
+  );
+  return (
+    <ExpandableSection
+      className="gpuaas-quota-usage-detail-section pf-v6-u-mt-xl"
+      data-testid="quota-usage-workloads-section"
+      toggleContent={CLUSTER_QUEUE_WORKLOADS_SECTION_TITLE}
+      toggleWrapper="h4"
+      isExpanded={isExpanded}
+      onToggle={(_event, expanded) => setIsExpanded(expanded)}
+    >
+      <Stack hasGutter>
+        <StackItem>
+          <Content component={ContentVariants.p}>
+            {CLUSTER_QUEUE_WORKLOADS_TABLE_DESCRIPTION}
+          </Content>
+        </StackItem>
+        <StackItem>
+          <ClusterQueueWorkloadsSection
+            clusterQueueName={clusterQueueName}
+            showDescription={false}
+            workloadRowsOptions={workloadRowsOptions}
+          />
+        </StackItem>
+      </Stack>
+    </ExpandableSection>
+  );
+};
+
+export default QuotaUsageWorkloadsCollapsible;

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -10,31 +10,49 @@ export const NON_KUEUE_PROJECTS_MODAL_DESCRIPTION =
   'Data from the following projects is not displayed on the Infrastructure page because they do not use Kueue for workload admission.';
 export const NON_KUEUE_PROJECT_STATUS_LABEL = 'not Kueue-managed';
 
+export const CLUSTER_QUEUE_WORKLOADS_SECTION_TITLE = 'Workloads';
 export const CLUSTER_QUEUE_WORKLOADS_TABLE_DESCRIPTION =
   'Workloads admitted or waiting in this cluster queue.';
 export const CLUSTER_QUEUE_WORKLOADS_EMPTY_TITLE = 'No workloads';
 export const CLUSTER_QUEUE_WORKLOADS_EMPTY_BODY = 'Admitted or waiting workloads will appear here.';
 export const CLUSTER_QUEUE_WORKLOADS_TYPE_HELP =
-  'Workload type: Workbench, Training, Ray job, Model serving, Ray cluster, or Unknown (e.g. pipeline workloads without a dedicated integration).';
+  'The type of workload: train job, Ray job, notebook, inference, or Ray cluster.';
 
 export enum ClusterQueueWorkloadsToolbarFilterOptions {
-  name = 'name',
   status = 'status',
+  priority = 'priority',
+  hardwareProfile = 'hardwareProfile',
 }
 
-export const clusterQueueWorkloadsFilterOptions: Record<string, string> = {
-  [ClusterQueueWorkloadsToolbarFilterOptions.name]: 'Name',
+export const clusterQueueWorkloadsFilterOptions: Record<
+  ClusterQueueWorkloadsToolbarFilterOptions,
+  string
+> = {
   [ClusterQueueWorkloadsToolbarFilterOptions.status]: 'Status',
+  [ClusterQueueWorkloadsToolbarFilterOptions.priority]: 'Priority',
+  [ClusterQueueWorkloadsToolbarFilterOptions.hardwareProfile]: 'Hardware profile',
+};
+
+export const clusterQueueWorkloadsFilterPlaceholders: Record<
+  ClusterQueueWorkloadsToolbarFilterOptions,
+  string
+> = {
+  [ClusterQueueWorkloadsToolbarFilterOptions.status]: 'Filter by status',
+  [ClusterQueueWorkloadsToolbarFilterOptions.priority]: 'Filter by priority',
+  [ClusterQueueWorkloadsToolbarFilterOptions.hardwareProfile]: 'Filter by hardware profile',
 };
 
 export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
+
+/** Pass to useFetch refreshRate to disable polling; initial load + manual refresh only. */
+export const INFRASTRUCTURE_MANUAL_REFRESH_ONLY = -1;
 
 export const TREND_REFRESH_INTERVAL = 5 * 60 * 1000;
 export const PROMETHEUS_CLUSTER_QUERY_PATH = '/api/prometheus/cluster/query';
 export const PROMETHEUS_CLUSTER_QUERY_RANGE_PATH = '/api/prometheus/cluster/queryRange';
 
 export const INFRASTRUCTURE_TABS = [
-  { id: 'utilization', title: 'Utilization' },
+  { id: 'utilization', title: 'Accelerator utilization' },
   { id: 'quota-usage', title: 'Quota usage' },
 ] as const;
 

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -47,6 +47,7 @@ export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
 /** Pass to useFetch refreshRate to disable polling; initial load + manual refresh only. */
 export const INFRASTRUCTURE_MANUAL_REFRESH_ONLY = -1;
 
+/** 5m polling for trend charts and quota-usage workload tables (see useBorrowingLendingMetrics). */
 export const TREND_REFRESH_INTERVAL = 5 * 60 * 1000;
 export const PROMETHEUS_CLUSTER_QUERY_PATH = '/api/prometheus/cluster/query';
 export const PROMETHEUS_CLUSTER_QUERY_RANGE_PATH = '/api/prometheus/cluster/queryRange';

--- a/packages/gpuaas/src/hooks/KueueNamespaceWorkloadCacheContext.tsx
+++ b/packages/gpuaas/src/hooks/KueueNamespaceWorkloadCacheContext.tsx
@@ -1,0 +1,372 @@
+import * as React from 'react';
+import type { ProjectKind } from '@odh-dashboard/k8s-core';
+import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
+import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import useFetch, {
+  NotReadyError,
+  type FetchStateObject,
+} from '@odh-dashboard/ui-core/hooks/useFetch';
+import { INFRASTRUCTURE_MANUAL_REFRESH_ONLY } from '../const';
+import { buildResourceFlavorByName } from '../utils/hardwareModels';
+import {
+  collectHardwareProfileRefs,
+  enrichNamespaceWorkloadData,
+  fetchHardwareProfilesByKey,
+  fetchHardwareProfilesForMatching,
+  fetchLocalQueueClusterQueueIndex,
+  fetchNamespaceWorkloadBaseData,
+  getNamespacesForClusterQueues,
+  toNamespaceWorkloadData,
+  type HardwareProfileByKey,
+  type KueueNamespaceWorkloadCache,
+  type LocalQueueClusterQueueIndex,
+  type NamespaceWorkloadBaseData,
+} from '../utils/clusterQueueWorkloads';
+import {
+  applyNamespaceEnrichment,
+  createNamespaceBundleState,
+  toDisplayBundle,
+  type NamespaceBundleState,
+  type NamespaceWorkloadEnrichment,
+} from '../utils/namespaceBundleState';
+import { getKueueManagedDataScienceProjects } from '../utils/kueueProjects';
+
+const emptyCache: KueueNamespaceWorkloadCache = {
+  namespaceData: [],
+  resourceFlavorByName: new Map(),
+  hardwareProfileByKey: new Map(),
+  hardwareProfilesForMatching: [],
+};
+
+const emptyIndex: LocalQueueClusterQueueIndex = new Map();
+
+const buildNamespacesKey = (namespaces: Iterable<string>): string =>
+  [...namespaces].toSorted((a, b) => a.localeCompare(b)).join('\0');
+
+const buildNamespaceLoadError = (failures: { namespace: string; error: Error }[]): Error =>
+  new Error(
+    `Failed to load workloads for: ${failures
+      .map(({ namespace, error }) => `${namespace} (${error.message})`)
+      .join('; ')}`,
+  );
+
+type KueueNamespaceWorkloadCacheContextValue = {
+  cache: KueueNamespaceWorkloadCache;
+  loaded: boolean;
+  /** True once pod/ISVC/hardware-profile enrichment matches the latest base fetch. */
+  enrichmentReady: boolean;
+  error: Error | undefined;
+  refresh: FetchStateObject<KueueNamespaceWorkloadCache>['refresh'];
+};
+
+const KueueNamespaceWorkloadCacheContext =
+  React.createContext<KueueNamespaceWorkloadCacheContextValue>({
+    cache: emptyCache,
+    loaded: false,
+    enrichmentReady: false,
+    error: undefined,
+    refresh: async () => emptyCache,
+  });
+
+type KueueNamespaceWorkloadCacheProviderProps = {
+  children: React.ReactNode;
+  /**
+   * Cluster queues currently in view (e.g. the selected Quota usage cluster queue). Namespace
+   * workload data is fetched only for namespaces with a LocalQueue targeting one of these cluster
+   * queues (via a cheap, cluster-wide LocalQueue index), instead of every Kueue-managed namespace.
+   * Empty array means inactive — no fetching happens.
+   */
+  clusterQueueNames: string[];
+};
+
+/**
+ * Provides workload-related K8s data scoped to the namespaces relevant to the selected cluster
+ * queue(s). Per-namespace bundles are cached across cluster-queue selections (in a ref, keyed by
+ * namespace), so switching between cluster queues that share a namespace reuses already-fetched
+ * data until the next refresh re-fetches all relevant namespaces in place.
+ *
+ * Loading is two-phase: B1 fetches workloads + LocalQueues; B2 enriches with pods, StatefulSets,
+ * InferenceServices, job-kind indexes, and hardware profiles. `loaded` stays false until B2
+ * completes for the current base generation so Type/HW profile columns are not misleading.
+ */
+const KueueNamespaceWorkloadCacheProvider: React.FC<KueueNamespaceWorkloadCacheProviderProps> = ({
+  children,
+  clusterQueueNames,
+}) => {
+  const [allProjects, projectsLoaded, projectsError] = useProjects();
+  const { dashboardNamespace } = useDashboardNamespace();
+  const active = clusterQueueNames.length > 0;
+
+  const namespaces = React.useMemo(() => {
+    const kueueProjects = getKueueManagedDataScienceProjects(allProjects);
+    return kueueProjects.flatMap((project: ProjectKind) => {
+      const namespace = project.metadata.name;
+      return namespace ? [namespace] : [];
+    });
+  }, [allProjects]);
+
+  const kueueNamespaceSet = React.useMemo(() => new Set(namespaces), [namespaces]);
+  const namespacesKey = React.useMemo(() => buildNamespacesKey(namespaces), [namespaces]);
+  const clusterQueueNamesKey = React.useMemo(
+    () => buildNamespacesKey(clusterQueueNames),
+    [clusterQueueNames],
+  );
+
+  // Phase A: cheap, cluster-wide LocalQueue index — only when a cluster queue is selected.
+  const {
+    data: index,
+    loaded: indexLoaded,
+    error: indexError,
+    refresh: refreshIndex,
+  } = useFetch<LocalQueueClusterQueueIndex>(
+    React.useCallback(async () => {
+      if (!active) {
+        return emptyIndex;
+      }
+      return fetchLocalQueueClusterQueueIndex();
+    }, [active]),
+    emptyIndex,
+    {
+      refreshRate: active ? INFRASTRUCTURE_MANUAL_REFRESH_ONLY : -1,
+      initialPromisePurity: true,
+    },
+  );
+
+  const namespaceBundleStateRef = React.useRef(new Map<string, NamespaceBundleState>());
+  const hardwareProfileCacheRef = React.useRef<HardwareProfileByKey>(new Map());
+  const hardwareProfilesForMatchingCacheRef = React.useRef<
+    KueueNamespaceWorkloadCache['hardwareProfilesForMatching']
+  >([]);
+  /** Bumps on each B1 completion; B2 must match before enriched cache is shown (avoids stale enrich on CQ switch / refresh). */
+  const baseFetchGenerationRef = React.useRef(0);
+  const enrichedFetchGenerationRef = React.useRef(0);
+  const clusterQueueNamesKeyRef = React.useRef(clusterQueueNamesKey);
+  const dashboardNamespaceRef = React.useRef(dashboardNamespace);
+  dashboardNamespaceRef.current = dashboardNamespace;
+
+  React.useEffect(() => {
+    if (clusterQueueNamesKeyRef.current === clusterQueueNamesKey) {
+      return;
+    }
+    clusterQueueNamesKeyRef.current = clusterQueueNamesKey;
+    for (const [namespace, state] of namespaceBundleStateRef.current) {
+      namespaceBundleStateRef.current.set(namespace, { base: state.base });
+    }
+    hardwareProfileCacheRef.current.clear();
+    hardwareProfilesForMatchingCacheRef.current = [];
+    enrichedFetchGenerationRef.current = 0;
+  }, [clusterQueueNamesKey]);
+
+  const clusterQueueNamesRef = React.useRef(clusterQueueNames);
+  clusterQueueNamesRef.current = clusterQueueNames;
+  const kueueNamespaceSetRef = React.useRef(kueueNamespaceSet);
+  kueueNamespaceSetRef.current = kueueNamespaceSet;
+  const indexRef = React.useRef(index);
+  indexRef.current = index;
+
+  // Phase B1: workloads + LocalQueues — optimistic enrichment reuse while B2 catches up.
+  const {
+    data: baseCache,
+    loaded: baseLoaded,
+    error: baseError,
+    refresh: refreshBase,
+  } = useFetch<KueueNamespaceWorkloadCache>(
+    React.useCallback(async () => {
+      if (!active) {
+        return emptyCache;
+      }
+      if (!projectsLoaded || !indexLoaded) {
+        throw new NotReadyError('Projects or LocalQueue index not loaded');
+      }
+
+      const relevantNamespaces = [
+        ...getNamespacesForClusterQueues(clusterQueueNamesRef.current, indexRef.current),
+      ].filter((namespace) => kueueNamespaceSetRef.current.has(namespace));
+
+      const pendingBaseGeneration = baseFetchGenerationRef.current + 1;
+
+      const [fetchResults, resourceFlavors] = await Promise.all([
+        Promise.all(
+          relevantNamespaces.map(async (namespace) => {
+            try {
+              const previousState = namespaceBundleStateRef.current.get(namespace);
+              let base = previousState?.base;
+              if (!base) {
+                base = await fetchNamespaceWorkloadBaseData(namespace);
+              }
+              const nextState = createNamespaceBundleState(base, previousState);
+              namespaceBundleStateRef.current.set(namespace, nextState);
+              const bundle = toDisplayBundle(nextState, pendingBaseGeneration, true);
+              return { namespace, bundle, error: undefined };
+            } catch (error) {
+              return {
+                namespace,
+                bundle: undefined,
+                error: error instanceof Error ? error : new Error(String(error)),
+              };
+            }
+          }),
+        ),
+        listResourceFlavors(),
+      ]);
+
+      const failures = fetchResults.flatMap((result) =>
+        result.error ? [{ namespace: result.namespace, error: result.error }] : [],
+      );
+
+      const namespaceData = relevantNamespaces.flatMap((namespace) => {
+        const state = namespaceBundleStateRef.current.get(namespace);
+        return state ? [toDisplayBundle(state, pendingBaseGeneration, true)] : [];
+      });
+
+      const namespaceLoadError =
+        failures.length > 0 ? buildNamespaceLoadError(failures) : undefined;
+
+      baseFetchGenerationRef.current = pendingBaseGeneration;
+
+      return {
+        namespaceData,
+        resourceFlavorByName: buildResourceFlavorByName(resourceFlavors),
+        hardwareProfileByKey: new Map(hardwareProfileCacheRef.current),
+        hardwareProfilesForMatching: hardwareProfilesForMatchingCacheRef.current,
+        namespaceLoadError,
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- keys fingerprint selection/namespace inputs
+    }, [active, projectsLoaded, indexLoaded, clusterQueueNamesKey, namespacesKey]),
+    emptyCache,
+    {
+      refreshRate: active ? INFRASTRUCTURE_MANUAL_REFRESH_ONLY : -1,
+      initialPromisePurity: true,
+    },
+  );
+
+  const baseCacheRef = React.useRef(baseCache);
+  baseCacheRef.current = baseCache;
+
+  // Phase B2: lazy pods/STS/ISVC/job lists + hardware profiles.
+  const { data: enrichedCache, refresh: refreshEnriched } = useFetch<KueueNamespaceWorkloadCache>(
+    React.useCallback(async () => {
+      if (!active || !baseLoaded) {
+        throw new NotReadyError('Base namespace workload cache not loaded');
+      }
+
+      const baseNamespaceData = baseCacheRef.current.namespaceData;
+      if (baseNamespaceData.length === 0) {
+        return baseCacheRef.current;
+      }
+
+      const baseGeneration = baseFetchGenerationRef.current;
+
+      const enrichResults = await Promise.all(
+        baseNamespaceData.map(async (baseBundle) => {
+          const state = namespaceBundleStateRef.current.get(baseBundle.namespace);
+          const base: NamespaceWorkloadBaseData = state?.base ?? {
+            namespace: baseBundle.namespace,
+            workloads: baseBundle.workloads,
+            localQueues: baseBundle.localQueues,
+          };
+          try {
+            const enriched = await enrichNamespaceWorkloadData(base, clusterQueueNamesRef.current);
+            const enrichment: NamespaceWorkloadEnrichment = {
+              pods: enriched.pods,
+              statefulSets: enriched.statefulSets,
+              inferenceServices: enriched.inferenceServices,
+              jobKindByUid: enriched.jobKindByUid,
+            };
+            const updatedState = applyNamespaceEnrichment(
+              state ?? { base },
+              enrichment,
+              baseGeneration,
+            );
+            namespaceBundleStateRef.current.set(base.namespace, updatedState);
+            return toDisplayBundle(updatedState, baseGeneration);
+          } catch {
+            return toNamespaceWorkloadData(base);
+          }
+        }),
+      );
+
+      const [fetchedHardwareProfiles, hardwareProfilesForMatching] = await Promise.all([
+        fetchHardwareProfilesByKey(collectHardwareProfileRefs(enrichResults)),
+        fetchHardwareProfilesForMatching(enrichResults, dashboardNamespaceRef.current),
+      ]);
+      for (const [key, hardwareProfile] of fetchedHardwareProfiles) {
+        hardwareProfileCacheRef.current.set(key, hardwareProfile);
+      }
+      hardwareProfilesForMatchingCacheRef.current = hardwareProfilesForMatching;
+
+      if (baseGeneration !== baseFetchGenerationRef.current) {
+        throw new NotReadyError('Base generation advanced during enrichment');
+      }
+      enrichedFetchGenerationRef.current = baseGeneration;
+
+      return {
+        namespaceData: enrichResults,
+        resourceFlavorByName: baseCacheRef.current.resourceFlavorByName,
+        hardwareProfileByKey: new Map(hardwareProfileCacheRef.current),
+        hardwareProfilesForMatching,
+        namespaceLoadError: baseCacheRef.current.namespaceLoadError,
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- keys fingerprint selection inputs
+    }, [active, baseLoaded, clusterQueueNamesKey, namespacesKey]),
+    emptyCache,
+    {
+      refreshRate: active ? INFRASTRUCTURE_MANUAL_REFRESH_ONLY : -1,
+      initialPromisePurity: true,
+    },
+  );
+
+  const isEnrichedCurrent =
+    enrichedCache.namespaceData.length > 0 &&
+    enrichedFetchGenerationRef.current === baseFetchGenerationRef.current;
+
+  const enrichmentReady = !active || baseCache.namespaceData.length === 0 || isEnrichedCurrent;
+
+  const cache = isEnrichedCurrent ? enrichedCache : baseCache;
+
+  const refresh = React.useCallback(async () => {
+    if (active) {
+      namespaceBundleStateRef.current.clear();
+      hardwareProfileCacheRef.current.clear();
+      hardwareProfilesForMatchingCacheRef.current = [];
+      enrichedFetchGenerationRef.current = 0;
+      await refreshIndex();
+    }
+    await refreshBase();
+    return refreshEnriched();
+  }, [active, refreshBase, refreshEnriched, refreshIndex]);
+
+  const value = React.useMemo(
+    (): KueueNamespaceWorkloadCacheContextValue => ({
+      cache,
+      loaded: active && projectsLoaded && indexLoaded && baseLoaded && enrichmentReady,
+      enrichmentReady,
+      error: projectsError ?? indexError ?? baseError ?? cache.namespaceLoadError,
+      refresh,
+    }),
+    [
+      active,
+      cache,
+      baseLoaded,
+      baseError,
+      enrichmentReady,
+      indexLoaded,
+      indexError,
+      projectsError,
+      projectsLoaded,
+      refresh,
+    ],
+  );
+
+  return (
+    <KueueNamespaceWorkloadCacheContext.Provider value={value}>
+      {children}
+    </KueueNamespaceWorkloadCacheContext.Provider>
+  );
+};
+
+export const useKueueNamespaceWorkloadCache = (): KueueNamespaceWorkloadCacheContextValue =>
+  React.useContext(KueueNamespaceWorkloadCacheContext);
+
+export default KueueNamespaceWorkloadCacheProvider;

--- a/packages/gpuaas/src/hooks/KueueNamespaceWorkloadCacheContext.tsx
+++ b/packages/gpuaas/src/hooks/KueueNamespaceWorkloadCacheContext.tsx
@@ -1,55 +1,41 @@
 import * as React from 'react';
 import type { ProjectKind } from '@odh-dashboard/k8s-core';
 import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
-import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import useFetch, {
+  isCommonStateError,
   NotReadyError,
+  type AdHocUpdate,
   type FetchStateObject,
 } from '@odh-dashboard/ui-core/hooks/useFetch';
-import { INFRASTRUCTURE_MANUAL_REFRESH_ONLY } from '../const';
-import { buildResourceFlavorByName } from '../utils/hardwareModels';
+import { INFRASTRUCTURE_MANUAL_REFRESH_ONLY, TREND_REFRESH_INTERVAL } from '../const';
+import type { KueueNamespaceWorkloadCache } from '../utils/clusterQueueWorkloads';
 import {
-  collectHardwareProfileRefs,
-  enrichNamespaceWorkloadData,
-  fetchHardwareProfilesByKey,
-  fetchHardwareProfilesForMatching,
-  fetchLocalQueueClusterQueueIndex,
-  fetchNamespaceWorkloadBaseData,
-  getNamespacesForClusterQueues,
-  toNamespaceWorkloadData,
-  type HardwareProfileByKey,
-  type KueueNamespaceWorkloadCache,
-  type LocalQueueClusterQueueIndex,
-  type NamespaceWorkloadBaseData,
-} from '../utils/clusterQueueWorkloads';
-import {
-  applyNamespaceEnrichment,
-  createNamespaceBundleState,
-  toDisplayBundle,
-  type NamespaceBundleState,
-  type NamespaceWorkloadEnrichment,
-} from '../utils/namespaceBundleState';
+  clearWorkloadCacheStore,
+  createWorkloadCacheStore,
+  loadWorkloadCache,
+  type WorkloadCacheMutableStore,
+} from '../utils/loadWorkloadCache';
 import { getKueueManagedDataScienceProjects } from '../utils/kueueProjects';
 
 const emptyCache: KueueNamespaceWorkloadCache = {
   namespaceData: [],
-  resourceFlavorByName: new Map(),
   hardwareProfileByKey: new Map(),
   hardwareProfilesForMatching: [],
 };
 
-const emptyIndex: LocalQueueClusterQueueIndex = new Map();
+type WorkloadCacheFetchState = {
+  cache: KueueNamespaceWorkloadCache;
+  enrichmentReady: boolean;
+};
+
+const emptyFetchState: WorkloadCacheFetchState = {
+  cache: emptyCache,
+  enrichmentReady: false,
+};
 
 const buildNamespacesKey = (namespaces: Iterable<string>): string =>
   [...namespaces].toSorted((a, b) => a.localeCompare(b)).join('\0');
-
-const buildNamespaceLoadError = (failures: { namespace: string; error: Error }[]): Error =>
-  new Error(
-    `Failed to load workloads for: ${failures
-      .map(({ namespace, error }) => `${namespace} (${error.message})`)
-      .join('; ')}`,
-  );
 
 type KueueNamespaceWorkloadCacheContextValue = {
   cache: KueueNamespaceWorkloadCache;
@@ -86,9 +72,9 @@ type KueueNamespaceWorkloadCacheProviderProps = {
  * namespace), so switching between cluster queues that share a namespace reuses already-fetched
  * data until the next refresh re-fetches all relevant namespaces in place.
  *
- * Loading is two-phase: B1 fetches workloads + LocalQueues; B2 enriches with pods, StatefulSets,
- * InferenceServices, job-kind indexes, and hardware profiles. `loaded` stays false until B2
- * completes for the current base generation so Type/HW profile columns are not misleading.
+ * Loading is two-phase: base workloads, then enrichment. `loaded` stays false until enrichment
+ * completes so Type/HW profile columns are not misleading. Updates use a single `loadWorkloadCache`
+ * pipeline — manual refresh badge and a 5m timer when a cluster queue is selected.
  */
 const KueueNamespaceWorkloadCacheProvider: React.FC<KueueNamespaceWorkloadCacheProviderProps> = ({
   children,
@@ -113,246 +99,155 @@ const KueueNamespaceWorkloadCacheProvider: React.FC<KueueNamespaceWorkloadCacheP
     [clusterQueueNames],
   );
 
-  // Phase A: cheap, cluster-wide LocalQueue index — only when a cluster queue is selected.
-  const {
-    data: index,
-    loaded: indexLoaded,
-    error: indexError,
-    refresh: refreshIndex,
-  } = useFetch<LocalQueueClusterQueueIndex>(
-    React.useCallback(async () => {
-      if (!active) {
-        return emptyIndex;
-      }
-      return fetchLocalQueueClusterQueueIndex();
-    }, [active]),
-    emptyIndex,
-    {
-      refreshRate: active ? INFRASTRUCTURE_MANUAL_REFRESH_ONLY : -1,
-      initialPromisePurity: true,
-    },
-  );
-
-  const namespaceBundleStateRef = React.useRef(new Map<string, NamespaceBundleState>());
-  const hardwareProfileCacheRef = React.useRef<HardwareProfileByKey>(new Map());
-  const hardwareProfilesForMatchingCacheRef = React.useRef<
-    KueueNamespaceWorkloadCache['hardwareProfilesForMatching']
-  >([]);
-  /** Bumps on each B1 completion; B2 must match before enriched cache is shown (avoids stale enrich on CQ switch / refresh). */
-  const baseFetchGenerationRef = React.useRef(0);
-  const enrichedFetchGenerationRef = React.useRef(0);
+  const storeRef = React.useRef<WorkloadCacheMutableStore>(createWorkloadCacheStore());
+  const invalidateOnNextLoadRef = React.useRef(false);
+  const loadCompletionRef = React.useRef<Promise<KueueNamespaceWorkloadCache>>();
   const clusterQueueNamesKeyRef = React.useRef(clusterQueueNamesKey);
-  const dashboardNamespaceRef = React.useRef(dashboardNamespace);
-  dashboardNamespaceRef.current = dashboardNamespace;
 
   React.useEffect(() => {
     if (clusterQueueNamesKeyRef.current === clusterQueueNamesKey) {
       return;
     }
     clusterQueueNamesKeyRef.current = clusterQueueNamesKey;
-    for (const [namespace, state] of namespaceBundleStateRef.current) {
-      namespaceBundleStateRef.current.set(namespace, { base: state.base });
-    }
-    hardwareProfileCacheRef.current.clear();
-    hardwareProfilesForMatchingCacheRef.current = [];
-    enrichedFetchGenerationRef.current = 0;
+    storeRef.current.stripEnrichmentOnClusterQueueSwitch();
   }, [clusterQueueNamesKey]);
 
   const clusterQueueNamesRef = React.useRef(clusterQueueNames);
   clusterQueueNamesRef.current = clusterQueueNames;
   const kueueNamespaceSetRef = React.useRef(kueueNamespaceSet);
   kueueNamespaceSetRef.current = kueueNamespaceSet;
-  const indexRef = React.useRef(index);
-  indexRef.current = index;
+  const dashboardNamespaceRef = React.useRef(dashboardNamespace);
+  dashboardNamespaceRef.current = dashboardNamespace;
 
-  // Phase B1: workloads + LocalQueues — optimistic enrichment reuse while B2 catches up.
+  const [pipelineError, setPipelineError] = React.useState<Error | undefined>();
+
   const {
-    data: baseCache,
-    loaded: baseLoaded,
-    error: baseError,
-    refresh: refreshBase,
-  } = useFetch<KueueNamespaceWorkloadCache>(
+    data: fetchState = emptyFetchState,
+    error: fetchError,
+    refresh: refreshFetch,
+  } = useFetch<WorkloadCacheFetchState | AdHocUpdate<WorkloadCacheFetchState>>(
     React.useCallback(async () => {
+      setPipelineError(undefined);
+
       if (!active) {
-        return emptyCache;
+        return { cache: emptyCache, enrichmentReady: true };
       }
-      if (!projectsLoaded || !indexLoaded) {
-        throw new NotReadyError('Projects or LocalQueue index not loaded');
+      if (!projectsLoaded) {
+        throw new NotReadyError('Projects not loaded');
       }
 
-      const relevantNamespaces = [
-        ...getNamespacesForClusterQueues(clusterQueueNamesRef.current, indexRef.current),
-      ].filter((namespace) => kueueNamespaceSetRef.current.has(namespace));
+      const invalidateBundles = invalidateOnNextLoadRef.current;
+      if (invalidateBundles) {
+        clearWorkloadCacheStore(storeRef.current);
+      }
+      invalidateOnNextLoadRef.current = false;
 
-      const pendingBaseGeneration = baseFetchGenerationRef.current + 1;
-
-      const [fetchResults, resourceFlavors] = await Promise.all([
-        Promise.all(
-          relevantNamespaces.map(async (namespace) => {
-            try {
-              const previousState = namespaceBundleStateRef.current.get(namespace);
-              let base = previousState?.base;
-              if (!base) {
-                base = await fetchNamespaceWorkloadBaseData(namespace);
-              }
-              const nextState = createNamespaceBundleState(base, previousState);
-              namespaceBundleStateRef.current.set(namespace, nextState);
-              const bundle = toDisplayBundle(nextState, pendingBaseGeneration, true);
-              return { namespace, bundle, error: undefined };
-            } catch (error) {
-              return {
-                namespace,
-                bundle: undefined,
-                error: error instanceof Error ? error : new Error(String(error)),
-              };
-            }
-          }),
-        ),
-        listResourceFlavors(),
-      ]);
-
-      const failures = fetchResults.flatMap((result) =>
-        result.error ? [{ namespace: result.namespace, error: result.error }] : [],
-      );
-
-      const namespaceData = relevantNamespaces.flatMap((namespace) => {
-        const state = namespaceBundleStateRef.current.get(namespace);
-        return state ? [toDisplayBundle(state, pendingBaseGeneration, true)] : [];
-      });
-
-      const namespaceLoadError =
-        failures.length > 0 ? buildNamespaceLoadError(failures) : undefined;
-
-      baseFetchGenerationRef.current = pendingBaseGeneration;
-
-      return {
-        namespaceData,
-        resourceFlavorByName: buildResourceFlavorByName(resourceFlavors),
-        hardwareProfileByKey: new Map(hardwareProfileCacheRef.current),
-        hardwareProfilesForMatching: hardwareProfilesForMatchingCacheRef.current,
-        namespaceLoadError,
+      const loadParams = {
+        clusterQueueNames: clusterQueueNamesRef.current,
+        kueueNamespaceSet: kueueNamespaceSetRef.current,
+        dashboardNamespace: dashboardNamespaceRef.current,
+        store: storeRef.current,
+        invalidateBundles,
       };
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- keys fingerprint selection/namespace inputs
-    }, [active, projectsLoaded, indexLoaded, clusterQueueNamesKey, namespacesKey]),
-    emptyCache,
-    {
-      refreshRate: active ? INFRASTRUCTURE_MANUAL_REFRESH_ONLY : -1,
-      initialPromisePurity: true,
-    },
-  );
 
-  const baseCacheRef = React.useRef(baseCache);
-  baseCacheRef.current = baseCache;
+      return new Promise<AdHocUpdate<WorkloadCacheFetchState>>((resolve, reject) => {
+        let adHocDelivered = false;
 
-  // Phase B2: lazy pods/STS/ISVC/job lists + hardware profiles.
-  const { data: enrichedCache, refresh: refreshEnriched } = useFetch<KueueNamespaceWorkloadCache>(
-    React.useCallback(async () => {
-      if (!active || !baseLoaded) {
-        throw new NotReadyError('Base namespace workload cache not loaded');
-      }
-
-      const baseNamespaceData = baseCacheRef.current.namespaceData;
-      if (baseNamespaceData.length === 0) {
-        return baseCacheRef.current;
-      }
-
-      const baseGeneration = baseFetchGenerationRef.current;
-
-      const enrichResults = await Promise.all(
-        baseNamespaceData.map(async (baseBundle) => {
-          const state = namespaceBundleStateRef.current.get(baseBundle.namespace);
-          const base: NamespaceWorkloadBaseData = state?.base ?? {
-            namespace: baseBundle.namespace,
-            workloads: baseBundle.workloads,
-            localQueues: baseBundle.localQueues,
-          };
-          try {
-            const enriched = await enrichNamespaceWorkloadData(base, clusterQueueNamesRef.current);
-            const enrichment: NamespaceWorkloadEnrichment = {
-              pods: enriched.pods,
-              statefulSets: enriched.statefulSets,
-              inferenceServices: enriched.inferenceServices,
-              jobKindByUid: enriched.jobKindByUid,
-            };
-            const updatedState = applyNamespaceEnrichment(
-              state ?? { base },
-              enrichment,
-              baseGeneration,
-            );
-            namespaceBundleStateRef.current.set(base.namespace, updatedState);
-            return toDisplayBundle(updatedState, baseGeneration);
-          } catch {
-            return toNamespaceWorkloadData(base);
+        const handlePipelineFailure = (reason: unknown) => {
+          if (reason instanceof Error && isCommonStateError(reason)) {
+            return;
           }
-        }),
-      );
+          const error = reason instanceof Error ? reason : new Error(String(reason));
+          if (!adHocDelivered) {
+            reject(error);
+            return;
+          }
+          setPipelineError(error);
+        };
 
-      const [fetchedHardwareProfiles, hardwareProfilesForMatching] = await Promise.all([
-        fetchHardwareProfilesByKey(collectHardwareProfileRefs(enrichResults)),
-        fetchHardwareProfilesForMatching(enrichResults, dashboardNamespaceRef.current),
-      ]);
-      for (const [key, hardwareProfile] of fetchedHardwareProfiles) {
-        hardwareProfileCacheRef.current.set(key, hardwareProfile);
-      }
-      hardwareProfilesForMatchingCacheRef.current = hardwareProfilesForMatching;
+        const loadPromise = loadWorkloadCache({
+          ...loadParams,
+          onBaseCache: (base) => {
+            resolve((setStateLater) => {
+              adHocDelivered = true;
+              setStateLater(() => ({
+                cache: base,
+                enrichmentReady: base.namespaceData.length === 0,
+              }));
+              void loadPromise
+                .then((enriched) => {
+                  setPipelineError(undefined);
+                  setStateLater(() => ({ cache: enriched, enrichmentReady: true }));
+                })
+                .catch(handlePipelineFailure);
+            });
+          },
+        });
+        loadCompletionRef.current = loadPromise;
 
-      if (baseGeneration !== baseFetchGenerationRef.current) {
-        throw new NotReadyError('Base generation advanced during enrichment');
-      }
-      enrichedFetchGenerationRef.current = baseGeneration;
-
-      return {
-        namespaceData: enrichResults,
-        resourceFlavorByName: baseCacheRef.current.resourceFlavorByName,
-        hardwareProfileByKey: new Map(hardwareProfileCacheRef.current),
-        hardwareProfilesForMatching,
-        namespaceLoadError: baseCacheRef.current.namespaceLoadError,
-      };
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- keys fingerprint selection inputs
-    }, [active, baseLoaded, clusterQueueNamesKey, namespacesKey]),
-    emptyCache,
+        void loadPromise.catch((reason) => {
+          if (!adHocDelivered) {
+            handlePipelineFailure(reason);
+          }
+        });
+      });
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- keys fingerprint selection/namespace inputs
+    }, [active, projectsLoaded, clusterQueueNamesKey, namespacesKey]),
+    emptyFetchState,
     {
       refreshRate: active ? INFRASTRUCTURE_MANUAL_REFRESH_ONLY : -1,
       initialPromisePurity: true,
     },
   );
 
-  const isEnrichedCurrent =
-    enrichedCache.namespaceData.length > 0 &&
-    enrichedFetchGenerationRef.current === baseFetchGenerationRef.current;
-
-  const enrichmentReady = !active || baseCache.namespaceData.length === 0 || isEnrichedCurrent;
-
-  const cache = isEnrichedCurrent ? enrichedCache : baseCache;
+  const resolvedState: WorkloadCacheFetchState =
+    typeof fetchState === 'function' ? emptyFetchState : fetchState;
 
   const refresh = React.useCallback(async () => {
-    if (active) {
-      namespaceBundleStateRef.current.clear();
-      hardwareProfileCacheRef.current.clear();
-      hardwareProfilesForMatchingCacheRef.current = [];
-      enrichedFetchGenerationRef.current = 0;
-      await refreshIndex();
+    if (!active) {
+      return undefined;
     }
-    await refreshBase();
-    return refreshEnriched();
-  }, [active, refreshBase, refreshEnriched, refreshIndex]);
+    invalidateOnNextLoadRef.current = true;
+    const refreshPromise = refreshFetch();
+    const loadCompletion = loadCompletionRef.current;
+    await refreshPromise;
+    if (!loadCompletion) {
+      return undefined;
+    }
+    try {
+      return await loadCompletion;
+    } catch {
+      return undefined;
+    }
+  }, [active, refreshFetch]);
+
+  React.useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+    const intervalId = setInterval(() => {
+      invalidateOnNextLoadRef.current = true;
+      void refreshFetch();
+    }, TREND_REFRESH_INTERVAL);
+    return () => clearInterval(intervalId);
+  }, [active, refreshFetch]);
+
+  const { cache, enrichmentReady } = resolvedState;
 
   const value = React.useMemo(
     (): KueueNamespaceWorkloadCacheContextValue => ({
       cache,
-      loaded: active && projectsLoaded && indexLoaded && baseLoaded && enrichmentReady,
+      loaded: active && projectsLoaded && enrichmentReady,
       enrichmentReady,
-      error: projectsError ?? indexError ?? baseError ?? cache.namespaceLoadError,
+      error: projectsError ?? fetchError ?? pipelineError ?? cache.namespaceLoadError,
       refresh,
     }),
     [
       active,
       cache,
-      baseLoaded,
-      baseError,
       enrichmentReady,
-      indexLoaded,
-      indexError,
+      fetchError,
+      pipelineError,
       projectsError,
       projectsLoaded,
       refresh,

--- a/packages/gpuaas/src/hooks/__tests__/KueueNamespaceWorkloadCacheContext.spec.tsx
+++ b/packages/gpuaas/src/hooks/__tests__/KueueNamespaceWorkloadCacheContext.spec.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { act, render, renderHook, waitFor } from '@testing-library/react';
-import type { PodKind } from '@odh-dashboard/k8s-core';
+import type { PodKind, WorkloadKind } from '@odh-dashboard/k8s-core';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
-import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
+import { listHardwareProfiles } from '@odh-dashboard/internal/api/k8s/hardwareProfiles';
 import KueueNamespaceWorkloadCacheProvider, {
   useKueueNamespaceWorkloadCache,
 } from '../KueueNamespaceWorkloadCacheContext';
+import { TREND_REFRESH_INTERVAL } from '../../const';
 import {
   enrichNamespaceWorkloadData,
   fetchLocalQueueClusterQueueIndex,
@@ -19,8 +20,9 @@ jest.mock('@odh-dashboard/internal/api/k8s/projects', () => ({
   useProjects: jest.fn(),
 }));
 
-jest.mock('@odh-dashboard/internal/api/k8s/resourceFlavors', () => ({
-  listResourceFlavors: jest.fn(),
+jest.mock('@odh-dashboard/internal/api/k8s/hardwareProfiles', () => ({
+  listHardwareProfiles: jest.fn(),
+  getHardwareProfile: jest.fn(),
 }));
 
 jest.mock('@odh-dashboard/internal/redux/selectors/project', () => ({
@@ -35,7 +37,7 @@ jest.mock('../../utils/clusterQueueWorkloads', () => ({
 }));
 
 const useProjectsMock = jest.mocked(useProjects);
-const listResourceFlavorsMock = jest.mocked(listResourceFlavors);
+const listHardwareProfilesMock = jest.mocked(listHardwareProfiles);
 const fetchLocalQueueClusterQueueIndexMock = jest.mocked(fetchLocalQueueClusterQueueIndex);
 const fetchNamespaceWorkloadBaseDataMock = jest.mocked(fetchNamespaceWorkloadBaseData);
 const enrichNamespaceWorkloadDataMock = jest.mocked(enrichNamespaceWorkloadData);
@@ -47,6 +49,18 @@ const base = (namespace: string) => ({
   namespace,
   workloads: [],
   localQueues: [],
+});
+
+const baseWithWorkload = (namespace: string, uid: string) => ({
+  ...base(namespace),
+  workloads: [
+    {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'Workload',
+      metadata: { name: `workload-${uid}`, namespace, uid },
+      spec: { queueName: 'queue', podSets: [] },
+    } satisfies WorkloadKind,
+  ],
 });
 
 const mockPod = (name: string): PodKind => ({
@@ -68,7 +82,7 @@ describe('KueueNamespaceWorkloadCacheProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useProjectsMock.mockReturnValue([[dsp1, dsp2], true, undefined]);
-    listResourceFlavorsMock.mockResolvedValue([]);
+    listHardwareProfilesMock.mockResolvedValue([]);
     fetchLocalQueueClusterQueueIndexMock.mockResolvedValue(
       new Map([
         ['gpu-cq', new Set(['dsp-1'])],
@@ -252,6 +266,16 @@ describe('KueueNamespaceWorkloadCacheProvider', () => {
     await waitFor(() => expect(enrichNamespaceWorkloadDataMock).toHaveBeenCalledTimes(3));
   });
 
+  it('keeps workload data loaded when hardware profile listing fails', async () => {
+    listHardwareProfilesMock.mockRejectedValue(new Error('hardware profiles forbidden'));
+
+    const { result } = renderWithProvider(['gpu-cq']);
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.error).toBeUndefined();
+    expect(enrichNamespaceWorkloadDataMock).toHaveBeenCalled();
+  });
+
   it('surfaces namespace fetch failures while keeping successful namespaces', async () => {
     fetchNamespaceWorkloadBaseDataMock.mockImplementation((namespace: string) => {
       if (namespace === 'dsp-2') {
@@ -272,18 +296,75 @@ describe('KueueNamespaceWorkloadCacheProvider', () => {
     expect(result.current.error?.message).toContain('forbidden');
   });
 
+  it('periodically refreshes at the trend refresh interval when active', async () => {
+    jest.useFakeTimers();
+    try {
+      const { result } = renderWithProvider(['gpu-cq']);
+
+      await waitFor(() => expect(result.current.loaded).toBe(true));
+      expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(TREND_REFRESH_INTERVAL);
+      });
+      await waitFor(() => expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledTimes(2));
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('re-fetches namespace bundles on refresh', async () => {
     const { result } = renderWithProvider(['gpu-cq']);
 
     await waitFor(() => expect(result.current.loaded).toBe(true));
     expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledTimes(1);
 
+    let refreshedCache: Awaited<ReturnType<typeof result.current.refresh>>;
     await act(async () => {
-      await result.current.refresh();
+      refreshedCache = await result.current.refresh();
     });
 
     expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledTimes(2);
     expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledWith('dsp-1');
+    expect(refreshedCache?.namespaceData.map((data) => data.namespace)).toEqual(['dsp-1']);
+  });
+
+  it('does not let a superseded base fetch overwrite the latest cache', async () => {
+    const refreshResolvers: Array<(value: ReturnType<typeof baseWithWorkload>) => void> = [];
+    fetchNamespaceWorkloadBaseDataMock.mockResolvedValueOnce(base('dsp-1')).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          refreshResolvers.push(resolve);
+        }),
+    );
+
+    const { result } = renderWithProvider(['gpu-cq']);
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    act(() => {
+      void result.current.refresh();
+    });
+    await waitFor(() => expect(refreshResolvers).toHaveLength(1));
+
+    let secondRefresh: Promise<unknown> | undefined;
+    act(() => {
+      secondRefresh = result.current.refresh();
+    });
+    await waitFor(() => expect(refreshResolvers).toHaveLength(2));
+
+    await act(async () => {
+      refreshResolvers[1]?.(baseWithWorkload('dsp-1', 'fresh'));
+      await secondRefresh;
+    });
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    await act(async () => {
+      refreshResolvers[0]?.(baseWithWorkload('dsp-1', 'stale'));
+    });
+
+    await waitFor(() =>
+      expect(result.current.cache.namespaceData[0]?.workloads[0]?.metadata?.uid).toBe('fresh'),
+    );
   });
 
   it('does not reuse stale enrichment after refresh', async () => {
@@ -324,5 +405,6 @@ describe('KueueNamespaceWorkloadCacheProvider', () => {
 
     await waitFor(() => expect(result.current.loaded).toBe(true));
     expect(result.current.cache.namespaceData[0]?.pods).toEqual([]);
+    expect(result.current.error?.message).toContain('enrichment failed');
   });
 });

--- a/packages/gpuaas/src/hooks/__tests__/KueueNamespaceWorkloadCacheContext.spec.tsx
+++ b/packages/gpuaas/src/hooks/__tests__/KueueNamespaceWorkloadCacheContext.spec.tsx
@@ -1,0 +1,328 @@
+import * as React from 'react';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
+import type { PodKind } from '@odh-dashboard/k8s-core';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
+import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
+import KueueNamespaceWorkloadCacheProvider, {
+  useKueueNamespaceWorkloadCache,
+} from '../KueueNamespaceWorkloadCacheContext';
+import {
+  enrichNamespaceWorkloadData,
+  fetchLocalQueueClusterQueueIndex,
+  fetchNamespaceWorkloadBaseData,
+  toNamespaceWorkloadData,
+  type NamespaceWorkloadData,
+} from '../../utils/clusterQueueWorkloads';
+
+jest.mock('@odh-dashboard/internal/api/k8s/projects', () => ({
+  useProjects: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/api/k8s/resourceFlavors', () => ({
+  listResourceFlavors: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/redux/selectors/project', () => ({
+  useDashboardNamespace: jest.fn(() => ({ dashboardNamespace: 'redhat-ods-applications' })),
+}));
+
+jest.mock('../../utils/clusterQueueWorkloads', () => ({
+  ...jest.requireActual('../../utils/clusterQueueWorkloads'),
+  fetchLocalQueueClusterQueueIndex: jest.fn(),
+  fetchNamespaceWorkloadBaseData: jest.fn(),
+  enrichNamespaceWorkloadData: jest.fn(),
+}));
+
+const useProjectsMock = jest.mocked(useProjects);
+const listResourceFlavorsMock = jest.mocked(listResourceFlavors);
+const fetchLocalQueueClusterQueueIndexMock = jest.mocked(fetchLocalQueueClusterQueueIndex);
+const fetchNamespaceWorkloadBaseDataMock = jest.mocked(fetchNamespaceWorkloadBaseData);
+const enrichNamespaceWorkloadDataMock = jest.mocked(enrichNamespaceWorkloadData);
+
+const dsp1 = mockProjectK8sResource({ k8sName: 'dsp-1', enableKueue: true });
+const dsp2 = mockProjectK8sResource({ k8sName: 'dsp-2', enableKueue: true });
+
+const base = (namespace: string) => ({
+  namespace,
+  workloads: [],
+  localQueues: [],
+});
+
+const mockPod = (name: string): PodKind => ({
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: { name },
+  spec: { containers: [{ name: 'main', image: 'test-image', env: [] }] },
+});
+
+const bundle = (namespace: string, podName?: string): NamespaceWorkloadData => ({
+  ...base(namespace),
+  pods: podName ? [mockPod(podName)] : [],
+  statefulSets: [],
+  inferenceServices: [],
+  jobKindByUid: new Map(),
+});
+
+describe('KueueNamespaceWorkloadCacheProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useProjectsMock.mockReturnValue([[dsp1, dsp2], true, undefined]);
+    listResourceFlavorsMock.mockResolvedValue([]);
+    fetchLocalQueueClusterQueueIndexMock.mockResolvedValue(
+      new Map([
+        ['gpu-cq', new Set(['dsp-1'])],
+        ['other-cq', new Set(['dsp-2'])],
+      ]),
+    );
+    fetchNamespaceWorkloadBaseDataMock.mockImplementation((namespace: string) =>
+      Promise.resolve(base(namespace)),
+    );
+    enrichNamespaceWorkloadDataMock.mockImplementation((baseData) =>
+      Promise.resolve(bundle(baseData.namespace)),
+    );
+  });
+
+  const renderWithProvider = (clusterQueueNames: string[]) =>
+    renderHook(() => useKueueNamespaceWorkloadCache(), {
+      wrapper: ({ children }) => (
+        <KueueNamespaceWorkloadCacheProvider clusterQueueNames={clusterQueueNames}>
+          {children}
+        </KueueNamespaceWorkloadCacheProvider>
+      ),
+    });
+
+  it('does not fetch namespace data when no cluster queue is selected', async () => {
+    const { result } = renderWithProvider([]);
+
+    await waitFor(() => expect(result.current.loaded).toBe(false));
+    expect(fetchLocalQueueClusterQueueIndexMock).not.toHaveBeenCalled();
+    expect(fetchNamespaceWorkloadBaseDataMock).not.toHaveBeenCalled();
+    expect(enrichNamespaceWorkloadDataMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches base namespace data only for namespaces relevant to the selected cluster queue', async () => {
+    const { result } = renderWithProvider(['gpu-cq']);
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledTimes(1);
+    expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledWith('dsp-1');
+    expect(result.current.cache.namespaceData.map((data) => data.namespace)).toEqual(['dsp-1']);
+    await waitFor(() => expect(enrichNamespaceWorkloadDataMock).toHaveBeenCalledTimes(1));
+    expect(enrichNamespaceWorkloadDataMock).toHaveBeenCalledWith(base('dsp-1'), ['gpu-cq']);
+  });
+
+  it('marks loaded only after enrichment completes', async () => {
+    let resolveEnrich: ((value: ReturnType<typeof bundle>) => void) | undefined;
+    enrichNamespaceWorkloadDataMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveEnrich = resolve;
+        }),
+    );
+
+    const { result } = renderWithProvider(['gpu-cq']);
+
+    await waitFor(() =>
+      expect(result.current.cache.namespaceData).toEqual([toNamespaceWorkloadData(base('dsp-1'))]),
+    );
+    expect(result.current.loaded).toBe(false);
+
+    await act(async () => {
+      resolveEnrich?.(bundle('dsp-1'));
+    });
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    await waitFor(() => expect(result.current.cache.namespaceData).toEqual([bundle('dsp-1')]));
+  });
+
+  it('does not show stale enrichment after switching cluster queues', async () => {
+    fetchLocalQueueClusterQueueIndexMock.mockResolvedValue(
+      new Map([
+        ['gpu-cq', new Set(['dsp-1'])],
+        ['other-cq', new Set(['dsp-1', 'dsp-2'])],
+      ]),
+    );
+
+    const pendingOtherEnrichResolvers: Array<() => void> = [];
+    enrichNamespaceWorkloadDataMock.mockImplementation((baseData, clusterQueueNames) => {
+      if (clusterQueueNames.includes('other-cq')) {
+        return new Promise((resolve) => {
+          pendingOtherEnrichResolvers.push(() =>
+            resolve(bundle(baseData.namespace, 'other-cq-enriched')),
+          );
+        });
+      }
+      return Promise.resolve(bundle(baseData.namespace, 'gpu-cq-enriched'));
+    });
+
+    let latestValue: ReturnType<typeof useKueueNamespaceWorkloadCache> | undefined;
+    let setClusterQueueNames: React.Dispatch<React.SetStateAction<string[]>> = () => undefined;
+
+    const Harness: React.FC = () => {
+      const [clusterQueueNames, setter] = React.useState<string[]>(['gpu-cq']);
+      setClusterQueueNames = setter;
+      return (
+        <KueueNamespaceWorkloadCacheProvider clusterQueueNames={clusterQueueNames}>
+          <Consumer />
+        </KueueNamespaceWorkloadCacheProvider>
+      );
+    };
+    const Consumer: React.FC = () => {
+      latestValue = useKueueNamespaceWorkloadCache();
+      return null;
+    };
+
+    render(<Harness />);
+
+    await waitFor(() =>
+      expect(latestValue?.cache.namespaceData[0]?.pods[0]?.metadata?.name).toBe('gpu-cq-enriched'),
+    );
+
+    act(() => setClusterQueueNames(['other-cq']));
+
+    await waitFor(() =>
+      expect(latestValue?.cache.namespaceData.map((data) => data.namespace).toSorted()).toEqual([
+        'dsp-1',
+        'dsp-2',
+      ]),
+    );
+    expect(latestValue?.loaded).toBe(false);
+    expect(
+      latestValue?.cache.namespaceData.every(
+        (data) => data.pods.length === 0 || data.pods[0]?.metadata?.name !== 'gpu-cq-enriched',
+      ),
+    ).toBe(true);
+
+    await act(async () => {
+      pendingOtherEnrichResolvers.splice(0).forEach((resolve) => resolve());
+    });
+
+    await waitFor(() =>
+      expect(
+        latestValue?.cache.namespaceData.some(
+          (data) => data.pods[0]?.metadata?.name === 'other-cq-enriched',
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it('re-fetches all relevant namespaces when switching cluster queues', async () => {
+    fetchLocalQueueClusterQueueIndexMock.mockResolvedValue(
+      new Map([
+        ['gpu-cq', new Set(['dsp-1'])],
+        ['other-cq', new Set(['dsp-1', 'dsp-2'])],
+      ]),
+    );
+
+    let latestValue: ReturnType<typeof useKueueNamespaceWorkloadCache> | undefined;
+    let setClusterQueueNames: React.Dispatch<React.SetStateAction<string[]>> = () => undefined;
+
+    const Harness: React.FC = () => {
+      const [clusterQueueNames, setter] = React.useState<string[]>(['gpu-cq']);
+      setClusterQueueNames = setter;
+      return (
+        <KueueNamespaceWorkloadCacheProvider clusterQueueNames={clusterQueueNames}>
+          <Consumer />
+        </KueueNamespaceWorkloadCacheProvider>
+      );
+    };
+    const Consumer: React.FC = () => {
+      latestValue = useKueueNamespaceWorkloadCache();
+      return null;
+    };
+
+    render(<Harness />);
+
+    await waitFor(() => expect(latestValue?.loaded).toBe(true));
+    expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledTimes(1);
+    expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledWith('dsp-1');
+
+    act(() => setClusterQueueNames(['other-cq']));
+
+    await waitFor(() =>
+      expect(latestValue?.cache.namespaceData.map((data) => data.namespace).toSorted()).toEqual([
+        'dsp-1',
+        'dsp-2',
+      ]),
+    );
+    expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledTimes(2);
+    expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledWith('dsp-2');
+    await waitFor(() => expect(enrichNamespaceWorkloadDataMock).toHaveBeenCalledTimes(3));
+  });
+
+  it('surfaces namespace fetch failures while keeping successful namespaces', async () => {
+    fetchNamespaceWorkloadBaseDataMock.mockImplementation((namespace: string) => {
+      if (namespace === 'dsp-2') {
+        return Promise.reject(new Error('forbidden'));
+      }
+      return Promise.resolve(base(namespace));
+    });
+    fetchLocalQueueClusterQueueIndexMock.mockResolvedValue(
+      new Map([['other-cq', new Set(['dsp-1', 'dsp-2'])]]),
+    );
+
+    const { result } = renderWithProvider(['other-cq']);
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    expect(result.current.cache.namespaceData.map((data) => data.namespace)).toEqual(['dsp-1']);
+    expect(result.current.error?.message).toContain('dsp-2');
+    expect(result.current.error?.message).toContain('forbidden');
+  });
+
+  it('re-fetches namespace bundles on refresh', async () => {
+    const { result } = renderWithProvider(['gpu-cq']);
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledTimes(2);
+    expect(fetchNamespaceWorkloadBaseDataMock).toHaveBeenCalledWith('dsp-1');
+  });
+
+  it('does not reuse stale enrichment after refresh', async () => {
+    enrichNamespaceWorkloadDataMock
+      .mockResolvedValueOnce(bundle('dsp-1', 'stale-pod'))
+      .mockResolvedValueOnce(bundle('dsp-1', 'fresh-pod'));
+
+    const { result } = renderWithProvider(['gpu-cq']);
+
+    await waitFor(() =>
+      expect(result.current.cache.namespaceData[0]?.pods[0]?.metadata?.name).toBe('stale-pod'),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() =>
+      expect(result.current.cache.namespaceData[0]?.pods[0]?.metadata?.name).toBe('fresh-pod'),
+    );
+    expect(enrichNamespaceWorkloadDataMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops enrichment instead of preserving stale pods when enrichment fails', async () => {
+    enrichNamespaceWorkloadDataMock
+      .mockResolvedValueOnce(bundle('dsp-1', 'stale-pod'))
+      .mockRejectedValueOnce(new Error('enrichment failed'));
+
+    const { result } = renderWithProvider(['gpu-cq']);
+
+    await waitFor(() =>
+      expect(result.current.cache.namespaceData[0]?.pods[0]?.metadata?.name).toBe('stale-pod'),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.cache.namespaceData[0]?.pods).toEqual([]);
+  });
+});

--- a/packages/gpuaas/src/hooks/__tests__/useClusterQueueWorkloadsData.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useClusterQueueWorkloadsData.spec.ts
@@ -45,7 +45,6 @@ const fetchQueuePositionsMock = jest.mocked(fetchQueuePositions);
 const kueueProject = mockProjectK8sResource({ k8sName: 'dsp-1', enableKueue: true });
 const emptyCache = {
   namespaceData: [],
-  resourceFlavorByName: new Map(),
   hardwareProfileByKey: new Map(),
   hardwareProfilesForMatching: [],
 };
@@ -117,7 +116,6 @@ const mockCacheWithTwoQueues = {
       jobKindByUid: new Map(),
     },
   ],
-  resourceFlavorByName: new Map(),
 } as unknown as KueueNamespaceWorkloadCache;
 
 const mockUseFetchDefaults = (): void => {

--- a/packages/gpuaas/src/hooks/__tests__/useClusterQueueWorkloadsData.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useClusterQueueWorkloadsData.spec.ts
@@ -2,12 +2,23 @@ import { testHook } from '@odh-dashboard/jest-config/hooks';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
 import useFetch from '@odh-dashboard/ui-core/hooks/useFetch';
-import { QuotaUsageWorkloadStatuses, QuotaUsageWorkloadTypes } from '../../types';
 import useClusterQueueWorkloadsData from '../useClusterQueueWorkloadsData';
-import { fetchWorkloadsForClusterQueues } from '../../utils/clusterQueueWorkloads';
+import { useKueueNamespaceWorkloadCache } from '../KueueNamespaceWorkloadCacheContext';
+import {
+  fetchQueuePositions,
+  type KueueNamespaceWorkloadCache,
+} from '../../utils/clusterQueueWorkloads';
 
 jest.mock('@odh-dashboard/internal/api/k8s/projects', () => ({
   useProjects: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/redux/selectors/project', () => ({
+  useDashboardNamespace: jest.fn(() => ({ dashboardNamespace: 'redhat-ods-applications' })),
+}));
+
+jest.mock('../KueueNamespaceWorkloadCacheContext', () => ({
+  useKueueNamespaceWorkloadCache: jest.fn(),
 }));
 
 jest.mock('@odh-dashboard/ui-core/hooks/useFetch', () => ({
@@ -23,35 +34,119 @@ jest.mock('@odh-dashboard/ui-core/hooks/useFetch', () => ({
 
 jest.mock('../../utils/clusterQueueWorkloads', () => ({
   ...jest.requireActual('../../utils/clusterQueueWorkloads'),
-  fetchWorkloadsForClusterQueues: jest.fn(),
+  fetchQueuePositions: jest.fn(),
 }));
 
 const useProjectsMock = jest.mocked(useProjects);
 const useFetchMock = jest.mocked(useFetch);
-const fetchWorkloadsForClusterQueuesMock = jest.mocked(fetchWorkloadsForClusterQueues);
+const useKueueNamespaceWorkloadCacheMock = jest.mocked(useKueueNamespaceWorkloadCache);
+const fetchQueuePositionsMock = jest.mocked(fetchQueuePositions);
 
 const kueueProject = mockProjectK8sResource({ k8sName: 'dsp-1', enableKueue: true });
+const emptyCache = {
+  namespaceData: [],
+  resourceFlavorByName: new Map(),
+  hardwareProfileByKey: new Map(),
+  hardwareProfilesForMatching: [],
+};
+
+const mockCacheWithTwoQueues = {
+  namespaceData: [
+    {
+      namespace: 'dsp-1',
+      workloads: [
+        {
+          apiVersion: 'kueue.x-k8s.io/v1beta2' as const,
+          kind: 'Workload' as const,
+          metadata: { name: 'wl-1', namespace: 'dsp-1' },
+          spec: {
+            active: true,
+            queueName: 'user-queue',
+            podSets: [
+              {
+                count: 1,
+                name: 'main',
+                template: {
+                  metadata: {},
+                  spec: {
+                    containers: [
+                      {
+                        name: 'main',
+                        image: 'test-image',
+                        env: [],
+                        resources: { requests: { 'nvidia.com/gpu': '1' } },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+          status: {
+            admission: { clusterQueue: 'gpu-cq', podSetAssignments: [] },
+            conditions: [
+              {
+                type: 'QuotaReserved',
+                status: 'True',
+                reason: 'QuotaReserved',
+                message: 'Quota reserved',
+                lastTransitionTime: '2026-01-01T00:00:00Z',
+              },
+              {
+                type: 'Admitted',
+                status: 'True',
+                reason: 'Admitted',
+                message: 'Admitted',
+                lastTransitionTime: '2026-01-01T00:00:00Z',
+              },
+            ],
+          },
+        },
+      ],
+      localQueues: [
+        {
+          apiVersion: 'kueue.x-k8s.io/v1beta2' as const,
+          kind: 'LocalQueue' as const,
+          metadata: { name: 'user-queue', namespace: 'dsp-1' },
+          spec: { clusterQueue: 'gpu-cq' },
+        },
+      ],
+      pods: [],
+      statefulSets: [],
+      inferenceServices: [],
+      jobKindByUid: new Map(),
+    },
+  ],
+  resourceFlavorByName: new Map(),
+} as unknown as KueueNamespaceWorkloadCache;
+
+const mockUseFetchDefaults = (): void => {
+  useFetchMock.mockImplementation((callback, initialValue) => {
+    void Promise.resolve(callback({ signal: new AbortController().signal })).catch(() => undefined);
+    return { data: initialValue, loaded: true, error: undefined, refresh: jest.fn() };
+  });
+};
 
 describe('useClusterQueueWorkloadsData', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useProjectsMock.mockReturnValue([[kueueProject], true, undefined]);
-    useFetchMock.mockImplementation((callback) => {
-      void callback({ signal: new AbortController().signal });
-      return {
-        data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: emptyCache,
+      loaded: true,
+      enrichmentReady: true,
+      error: undefined,
+      refresh: jest.fn(),
     });
+    fetchQueuePositionsMock.mockResolvedValue(new Map());
+    mockUseFetchDefaults();
   });
 
-  it('returns loading until projects and workloads are loaded', () => {
-    useProjectsMock.mockReturnValue([[], false, undefined]);
-    useFetchMock.mockReturnValue({
-      data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
+  it('returns loading until namespace workload cache is loaded', () => {
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: emptyCache,
       loaded: false,
+      enrichmentReady: false,
       error: undefined,
       refresh: jest.fn(),
     });
@@ -60,45 +155,19 @@ describe('useClusterQueueWorkloadsData', () => {
     expect(renderResult.result.current.loaded).toBe(false);
   });
 
-  it('fetches workloads once for all cluster queues', () => {
-    const workloadsByClusterQueue = new Map([
-      [
-        'gpu-cq',
-        [
-          {
-            name: 'wl-1',
-            namespace: 'dsp-1',
-            project: 'dsp-1',
-            clusterQueue: 'gpu-cq',
-            type: QuotaUsageWorkloadTypes.Workbench,
-            status: QuotaUsageWorkloadStatuses.Queued,
-            localQueue: 'user-queue',
-            accelerators: 1,
-            queuePosition: 2,
-          },
-        ],
-      ],
-    ]);
-
-    fetchWorkloadsForClusterQueuesMock.mockResolvedValue(workloadsByClusterQueue);
-    useFetchMock.mockImplementation((callback) => {
-      void callback({ signal: new AbortController().signal });
-      return {
-        data: { mode: 'clusterQueues', workloadsByClusterQueue },
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
+  it('maps workloads for all requested cluster queues from the shared cache', () => {
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: mockCacheWithTwoQueues,
+      loaded: true,
+      enrichmentReady: true,
+      error: undefined,
+      refresh: jest.fn(),
     });
 
     const renderResult = testHook(useClusterQueueWorkloadsData)(['gpu-cq', 'other-cq']);
-    expect(fetchWorkloadsForClusterQueuesMock).toHaveBeenCalledWith(
-      ['gpu-cq', 'other-cq'],
-      ['dsp-1'],
-      expect.any(Map),
-      false,
-    );
+
     expect(renderResult.result.current.workloadsByClusterQueue.get('gpu-cq')).toHaveLength(1);
+    expect(renderResult.result.current.workloadsByClusterQueue.get('other-cq')).toHaveLength(0);
     expect(renderResult.result.current.loaded).toBe(true);
   });
 

--- a/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
@@ -4,13 +4,23 @@ import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
 import useFetch from '@odh-dashboard/ui-core/hooks/useFetch';
 import { QuotaUsageWorkloadStatuses, QuotaUsageWorkloadTypes } from '../../types';
 import useWorkloadRows from '../useWorkloadRows';
+import { useKueueNamespaceWorkloadCache } from '../KueueNamespaceWorkloadCacheContext';
 import {
   fetchNamespaceWorkloads,
-  fetchWorkloadsForClusterQueues,
+  fetchQueuePositions,
+  type KueueNamespaceWorkloadCache,
 } from '../../utils/clusterQueueWorkloads';
 
 jest.mock('@odh-dashboard/internal/api/k8s/projects', () => ({
   useProjects: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/redux/selectors/project', () => ({
+  useDashboardNamespace: jest.fn(() => ({ dashboardNamespace: 'redhat-ods-applications' })),
+}));
+
+jest.mock('../KueueNamespaceWorkloadCacheContext', () => ({
+  useKueueNamespaceWorkloadCache: jest.fn(),
 }));
 
 jest.mock('@odh-dashboard/ui-core/hooks/useFetch', () => ({
@@ -26,74 +36,140 @@ jest.mock('@odh-dashboard/ui-core/hooks/useFetch', () => ({
 
 jest.mock('../../utils/clusterQueueWorkloads', () => ({
   ...jest.requireActual('../../utils/clusterQueueWorkloads'),
-  fetchWorkloadsForClusterQueues: jest.fn(),
+  fetchQueuePositions: jest.fn(),
   fetchNamespaceWorkloads: jest.fn(),
 }));
 
 const useProjectsMock = jest.mocked(useProjects);
 const useFetchMock = jest.mocked(useFetch);
-const fetchWorkloadsForClusterQueuesMock = jest.mocked(fetchWorkloadsForClusterQueues);
+const useKueueNamespaceWorkloadCacheMock = jest.mocked(useKueueNamespaceWorkloadCache);
+const fetchQueuePositionsMock = jest.mocked(fetchQueuePositions);
 const fetchNamespaceWorkloadsMock = jest.mocked(fetchNamespaceWorkloads);
 
 const kueueProject = mockProjectK8sResource({ k8sName: 'dsp-1', enableKueue: true });
+
+const gpuCqRow = {
+  name: 'wl-1',
+  namespace: 'dsp-1',
+  project: 'dsp-1',
+  clusterQueue: 'gpu-cq',
+  type: QuotaUsageWorkloadTypes.Workbench,
+  status: QuotaUsageWorkloadStatuses.Queued,
+  localQueue: 'user-queue',
+  accelerators: 1,
+  queuePosition: undefined,
+};
+
+const mockCacheWithGpuCq = {
+  namespaceData: [
+    {
+      namespace: 'dsp-1',
+      workloads: [
+        {
+          apiVersion: 'kueue.x-k8s.io/v1beta2' as const,
+          kind: 'Workload' as const,
+          metadata: { name: 'wl-1', namespace: 'dsp-1' },
+          spec: {
+            active: true,
+            queueName: 'user-queue',
+            podSets: [
+              {
+                count: 1,
+                name: 'main',
+                template: {
+                  metadata: {},
+                  spec: {
+                    containers: [
+                      {
+                        name: 'main',
+                        image: 'test-image',
+                        env: [],
+                        resources: { requests: { 'nvidia.com/gpu': '1' } },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+          status: {
+            conditions: [
+              {
+                type: 'QuotaReserved',
+                status: 'False',
+                reason: 'Pending',
+                message: 'Waiting',
+                lastTransitionTime: '2026-01-01T00:00:00Z',
+              },
+            ],
+          },
+        },
+      ],
+      localQueues: [
+        {
+          apiVersion: 'kueue.x-k8s.io/v1beta2' as const,
+          kind: 'LocalQueue' as const,
+          metadata: { name: 'user-queue', namespace: 'dsp-1' },
+          spec: { clusterQueue: 'gpu-cq' },
+        },
+      ],
+      pods: [],
+      statefulSets: [],
+      inferenceServices: [],
+      jobKindByUid: new Map(),
+    },
+  ],
+  resourceFlavorByName: new Map(),
+} as unknown as KueueNamespaceWorkloadCache;
+
+const emptyCache = {
+  namespaceData: [],
+  resourceFlavorByName: new Map(),
+  hardwareProfileByKey: new Map(),
+  hardwareProfilesForMatching: [],
+};
+
+// Distinguish which useFetch call is which by inspecting the initial value shape (Map -> queue
+// positions fetch; { mode: 'namespace' | 'clusterQueues', ... } -> namespace fetch).
+const mockUseFetchDefaults = (): void => {
+  useFetchMock.mockImplementation((callback, initialValue) => {
+    void Promise.resolve(callback({ signal: new AbortController().signal })).catch(() => undefined);
+    if (initialValue instanceof Map) {
+      return { data: initialValue, loaded: true, error: undefined, refresh: jest.fn() };
+    }
+    return { data: initialValue, loaded: true, error: undefined, refresh: jest.fn() };
+  });
+};
 
 describe('useWorkloadRows', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useProjectsMock.mockReturnValue([[kueueProject], true, undefined]);
-    useFetchMock.mockImplementation((callback) => {
-      void callback({ signal: new AbortController().signal });
-      return {
-        data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: emptyCache,
+      loaded: true,
+      enrichmentReady: true,
+      error: undefined,
+      refresh: jest.fn(),
     });
+    fetchQueuePositionsMock.mockResolvedValue(new Map());
+    mockUseFetchDefaults();
   });
 
-  it('fetches workloads for all cluster queues in clusterQueues scope', () => {
-    const workloadsByClusterQueue = new Map([
-      [
-        'gpu-cq',
-        [
-          {
-            name: 'wl-1',
-            namespace: 'dsp-1',
-            project: 'dsp-1',
-            clusterQueue: 'gpu-cq',
-            type: QuotaUsageWorkloadTypes.Workbench,
-            status: QuotaUsageWorkloadStatuses.Queued,
-            localQueue: 'user-queue',
-            accelerators: 1,
-            queuePosition: 2,
-          },
-        ],
-      ],
-    ]);
-
-    fetchWorkloadsForClusterQueuesMock.mockResolvedValue(workloadsByClusterQueue);
-    useFetchMock.mockImplementation((callback) => {
-      void callback({ signal: new AbortController().signal });
-      return {
-        data: { mode: 'clusterQueues', workloadsByClusterQueue },
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
+  it('maps workloads for cluster queues synchronously from the shared cache', () => {
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: mockCacheWithGpuCq,
+      loaded: true,
+      enrichmentReady: true,
+      error: undefined,
+      refresh: jest.fn(),
     });
 
     const renderResult = testHook(useWorkloadRows)({
       mode: 'clusterQueues',
-      clusterQueueNames: ['gpu-cq', 'other-cq'],
+      clusterQueueNames: ['gpu-cq'],
     });
 
-    expect(fetchWorkloadsForClusterQueuesMock).toHaveBeenCalledWith(
-      ['gpu-cq', 'other-cq'],
-      ['dsp-1'],
-      expect.any(Map),
-      false,
-    );
     expect(renderResult.result.current.data.mode).toBe('clusterQueues');
     if (renderResult.result.current.data.mode === 'clusterQueues') {
       expect(renderResult.result.current.data.workloadsByClusterQueue.get('gpu-cq')).toHaveLength(
@@ -103,24 +179,53 @@ describe('useWorkloadRows', () => {
     expect(renderResult.result.current.loaded).toBe(true);
   });
 
+  it('enriches queued rows with queue positions asynchronously', () => {
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: mockCacheWithGpuCq,
+      loaded: true,
+      enrichmentReady: true,
+      error: undefined,
+      refresh: jest.fn(),
+    });
+    useFetchMock.mockImplementation((callback, initialValue) => {
+      void Promise.resolve(callback({ signal: new AbortController().signal })).catch(
+        () => undefined,
+      );
+      if (initialValue instanceof Map) {
+        return {
+          data: new Map([['dsp-1/wl-1', 3]]),
+          loaded: true,
+          error: undefined,
+          refresh: jest.fn(),
+        };
+      }
+      return { data: initialValue, loaded: true, error: undefined, refresh: jest.fn() };
+    });
+
+    const renderResult = testHook(useWorkloadRows)({
+      mode: 'clusterQueues',
+      clusterQueueNames: ['gpu-cq'],
+    });
+
+    expect(renderResult.result.current.data.mode).toBe('clusterQueues');
+    if (renderResult.result.current.data.mode === 'clusterQueues') {
+      const rows = renderResult.result.current.data.workloadsByClusterQueue.get('gpu-cq') ?? [];
+      expect(rows[0].queuePosition).toBe(3);
+      expect(rows[0].status).toBe(QuotaUsageWorkloadStatuses.Queued);
+    }
+  });
+
   it('fetches all workloads for a namespace scope', () => {
-    const workloads = [
-      {
-        name: 'wl-1',
-        namespace: 'dsp-1',
-        project: 'DSP 1',
-        clusterQueue: 'gpu-cq',
-        type: QuotaUsageWorkloadTypes.Serve,
-        status: QuotaUsageWorkloadStatuses.Admitted,
-        localQueue: 'user-queue',
-        accelerators: 1,
-        queuePosition: undefined,
-      },
-    ];
+    const workloads = [{ ...gpuCqRow, status: QuotaUsageWorkloadStatuses.Admitted }];
 
     fetchNamespaceWorkloadsMock.mockResolvedValue(workloads);
-    useFetchMock.mockImplementation((callback) => {
-      void callback({ signal: new AbortController().signal });
+    useFetchMock.mockImplementation((callback, initialValue) => {
+      void Promise.resolve(callback({ signal: new AbortController().signal })).catch(
+        () => undefined,
+      );
+      if (initialValue instanceof Map) {
+        return { data: initialValue, loaded: true, error: undefined, refresh: jest.fn() };
+      }
       return {
         data: { mode: 'namespace', workloads },
         loaded: true,
@@ -135,7 +240,11 @@ describe('useWorkloadRows', () => {
       projectDisplayName: 'DSP 1',
     });
 
-    expect(fetchNamespaceWorkloadsMock).toHaveBeenCalledWith('dsp-1', 'DSP 1', false);
+    expect(fetchNamespaceWorkloadsMock).toHaveBeenCalledWith(
+      'dsp-1',
+      'DSP 1',
+      'redhat-ods-applications',
+    );
     expect(renderResult.result.current.data.mode).toBe('namespace');
     if (renderResult.result.current.data.mode === 'namespace') {
       expect(renderResult.result.current.data.workloads).toHaveLength(1);
@@ -143,11 +252,11 @@ describe('useWorkloadRows', () => {
     expect(renderResult.result.current.loaded).toBe(true);
   });
 
-  it('waits for projects in clusterQueues scope', () => {
-    useProjectsMock.mockReturnValue([[], false, undefined]);
-    useFetchMock.mockReturnValue({
-      data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
+  it('waits for namespace workload cache in clusterQueues scope', () => {
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: emptyCache,
       loaded: false,
+      enrichmentReady: false,
       error: undefined,
       refresh: jest.fn(),
     });
@@ -159,39 +268,90 @@ describe('useWorkloadRows', () => {
     expect(renderResult.result.current.loaded).toBe(false);
   });
 
-  it('returns loaded empty result for clusterQueues scope with no cluster queues', async () => {
-    useFetchMock.mockImplementation(() => {
-      return {
-        data: { mode: 'clusterQueues', workloadsByClusterQueue: new Map() },
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
-    });
-    useProjectsMock.mockReturnValue([[], false, new Error('projects failed')]);
-
+  it('returns loaded empty result for clusterQueues scope with no cluster queues', () => {
     const renderResult = testHook(useWorkloadRows)({
       mode: 'clusterQueues',
       clusterQueueNames: [],
     });
 
-    const fetchCallback = useFetchMock.mock.calls[0][0];
-    await expect(fetchCallback({ signal: new AbortController().signal })).resolves.toEqual({
+    expect(renderResult.result.current.data).toEqual({
       mode: 'clusterQueues',
       workloadsByClusterQueue: new Map(),
     });
-    expect(fetchWorkloadsForClusterQueuesMock).not.toHaveBeenCalled();
     expect(renderResult.result.current.loaded).toBe(true);
     expect(renderResult.result.current.error).toBeUndefined();
   });
 
-  it('passes initialPromisePurity to useFetch', () => {
-    testHook(useWorkloadRows)({ mode: 'clusterQueues', clusterQueueNames: ['gpu-cq'] });
+  it('surfaces project and cache errors for clusterQueues scope', () => {
+    const cacheError = new Error('cache failed');
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: emptyCache,
+      loaded: true,
+      enrichmentReady: true,
+      error: cacheError,
+      refresh: jest.fn(),
+    });
 
-    expect(useFetchMock).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.anything(),
-      expect.objectContaining({ initialPromisePurity: true }),
-    );
+    const renderResult = testHook(useWorkloadRows)({
+      mode: 'clusterQueues',
+      clusterQueueNames: ['gpu-cq'],
+    });
+    expect(renderResult.result.current.error).toBe(cacheError);
+  });
+
+  it('surfaces namespace load errors from the cache payload', () => {
+    const namespaceLoadError = new Error('dsp-2 failed');
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: { ...emptyCache, namespaceLoadError },
+      loaded: true,
+      enrichmentReady: true,
+      error: undefined,
+      refresh: jest.fn(),
+    });
+
+    const renderResult = testHook(useWorkloadRows)({
+      mode: 'clusterQueues',
+      clusterQueueNames: ['gpu-cq'],
+    });
+    expect(renderResult.result.current.error).toBe(namespaceLoadError);
+  });
+
+  it('refreshes namespace cache and queue positions for clusterQueues scope', async () => {
+    const refreshCache = jest.fn().mockResolvedValue(mockCacheWithGpuCq);
+    fetchQueuePositionsMock.mockResolvedValue(new Map());
+    useKueueNamespaceWorkloadCacheMock.mockReturnValue({
+      cache: mockCacheWithGpuCq,
+      loaded: true,
+      enrichmentReady: true,
+      error: undefined,
+      refresh: refreshCache,
+    });
+    useFetchMock.mockImplementation((callback, initialValue) => {
+      void Promise.resolve(callback({ signal: new AbortController().signal })).catch(
+        () => undefined,
+      );
+      if (initialValue instanceof Map) {
+        return {
+          data: initialValue,
+          loaded: true,
+          error: undefined,
+          refresh: jest.fn(),
+        };
+      }
+      return { data: initialValue, loaded: true, error: undefined, refresh: jest.fn() };
+    });
+
+    const renderResult = testHook(useWorkloadRows)({
+      mode: 'clusterQueues',
+      clusterQueueNames: ['gpu-cq'],
+    });
+
+    const refreshed = await renderResult.result.current.refresh();
+    expect(refreshCache).toHaveBeenCalled();
+    expect(fetchQueuePositionsMock).toHaveBeenCalled();
+    expect(refreshed?.mode).toBe('clusterQueues');
+    if (refreshed?.mode === 'clusterQueues') {
+      expect(refreshed.workloadsByClusterQueue.get('gpu-cq')?.[0]?.name).toBe('wl-1');
+    }
   });
 });

--- a/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useWorkloadRows.spec.ts
@@ -119,12 +119,10 @@ const mockCacheWithGpuCq = {
       jobKindByUid: new Map(),
     },
   ],
-  resourceFlavorByName: new Map(),
 } as unknown as KueueNamespaceWorkloadCache;
 
 const emptyCache = {
   namespaceData: [],
-  resourceFlavorByName: new Map(),
   hardwareProfileByKey: new Map(),
   hardwareProfilesForMatching: [],
 };
@@ -316,7 +314,7 @@ describe('useWorkloadRows', () => {
     expect(renderResult.result.current.error).toBe(namespaceLoadError);
   });
 
-  it('refreshes namespace cache and queue positions for clusterQueues scope', async () => {
+  it('refreshes namespace cache and lets position fetch follow cache refresh', async () => {
     const refreshCache = jest.fn().mockResolvedValue(mockCacheWithGpuCq);
     fetchQueuePositionsMock.mockResolvedValue(new Map());
     useKueueNamespaceWorkloadCacheMock.mockReturnValue({
@@ -348,7 +346,7 @@ describe('useWorkloadRows', () => {
 
     const refreshed = await renderResult.result.current.refresh();
     expect(refreshCache).toHaveBeenCalled();
-    expect(fetchQueuePositionsMock).toHaveBeenCalled();
+    expect(fetchQueuePositionsMock).toHaveBeenCalledTimes(1);
     expect(refreshed?.mode).toBe('clusterQueues');
     if (refreshed?.mode === 'clusterQueues') {
       expect(refreshed.workloadsByClusterQueue.get('gpu-cq')?.[0]?.name).toBe('wl-1');

--- a/packages/gpuaas/src/hooks/useClusterQueueWorkloads.ts
+++ b/packages/gpuaas/src/hooks/useClusterQueueWorkloads.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import useWorkloadRows, { type UseWorkloadRowsOptions } from './useWorkloadRows';
-import type { ClusterQueueWorkloadRow, WorkloadRowsScope } from '../types';
+import type { ClusterQueueWorkloadRow } from '../types';
 
 export type UseClusterQueueWorkloadsResult = {
   workloads: ClusterQueueWorkloadRow[];
@@ -11,22 +11,21 @@ export type UseClusterQueueWorkloadsResult = {
 };
 
 /**
- * Fetches workloads for one cluster queue — for drawer/panel UX when user selects a CQ.
- * Pass undefined to skip fetch (drawer closed).
+ * Workloads for one cluster queue (Quota usage detail panel).
+ * Row mapping runs synchronously against the shared, pre-scoped namespace workload cache; queue
+ * positions are enriched asynchronously (see useWorkloadRows).
  */
 const useClusterQueueWorkloads = (
   clusterQueueName: string | undefined,
   options: UseWorkloadRowsOptions = {},
 ): UseClusterQueueWorkloadsResult => {
-  const scope = React.useMemo(
-    (): WorkloadRowsScope => ({
+  const { data, loaded, error, refresh } = useWorkloadRows(
+    {
       mode: 'clusterQueues',
       clusterQueueNames: clusterQueueName ? [clusterQueueName] : [],
-    }),
-    [clusterQueueName],
+    },
+    options,
   );
-
-  const { data, loaded, error, refresh } = useWorkloadRows(scope, options);
 
   const workloads = React.useMemo(() => {
     if (!clusterQueueName || data.mode !== 'clusterQueues') {

--- a/packages/gpuaas/src/hooks/useWorkloadRows.ts
+++ b/packages/gpuaas/src/hooks/useWorkloadRows.ts
@@ -190,19 +190,16 @@ const useWorkloadRows = (
       refreshedCache,
       projectDisplayNames,
     );
-    const flattenedRows = [...workloadsByClusterQueue.values()].flat();
-    const refreshedPositions =
-      flattenedRows.length > 0 ? await fetchQueuePositions(flattenedRows) : emptyPositions;
 
     return {
       mode: 'clusterQueues',
       workloadsByClusterQueue: applyQueuePositionsToMap(
         workloadsByClusterQueue,
-        refreshedPositions,
-        true,
+        positions,
+        positionsLoaded,
       ),
     };
-  }, [refreshCache, projectDisplayNames]);
+  }, [positions, positionsLoaded, projectDisplayNames, refreshCache]);
 
   if (scope.mode === 'namespace') {
     return {

--- a/packages/gpuaas/src/hooks/useWorkloadRows.ts
+++ b/packages/gpuaas/src/hooks/useWorkloadRows.ts
@@ -1,22 +1,25 @@
 import * as React from 'react';
 import type { ProjectKind } from '@odh-dashboard/k8s-core';
 import { useProjects } from '@odh-dashboard/internal/api/k8s/projects';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import useFetch, {
   NotReadyError,
   type FetchStateObject,
 } from '@odh-dashboard/ui-core/hooks/useFetch';
-import type { WorkloadRowsFetchResult, WorkloadRowsScope } from '../types';
-import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../const';
+import { useKueueNamespaceWorkloadCache } from './KueueNamespaceWorkloadCacheContext';
+import type { WorkloadRowsFetchResult, WorkloadRowsScope, ClusterQueueWorkloadRow } from '../types';
+import { INFRASTRUCTURE_MANUAL_REFRESH_ONLY } from '../const';
 import {
+  applyQueuePositionsToMap,
   fetchNamespaceWorkloads,
-  fetchWorkloadsForClusterQueues,
+  fetchQueuePositions,
   getProjectDisplayName,
+  mapWorkloadsForClusterQueuesSync,
+  type QueuePositionKey,
 } from '../utils/clusterQueueWorkloads';
 import { getKueueManagedDataScienceProjects } from '../utils/kueueProjects';
 
 export type UseWorkloadRowsOptions = {
-  /** When true, includes Complete and Failed workloads. Defaults to active-only. */
-  includeTerminal?: boolean;
   refreshRate?: number;
 };
 
@@ -27,6 +30,9 @@ export type UseWorkloadRowsResult = {
   refresh: FetchStateObject<WorkloadRowsFetchResult>['refresh'];
 };
 
+const emptyPositions = new Map<QueuePositionKey, number>();
+const emptyWorkloadsByClusterQueue = new Map<string, ClusterQueueWorkloadRow[]>();
+
 const buildProjectDisplayNames = (projects: ProjectKind[]): Map<string, string> =>
   new Map(
     projects.flatMap((project) => {
@@ -35,25 +41,11 @@ const buildProjectDisplayNames = (projects: ProjectKind[]): Map<string, string> 
     }),
   );
 
-const buildNamespacesKey = (namespaces: string[]): string =>
-  namespaces.toSorted((a, b) => a.localeCompare(b)).join('\0');
-
-const buildProjectDisplayNamesKey = (projectDisplayNames: Map<string, string>): string =>
-  [...projectDisplayNames.entries()]
-    .toSorted(([a], [b]) => a.localeCompare(b))
-    .map(([namespace, displayName]) => `${namespace}\0${displayName}`)
-    .join('\n');
-
-const buildClusterQueueNamesKey = (clusterQueueNames: string[]): string =>
-  clusterQueueNames.toSorted((a, b) => a.localeCompare(b)).join('\0');
-
 const buildNamespaceScopeKey = (namespace: string, projectDisplayName: string): string =>
   `${namespace}\0${projectDisplayName}`;
 
-const getInitialFetchResult = (scope: WorkloadRowsScope): WorkloadRowsFetchResult =>
-  scope.mode === 'namespace'
-    ? { mode: 'namespace', workloads: [] }
-    : { mode: 'clusterQueues', workloadsByClusterQueue: new Map() };
+const buildClusterQueueNamesKey = (clusterQueueNames: string[]): string =>
+  clusterQueueNames.toSorted((a, b) => a.localeCompare(b)).join('\0');
 
 const buildScopeKey = (scope: WorkloadRowsScope): string => {
   if (scope.mode === 'namespace') {
@@ -64,13 +56,25 @@ const buildScopeKey = (scope: WorkloadRowsScope): string => {
 
 /**
  * Core workload rows hook. Scope selects admin cluster-queue view or single-namespace view.
+ *
+ * Cluster-queue mode: row mapping runs synchronously (`React.useMemo`) against the shared,
+ * pre-scoped namespace workload cache — no second `useFetch` round-trip on a cache hit. Queue
+ * positions (Visibility API) are fetched separately and patched in once available, so the table
+ * renders before that latency resolves.
  */
 const useWorkloadRows = (
   scope: WorkloadRowsScope,
   options: UseWorkloadRowsOptions = {},
 ): UseWorkloadRowsResult => {
-  const { includeTerminal = false, refreshRate = INFRASTRUCTURE_REFRESH_INTERVAL } = options;
-  const [allProjects, projectsLoaded, projectsError] = useProjects();
+  const { refreshRate = INFRASTRUCTURE_MANUAL_REFRESH_ONLY } = options;
+  const [allProjects, , projectsError] = useProjects();
+  const { dashboardNamespace } = useDashboardNamespace();
+  const {
+    cache,
+    loaded: cacheLoaded,
+    error: cacheError,
+    refresh: refreshCache,
+  } = useKueueNamespaceWorkloadCache();
 
   const kueueProjects = React.useMemo(
     () => getKueueManagedDataScienceProjects(allProjects),
@@ -82,93 +86,140 @@ const useWorkloadRows = (
     [kueueProjects],
   );
 
-  const namespaces = React.useMemo(
-    () =>
-      kueueProjects.flatMap((project) => {
-        const namespace = project.metadata.name;
-        return namespace ? [namespace] : [];
-      }),
-    [kueueProjects],
-  );
-
-  const namespacesKey = React.useMemo(() => buildNamespacesKey(namespaces), [namespaces]);
-  const projectDisplayNamesKey = React.useMemo(
-    () => buildProjectDisplayNamesKey(projectDisplayNames),
-    [projectDisplayNames],
-  );
   const scopeKey = React.useMemo(() => buildScopeKey(scope), [scope]);
+  const isClusterQueuesScope = scope.mode === 'clusterQueues';
+  const isSkippedClusterQueueScope = isClusterQueuesScope && scope.clusterQueueNames.length === 0;
 
   const scopeRef = React.useRef(scope);
   scopeRef.current = scope;
-  const namespacesRef = React.useRef(namespaces);
-  namespacesRef.current = namespaces;
-  const projectDisplayNamesRef = React.useRef(projectDisplayNames);
-  projectDisplayNamesRef.current = projectDisplayNames;
 
-  const initialFetchResult = React.useMemo(() => getInitialFetchResult(scope), [scope]);
+  // --- Cluster-queue scope: synchronous row mapping against the shared namespace cache. ---
+  const baseWorkloadsByClusterQueue = React.useMemo(() => {
+    const currentScope = scopeRef.current;
+    if (currentScope.mode !== 'clusterQueues' || currentScope.clusterQueueNames.length === 0) {
+      return emptyWorkloadsByClusterQueue;
+    }
+    if (!cacheLoaded) {
+      return emptyWorkloadsByClusterQueue;
+    }
+    return mapWorkloadsForClusterQueuesSync(
+      currentScope.clusterQueueNames,
+      cache,
+      projectDisplayNames,
+      // scopeKey drives re-mapping when the selected cluster queue(s) change; cache identity
+      // drives re-mapping when the underlying namespace data refreshes.
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scopeKey fingerprints scope; cache identity fingerprints namespace data
+  }, [scopeKey, cache, cacheLoaded, projectDisplayNames]);
 
-  const {
-    data,
-    loaded: workloadsLoaded,
-    error: workloadsError,
-    refresh,
-  } = useFetch<WorkloadRowsFetchResult>(
+  const flattenedBaseRows = React.useMemo(
+    () => [...baseWorkloadsByClusterQueue.values()].flat(),
+    [baseWorkloadsByClusterQueue],
+  );
+
+  // --- Phase C: queue-position enrichment, decoupled from row mapping. ---
+  const { data: positions, loaded: positionsLoaded } = useFetch<Map<QueuePositionKey, number>>(
     React.useCallback(async () => {
-      const currentScope = scopeRef.current;
-
-      if (currentScope.mode === 'namespace') {
-        if (!currentScope.namespace) {
-          return { mode: 'namespace', workloads: [] };
-        }
-
-        const workloads = await fetchNamespaceWorkloads(
-          currentScope.namespace,
-          currentScope.projectDisplayName,
-          includeTerminal,
-        );
-        return { mode: 'namespace', workloads };
+      if (!isClusterQueuesScope || flattenedBaseRows.length === 0) {
+        return emptyPositions;
       }
-
-      if (currentScope.clusterQueueNames.length === 0) {
-        return { mode: 'clusterQueues', workloadsByClusterQueue: new Map() };
-      }
-
-      if (!projectsLoaded) {
-        throw new NotReadyError('Projects not loaded');
-      }
-
-      const workloadsByClusterQueue = await fetchWorkloadsForClusterQueues(
-        currentScope.clusterQueueNames,
-        namespacesRef.current,
-        projectDisplayNamesRef.current,
-        includeTerminal,
-      );
-
-      return { mode: 'clusterQueues', workloadsByClusterQueue };
-      // scopeKey / namespacesKey / projectDisplayNamesKey are content fingerprints.
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- keys trigger refetch when inputs change
-    }, [scopeKey, namespacesKey, projectDisplayNamesKey, includeTerminal, projectsLoaded]),
-    initialFetchResult,
+      return fetchQueuePositions(flattenedBaseRows);
+    }, [isClusterQueuesScope, flattenedBaseRows]),
+    emptyPositions,
     { refreshRate, initialPromisePurity: true },
   );
 
-  const isSkippedClusterQueueScope =
-    scope.mode === 'clusterQueues' && scope.clusterQueueNames.length === 0;
+  const clusterQueuesData = React.useMemo(
+    (): WorkloadRowsFetchResult => ({
+      mode: 'clusterQueues',
+      workloadsByClusterQueue: applyQueuePositionsToMap(
+        baseWorkloadsByClusterQueue,
+        positions,
+        positionsLoaded,
+      ),
+    }),
+    [baseWorkloadsByClusterQueue, positions, positionsLoaded],
+  );
 
-  const loaded =
-    scope.mode === 'namespace' || isSkippedClusterQueueScope
-      ? workloadsLoaded
-      : projectsLoaded && workloadsLoaded;
-  const error =
-    scope.mode === 'namespace' || isSkippedClusterQueueScope
-      ? workloadsError
-      : projectsError ?? workloadsError;
+  // --- Namespace scope: unchanged single fetch (rows + positions together). ---
+  const {
+    data: namespaceData,
+    loaded: namespaceLoaded,
+    error: namespaceError,
+    refresh: namespaceRefresh,
+  } = useFetch<WorkloadRowsFetchResult>(
+    React.useCallback(async () => {
+      const currentScope = scopeRef.current;
+      if (currentScope.mode !== 'namespace') {
+        throw new NotReadyError('Not in namespace scope');
+      }
+      if (!currentScope.namespace) {
+        return { mode: 'namespace', workloads: [] };
+      }
+
+      const workloads = await fetchNamespaceWorkloads(
+        currentScope.namespace,
+        currentScope.projectDisplayName,
+        dashboardNamespace,
+      );
+      return { mode: 'namespace', workloads };
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- scopeKey fingerprints namespace + display name
+    }, [scopeKey, dashboardNamespace]),
+    { mode: 'namespace', workloads: [] },
+    { refreshRate, initialPromisePurity: true },
+  );
+
+  const clusterQueuesRefresh = React.useCallback(async (): Promise<
+    WorkloadRowsFetchResult | undefined
+  > => {
+    const currentScope = scopeRef.current;
+    if (currentScope.mode !== 'clusterQueues') {
+      return {
+        mode: 'clusterQueues',
+        workloadsByClusterQueue: emptyWorkloadsByClusterQueue,
+      };
+    }
+
+    const refreshedCache = await refreshCache();
+    if (!refreshedCache) {
+      return undefined;
+    }
+
+    const workloadsByClusterQueue = mapWorkloadsForClusterQueuesSync(
+      currentScope.clusterQueueNames,
+      refreshedCache,
+      projectDisplayNames,
+    );
+    const flattenedRows = [...workloadsByClusterQueue.values()].flat();
+    const refreshedPositions =
+      flattenedRows.length > 0 ? await fetchQueuePositions(flattenedRows) : emptyPositions;
+
+    return {
+      mode: 'clusterQueues',
+      workloadsByClusterQueue: applyQueuePositionsToMap(
+        workloadsByClusterQueue,
+        refreshedPositions,
+        true,
+      ),
+    };
+  }, [refreshCache, projectDisplayNames]);
+
+  if (scope.mode === 'namespace') {
+    return {
+      data: namespaceData,
+      loaded: namespaceLoaded,
+      error: namespaceError,
+      refresh: namespaceRefresh,
+    };
+  }
 
   return {
-    data,
-    loaded,
-    error,
-    refresh,
+    data: clusterQueuesData,
+    loaded: isSkippedClusterQueueScope || cacheLoaded,
+    error: isSkippedClusterQueueScope
+      ? undefined
+      : projectsError ?? cacheError ?? cache.namespaceLoadError,
+    refresh: clusterQueuesRefresh,
   };
 };
 

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -93,6 +93,7 @@ const InfrastructurePage: React.FC = () => {
   const metrics = useInfrastructureMetrics();
   const quotaHierarchy = useQuotaHierarchy();
   const { refresh: refreshQuotaHierarchy } = quotaHierarchy;
+  const quotaWorkloadRefreshRef = React.useRef<(() => Promise<unknown>) | undefined>(undefined);
   const isKueueAvailable = useIsAreaAvailable(SupportedArea.KUEUE).status;
   const hasTrackedPageView = React.useRef(false);
   const [activeTabKey, setActiveTabKey] = React.useState<InfrastructureTabId>(
@@ -144,6 +145,7 @@ const InfrastructurePage: React.FC = () => {
 
   const handleQuotaRefresh = React.useCallback(() => {
     void refreshQuotaHierarchy();
+    void quotaWorkloadRefreshRef.current?.();
     handleRefresh();
   }, [handleRefresh, refreshQuotaHierarchy]);
 
@@ -169,6 +171,9 @@ const InfrastructurePage: React.FC = () => {
         tree={quotaHierarchy.data.tree}
         loaded={quotaHierarchy.loaded}
         error={quotaHierarchy.error}
+        onRegisterWorkloadRefresh={(refresh) => {
+          quotaWorkloadRefreshRef.current = refresh;
+        }}
       />
     ),
   };

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -1,4 +1,5 @@
 import { ClusterQueueKind, CohortKind, ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+import { KueueWorkloadStatus } from '@odh-dashboard/k8s-core/kueue/types';
 
 export const QUOTA_NODE_TYPE = {
   unassigned: 'unassigned',
@@ -61,10 +62,13 @@ export type KueueProject = {
 /** UXD Quota usage workloads table — Type column values (ODH + Kueue workload taxonomy). */
 export const QuotaUsageWorkloadTypes = {
   Workbench: 'Workbench',
+  /** TrainJob and RayJob CR-backed training workloads. */
   Train: 'Train',
-  RayJob: 'Ray job',
+  /** Generic Job owner workloads (batch jobs), not notebook workbenches. */
+  Batch: 'Batch',
   Serve: 'Serve',
   RayCluster: 'Ray cluster',
+  /** Unclassified workloads (e.g. pipeline runs without ODH integration). */
   Unknown: 'Unknown',
 } as const;
 
@@ -73,9 +77,20 @@ export type QuotaUsageWorkloadType =
 
 /**
  * UXD Quota usage workloads table — Status column values.
- * All Kueue workload statuses; mapped 1:1 from KueueWorkloadStatus via mapKueueStatusToQuotaUsageStatus.
+ *
+ * Kueue Workload condition → column display:
+ * | Inadmissible | Inadmissible |
+ * | Pending / no admission | Pending (Queued without visibility position) or Queued (+ queue position) |
+ * | Admitted, no PodsReady | Admitted |
+ * | PodsReady | Running |
+ * | Finished | Complete |
+ * | Failed / Preempted / Evicted / Requeued / … | same name |
+ *
+ * Mapped from KueueWorkloadStatus via mapKueueStatusToQuotaUsageStatus; Pending is display-only.
  */
 export const QuotaUsageWorkloadStatuses = {
+  /** Kueue Queued without a visibility API position yet (pending admission). */
+  Pending: 'Pending',
   Queued: 'Queued',
   Failed: 'Failed',
   Preempted: 'Preempted',
@@ -98,6 +113,49 @@ export const QUOTA_USAGE_STATUSES_WITH_QUEUE_POSITION: QuotaUsageWorkloadStatus[
   QuotaUsageWorkloadStatuses.Inadmissible,
 ];
 
+/** All UXD status filter options in display order (workloads table toolbar). */
+export const QUOTA_USAGE_WORKLOAD_STATUS_FILTER_OPTIONS: QuotaUsageWorkloadStatus[] = [
+  QuotaUsageWorkloadStatuses.Pending,
+  QuotaUsageWorkloadStatuses.Queued,
+  QuotaUsageWorkloadStatuses.Inadmissible,
+  QuotaUsageWorkloadStatuses.Admitted,
+  QuotaUsageWorkloadStatuses.Running,
+  QuotaUsageWorkloadStatuses.Complete,
+  QuotaUsageWorkloadStatuses.Failed,
+  QuotaUsageWorkloadStatuses.Preempted,
+  QuotaUsageWorkloadStatuses.Evicted,
+  QuotaUsageWorkloadStatuses.Requeued,
+  QuotaUsageWorkloadStatuses.AdmissionCheck,
+  QuotaUsageWorkloadStatuses.BlockedOnPreemptionGates,
+];
+
+/** Maps UXD display status to Kueue for shared icon/color styling (Pending has no Kueue equivalent). */
+export const QUOTA_USAGE_TO_KUEUE_STATUS: Partial<
+  Record<QuotaUsageWorkloadStatus, KueueWorkloadStatus>
+> = {
+  [QuotaUsageWorkloadStatuses.Queued]: KueueWorkloadStatus.Queued,
+  [QuotaUsageWorkloadStatuses.Failed]: KueueWorkloadStatus.Failed,
+  [QuotaUsageWorkloadStatuses.Preempted]: KueueWorkloadStatus.Preempted,
+  [QuotaUsageWorkloadStatuses.Evicted]: KueueWorkloadStatus.Evicted,
+  [QuotaUsageWorkloadStatuses.Requeued]: KueueWorkloadStatus.Requeued,
+  [QuotaUsageWorkloadStatuses.Inadmissible]: KueueWorkloadStatus.Inadmissible,
+  [QuotaUsageWorkloadStatuses.AdmissionCheck]: KueueWorkloadStatus.AdmissionCheck,
+  [QuotaUsageWorkloadStatuses.BlockedOnPreemptionGates]:
+    KueueWorkloadStatus.BlockedOnPreemptionGates,
+  [QuotaUsageWorkloadStatuses.Running]: KueueWorkloadStatus.Running,
+  [QuotaUsageWorkloadStatuses.Admitted]: KueueWorkloadStatus.Admitted,
+  [QuotaUsageWorkloadStatuses.Complete]: KueueWorkloadStatus.Complete,
+};
+
+/**
+ * Default Quota usage cluster-queue table scope (RHOAIENG-88168): active workloads only.
+ * Complete and Failed are excluded unless product scope changes.
+ */
+export const QUOTA_USAGE_EXCLUDED_WORKLOAD_STATUSES: QuotaUsageWorkloadStatus[] = [
+  QuotaUsageWorkloadStatuses.Complete,
+  QuotaUsageWorkloadStatuses.Failed,
+];
+
 /** Statuses indicating the workload has passed Kueue admission. */
 export const QUOTA_USAGE_STATUSES_PAST_ADMISSION: QuotaUsageWorkloadStatus[] = [
   QuotaUsageWorkloadStatuses.Admitted,
@@ -118,10 +176,17 @@ export type ClusterQueueWorkloadRow = {
   accelerators: number;
   /** 1-indexed position in the local queue; undefined when admitted or unavailable. */
   queuePosition: number | undefined;
-  /** Formatted from spec.priorityClassRef and spec.priority, e.g. "on-demand (100)". */
+  /** Formatted from spec.priorityClassRef.name and spec.priority, e.g. "on demand (100)". */
   priority?: string;
-  /** GPU product from admitted ResourceFlavor assignment, e.g. "NVIDIA-L40S". */
+  /**
+   * Hardware profile display name — resolved from the real HardwareProfile CR when the workload's
+   * Pod carries the `opendatahub.io/hardware-profile-name` annotation (e.g. "Research notebook MIG
+   * 7g"), falling back to the GPU product from the admitted ResourceFlavor's nodeLabels (e.g.
+   * "NVIDIA-L40S").
+   */
   hardwareProfile?: string;
+  /** Accelerator resource identifier for the resolved hardware profile, e.g. "nvidia.com/mig-7g.80gb". */
+  hardwareProfileResourceType?: string;
 };
 
 /** Fetch scope for shared workload table data layer. */

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -147,15 +147,6 @@ export const QUOTA_USAGE_TO_KUEUE_STATUS: Partial<
   [QuotaUsageWorkloadStatuses.Complete]: KueueWorkloadStatus.Complete,
 };
 
-/**
- * Default Quota usage cluster-queue table scope (RHOAIENG-88168): active workloads only.
- * Complete and Failed are excluded unless product scope changes.
- */
-export const QUOTA_USAGE_EXCLUDED_WORKLOAD_STATUSES: QuotaUsageWorkloadStatus[] = [
-  QuotaUsageWorkloadStatuses.Complete,
-  QuotaUsageWorkloadStatuses.Failed,
-];
-
 /** Statuses indicating the workload has passed Kueue admission. */
 export const QUOTA_USAGE_STATUSES_PAST_ADMISSION: QuotaUsageWorkloadStatus[] = [
   QuotaUsageWorkloadStatuses.Admitted,
@@ -181,8 +172,7 @@ export type ClusterQueueWorkloadRow = {
   /**
    * Hardware profile display name — resolved from the real HardwareProfile CR when the workload's
    * Pod carries the `opendatahub.io/hardware-profile-name` annotation (e.g. "Research notebook MIG
-   * 7g"), falling back to the GPU product from the admitted ResourceFlavor's nodeLabels (e.g.
-   * "NVIDIA-L40S").
+   * 7g"), or by matching workload resources to a HardwareProfile.
    */
   hardwareProfile?: string;
   /** Accelerator resource identifier for the resolved hardware profile, e.g. "nvidia.com/mig-7g.80gb". */

--- a/packages/gpuaas/src/types/inferenceService.ts
+++ b/packages/gpuaas/src/types/inferenceService.ts
@@ -1,0 +1,24 @@
+import type {
+  ContainerResources,
+  K8sResourceCommon,
+  NodeSelector,
+  Toleration,
+} from '@odh-dashboard/k8s-core';
+
+/** Minimal InferenceService shape for Quota usage hardware-profile resolution (no model-serving dep). */
+export type WorkloadInferenceService = K8sResourceCommon & {
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    annotations?: Record<string, string>;
+  };
+  spec?: {
+    predictor?: {
+      model?: {
+        resources?: ContainerResources;
+      };
+      tolerations?: Toleration[];
+      nodeSelector?: NodeSelector;
+    };
+  };
+};

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloadStatusLabelUtils.spec.tsx
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloadStatusLabelUtils.spec.tsx
@@ -1,0 +1,34 @@
+import { getQuotaUsageWorkloadStatusLabelSettings } from '../clusterQueueWorkloadStatusLabelUtils';
+import { QuotaUsageWorkloadStatuses } from '../../types';
+
+describe('getQuotaUsageWorkloadStatusLabelSettings', () => {
+  it('uses purple clock styling for Pending', () => {
+    expect(getQuotaUsageWorkloadStatusLabelSettings(QuotaUsageWorkloadStatuses.Pending)).toEqual(
+      expect.objectContaining({
+        label: 'Pending',
+        color: 'purple',
+      }),
+    );
+  });
+
+  it('uses grey checkmark styling for Admitted', () => {
+    expect(getQuotaUsageWorkloadStatusLabelSettings(QuotaUsageWorkloadStatuses.Admitted)).toEqual(
+      expect.objectContaining({
+        label: 'Admitted',
+        color: 'grey',
+      }),
+    );
+  });
+
+  it('maps Running through shared Kueue status info', () => {
+    const settings = getQuotaUsageWorkloadStatusLabelSettings(QuotaUsageWorkloadStatuses.Running);
+    expect(settings.label).toBe('Running');
+    expect(settings.color).toBeDefined();
+  });
+
+  it('falls back to grey clock for unmapped statuses', () => {
+    expect(getQuotaUsageWorkloadStatusLabelSettings(QuotaUsageWorkloadStatuses.Pending).color).toBe(
+      'purple',
+    );
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
@@ -1,4 +1,5 @@
 import type {
+  K8sResourceCommon,
   LocalQueueKind,
   PodKind,
   ResourceFlavorKind,
@@ -7,16 +8,25 @@ import type {
 } from '@odh-dashboard/k8s-core';
 import { WorkloadOwnerType } from '@odh-dashboard/k8s-core';
 import { getPendingWorkloads } from '@odh-dashboard/internal/api/k8s/pendingWorkloads';
+import { listAllLocalQueues } from '@odh-dashboard/internal/api/k8s/localQueues';
+import { getHardwareProfile } from '@odh-dashboard/internal/api/k8s/hardwareProfiles';
 import { KueueWorkloadStatus } from '@odh-dashboard/k8s-core/kueue/types';
 import { QuotaUsageWorkloadStatuses, QuotaUsageWorkloadTypes } from '../../types';
 import {
+  applyDisplayStatuses,
   applyQueuePositions,
+  applyQueuePositionsToMap,
   buildLocalQueueByName,
+  collectHardwareProfileRefs,
+  fetchHardwareProfilesByKey,
+  fetchLocalQueueClusterQueueIndex,
   fetchQueuePositions,
   filterAndMapClusterQueueWorkloads,
   filterAndMapNamespaceWorkloads,
+  findWorkloadPods,
   formatWorkloadPriority,
-  isActiveWorkload,
+  getNamespacesForClusterQueues,
+  isActiveQuotaUsageClusterQueueWorkload,
   isGpuAwareWorkload,
   getWorkloadAcceleratorCount,
   isKueueManagedWorkload,
@@ -28,8 +38,12 @@ import {
   isTrainingJobWorkload,
   isWorkbenchWorkload,
   mapKueueStatusToQuotaUsageStatus,
+  resolveQuotaUsageWorkloadStatus,
   mapWorkloadToRow,
+  mapWorkloadsForClusterQueuesSync,
+  mergePodsByUid,
   resolveWorkloadClusterQueue,
+  resolveWorkloadLocalQueueName,
   resolveWorkloadType,
   workloadMatchesClusterQueue,
 } from '../clusterQueueWorkloads';
@@ -38,7 +52,23 @@ jest.mock('@odh-dashboard/internal/api/k8s/pendingWorkloads', () => ({
   getPendingWorkloads: jest.fn(),
 }));
 
+jest.mock('@odh-dashboard/internal/api/k8s/localQueues', () => ({
+  ...jest.requireActual('@odh-dashboard/internal/api/k8s/localQueues'),
+  listAllLocalQueues: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/api/k8s/hardwareProfiles', () => ({
+  getHardwareProfile: jest.fn(),
+  listHardwareProfiles: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@odh-dashboard/internal/api/k8s/inferenceServices', () => ({
+  listInferenceService: jest.fn().mockResolvedValue([]),
+}));
+
 const getPendingWorkloadsMock = jest.mocked(getPendingWorkloads);
+const listAllLocalQueuesMock = jest.mocked(listAllLocalQueues);
+const getHardwareProfileMock = jest.mocked(getHardwareProfile);
 
 const NS = 'dsp-1';
 const CQ = 'gpu-cq';
@@ -125,13 +155,45 @@ const completeConditions: WorkloadCondition[] = [
   },
 ];
 
-const makePod = (uid: string, labels: Record<string, string>): PodKind =>
+const failedConditions: WorkloadCondition[] = [
+  {
+    type: 'Finished',
+    status: 'True',
+    reason: 'Failed',
+    message: 'Job failed',
+    lastTransitionTime: '2026-01-02T00:00:00Z',
+  },
+];
+
+const makePod = (
+  uid: string,
+  labels: Record<string, string>,
+  options: {
+    ready?: boolean;
+    phase?: PodKind['status'] extends infer S ? (S extends { phase?: infer P } ? P : never) : never;
+  } = {},
+): PodKind =>
   ({
     apiVersion: 'v1',
     kind: 'Pod',
     metadata: { name: `pod-${uid}`, namespace: NS, uid, labels },
-    spec: {},
-    status: { phase: 'Running' },
+    spec: {
+      containers: [{ name: 'main', image: 'test-image' }],
+    },
+    status: {
+      phase: options.phase ?? 'Running',
+      ...(options.ready !== false && (options.phase ?? 'Running') === 'Running'
+        ? {
+            containerStatuses: [
+              {
+                name: 'main',
+                ready: true,
+                state: { running: { startedAt: '2026-01-01T00:00:00Z' } },
+              },
+            ],
+          }
+        : {}),
+    },
   } as PodKind);
 
 describe('clusterQueueWorkloads', () => {
@@ -168,27 +230,6 @@ describe('clusterQueueWorkloads', () => {
     });
   });
 
-  describe('isActiveWorkload', () => {
-    it('excludes complete workloads by default scope', () => {
-      expect(isActiveWorkload(baseWorkload({ status: { conditions: completeConditions } }))).toBe(
-        false,
-      );
-    });
-
-    it('includes admitted active workloads', () => {
-      expect(
-        isActiveWorkload(
-          baseWorkload({
-            status: {
-              admission: { clusterQueue: CQ, podSetAssignments: [] },
-              conditions: admittedConditions,
-            },
-          }),
-        ),
-      ).toBe(true);
-    });
-  });
-
   describe('resolveWorkloadType', () => {
     it('resolves workbench workloads from job-name label and owner refs', () => {
       const workload = baseWorkload({
@@ -217,6 +258,22 @@ describe('clusterQueueWorkloads', () => {
       expect(isWorkbenchWorkload(workload)).toBe(true);
     });
 
+    it('resolves workbench workloads from Kueue job-owner annotations when ownerReferences are absent', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'statefulset-umb-wkb-89877',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-uid': '5ff915da-2bc6-43a1-a13b-1a78cc822c89' },
+          annotations: {
+            'kueue.x-k8s.io/job-owner-name': 'umb-wkb',
+            'kueue.x-k8s.io/job-owner-gvk': 'apps/v1, Kind=StatefulSet',
+          },
+        },
+      });
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Workbench);
+      expect(isWorkbenchWorkload(workload)).toBe(true);
+    });
+
     it('resolves ray cluster workloads from RayCluster owner', () => {
       const workload = baseWorkload({
         metadata: {
@@ -231,7 +288,7 @@ describe('clusterQueueWorkloads', () => {
       expect(isRayClusterWorkload(workload)).toBe(true);
     });
 
-    it('resolves ray job workloads from RayJob owner', () => {
+    it('resolves RayJob workloads as Train', () => {
       const workload = baseWorkload({
         metadata: {
           name: 'rayjob-wl',
@@ -241,11 +298,11 @@ describe('clusterQueueWorkloads', () => {
           ],
         },
       });
-      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.RayJob);
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Train);
       expect(isRayJobWorkload(workload)).toBe(true);
     });
 
-    it('resolves ray job workloads from job-uid label matching a RayJob CR', () => {
+    it('resolves RayJob workloads from job-uid label as Train', () => {
       const workload = baseWorkload({
         metadata: {
           name: 'rayjob-wl',
@@ -255,7 +312,7 @@ describe('clusterQueueWorkloads', () => {
         },
       });
       const jobKindByUid = new Map([['rayjob-cr-uid', 'RayJob' as const]]);
-      expect(resolveWorkloadType(workload, [], jobKindByUid)).toBe(QuotaUsageWorkloadTypes.RayJob);
+      expect(resolveWorkloadType(workload, [], jobKindByUid)).toBe(QuotaUsageWorkloadTypes.Train);
       expect(isRayJobWorkload(workload, jobKindByUid)).toBe(true);
       expect(getWorkloadJobKind(workload, jobKindByUid)).toBe('RayJob');
     });
@@ -295,7 +352,7 @@ describe('clusterQueueWorkloads', () => {
       expect(getWorkloadJobKind(workload, jobKindByUid)).toBe('TrainJob');
     });
 
-    it('classifies generic Job-owned workloads as unknown when not a TrainJob or RayJob', () => {
+    it('classifies generic Job-owned workloads as Batch when not a TrainJob or RayJob', () => {
       const workload = baseWorkload({
         metadata: {
           name: 'batch-wl',
@@ -303,7 +360,7 @@ describe('clusterQueueWorkloads', () => {
           ownerReferences: [{ apiVersion: 'v1', kind: 'Job', name: 'batch-job', uid: 'job-uid' }],
         },
       });
-      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Unknown);
+      expect(resolveWorkloadType(workload, [])).toBe(QuotaUsageWorkloadTypes.Batch);
       expect(isTrainingJobWorkload(workload)).toBe(true);
       expect(getWorkloadJobKind(workload)).toBeUndefined();
     });
@@ -364,6 +421,16 @@ describe('clusterQueueWorkloads', () => {
       });
       const pods = [makePod(podUid, { component: 'data-science-pipelines' })];
       expect(resolveWorkloadType(workload, pods)).toBe(QuotaUsageWorkloadTypes.Unknown);
+    });
+  });
+
+  describe('mergePodsByUid', () => {
+    it('dedupes pods by uid and keeps the latest entry', () => {
+      const podA = makePod('uid-a', { role: 'old' });
+      const podB = makePod('uid-b', {});
+      const podAUpdated = makePod('uid-a', { role: 'new' });
+
+      expect(mergePodsByUid([[podA, podB], [podAUpdated]])).toEqual([podAUpdated, podB]);
     });
   });
 
@@ -486,7 +553,7 @@ describe('clusterQueueWorkloads', () => {
   describe('filterAndMapClusterQueueWorkloads', () => {
     const projectDisplayNames = new Map([[NS, 'DSP One']]);
 
-    it('maps rows with accelerators and excludes terminal workloads by default', () => {
+    it('maps active workloads and excludes Complete and Failed (default scope)', () => {
       const admitted = baseWorkload({
         metadata: {
           name: 'admitted-wl',
@@ -514,15 +581,21 @@ describe('clusterQueueWorkloads', () => {
         metadata: { name: 'complete-wl', namespace: NS },
         status: { conditions: completeConditions },
       });
+      const failed = baseWorkload({
+        metadata: { name: 'failed-wl', namespace: NS },
+        status: { conditions: failedConditions },
+      });
 
       const rows = filterAndMapClusterQueueWorkloads(
         CQ,
         [
           {
             namespace: NS,
-            workloads: [admitted, queued, complete],
+            workloads: [admitted, queued, complete, failed],
             localQueues: [localQueue(LQ, CQ)],
             pods: [],
+            statefulSets: [],
+            inferenceServices: [],
             jobKindByUid: new Map(),
           },
         ],
@@ -543,7 +616,8 @@ describe('clusterQueueWorkloads', () => {
         type: QuotaUsageWorkloadTypes.Workbench,
         status: QuotaUsageWorkloadStatuses.Queued,
       });
-      expect(rows.some((row) => row.name === 'complete-wl')).toBe(false);
+      expect(rows.find((row) => row.name === 'complete-wl')).toBeUndefined();
+      expect(rows.find((row) => row.name === 'failed-wl')).toBeUndefined();
     });
 
     it('excludes workloads not actively managed by Kueue', () => {
@@ -606,6 +680,8 @@ describe('clusterQueueWorkloads', () => {
             ],
             localQueues: [localQueue(LQ, CQ)],
             pods: [servingPod, servingPodWithQueue],
+            statefulSets: [],
+            inferenceServices: [],
             jobKindByUid: new Map(),
           },
         ],
@@ -661,6 +737,8 @@ describe('clusterQueueWorkloads', () => {
             workloads: [cpuOnly],
             localQueues: [localQueue(LQ, CQ)],
             pods: [],
+            statefulSets: [],
+            inferenceServices: [],
             jobKindByUid: new Map(),
           },
         ],
@@ -703,6 +781,8 @@ describe('clusterQueueWorkloads', () => {
             workloads: [infraWorkload],
             localQueues: [localQueue(LQ, CQ)],
             pods: [infraPod],
+            statefulSets: [],
+            inferenceServices: [],
             jobKindByUid: new Map(),
           },
         ],
@@ -758,6 +838,8 @@ describe('clusterQueueWorkloads', () => {
             workloads: [workload],
             localQueues: [localQueue(LQ, CQ)],
             pods: [servingPod],
+            statefulSets: [],
+            inferenceServices: [],
             jobKindByUid: new Map(),
           },
         ],
@@ -842,6 +924,34 @@ describe('clusterQueueWorkloads', () => {
     });
   });
 
+  describe('isActiveQuotaUsageClusterQueueWorkload', () => {
+    it('returns false for Complete and Failed workloads', () => {
+      expect(
+        isActiveQuotaUsageClusterQueueWorkload(
+          baseWorkload({ status: { conditions: completeConditions } }),
+        ),
+      ).toBe(false);
+      expect(
+        isActiveQuotaUsageClusterQueueWorkload(
+          baseWorkload({ status: { conditions: failedConditions } }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true for admitted and queued workloads', () => {
+      expect(
+        isActiveQuotaUsageClusterQueueWorkload(
+          baseWorkload({ status: { conditions: admittedConditions } }),
+        ),
+      ).toBe(true);
+      expect(
+        isActiveQuotaUsageClusterQueueWorkload(
+          baseWorkload({ status: { conditions: queuedConditions } }),
+        ),
+      ).toBe(true);
+    });
+  });
+
   describe('fetchQueuePositions', () => {
     it('returns 1-indexed positions for queued workloads', async () => {
       getPendingWorkloadsMock.mockResolvedValue({
@@ -915,6 +1025,114 @@ describe('clusterQueueWorkloads', () => {
     });
   });
 
+  describe('resolveWorkloadLocalQueueName', () => {
+    it('prefers StatefulSet queue label over workload spec (workbench pattern)', () => {
+      const workload = baseWorkload({
+        spec: { queueName: 'spec-queue', active: true, podSets: baseWorkload().spec.podSets },
+        metadata: {
+          ownerReferences: [
+            {
+              apiVersion: 'apps/v1',
+              kind: WorkloadOwnerType.StatefulSet,
+              name: 'nb-sts',
+              uid: 'sts-uid',
+            },
+          ],
+        },
+      });
+      const statefulSetsByName = new Map<string, K8sResourceCommon>([
+        [
+          'nb-sts',
+          {
+            apiVersion: 'apps/v1',
+            kind: 'StatefulSet',
+            metadata: {
+              name: 'nb-sts',
+              labels: { 'kueue.x-k8s.io/queue-name': 'label-queue' },
+            },
+          },
+        ],
+      ]);
+
+      expect(resolveWorkloadLocalQueueName(workload, [], statefulSetsByName, new Map())).toBe(
+        'label-queue',
+      );
+    });
+
+    it('resolves StatefulSet queue label from Kueue job-owner annotations', () => {
+      const workload = baseWorkload({
+        metadata: {
+          annotations: {
+            'kueue.x-k8s.io/job-owner-name': 'umb-wkb',
+            'kueue.x-k8s.io/job-owner-gvk': 'apps/v1, Kind=StatefulSet',
+          },
+        },
+        spec: { queueName: 'spec-queue', active: true, podSets: baseWorkload().spec.podSets },
+      });
+      const statefulSetsByName = new Map<string, K8sResourceCommon>([
+        [
+          'umb-wkb',
+          {
+            apiVersion: 'apps/v1',
+            kind: 'StatefulSet',
+            metadata: {
+              name: 'umb-wkb',
+              labels: { 'kueue.x-k8s.io/queue-name': 'default' },
+            },
+          },
+        ],
+      ]);
+
+      expect(resolveWorkloadLocalQueueName(workload, [], statefulSetsByName, new Map())).toBe(
+        'default',
+      );
+    });
+  });
+
+  describe('resolveQuotaUsageWorkloadStatus', () => {
+    it('maps admitted Workload CR conditions to Admitted regardless of pod readiness', () => {
+      const podUid = 'serve-pod-uid';
+      const workload = baseWorkload({
+        metadata: {
+          name: 'serve-wl',
+          namespace: NS,
+          ownerReferences: [{ apiVersion: 'v1', kind: 'Pod', name: 'serve-pod', uid: podUid }],
+        },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+
+      expect(resolveQuotaUsageWorkloadStatus(workload)).toBe(QuotaUsageWorkloadStatuses.Admitted);
+    });
+
+    it('maps queued Workload CR conditions to Queued', () => {
+      const workload = baseWorkload({ status: { conditions: queuedConditions } });
+      expect(resolveQuotaUsageWorkloadStatus(workload)).toBe(QuotaUsageWorkloadStatuses.Queued);
+    });
+
+    it('returns Running only when Kueue PodsReady is set on the Workload CR', () => {
+      const workload = baseWorkload({
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: [
+            ...admittedConditions,
+            {
+              type: 'PodsReady',
+              status: 'True',
+              reason: 'PodsReady',
+              message: 'All pods are ready',
+              lastTransitionTime: '2026-01-01T00:00:00Z',
+            },
+          ],
+        },
+      });
+
+      expect(resolveQuotaUsageWorkloadStatus(workload)).toBe(QuotaUsageWorkloadStatuses.Running);
+    });
+  });
+
   describe('mapWorkloadToRow', () => {
     it('maps priority and hardware profile from workload spec and admission', () => {
       const resourceFlavor: ResourceFlavorKind = {
@@ -957,7 +1175,7 @@ describe('clusterQueueWorkloads', () => {
 
       expect(row).toMatchObject({
         clusterQueue: CQ,
-        priority: 'on-demand (100)',
+        priority: 'on demand (100)',
         hardwareProfile: 'NVIDIA-L40S',
       });
     });
@@ -981,7 +1199,54 @@ describe('clusterQueueWorkloads', () => {
             },
           }),
         ),
-      ).toBe('on-demand (100)');
+      ).toBe('on demand (100)');
+    });
+
+    it('falls back to numeric priority when priority class name is missing', () => {
+      expect(
+        formatWorkloadPriority(
+          baseWorkload({
+            spec: {
+              queueName: LQ,
+              active: true,
+              podSets: baseWorkload().spec.podSets,
+              priority: 0,
+            },
+          }),
+        ),
+      ).toBe('0');
+
+      expect(
+        formatWorkloadPriority(
+          baseWorkload({
+            spec: {
+              queueName: LQ,
+              active: true,
+              podSets: baseWorkload().spec.podSets,
+              priority: 100,
+            },
+          }),
+        ),
+      ).toBe('100');
+    });
+
+    it('returns undefined when numeric priority is missing', () => {
+      expect(
+        formatWorkloadPriority(
+          baseWorkload({
+            spec: {
+              queueName: LQ,
+              active: true,
+              podSets: baseWorkload().spec.podSets,
+              priorityClassRef: {
+                group: 'kueue.x-k8s.io',
+                kind: 'WorkloadPriorityClass',
+                name: 'on-demand',
+              },
+            },
+          }),
+        ),
+      ).toBeUndefined();
     });
   });
 
@@ -997,7 +1262,7 @@ describe('clusterQueueWorkloads', () => {
   });
 
   describe('filterAndMapNamespaceWorkloads', () => {
-    it('maps all active workloads in a namespace regardless of cluster queue', () => {
+    it('maps all Kueue-managed workloads in a namespace regardless of cluster queue', () => {
       const admitted = baseWorkload({
         metadata: { name: 'admitted-wl', namespace: NS },
         status: { conditions: admittedConditions },
@@ -1017,16 +1282,415 @@ describe('clusterQueueWorkloads', () => {
           workloads: [admitted, queued, complete],
           localQueues: [localQueue(LQ, CQ)],
           pods: [],
+          statefulSets: [],
+          inferenceServices: [],
           jobKindByUid: new Map(),
         },
         'DSP One',
         emptyResourceFlavors,
       );
 
-      expect(rows).toHaveLength(2);
+      expect(rows).toHaveLength(3);
       expect(rows.map((row) => row.name)).toEqual(
-        expect.arrayContaining(['admitted-wl', 'queued-wl']),
+        expect.arrayContaining(['admitted-wl', 'queued-wl', 'complete-wl']),
       );
+    });
+  });
+
+  describe('applyDisplayStatuses', () => {
+    const queuedRow = {
+      name: 'queued-wl',
+      namespace: NS,
+      project: 'DSP One',
+      clusterQueue: CQ,
+      type: QuotaUsageWorkloadTypes.Train,
+      status: QuotaUsageWorkloadStatuses.Queued,
+      localQueue: LQ,
+      accelerators: 2,
+      queuePosition: undefined,
+    };
+
+    it('maps queued workloads without position to Pending', () => {
+      const [row] = applyDisplayStatuses([queuedRow]);
+      expect(row.status).toBe(QuotaUsageWorkloadStatuses.Pending);
+    });
+
+    it('keeps queued workloads with position as Queued', () => {
+      const [row] = applyDisplayStatuses([{ ...queuedRow, queuePosition: 1 }]);
+      expect(row.status).toBe(QuotaUsageWorkloadStatuses.Queued);
+    });
+
+    it('does not change admitted workloads', () => {
+      const admittedRow = {
+        ...queuedRow,
+        status: QuotaUsageWorkloadStatuses.Admitted,
+      };
+      const [row] = applyDisplayStatuses([admittedRow]);
+      expect(row.status).toBe(QuotaUsageWorkloadStatuses.Admitted);
+    });
+  });
+
+  describe('fetchLocalQueueClusterQueueIndex', () => {
+    it('builds a clusterQueueName -> Set<namespace> index from a single cluster-wide call', async () => {
+      listAllLocalQueuesMock.mockResolvedValue([
+        localQueue(LQ, CQ),
+        { ...localQueue('other-lq', CQ), metadata: { name: 'other-lq', namespace: 'dsp-2' } },
+        {
+          ...localQueue('unrelated-lq', 'other-cq'),
+          metadata: { name: 'unrelated-lq', namespace: 'dsp-3' },
+        },
+      ]);
+
+      const index = await fetchLocalQueueClusterQueueIndex();
+
+      expect(listAllLocalQueuesMock).toHaveBeenCalledTimes(1);
+      expect(index.get(CQ)).toEqual(new Set(['dsp-1', 'dsp-2']));
+      expect(index.get('other-cq')).toEqual(new Set(['dsp-3']));
+    });
+
+    it('skips LocalQueues missing a target cluster queue or namespace', async () => {
+      listAllLocalQueuesMock.mockResolvedValue([
+        { ...localQueue(LQ, ''), spec: { clusterQueue: '' } },
+      ]);
+
+      const index = await fetchLocalQueueClusterQueueIndex();
+      expect(index.size).toBe(0);
+    });
+  });
+
+  describe('getNamespacesForClusterQueues', () => {
+    it('returns the union of namespaces for the requested cluster queues', () => {
+      const index = new Map([
+        [CQ, new Set(['dsp-1', 'dsp-2'])],
+        ['other-cq', new Set(['dsp-3'])],
+      ]);
+
+      expect(getNamespacesForClusterQueues([CQ, 'other-cq'], index)).toEqual(
+        new Set(['dsp-1', 'dsp-2', 'dsp-3']),
+      );
+    });
+
+    it('returns an empty set for cluster queues absent from the index', () => {
+      expect(getNamespacesForClusterQueues(['missing-cq'], new Map())).toEqual(new Set());
+    });
+  });
+
+  describe('mapWorkloadsForClusterQueuesSync + applyQueuePositionsToMap', () => {
+    const projectDisplayNames = new Map([[NS, 'DSP One']]);
+
+    it('maps rows without fetching queue positions, then applies them separately', () => {
+      const queued = baseWorkload({
+        metadata: { name: 'queued-wl', namespace: NS },
+        status: { conditions: queuedConditions },
+      });
+
+      const cache = {
+        namespaceData: [
+          {
+            namespace: NS,
+            workloads: [queued],
+            localQueues: [localQueue(LQ, CQ)],
+            pods: [],
+            statefulSets: [],
+            inferenceServices: [],
+            jobKindByUid: new Map(),
+          },
+        ],
+        resourceFlavorByName: emptyResourceFlavors,
+        hardwareProfileByKey: new Map(),
+        hardwareProfilesForMatching: [],
+      };
+
+      const initial = mapWorkloadsForClusterQueuesSync([CQ], cache, projectDisplayNames);
+      expect(getPendingWorkloadsMock).not.toHaveBeenCalled();
+      expect(initial.get(CQ)?.[0]).toMatchObject({
+        status: QuotaUsageWorkloadStatuses.Queued,
+        queuePosition: undefined,
+      });
+
+      const withNoPositions = applyQueuePositionsToMap(initial, new Map());
+      expect(withNoPositions.get(CQ)?.[0].status).toBe(QuotaUsageWorkloadStatuses.Pending);
+
+      const withNoPositionsBeforeLoaded = applyQueuePositionsToMap(initial, new Map(), false);
+      expect(withNoPositionsBeforeLoaded.get(CQ)?.[0].status).toBe(
+        QuotaUsageWorkloadStatuses.Queued,
+      );
+
+      const withPositions = applyQueuePositionsToMap(initial, new Map([[`${NS}/queued-wl`, 1]]));
+      expect(withPositions.get(CQ)?.[0]).toMatchObject({
+        status: QuotaUsageWorkloadStatuses.Queued,
+        queuePosition: 1,
+      });
+    });
+  });
+
+  describe('hardware profile resolution (annotation-based)', () => {
+    const hardwareProfilePod = (overrides: Partial<PodKind['metadata']> = {}): PodKind =>
+      ({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          name: 'nb-0',
+          namespace: NS,
+          uid: 'pod-uid-1',
+          labels: { 'kueue.x-k8s.io/pod-group-name': 'wl-1' },
+          annotations: {
+            'opendatahub.io/hardware-profile-name': 'mig-7g',
+            'opendatahub.io/hardware-profile-namespace': 'redhat-ods-applications',
+          },
+          ...overrides,
+        },
+        spec: {},
+        status: { phase: 'Running' },
+      } as PodKind);
+
+    const hardwareProfileCr = {
+      apiVersion: 'infrastructure.opendatahub.io/v1',
+      kind: 'HardwareProfile',
+      metadata: {
+        name: 'mig-7g',
+        namespace: 'redhat-ods-applications',
+        annotations: { 'opendatahub.io/display-name': 'Research notebook MIG 7g' },
+      },
+      spec: {
+        identifiers: [
+          { displayName: 'GPU', identifier: 'nvidia.com/mig-7g.80gb', resourceType: 'Accelerator' },
+        ],
+      },
+    };
+
+    it('finds a workload pod-group by the pod-group-name label', () => {
+      const workload = baseWorkload({ metadata: { name: 'wl-1', namespace: NS } });
+      const pod = hardwareProfilePod();
+      expect(findWorkloadPods(workload, [pod])).toEqual([pod]);
+    });
+
+    it('collects distinct HardwareProfile refs from Pod annotations', () => {
+      const pod = hardwareProfilePod();
+      const refs = collectHardwareProfileRefs([
+        {
+          namespace: NS,
+          workloads: [],
+          localQueues: [],
+          pods: [pod, pod],
+          statefulSets: [],
+          inferenceServices: [],
+          jobKindByUid: new Map(),
+        },
+      ]);
+      expect(refs).toEqual([{ name: 'mig-7g', namespace: 'redhat-ods-applications' }]);
+    });
+
+    it('fetches HardwareProfile CRs by ref, skipping errors', async () => {
+      getHardwareProfileMock.mockResolvedValueOnce(hardwareProfileCr as never);
+      const byKey = await fetchHardwareProfilesByKey([
+        { name: 'mig-7g', namespace: 'redhat-ods-applications' },
+      ]);
+      expect(byKey.get('redhat-ods-applications/mig-7g')).toEqual(hardwareProfileCr);
+
+      getHardwareProfileMock.mockRejectedValueOnce(new Error('not found'));
+      const withError = await fetchHardwareProfilesByKey([
+        { name: 'missing', namespace: 'redhat-ods-applications' },
+      ]);
+      expect(withError.size).toBe(0);
+    });
+
+    it('resolves hardwareProfile + hardwareProfileResourceType from the Pod annotation over ResourceFlavor', () => {
+      const workload = baseWorkload({
+        metadata: { name: 'wl-1', namespace: NS },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      const pod = hardwareProfilePod();
+      const hardwareProfileByKey = new Map([
+        ['redhat-ods-applications/mig-7g', hardwareProfileCr as never],
+      ]);
+
+      const row = mapWorkloadToRow(
+        workload,
+        NS,
+        'DSP One',
+        [pod],
+        buildLocalQueueByName([localQueue(LQ, CQ)]),
+        emptyResourceFlavors,
+        new Map(),
+        CQ,
+        hardwareProfileByKey,
+      );
+
+      expect(row.hardwareProfile).toBe('Research notebook MIG 7g');
+      expect(row.hardwareProfileResourceType).toBe('nvidia.com/mig-7g.80gb');
+    });
+
+    it('resolves hardware profile from StatefulSet pod template when the workbench is stopped (no pods)', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'statefulset-hrathina-test-checkpointing-fcd62',
+          namespace: NS,
+          ownerReferences: [
+            {
+              apiVersion: 'apps/v1',
+              kind: 'StatefulSet',
+              name: 'hrathina-test-checkpointing',
+              uid: 'sts-uid',
+            },
+          ],
+        },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      const statefulSet = {
+        apiVersion: 'apps/v1',
+        kind: 'StatefulSet',
+        metadata: { name: 'hrathina-test-checkpointing', namespace: NS, uid: 'sts-uid' },
+        spec: {
+          template: {
+            metadata: {
+              annotations: {
+                'opendatahub.io/hardware-profile-name': 'default-profile',
+                'opendatahub.io/hardware-profile-namespace': 'redhat-ods-applications',
+              },
+            },
+          },
+        },
+      };
+      const defaultProfileCr = {
+        apiVersion: 'infrastructure.opendatahub.io/v1',
+        kind: 'HardwareProfile',
+        metadata: {
+          name: 'default-profile',
+          namespace: 'redhat-ods-applications',
+          annotations: { 'opendatahub.io/display-name': 'default-profile' },
+        },
+        spec: {
+          identifiers: [
+            { displayName: 'GPU', identifier: 'nvidia.com/gpu', resourceType: 'Accelerator' },
+          ],
+        },
+      };
+      const hardwareProfileByKey = new Map([
+        ['redhat-ods-applications/default-profile', defaultProfileCr as never],
+      ]);
+      const statefulSetsByName = new Map([['hrathina-test-checkpointing', statefulSet]]);
+
+      const row = mapWorkloadToRow(
+        workload,
+        NS,
+        'DSP One',
+        [],
+        buildLocalQueueByName([localQueue(LQ, CQ)]),
+        emptyResourceFlavors,
+        new Map(),
+        CQ,
+        hardwareProfileByKey,
+        statefulSetsByName,
+      );
+
+      expect(row.hardwareProfile).toBe('default-profile');
+      expect(row.hardwareProfileResourceType).toBe('nvidia.com/gpu');
+    });
+
+    it('resolves hardware profile from StatefulSet via Kueue job-owner annotations (no ownerReferences)', () => {
+      const workload = baseWorkload({
+        metadata: {
+          name: 'statefulset-umb-wkb-89877',
+          namespace: NS,
+          labels: { 'kueue.x-k8s.io/job-uid': '5ff915da-2bc6-43a1-a13b-1a78cc822c89' },
+          annotations: {
+            'kueue.x-k8s.io/job-owner-name': 'umb-wkb',
+            'kueue.x-k8s.io/job-owner-gvk': 'apps/v1, Kind=StatefulSet',
+          },
+        },
+        status: {
+          admission: { clusterQueue: CQ, podSetAssignments: [] },
+          conditions: admittedConditions,
+        },
+      });
+      const statefulSet = {
+        apiVersion: 'apps/v1',
+        kind: 'StatefulSet',
+        metadata: { name: 'umb-wkb', namespace: NS },
+        spec: {
+          template: {
+            metadata: {
+              annotations: {
+                'opendatahub.io/hardware-profile-name': 'default-profile',
+                'opendatahub.io/hardware-profile-namespace': 'redhat-ods-applications',
+              },
+            },
+          },
+        },
+      };
+      const defaultProfileCr = {
+        apiVersion: 'infrastructure.opendatahub.io/v1',
+        kind: 'HardwareProfile',
+        metadata: {
+          name: 'default-profile',
+          namespace: 'redhat-ods-applications',
+          annotations: { 'opendatahub.io/display-name': 'default-profile' },
+        },
+        spec: {
+          identifiers: [
+            { displayName: 'GPU', identifier: 'nvidia.com/gpu', resourceType: 'Accelerator' },
+          ],
+        },
+      };
+      const hardwareProfileByKey = new Map([
+        ['redhat-ods-applications/default-profile', defaultProfileCr as never],
+      ]);
+      const statefulSetsByName = new Map([['umb-wkb', statefulSet]]);
+
+      const row = mapWorkloadToRow(
+        workload,
+        NS,
+        'DSP One',
+        [],
+        buildLocalQueueByName([localQueue(LQ, CQ)]),
+        emptyResourceFlavors,
+        new Map(),
+        CQ,
+        hardwareProfileByKey,
+        statefulSetsByName,
+      );
+
+      expect(row.type).toBe(QuotaUsageWorkloadTypes.Workbench);
+      expect(row.hardwareProfile).toBe('default-profile');
+      expect(row.hardwareProfileResourceType).toBe('nvidia.com/gpu');
+    });
+
+    it('collects HardwareProfile refs from StatefulSet pod templates', () => {
+      const refs = collectHardwareProfileRefs([
+        {
+          namespace: NS,
+          workloads: [],
+          localQueues: [],
+          pods: [],
+          statefulSets: [
+            {
+              apiVersion: 'apps/v1',
+              kind: 'StatefulSet',
+              metadata: { name: 'hrathina-test-checkpointing', namespace: NS },
+              spec: {
+                template: {
+                  metadata: {
+                    annotations: {
+                      'opendatahub.io/hardware-profile-name': 'default-profile',
+                      'opendatahub.io/hardware-profile-namespace': 'redhat-ods-applications',
+                    },
+                  },
+                },
+              },
+            },
+          ],
+          inferenceServices: [],
+          jobKindByUid: new Map(),
+        },
+      ]);
+      expect(refs).toEqual([{ name: 'default-profile', namespace: 'redhat-ods-applications' }]);
     });
   });
 });

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloads.spec.ts
@@ -2,7 +2,6 @@ import type {
   K8sResourceCommon,
   LocalQueueKind,
   PodKind,
-  ResourceFlavorKind,
   WorkloadCondition,
   WorkloadKind,
 } from '@odh-dashboard/k8s-core';
@@ -26,7 +25,6 @@ import {
   findWorkloadPods,
   formatWorkloadPriority,
   getNamespacesForClusterQueues,
-  isActiveQuotaUsageClusterQueueWorkload,
   isGpuAwareWorkload,
   getWorkloadAcceleratorCount,
   isKueueManagedWorkload,
@@ -73,7 +71,6 @@ const getHardwareProfileMock = jest.mocked(getHardwareProfile);
 const NS = 'dsp-1';
 const CQ = 'gpu-cq';
 const LQ = 'user-queue';
-const emptyResourceFlavors = new Map<string, ResourceFlavorKind>();
 
 const baseWorkload = (overrides: Partial<WorkloadKind> = {}): WorkloadKind => ({
   apiVersion: 'kueue.x-k8s.io/v1beta2',
@@ -217,6 +214,45 @@ describe('clusterQueueWorkloads', () => {
     it('matches pending workloads targeting the cluster queue via local queue', () => {
       const workload = baseWorkload({ status: { conditions: queuedConditions } });
       expect(workloadMatchesClusterQueue(workload, CQ, localQueueByName)).toBe(true);
+    });
+
+    it('collects hardware profile references from workload pod-set annotations', () => {
+      const workload = baseWorkload({
+        spec: {
+          queueName: LQ,
+          podSets: [
+            {
+              count: 1,
+              name: 'main',
+              template: {
+                metadata: {
+                  annotations: {
+                    'opendatahub.io/hardware-profile-name': 'gpu-profile',
+                    'opendatahub.io/hardware-profile-namespace': NS,
+                  },
+                },
+                spec: {
+                  containers: [],
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      expect(
+        collectHardwareProfileRefs([
+          {
+            namespace: NS,
+            workloads: [workload],
+            localQueues: [],
+            pods: [],
+            statefulSets: [],
+            inferenceServices: [],
+            jobKindByUid: new Map(),
+          },
+        ]),
+      ).toEqual([{ name: 'gpu-profile', namespace: NS }]);
     });
 
     it('excludes workloads on a different cluster queue', () => {
@@ -553,7 +589,7 @@ describe('clusterQueueWorkloads', () => {
   describe('filterAndMapClusterQueueWorkloads', () => {
     const projectDisplayNames = new Map([[NS, 'DSP One']]);
 
-    it('maps active workloads and excludes Complete and Failed (default scope)', () => {
+    it('maps active, Complete, and Failed workloads', () => {
       const admitted = baseWorkload({
         metadata: {
           name: 'admitted-wl',
@@ -600,10 +636,9 @@ describe('clusterQueueWorkloads', () => {
           },
         ],
         projectDisplayNames,
-        emptyResourceFlavors,
       );
 
-      expect(rows).toHaveLength(2);
+      expect(rows).toHaveLength(4);
       expect(rows.find((row) => row.name === 'admitted-wl')).toMatchObject({
         project: 'DSP One',
         clusterQueue: CQ,
@@ -616,8 +651,12 @@ describe('clusterQueueWorkloads', () => {
         type: QuotaUsageWorkloadTypes.Workbench,
         status: QuotaUsageWorkloadStatuses.Queued,
       });
-      expect(rows.find((row) => row.name === 'complete-wl')).toBeUndefined();
-      expect(rows.find((row) => row.name === 'failed-wl')).toBeUndefined();
+      expect(rows.find((row) => row.name === 'complete-wl')).toMatchObject({
+        status: QuotaUsageWorkloadStatuses.Complete,
+      });
+      expect(rows.find((row) => row.name === 'failed-wl')).toMatchObject({
+        status: QuotaUsageWorkloadStatuses.Failed,
+      });
     });
 
     it('excludes workloads not actively managed by Kueue', () => {
@@ -686,7 +725,6 @@ describe('clusterQueueWorkloads', () => {
           },
         ],
         projectDisplayNames,
-        emptyResourceFlavors,
       );
 
       expect(rows.map((row) => row.name)).toEqual(['admitted-wl', 'serving-kueue-wl']);
@@ -743,7 +781,6 @@ describe('clusterQueueWorkloads', () => {
           },
         ],
         projectDisplayNames,
-        emptyResourceFlavors,
       );
 
       expect(rows).toHaveLength(0);
@@ -787,7 +824,6 @@ describe('clusterQueueWorkloads', () => {
           },
         ],
         projectDisplayNames,
-        emptyResourceFlavors,
       );
 
       expect(rows).toHaveLength(1);
@@ -844,7 +880,6 @@ describe('clusterQueueWorkloads', () => {
           },
         ],
         projectDisplayNames,
-        emptyResourceFlavors,
       );
 
       expect(rows).toHaveLength(1);
@@ -921,34 +956,6 @@ describe('clusterQueueWorkloads', () => {
       } as PodKind;
 
       expect(isKueueManagedWorkload(workload, [servingPod], localQueueByName)).toBe(true);
-    });
-  });
-
-  describe('isActiveQuotaUsageClusterQueueWorkload', () => {
-    it('returns false for Complete and Failed workloads', () => {
-      expect(
-        isActiveQuotaUsageClusterQueueWorkload(
-          baseWorkload({ status: { conditions: completeConditions } }),
-        ),
-      ).toBe(false);
-      expect(
-        isActiveQuotaUsageClusterQueueWorkload(
-          baseWorkload({ status: { conditions: failedConditions } }),
-        ),
-      ).toBe(false);
-    });
-
-    it('returns true for admitted and queued workloads', () => {
-      expect(
-        isActiveQuotaUsageClusterQueueWorkload(
-          baseWorkload({ status: { conditions: admittedConditions } }),
-        ),
-      ).toBe(true);
-      expect(
-        isActiveQuotaUsageClusterQueueWorkload(
-          baseWorkload({ status: { conditions: queuedConditions } }),
-        ),
-      ).toBe(true);
     });
   });
 
@@ -1134,13 +1141,7 @@ describe('clusterQueueWorkloads', () => {
   });
 
   describe('mapWorkloadToRow', () => {
-    it('maps priority and hardware profile from workload spec and admission', () => {
-      const resourceFlavor: ResourceFlavorKind = {
-        apiVersion: 'kueue.x-k8s.io/v1beta2',
-        kind: 'ResourceFlavor',
-        metadata: { name: 'gpu-l40s' },
-        spec: { nodeLabels: { 'nvidia.com/gpu.product': 'NVIDIA-L40S' } },
-      };
+    it('maps priority without deriving a hardware profile from resource flavor admission', () => {
       const workload = baseWorkload({
         spec: {
           queueName: LQ,
@@ -1168,7 +1169,6 @@ describe('clusterQueueWorkloads', () => {
         'DSP One',
         [],
         buildLocalQueueByName([localQueue(LQ, CQ)]),
-        new Map([['gpu-l40s', resourceFlavor]]),
         new Map(),
         CQ,
       );
@@ -1176,7 +1176,7 @@ describe('clusterQueueWorkloads', () => {
       expect(row).toMatchObject({
         clusterQueue: CQ,
         priority: 'on demand (100)',
-        hardwareProfile: 'NVIDIA-L40S',
+        hardwareProfile: undefined,
       });
     });
   });
@@ -1287,7 +1287,6 @@ describe('clusterQueueWorkloads', () => {
           jobKindByUid: new Map(),
         },
         'DSP One',
-        emptyResourceFlavors,
       );
 
       expect(rows).toHaveLength(3);
@@ -1396,7 +1395,6 @@ describe('clusterQueueWorkloads', () => {
             jobKindByUid: new Map(),
           },
         ],
-        resourceFlavorByName: emptyResourceFlavors,
         hardwareProfileByKey: new Map(),
         hardwareProfilesForMatching: [],
       };
@@ -1514,7 +1512,6 @@ describe('clusterQueueWorkloads', () => {
         'DSP One',
         [pod],
         buildLocalQueueByName([localQueue(LQ, CQ)]),
-        emptyResourceFlavors,
         new Map(),
         CQ,
         hardwareProfileByKey,
@@ -1583,7 +1580,6 @@ describe('clusterQueueWorkloads', () => {
         'DSP One',
         [],
         buildLocalQueueByName([localQueue(LQ, CQ)]),
-        emptyResourceFlavors,
         new Map(),
         CQ,
         hardwareProfileByKey,
@@ -1650,7 +1646,6 @@ describe('clusterQueueWorkloads', () => {
         'DSP One',
         [],
         buildLocalQueueByName([localQueue(LQ, CQ)]),
-        emptyResourceFlavors,
         new Map(),
         CQ,
         hardwareProfileByKey,

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloadsTableUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloadsTableUtils.spec.ts
@@ -43,11 +43,13 @@ describe('clusterQueueWorkloadsTableUtils', () => {
       priority: 'on demand (100)',
       hardwareProfile: 'Standard (H100 MIG - 20GB)',
     }),
+    baseRow({ name: 'completed-training', status: QuotaUsageWorkloadStatuses.Complete }),
+    baseRow({ name: 'failed-training', status: QuotaUsageWorkloadStatuses.Failed }),
   ];
 
   describe('filterClusterQueueWorkloads', () => {
     it('should return all workloads when no filters are active', () => {
-      expect(filterClusterQueueWorkloads(workloads, {})).toHaveLength(3);
+      expect(filterClusterQueueWorkloads(workloads, {})).toHaveLength(5);
     });
 
     it('should filter workloads by name', () => {
@@ -64,6 +66,13 @@ describe('clusterQueueWorkloadsTableUtils', () => {
           status: { label: 'Admitted', value: QuotaUsageWorkloadStatuses.Admitted },
         }),
       ).toEqual([workloads[2]]);
+    });
+
+    it.each([
+      [QuotaUsageWorkloadStatuses.Complete, workloads[3]],
+      [QuotaUsageWorkloadStatuses.Failed, workloads[4]],
+    ])('should filter workloads by %s status', (status, expectedWorkload) => {
+      expect(filterClusterQueueWorkloads(workloads, { status })).toEqual([expectedWorkload]);
     });
 
     it('should apply name and status filters together', () => {

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloadsTableUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueWorkloadsTableUtils.spec.ts
@@ -1,0 +1,119 @@
+import {
+  QuotaUsageWorkloadStatuses,
+  QuotaUsageWorkloadTypes,
+  type ClusterQueueWorkloadRow,
+} from '../../types';
+import {
+  filterClusterQueueWorkloads,
+  hasActiveWorkloadFilters,
+} from '../clusterQueueWorkloadsTableUtils';
+
+const baseRow = (overrides: Partial<ClusterQueueWorkloadRow> = {}): ClusterQueueWorkloadRow => ({
+  name: 'wl-1',
+  namespace: 'dsp-1',
+  project: 'Project A',
+  clusterQueue: 'gpu-cq',
+  type: QuotaUsageWorkloadTypes.Train,
+  status: QuotaUsageWorkloadStatuses.Pending,
+  localQueue: 'user-queue',
+  accelerators: 2,
+  queuePosition: 1,
+  ...overrides,
+});
+
+describe('clusterQueueWorkloadsTableUtils', () => {
+  const workloads = [
+    baseRow({
+      name: 'llm-pretrain-run',
+      project: 'Project D',
+      status: QuotaUsageWorkloadStatuses.Pending,
+    }),
+    baseRow({
+      name: 'multimodal-trial',
+      project: 'Project D',
+      status: QuotaUsageWorkloadStatuses.Inadmissible,
+      queuePosition: undefined,
+    }),
+    baseRow({
+      name: 'serving-deploy',
+      project: 'Project E',
+      status: QuotaUsageWorkloadStatuses.Admitted,
+      queuePosition: undefined,
+      type: QuotaUsageWorkloadTypes.Serve,
+      priority: 'on demand (100)',
+      hardwareProfile: 'Standard (H100 MIG - 20GB)',
+    }),
+  ];
+
+  describe('filterClusterQueueWorkloads', () => {
+    it('should return all workloads when no filters are active', () => {
+      expect(filterClusterQueueWorkloads(workloads, {})).toHaveLength(3);
+    });
+
+    it('should filter workloads by name', () => {
+      expect(filterClusterQueueWorkloads(workloads, { name: 'llm' })).toEqual([workloads[0]]);
+    });
+
+    it('should filter workloads by project name', () => {
+      expect(filterClusterQueueWorkloads(workloads, { name: 'project e' })).toEqual([workloads[2]]);
+    });
+
+    it('should filter workloads by status', () => {
+      expect(
+        filterClusterQueueWorkloads(workloads, {
+          status: { label: 'Admitted', value: QuotaUsageWorkloadStatuses.Admitted },
+        }),
+      ).toEqual([workloads[2]]);
+    });
+
+    it('should apply name and status filters together', () => {
+      expect(
+        filterClusterQueueWorkloads(workloads, {
+          name: 'multimodal',
+          status: QuotaUsageWorkloadStatuses.Inadmissible,
+        }),
+      ).toEqual([workloads[1]]);
+    });
+
+    it('should filter workloads by priority', () => {
+      expect(
+        filterClusterQueueWorkloads(workloads, {
+          priority: { label: 'on demand (100)', value: 'on demand (100)' },
+        }),
+      ).toEqual([workloads[2]]);
+    });
+
+    it('should filter workloads by hardware profile', () => {
+      expect(
+        filterClusterQueueWorkloads(workloads, {
+          hardwareProfile: {
+            label: 'Standard (H100 MIG - 20GB)',
+            value: 'Standard (H100 MIG - 20GB)',
+          },
+        }),
+      ).toEqual([workloads[2]]);
+    });
+  });
+
+  describe('hasActiveWorkloadFilters', () => {
+    it('should return false when filters are empty', () => {
+      expect(hasActiveWorkloadFilters({})).toBe(false);
+    });
+
+    it('should return true when a name filter is set', () => {
+      expect(hasActiveWorkloadFilters({ name: 'llm' })).toBe(true);
+    });
+
+    it('should return true when a status filter is set', () => {
+      expect(
+        hasActiveWorkloadFilters({
+          status: QuotaUsageWorkloadStatuses.Queued,
+        }),
+      ).toBe(true);
+    });
+
+    it('should return true when a priority filter is set', () => {
+      expect(hasActiveWorkloadFilters({ priority: 'on demand (100)' })).toBe(true);
+    });
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
@@ -1,10 +1,5 @@
-import { ClusterQueueKind, ResourceFlavorKind, type WorkloadKind } from '@odh-dashboard/k8s-core';
-import {
-  buildResourceFlavorByName,
-  resolveHardwareModels,
-  resolvePerModelGpuCounts,
-  resolveWorkloadHardwareProfile,
-} from '../hardwareModels';
+import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/k8s-core';
+import { resolveHardwareModels, resolvePerModelGpuCounts } from '../hardwareModels';
 
 const makeGpuCQ = (
   name: string,
@@ -116,7 +111,6 @@ describe('resolveHardwareModels', () => {
     expect(result.get('cq-dup')).toEqual(['NVIDIA H100']);
   });
 });
-
 describe('resolvePerModelGpuCounts', () => {
   it.each([
     [
@@ -217,86 +211,5 @@ describe('resolvePerModelGpuCounts', () => {
     expect(result.get('cq-2')).toEqual([
       { model: 'NVIDIA H100', nominal: 4, used: 4, borrowed: 2 },
     ]);
-  });
-});
-
-describe('resolveWorkloadHardwareProfile', () => {
-  it('maps admitted resource flavor assignments to GPU product labels', () => {
-    const resourceFlavor = makeRF('gpu-l40s', 'NVIDIA-L40S');
-    const workload: WorkloadKind = {
-      apiVersion: 'kueue.x-k8s.io/v1beta2',
-      kind: 'Workload',
-      metadata: { name: 'wl-test', namespace: 'test-ns' },
-      spec: { podSets: [] },
-      status: {
-        admission: {
-          clusterQueue: 'gpu-cq',
-          podSetAssignments: [{ name: 'main', flavors: { 'nvidia.com/gpu': 'gpu-l40s' } }],
-        },
-      },
-    };
-
-    expect(
-      resolveWorkloadHardwareProfile(workload, buildResourceFlavorByName([resourceFlavor])),
-    ).toBe('NVIDIA-L40S');
-  });
-
-  it('returns undefined when no flavor matches', () => {
-    const workload: WorkloadKind = {
-      apiVersion: 'kueue.x-k8s.io/v1beta2',
-      kind: 'Workload',
-      metadata: { name: 'wl-test', namespace: 'test-ns' },
-      spec: { podSets: [] },
-      status: {
-        admission: {
-          clusterQueue: 'gpu-cq',
-          podSetAssignments: [{ name: 'main', flavors: { 'nvidia.com/gpu': 'missing-flavor' } }],
-        },
-      },
-    };
-
-    expect(
-      resolveWorkloadHardwareProfile(workload, buildResourceFlavorByName([makeRF('gpu-l40s')])),
-    ).toBeUndefined();
-  });
-
-  it('deduplicates, sorts, and joins multiple GPU product labels', () => {
-    const l40sFlavor: ResourceFlavorKind = {
-      apiVersion: 'kueue.x-k8s.io/v1beta2',
-      kind: 'ResourceFlavor',
-      metadata: { name: 'gpu-l40s' },
-      spec: { nodeLabels: { 'nvidia.com/gpu.product': 'NVIDIA-L40S' } },
-    };
-    const h100Flavor: ResourceFlavorKind = {
-      apiVersion: 'kueue.x-k8s.io/v1beta2',
-      kind: 'ResourceFlavor',
-      metadata: { name: 'gpu-h100' },
-      spec: { nodeLabels: { 'nvidia.com/gpu.product': 'NVIDIA-H100' } },
-    };
-    const workload: WorkloadKind = {
-      apiVersion: 'kueue.x-k8s.io/v1beta2',
-      kind: 'Workload',
-      metadata: { name: 'wl-multi', namespace: 'test-ns' },
-      spec: { podSets: [] },
-      status: {
-        admission: {
-          clusterQueue: 'gpu-cq',
-          podSetAssignments: [
-            {
-              name: 'main',
-              flavors: {
-                'nvidia.com/gpu': 'gpu-l40s',
-                'amd.com/gpu': 'gpu-h100',
-                'intel.com/gpu': 'gpu-l40s',
-              },
-            },
-          ],
-        },
-      },
-    };
-
-    expect(
-      resolveWorkloadHardwareProfile(workload, buildResourceFlavorByName([l40sFlavor, h100Flavor])),
-    ).toBe('NVIDIA-H100, NVIDIA-L40S');
   });
 });

--- a/packages/gpuaas/src/utils/__tests__/matchToHardwareProfile.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/matchToHardwareProfile.spec.ts
@@ -1,0 +1,103 @@
+import {
+  SchedulingType,
+  TolerationEffect,
+  TolerationOperator,
+  type HardwareProfileKind,
+} from '@odh-dashboard/k8s-core';
+import { matchToHardwareProfile } from '../matchToHardwareProfile';
+
+const gpuProfile = (tolerations: HardwareProfileKind['spec']['scheduling']): HardwareProfileKind =>
+  ({
+    apiVersion: 'dashboard.opendatahub.io/v1',
+    kind: 'HardwareProfile',
+    metadata: { name: 'gpu-profile' },
+    spec: {
+      identifiers: [
+        {
+          identifier: 'nvidia.com/gpu',
+          minCount: 1,
+          maxCount: 1,
+          defaultCount: 1,
+        },
+      ],
+      scheduling: tolerations,
+    },
+  } as HardwareProfileKind);
+
+const gpuResources = {
+  requests: { 'nvidia.com/gpu': '1', cpu: '1', memory: '4Gi' },
+  limits: { 'nvidia.com/gpu': '1', cpu: '1', memory: '4Gi' },
+};
+
+describe('matchToHardwareProfile', () => {
+  it('matches when workload omits toleration operator and profile uses Equal', () => {
+    const profile = gpuProfile({
+      type: SchedulingType.NODE,
+      node: {
+        tolerations: [
+          {
+            key: 'gpu-node',
+            operator: TolerationOperator.EQUAL,
+            value: 'true',
+            effect: TolerationEffect.NO_SCHEDULE,
+          },
+        ],
+      },
+    });
+
+    expect(
+      matchToHardwareProfile([profile], gpuResources, [
+        { key: 'gpu-node', value: 'true', effect: TolerationEffect.NO_SCHEDULE },
+      ]),
+    ).toBe(profile);
+  });
+
+  it('matches when workload toleration omits effect', () => {
+    const profile = gpuProfile({
+      type: SchedulingType.NODE,
+      node: {
+        tolerations: [
+          {
+            key: 'gpu-node',
+            operator: TolerationOperator.EQUAL,
+            value: 'true',
+            effect: TolerationEffect.NO_SCHEDULE,
+          },
+        ],
+      },
+    });
+
+    expect(
+      matchToHardwareProfile([profile], gpuResources, [
+        { key: 'gpu-node', operator: TolerationOperator.EQUAL, value: 'true' },
+      ]),
+    ).toBe(profile);
+  });
+
+  it('does not match when explicit workload effect differs from profile effect', () => {
+    const profile = gpuProfile({
+      type: SchedulingType.NODE,
+      node: {
+        tolerations: [
+          {
+            key: 'gpu-node',
+            operator: TolerationOperator.EQUAL,
+            value: 'true',
+            effect: TolerationEffect.NO_SCHEDULE,
+          },
+        ],
+      },
+    });
+
+    expect(
+      matchToHardwareProfile([profile], gpuResources, [
+        {
+          key: 'gpu-node',
+          operator: TolerationOperator.EQUAL,
+          value: 'true',
+          effect: TolerationEffect.NO_EXECUTE,
+        },
+      ]),
+    ).toBeUndefined();
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/matchToHardwareProfile.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/matchToHardwareProfile.spec.ts
@@ -30,6 +30,12 @@ const gpuResources = {
 };
 
 describe('matchToHardwareProfile', () => {
+  it('matches a profile without scheduling configuration', () => {
+    const profile = gpuProfile(undefined);
+
+    expect(matchToHardwareProfile([profile], gpuResources)).toBe(profile);
+  });
+
   it('matches when workload omits toleration operator and profile uses Equal', () => {
     const profile = gpuProfile({
       type: SchedulingType.NODE,
@@ -74,6 +80,54 @@ describe('matchToHardwareProfile', () => {
     ).toBe(profile);
   });
 
+  it('matches when profile toleration omits effect', () => {
+    const profile = gpuProfile({
+      type: SchedulingType.NODE,
+      node: {
+        tolerations: [{ key: 'gpu-node', value: 'true' }],
+      },
+    });
+
+    expect(
+      matchToHardwareProfile([profile], gpuResources, [
+        {
+          key: 'gpu-node',
+          operator: TolerationOperator.EQUAL,
+          value: 'true',
+          effect: TolerationEffect.NO_SCHEDULE,
+        },
+      ]),
+    ).toBe(profile);
+  });
+
+  it('ignores toleration seconds when matching scheduling tolerations', () => {
+    const profile = gpuProfile({
+      type: SchedulingType.NODE,
+      node: {
+        tolerations: [
+          {
+            key: 'gpu-node',
+            operator: TolerationOperator.EQUAL,
+            value: 'true',
+            effect: TolerationEffect.NO_SCHEDULE,
+          },
+        ],
+      },
+    });
+
+    expect(
+      matchToHardwareProfile([profile], gpuResources, [
+        {
+          key: 'gpu-node',
+          operator: TolerationOperator.EQUAL,
+          value: 'true',
+          effect: TolerationEffect.NO_SCHEDULE,
+          tolerationSeconds: 60,
+        },
+      ]),
+    ).toBe(profile);
+  });
+
   it('does not match when explicit workload effect differs from profile effect', () => {
     const profile = gpuProfile({
       type: SchedulingType.NODE,
@@ -99,5 +153,30 @@ describe('matchToHardwareProfile', () => {
         },
       ]),
     ).toBeUndefined();
+  });
+
+  it('matches an empty-key Exists toleration', () => {
+    const profile = gpuProfile({
+      type: SchedulingType.NODE,
+      node: {
+        tolerations: [
+          {
+            key: '',
+            operator: TolerationOperator.EXISTS,
+            effect: TolerationEffect.NO_SCHEDULE,
+          },
+        ],
+      },
+    });
+
+    expect(
+      matchToHardwareProfile([profile], gpuResources, [
+        {
+          key: '',
+          operator: TolerationOperator.EXISTS,
+          effect: TolerationEffect.NO_SCHEDULE,
+        },
+      ]),
+    ).toBe(profile);
   });
 });

--- a/packages/gpuaas/src/utils/__tests__/namespaceBundleState.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/namespaceBundleState.spec.ts
@@ -1,0 +1,81 @@
+import type { PodKind } from '@odh-dashboard/k8s-core';
+import {
+  applyNamespaceEnrichment,
+  canPreserveNamespaceEnrichment,
+  createNamespaceBundleState,
+  type NamespaceWorkloadEnrichment,
+  toDisplayBundle,
+} from '../namespaceBundleState';
+import type { NamespaceWorkloadBaseData } from '../clusterQueueWorkloads';
+
+const mockPod = (name: string): PodKind => ({
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: { name },
+  spec: { containers: [{ name: 'main', image: 'test-image', env: [] }] },
+});
+
+const base = (namespace: string, workloadUid = 'uid-1'): NamespaceWorkloadBaseData => ({
+  namespace,
+  workloads: [
+    {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'Workload',
+      metadata: { name: 'wl-1', namespace, uid: workloadUid },
+      spec: { queueName: 'lq-1', podSets: [] },
+    },
+  ],
+  localQueues: [],
+});
+
+const enrichment: NamespaceWorkloadEnrichment = {
+  pods: [mockPod('pod-1')],
+  statefulSets: [],
+  inferenceServices: [],
+  jobKindByUid: new Map(),
+};
+
+describe('namespaceBundleState', () => {
+  it('does not preserve enrichment when workload identities change', () => {
+    const previous = createNamespaceBundleState(base('dsp-1', 'uid-1'), undefined);
+    const withEnrichment = applyNamespaceEnrichment(previous, enrichment, 1);
+
+    expect(canPreserveNamespaceEnrichment(withEnrichment, base('dsp-1', 'uid-2'))).toBe(false);
+    expect(createNamespaceBundleState(base('dsp-1', 'uid-2'), withEnrichment)).toEqual({
+      base: base('dsp-1', 'uid-2'),
+    });
+  });
+
+  it('preserves enrichment when workload identities match', () => {
+    const previous = applyNamespaceEnrichment(
+      createNamespaceBundleState(base('dsp-1'), undefined),
+      enrichment,
+      1,
+    );
+
+    const next = createNamespaceBundleState(base('dsp-1'), previous);
+    expect(next.enrichment).toBe(enrichment);
+  });
+
+  it('only applies enrichment for the matching base generation', () => {
+    const state = applyNamespaceEnrichment(
+      createNamespaceBundleState(base('dsp-1'), undefined),
+      enrichment,
+      2,
+    );
+
+    expect(toDisplayBundle(state, 1, false).pods).toEqual([]);
+    expect(toDisplayBundle(state, 2, false).pods).toEqual(enrichment.pods);
+  });
+
+  it('shows optimistic enrichment while B2 is in flight', () => {
+    const state = applyNamespaceEnrichment(
+      createNamespaceBundleState(base('dsp-1'), undefined),
+      enrichment,
+      1,
+    );
+
+    expect(toDisplayBundle(state, 2, true).pods).toEqual(enrichment.pods);
+    expect(toDisplayBundle(state, 2, false).pods).toEqual([]);
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/workloadHardwareProfileResolver.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/workloadHardwareProfileResolver.spec.ts
@@ -1,0 +1,217 @@
+import {
+  HardwareProfileFeatureVisibility,
+  IdentifierResourceType,
+  SchedulingType,
+  type HardwareProfileKind,
+  type WorkloadKind,
+} from '@odh-dashboard/k8s-core';
+import type { WorkloadInferenceService } from '../../types/inferenceService';
+import { QuotaUsageWorkloadTypes } from '../../types';
+import { resolveWorkloadHardwareProfileForRow } from '../workloadHardwareProfileResolver';
+
+const servingProfile: HardwareProfileKind = {
+  apiVersion: 'infrastructure.opendatahub.io/v1',
+  kind: 'HardwareProfile',
+  metadata: {
+    name: 'brno-ai-serving-profile',
+    namespace: 'redhat-ods-applications',
+    annotations: {
+      'opendatahub.io/display-name': 'brno-ai-serving-profile',
+      'opendatahub.io/dashboard-feature-visibility': JSON.stringify([
+        HardwareProfileFeatureVisibility.MODEL_SERVING,
+      ]),
+      'opendatahub.io/disabled': 'false',
+    },
+  },
+  spec: {
+    identifiers: [
+      {
+        displayName: 'CPU',
+        identifier: 'cpu',
+        minCount: 1,
+        maxCount: 4,
+        defaultCount: 2,
+        resourceType: IdentifierResourceType.CPU,
+      },
+      {
+        displayName: 'Memory',
+        identifier: 'memory',
+        minCount: '2Gi',
+        maxCount: '8Gi',
+        defaultCount: '4Gi',
+        resourceType: IdentifierResourceType.MEMORY,
+      },
+      {
+        displayName: 'GPU',
+        identifier: 'nvidia.com/gpu',
+        minCount: 1,
+        maxCount: 8,
+        defaultCount: 1,
+        resourceType: IdentifierResourceType.ACCELERATOR,
+      },
+    ],
+    // Old matcher (same as useHardwareProfileConfig) needs scheduling.node present;
+    // missing tolerations field makes resource match fail.
+    scheduling: { type: SchedulingType.NODE, node: { tolerations: [], nodeSelector: {} } },
+  },
+};
+
+const trainWorkload = (): WorkloadKind =>
+  ({
+    apiVersion: 'kueue.x-k8s.io/v1beta2',
+    kind: 'Workload',
+    metadata: { name: 'trainjob-llama', namespace: 'dsp-1' },
+    spec: {
+      active: true,
+      podSets: [
+        {
+          count: 1,
+          name: 'main',
+          template: {
+            metadata: {},
+            spec: {
+              containers: [
+                {
+                  name: 'main',
+                  image: 'train',
+                  resources: {
+                    requests: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': '1' },
+                    limits: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': '1' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  } as unknown as WorkloadKind);
+
+describe('workloadHardwareProfileResolver', () => {
+  it('returns configured profile from StatefulSet pod-template annotations (notebook path)', () => {
+    const hardwareProfileByKey = new Map([
+      [
+        'redhat-ods-applications/default-profile',
+        {
+          ...servingProfile,
+          metadata: {
+            ...servingProfile.metadata,
+            name: 'default-profile',
+            annotations: {
+              'opendatahub.io/display-name': 'default-profile',
+              'opendatahub.io/disabled': 'false',
+            },
+          },
+        },
+      ],
+    ]);
+
+    const result = resolveWorkloadHardwareProfileForRow(trainWorkload(), {
+      annotationSources: [
+        {
+          'opendatahub.io/hardware-profile-name': 'default-profile',
+          'opendatahub.io/hardware-profile-namespace': 'redhat-ods-applications',
+        },
+      ],
+      hardwareProfileByKey,
+      hardwareProfilesForMatching: [],
+      resourceFlavorByName: new Map(),
+      workloadType: QuotaUsageWorkloadTypes.Workbench,
+    });
+
+    expect(result).toEqual({
+      displayName: 'default-profile',
+      acceleratorIdentifier: 'nvidia.com/gpu',
+    });
+  });
+
+  it('matches model deployment resources to a serving HardwareProfile when no annotation exists', () => {
+    const inferenceService = {
+      apiVersion: 'serving.kserve.io/v1beta1',
+      kind: 'InferenceService',
+      metadata: { name: 'my-model', namespace: 'dsp-1' },
+      spec: {
+        predictor: {
+          model: {
+            resources: {
+              requests: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': '1' },
+              limits: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': '1' },
+            },
+          },
+        },
+      },
+    } as WorkloadInferenceService;
+
+    const result = resolveWorkloadHardwareProfileForRow(trainWorkload(), {
+      annotationSources: [],
+      inferenceService,
+      hardwareProfileByKey: new Map(),
+      hardwareProfilesForMatching: [servingProfile],
+      resourceFlavorByName: new Map(),
+      workloadType: QuotaUsageWorkloadTypes.Serve,
+    });
+
+    expect(result).toEqual({
+      displayName: 'brno-ai-serving-profile',
+      acceleratorIdentifier: 'nvidia.com/gpu',
+    });
+  });
+
+  it('returns undefined when resources do not match any profile or flavor', () => {
+    const unmatchedWorkload = (): WorkloadKind =>
+      ({
+        ...trainWorkload(),
+        spec: {
+          ...trainWorkload().spec,
+          podSets: [
+            {
+              count: 1,
+              name: 'main',
+              template: {
+                metadata: {},
+                spec: {
+                  containers: [
+                    {
+                      name: 'main',
+                      image: 'train',
+                      resources: {
+                        requests: { cpu: '8', memory: '32Gi', 'nvidia.com/gpu': '2' },
+                        limits: { cpu: '16', memory: '64Gi', 'nvidia.com/gpu': '2' },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      } as unknown as WorkloadKind);
+
+    const inferenceService = {
+      apiVersion: 'serving.kserve.io/v1beta1',
+      kind: 'InferenceService',
+      metadata: { name: 'qwen38-27b', namespace: 'qwen' },
+      spec: {
+        predictor: {
+          model: {
+            resources: {
+              requests: { cpu: '8', memory: '32Gi', 'nvidia.com/gpu': '2' },
+              limits: { cpu: '16', memory: '64Gi', 'nvidia.com/gpu': '2' },
+            },
+          },
+        },
+      },
+    } as WorkloadInferenceService;
+
+    const result = resolveWorkloadHardwareProfileForRow(unmatchedWorkload(), {
+      annotationSources: [],
+      inferenceService,
+      hardwareProfileByKey: new Map(),
+      hardwareProfilesForMatching: [servingProfile],
+      resourceFlavorByName: new Map(),
+      workloadType: QuotaUsageWorkloadTypes.Serve,
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/workloadHardwareProfileResolver.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/workloadHardwareProfileResolver.spec.ts
@@ -115,7 +115,6 @@ describe('workloadHardwareProfileResolver', () => {
       ],
       hardwareProfileByKey,
       hardwareProfilesForMatching: [],
-      resourceFlavorByName: new Map(),
       workloadType: QuotaUsageWorkloadTypes.Workbench,
     });
 
@@ -147,7 +146,6 @@ describe('workloadHardwareProfileResolver', () => {
       inferenceService,
       hardwareProfileByKey: new Map(),
       hardwareProfilesForMatching: [servingProfile],
-      resourceFlavorByName: new Map(),
       workloadType: QuotaUsageWorkloadTypes.Serve,
     });
 
@@ -157,7 +155,7 @@ describe('workloadHardwareProfileResolver', () => {
     });
   });
 
-  it('returns undefined when resources do not match any profile or flavor', () => {
+  it('returns undefined when resources do not match any hardware profile', () => {
     const unmatchedWorkload = (): WorkloadKind =>
       ({
         ...trainWorkload(),
@@ -208,7 +206,6 @@ describe('workloadHardwareProfileResolver', () => {
       inferenceService,
       hardwareProfileByKey: new Map(),
       hardwareProfilesForMatching: [servingProfile],
-      resourceFlavorByName: new Map(),
       workloadType: QuotaUsageWorkloadTypes.Serve,
     });
 

--- a/packages/gpuaas/src/utils/clusterQueueWorkloadStatusLabelUtils.tsx
+++ b/packages/gpuaas/src/utils/clusterQueueWorkloadStatusLabelUtils.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import type { LabelProps } from '@patternfly/react-core';
+import { CheckIcon, OutlinedClockIcon } from '@patternfly/react-icons';
+import { getKueueStatusInfo } from '@odh-dashboard/ui-core/kueue/statusInfo';
+import {
+  QUOTA_USAGE_TO_KUEUE_STATUS,
+  QuotaUsageWorkloadStatuses,
+  type QuotaUsageWorkloadStatus,
+} from '../types';
+
+export type QuotaUsageWorkloadStatusLabelSettings = {
+  label: string;
+  color?: LabelProps['color'];
+  status?: LabelProps['status'];
+  icon: React.ReactNode;
+};
+
+export const getQuotaUsageWorkloadStatusLabelSettings = (
+  status: QuotaUsageWorkloadStatus,
+): QuotaUsageWorkloadStatusLabelSettings => {
+  if (status === QuotaUsageWorkloadStatuses.Pending) {
+    return {
+      label: status,
+      color: 'purple',
+      icon: <OutlinedClockIcon />,
+    };
+  }
+
+  // UXD quota table — grey pill + checkmark (not workbench "Starting" blue spinner).
+  if (status === QuotaUsageWorkloadStatuses.Admitted) {
+    return {
+      label: status,
+      color: 'grey',
+      icon: <CheckIcon />,
+    };
+  }
+
+  const kueueStatus = QUOTA_USAGE_TO_KUEUE_STATUS[status];
+  if (kueueStatus) {
+    const info = getKueueStatusInfo(kueueStatus);
+    const Icon = info.IconComponent;
+    return {
+      label: status,
+      color: info.color,
+      status: info.status,
+      icon: <Icon className={info.iconClassName} />,
+    };
+  }
+
+  return {
+    label: status,
+    color: 'grey',
+    icon: <OutlinedClockIcon />,
+  };
+};

--- a/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
+++ b/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
@@ -5,7 +5,6 @@ import {
   type LocalQueueKind,
   type PodKind,
   type ProjectKind,
-  type ResourceFlavorKind,
   WorkloadOwnerType,
   type WorkloadKind,
 } from '@odh-dashboard/k8s-core';
@@ -16,7 +15,6 @@ import {
 } from '@odh-dashboard/internal/api/k8s/hardwareProfiles';
 import { listInferenceService } from '@odh-dashboard/internal/api/k8s/inferenceServices';
 import { getPendingWorkloads } from '@odh-dashboard/internal/api/k8s/pendingWorkloads';
-import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
 import { listWorkloads } from '@odh-dashboard/internal/api/k8s/workloads';
 import { PodModel, StatefulSetModel } from '@odh-dashboard/internal/api/models';
 import { RayJobModel, TrainJobModel } from '@odh-dashboard/internal/api/models/kubeflow';
@@ -27,7 +25,6 @@ import {
 import { KueueWorkloadStatus } from '@odh-dashboard/k8s-core/kueue/types';
 import {
   buildHardwareProfileKey,
-  buildResourceFlavorByName,
   getHardwareProfileRefFromAnnotations,
   getHardwareProfileRefFromPod,
   type HardwareProfileByKey,
@@ -47,7 +44,6 @@ import {
   type QuotaUsageWorkloadType,
 } from '../types';
 
-const EMPTY_HARDWARE_PROFILES: HardwareProfileKind[] = [];
 const EMPTY_INFERENCE_SERVICES: WorkloadInferenceService[] = [];
 
 const NOTEBOOK_OWNER_KINDS = new Set(['job', 'statefulset', 'notebook', 'pod']);
@@ -103,7 +99,6 @@ export type { HardwareProfileByKey } from './hardwareModels';
 
 export type KueueNamespaceWorkloadCache = {
   namespaceData: NamespaceWorkloadData[];
-  resourceFlavorByName: Map<string, ResourceFlavorKind>;
   hardwareProfileByKey: HardwareProfileByKey;
   /** All HardwareProfile CRs used for resource-based matching (global + project namespaces). */
   hardwareProfilesForMatching: HardwareProfileKind[];
@@ -111,12 +106,25 @@ export type KueueNamespaceWorkloadCache = {
   namespaceLoadError?: Error;
 };
 
-/** Collects the distinct HardwareProfile refs referenced by Pod, StatefulSet, or InferenceService annotations. */
+/**
+ * Collects distinct HardwareProfile refs referenced by workload-related annotations.
+ *
+ * Pending workloads may carry the profile annotation only on the Workload pod-set template, before
+ * a Pod or owning StatefulSet exists, so those annotations must be included here as well.
+ */
 export const collectHardwareProfileRefs = (
   namespaceData: NamespaceWorkloadData[],
 ): HardwareProfileRef[] => {
   const refsByKey = new Map<string, HardwareProfileRef>();
-  for (const { pods, statefulSets, inferenceServices } of namespaceData) {
+  for (const { workloads, pods, statefulSets, inferenceServices } of namespaceData) {
+    for (const workload of workloads) {
+      for (const podSet of workload.spec.podSets) {
+        const ref = getHardwareProfileRefFromAnnotations(podSet.template.metadata?.annotations);
+        if (ref) {
+          refsByKey.set(buildHardwareProfileKey(ref), ref);
+        }
+      }
+    }
     for (const pod of pods) {
       const ref = getHardwareProfileRefFromPod(pod);
       if (ref) {
@@ -156,9 +164,15 @@ export const fetchHardwareProfilesForMatching = async (
   }
 
   const profileLists = await Promise.all(
-    [...namespaces].map((namespace) =>
-      listHardwareProfiles(namespace).catch(() => EMPTY_HARDWARE_PROFILES),
-    ),
+    [...namespaces].map(async (namespace) => {
+      try {
+        return await listHardwareProfiles(namespace);
+      } catch {
+        // Hardware-profile matching is optional enrichment; one inaccessible namespace should not
+        // prevent workload rows from rendering with an unavailable profile value.
+        return [];
+      }
+    }),
   );
 
   const profilesByKey = new Map<string, HardwareProfileKind>();
@@ -466,25 +480,12 @@ export const isKueueManagedWorkload = (
   return true;
 };
 
-const EXCLUDED_KUEUE_STATUSES_FOR_CQ_TABLE = new Set([
-  KueueWorkloadStatus.Complete,
-  KueueWorkloadStatus.Failed,
-]);
-
-/** Default CQ table scope: active workloads only — excludes Complete and Failed. */
-export const isActiveQuotaUsageClusterQueueWorkload = (workload: WorkloadKind): boolean => {
-  const { status } = getKueueWorkloadStatusWithMessage(workload);
-  return !EXCLUDED_KUEUE_STATUSES_FOR_CQ_TABLE.has(status);
-};
-
 export const isQuotaUsageClusterQueueWorkload = (
   workload: WorkloadKind,
   pods: PodKind[],
   localQueueByName: Map<string, LocalQueueKind>,
 ): boolean =>
-  isGpuAwareWorkload(workload) &&
-  isKueueManagedWorkload(workload, pods, localQueueByName) &&
-  isActiveQuotaUsageClusterQueueWorkload(workload);
+  isGpuAwareWorkload(workload) && isKueueManagedWorkload(workload, pods, localQueueByName);
 
 /**
  * Notebook-style workbench workloads carry the job-name label and a supported owner ref.
@@ -1041,7 +1042,6 @@ export const mapWorkloadToRow = (
   projectDisplayName: string,
   pods: PodKind[],
   localQueueByName: Map<string, LocalQueueKind>,
-  resourceFlavorByName: Map<string, ResourceFlavorKind>,
   jobKindByUid: ReadonlyMap<string, WorkloadJobKind> = new Map(),
   clusterQueueName?: string,
   hardwareProfileByKey: HardwareProfileByKey = new Map(),
@@ -1068,7 +1068,6 @@ export const mapWorkloadToRow = (
     inferenceService,
     hardwareProfileByKey,
     hardwareProfilesForMatching,
-    resourceFlavorByName,
     workloadType,
   });
 
@@ -1097,7 +1096,6 @@ export const filterAndMapClusterQueueWorkloads = (
   clusterQueueName: string,
   namespaceData: NamespaceWorkloadData[],
   projectDisplayNames: Map<string, string>,
-  resourceFlavorByName: Map<string, ResourceFlavorKind>,
   hardwareProfileByKey: HardwareProfileByKey = new Map(),
   hardwareProfilesForMatching: HardwareProfileKind[] = [],
 ): ClusterQueueWorkloadRow[] =>
@@ -1129,7 +1127,6 @@ export const filterAndMapClusterQueueWorkloads = (
             projectDisplayName,
             pods,
             localQueueByName,
-            resourceFlavorByName,
             jobKindByUid,
             clusterQueueName,
             hardwareProfileByKey,
@@ -1153,7 +1150,6 @@ export const filterAndMapNamespaceWorkloads = (
     jobKindByUid,
   }: NamespaceWorkloadData,
   projectDisplayName: string,
-  resourceFlavorByName: Map<string, ResourceFlavorKind>,
   hardwareProfileByKey: HardwareProfileByKey = new Map(),
   hardwareProfilesForMatching: HardwareProfileKind[] = [],
 ): ClusterQueueWorkloadRow[] => {
@@ -1168,7 +1164,6 @@ export const filterAndMapNamespaceWorkloads = (
       projectDisplayName,
       pods,
       localQueueByName,
-      resourceFlavorByName,
       jobKindByUid,
       undefined,
       hardwareProfileByKey,
@@ -1264,24 +1259,20 @@ export const fetchKueueNamespaceWorkloadCache = async (
   if (namespaces.length === 0) {
     return {
       namespaceData: [],
-      resourceFlavorByName: new Map(),
       hardwareProfileByKey: new Map(),
       hardwareProfilesForMatching: [],
     };
   }
 
-  const [namespaceResults, resourceFlavors] = await Promise.all([
-    Promise.all(
-      namespaces.map(async (namespace) => {
-        try {
-          return await fetchNamespaceWorkloadData(namespace);
-        } catch {
-          return undefined;
-        }
-      }),
-    ),
-    listResourceFlavors(),
-  ]);
+  const namespaceResults = await Promise.all(
+    namespaces.map(async (namespace) => {
+      try {
+        return await fetchNamespaceWorkloadData(namespace);
+      } catch {
+        return undefined;
+      }
+    }),
+  );
 
   const namespaceData = namespaceResults.filter(
     (result): result is NamespaceWorkloadData => result != null,
@@ -1293,7 +1284,6 @@ export const fetchKueueNamespaceWorkloadCache = async (
 
   return {
     namespaceData,
-    resourceFlavorByName: buildResourceFlavorByName(resourceFlavors),
     hardwareProfileByKey,
     hardwareProfilesForMatching,
   };
@@ -1323,7 +1313,6 @@ export const mapWorkloadsForClusterQueuesSync = (
         clusterQueueName,
         cache.namespaceData,
         projectDisplayNames,
-        cache.resourceFlavorByName,
         cache.hardwareProfileByKey,
         cache.hardwareProfilesForMatching,
       ),
@@ -1394,11 +1383,7 @@ export const fetchNamespaceWorkloads = async (
     return [];
   }
 
-  const [namespaceData, resourceFlavors] = await Promise.all([
-    fetchNamespaceWorkloadData(namespace),
-    listResourceFlavors(),
-  ]);
-  const resourceFlavorByName = buildResourceFlavorByName(resourceFlavors);
+  const namespaceData = await fetchNamespaceWorkloadData(namespace);
   const [hardwareProfileByKey, hardwareProfilesForMatching] = await Promise.all([
     fetchHardwareProfilesByKey(collectHardwareProfileRefs([namespaceData])),
     fetchHardwareProfilesForMatching([namespaceData], dashboardNamespace),
@@ -1406,7 +1391,6 @@ export const fetchNamespaceWorkloads = async (
   const rows = filterAndMapNamespaceWorkloads(
     namespaceData,
     projectDisplayName,
-    resourceFlavorByName,
     hardwareProfileByKey,
     hardwareProfilesForMatching,
   );

--- a/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
+++ b/packages/gpuaas/src/utils/clusterQueueWorkloads.ts
@@ -1,5 +1,6 @@
-import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sGetResource, k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
 import {
+  type HardwareProfileKind,
   type K8sResourceCommon,
   type LocalQueueKind,
   type PodKind,
@@ -8,20 +9,34 @@ import {
   WorkloadOwnerType,
   type WorkloadKind,
 } from '@odh-dashboard/k8s-core';
-import { listLocalQueues } from '@odh-dashboard/internal/api/k8s/localQueues';
+import { listAllLocalQueues, listLocalQueues } from '@odh-dashboard/internal/api/k8s/localQueues';
+import {
+  getHardwareProfile,
+  listHardwareProfiles,
+} from '@odh-dashboard/internal/api/k8s/hardwareProfiles';
+import { listInferenceService } from '@odh-dashboard/internal/api/k8s/inferenceServices';
 import { getPendingWorkloads } from '@odh-dashboard/internal/api/k8s/pendingWorkloads';
 import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
 import { listWorkloads } from '@odh-dashboard/internal/api/k8s/workloads';
-import { PodModel } from '@odh-dashboard/internal/api/models';
+import { PodModel, StatefulSetModel } from '@odh-dashboard/internal/api/models';
 import { RayJobModel, TrainJobModel } from '@odh-dashboard/internal/api/models/kubeflow';
 import {
   getKueueWorkloadStatusWithMessage,
   KUEUE_QUEUE_LABEL,
 } from '@odh-dashboard/k8s-core/kueue/workloadStatus';
 import { KueueWorkloadStatus } from '@odh-dashboard/k8s-core/kueue/types';
-import { buildResourceFlavorByName, resolveWorkloadHardwareProfile } from './hardwareModels';
+import {
+  buildHardwareProfileKey,
+  buildResourceFlavorByName,
+  getHardwareProfileRefFromAnnotations,
+  getHardwareProfileRefFromPod,
+  type HardwareProfileByKey,
+  type HardwareProfileRef,
+} from './hardwareModels';
+import { resolveWorkloadHardwareProfileForRow } from './workloadHardwareProfileResolver';
 import { isAcceleratorResource } from './clusterQueueUtils';
 import parseK8sQuantity from './parseK8sQuantity';
+import type { WorkloadInferenceService } from '../types/inferenceService';
 import {
   type ClusterQueueWorkloadRow,
   QUOTA_USAGE_STATUSES_PAST_ADMISSION,
@@ -32,23 +47,146 @@ import {
   type QuotaUsageWorkloadType,
 } from '../types';
 
+const EMPTY_HARDWARE_PROFILES: HardwareProfileKind[] = [];
+const EMPTY_INFERENCE_SERVICES: WorkloadInferenceService[] = [];
+
 const NOTEBOOK_OWNER_KINDS = new Set(['job', 'statefulset', 'notebook', 'pod']);
 
 const KUEUE_JOB_NAME_LABEL = 'kueue.x-k8s.io/job-name';
 const KUEUE_JOB_UID_LABEL = 'kueue.x-k8s.io/job-uid';
-
-const TERMINAL_KUEUE_STATUSES = new Set([KueueWorkloadStatus.Complete, KueueWorkloadStatus.Failed]);
+const KUEUE_JOB_OWNER_NAME_ANNOTATION = 'kueue.x-k8s.io/job-owner-name';
+const KUEUE_JOB_OWNER_GVK_ANNOTATION = 'kueue.x-k8s.io/job-owner-gvk';
+const KUEUE_POD_GROUP_NAME_LABEL = 'kueue.x-k8s.io/pod-group-name';
 
 /** Mirrors UnifiedJobKind.kind on the model training page (TrainJob | RayJob). */
 export type WorkloadJobKind = 'RayJob' | 'TrainJob';
 
-export type NamespaceWorkloadData = {
+export type NamespaceWorkloadBaseData = {
   namespace: string;
   workloads: WorkloadKind[];
   localQueues: LocalQueueKind[];
+};
+
+export type NamespaceWorkloadData = NamespaceWorkloadBaseData & {
   pods: PodKind[];
-  /** job-uid label → job CR kind; used to classify Job-owned Kueue workloads as Train or Ray job. */
+  /** Workbench StatefulSets; pod template carries hardware-profile annotations when the notebook is stopped. */
+  statefulSets: K8sResourceCommon[];
+  /** KServe InferenceServices in the namespace (Model Serving hardware-profile source). */
+  inferenceServices: WorkloadInferenceService[];
+  /** job-uid label → job CR kind; used to classify Job-owned Kueue workloads as Train (TrainJob/RayJob). */
   jobKindByUid: Map<string, WorkloadJobKind>;
+};
+
+export const emptyNamespaceEnrichment = (): Pick<
+  NamespaceWorkloadData,
+  'pods' | 'statefulSets' | 'inferenceServices' | 'jobKindByUid'
+> => ({
+  pods: [],
+  statefulSets: [],
+  inferenceServices: [],
+  jobKindByUid: new Map(),
+});
+
+export const toNamespaceWorkloadData = (
+  base: NamespaceWorkloadBaseData,
+  enrichment: Pick<
+    NamespaceWorkloadData,
+    'pods' | 'statefulSets' | 'inferenceServices' | 'jobKindByUid'
+  > = emptyNamespaceEnrichment(),
+): NamespaceWorkloadData => ({
+  ...base,
+  ...enrichment,
+});
+
+/** HardwareProfile CRs referenced by workload Pods, keyed by `${namespace}/${name}`. */
+export type { HardwareProfileByKey } from './hardwareModels';
+
+export type KueueNamespaceWorkloadCache = {
+  namespaceData: NamespaceWorkloadData[];
+  resourceFlavorByName: Map<string, ResourceFlavorKind>;
+  hardwareProfileByKey: HardwareProfileByKey;
+  /** All HardwareProfile CRs used for resource-based matching (global + project namespaces). */
+  hardwareProfilesForMatching: HardwareProfileKind[];
+  /** Set when one or more namespace bundle fetches failed but other namespaces may still have loaded. */
+  namespaceLoadError?: Error;
+};
+
+/** Collects the distinct HardwareProfile refs referenced by Pod, StatefulSet, or InferenceService annotations. */
+export const collectHardwareProfileRefs = (
+  namespaceData: NamespaceWorkloadData[],
+): HardwareProfileRef[] => {
+  const refsByKey = new Map<string, HardwareProfileRef>();
+  for (const { pods, statefulSets, inferenceServices } of namespaceData) {
+    for (const pod of pods) {
+      const ref = getHardwareProfileRefFromPod(pod);
+      if (ref) {
+        refsByKey.set(buildHardwareProfileKey(ref), ref);
+      }
+    }
+    for (const statefulSet of statefulSets) {
+      const ref = getHardwareProfileRefFromAnnotations(getPodTemplateAnnotations(statefulSet));
+      if (ref) {
+        refsByKey.set(buildHardwareProfileKey(ref), ref);
+      }
+    }
+    for (const inferenceService of inferenceServices) {
+      const ref = getHardwareProfileRefFromAnnotations(inferenceService.metadata?.annotations);
+      if (ref) {
+        refsByKey.set(buildHardwareProfileKey(ref), ref);
+      }
+    }
+  }
+  return [...refsByKey.values()];
+};
+
+/** Lists enabled HardwareProfile CRs from the dashboard namespace and each project namespace (for resource matching). */
+export const fetchHardwareProfilesForMatching = async (
+  namespaceData: NamespaceWorkloadData[],
+  dashboardNamespace: string,
+): Promise<HardwareProfileKind[]> => {
+  const namespaces = new Set<string>();
+  if (dashboardNamespace) {
+    namespaces.add(dashboardNamespace);
+  }
+  for (const bundle of namespaceData) {
+    namespaces.add(bundle.namespace);
+  }
+  for (const ref of collectHardwareProfileRefs(namespaceData)) {
+    namespaces.add(ref.namespace);
+  }
+
+  const profileLists = await Promise.all(
+    [...namespaces].map((namespace) =>
+      listHardwareProfiles(namespace).catch(() => EMPTY_HARDWARE_PROFILES),
+    ),
+  );
+
+  const profilesByKey = new Map<string, HardwareProfileKind>();
+  for (const hardwareProfile of profileLists.flat()) {
+    profilesByKey.set(
+      `${hardwareProfile.metadata.namespace}/${hardwareProfile.metadata.name}`,
+      hardwareProfile,
+    );
+  }
+  return [...profilesByKey.values()];
+};
+
+/** Fetches the given HardwareProfile CRs, keyed by `${namespace}/${name}`. Missing/denied refs are skipped. */
+export const fetchHardwareProfilesByKey = async (
+  refs: HardwareProfileRef[],
+): Promise<HardwareProfileByKey> => {
+  const entries = await Promise.all(
+    refs.map(async (ref) => {
+      try {
+        const hardwareProfile = await getHardwareProfile(ref.name, ref.namespace);
+        return [buildHardwareProfileKey(ref), hardwareProfile] as const;
+      } catch {
+        return undefined;
+      }
+    }),
+  );
+
+  return new Map(entries.filter((entry): entry is [string, HardwareProfileKind] => entry != null));
 };
 
 export const listPods = async (namespace: string): Promise<PodKind[]> =>
@@ -56,6 +194,123 @@ export const listPods = async (namespace: string): Promise<PodKind[]> =>
     model: PodModel,
     queryOptions: { ns: namespace },
   }).then((response) => response.items);
+
+export const listStatefulSets = async (namespace: string): Promise<K8sResourceCommon[]> =>
+  k8sListResource<K8sResourceCommon>({
+    model: StatefulSetModel,
+    queryOptions: { ns: namespace },
+  }).then((response) => response.items);
+
+export const listNamespaceInferenceServices = async (
+  namespace: string,
+): Promise<WorkloadInferenceService[]> =>
+  listInferenceService(namespace).catch(() => EMPTY_INFERENCE_SERVICES);
+
+const buildInferenceServicesByName = (
+  inferenceServices: WorkloadInferenceService[],
+): Map<string, WorkloadInferenceService> =>
+  new Map(
+    inferenceServices.flatMap((inferenceService) => {
+      const name = inferenceService.metadata?.name;
+      return name ? [[name, inferenceService] as const] : [];
+    }),
+  );
+
+const KSERVE_INFERENCE_SERVICE_LABEL = 'serving.kserve.io/inferenceservice';
+const LLMIS_POD_COMPONENT_LABEL = 'app.kubernetes.io/component';
+const LLMIS_POD_COMPONENT_VALUE = 'llminferenceservice-workload';
+
+/** Dedupes pods by UID (last write wins). */
+export const mergePodsByUid = (podLists: PodKind[][]): PodKind[] => {
+  const podByUid = new Map<string, PodKind>();
+  for (const pods of podLists) {
+    for (const pod of pods) {
+      const { uid } = pod.metadata;
+      if (uid) {
+        podByUid.set(uid, pod);
+      }
+    }
+  }
+  return [...podByUid.values()];
+};
+
+/**
+ * KServe / LLMIS predictor pods for Plain-Pod and ReplicaSet serving integrations.
+ * Pod-group label fetch misses these; needed for Serve type + hardware profile resolution.
+ */
+export const listServingPodsInNamespace = async (namespace: string): Promise<PodKind[]> => {
+  const [kservePods, llmisPods] = await Promise.all([
+    k8sListResource<PodKind>({
+      model: PodModel,
+      queryOptions: {
+        ns: namespace,
+        queryParams: { labelSelector: KSERVE_INFERENCE_SERVICE_LABEL },
+      },
+    })
+      .then((response) => response.items)
+      .catch(() => []),
+    k8sListResource<PodKind>({
+      model: PodModel,
+      queryOptions: {
+        ns: namespace,
+        queryParams: {
+          labelSelector: `${LLMIS_POD_COMPONENT_LABEL}=${LLMIS_POD_COMPONENT_VALUE}`,
+        },
+      },
+    })
+      .then((response) => response.items)
+      .catch(() => []),
+  ]);
+
+  return mergePodsByUid([kservePods, llmisPods]);
+};
+
+/** Resolves the KServe InferenceService name from serving Pods owned by this Workload. */
+export const resolveInferenceServiceNameForWorkload = (
+  workload: WorkloadKind,
+  pods: PodKind[],
+): string | undefined => {
+  for (const pod of findWorkloadPods(workload, pods)) {
+    const inferenceServiceName = pod.metadata.labels?.[KSERVE_INFERENCE_SERVICE_LABEL];
+    if (inferenceServiceName) {
+      return inferenceServiceName;
+    }
+  }
+  return undefined;
+};
+
+/** Minimal shape for owners (StatefulSet, etc.) whose pod template may carry hardware-profile annotations. */
+type PodTemplateOwner = K8sResourceCommon & {
+  spec: {
+    template?: {
+      metadata?: {
+        annotations?: Record<string, string>;
+      };
+    };
+  };
+};
+
+const isPodTemplateOwner = (owner: K8sResourceCommon | undefined): owner is PodTemplateOwner =>
+  owner != null && typeof owner.spec === 'object' && 'template' in owner.spec;
+
+const getPodTemplateAnnotations = (
+  owner: K8sResourceCommon | undefined,
+): Record<string, string> | undefined => {
+  if (!isPodTemplateOwner(owner)) {
+    return undefined;
+  }
+  return owner.spec.template?.metadata?.annotations;
+};
+
+const buildStatefulSetsByName = (
+  statefulSets: K8sResourceCommon[],
+): Map<string, K8sResourceCommon> =>
+  new Map(
+    statefulSets.flatMap((statefulSet) => {
+      const name = statefulSet.metadata?.name;
+      return name ? [[name, statefulSet] as const] : [];
+    }),
+  );
 
 const addJobKindsToMap = (
   jobs: K8sResourceCommon[],
@@ -95,17 +350,57 @@ const buildJobKindByUid = async (namespace: string): Promise<Map<string, Workloa
   return jobKindByUid;
 };
 
-export const fetchNamespaceWorkloadData = async (
+/** Fast path: Workloads + LocalQueues only (table can render before enrichment). */
+export const fetchNamespaceWorkloadBaseData = async (
   namespace: string,
-): Promise<NamespaceWorkloadData> => {
-  const [workloads, localQueues, pods, jobKindByUid] = await Promise.all([
+): Promise<NamespaceWorkloadBaseData> => {
+  const [workloads, localQueues] = await Promise.all([
     listWorkloads(namespace),
     listLocalQueues(namespace),
-    listPods(namespace),
-    buildJobKindByUid(namespace),
   ]);
+  return { namespace, workloads, localQueues };
+};
 
-  return { namespace, workloads, localQueues, pods, jobKindByUid };
+/** Cluster-scoped LocalQueue → ClusterQueue index, keyed by cluster queue name to the set of namespaces with a LocalQueue targeting it. */
+export type LocalQueueClusterQueueIndex = Map<string, Set<string>>;
+
+/**
+ * Fetches all LocalQueues cluster-wide in a single API call and builds an index of
+ * clusterQueueName -> Set<namespace>. Used to scope namespace workload fetches to only the
+ * namespaces relevant to the selected cluster queue(s), instead of fetching every Kueue-managed
+ * namespace up front.
+ */
+export const fetchLocalQueueClusterQueueIndex = async (): Promise<LocalQueueClusterQueueIndex> => {
+  const localQueues = await listAllLocalQueues();
+  const index: LocalQueueClusterQueueIndex = new Map();
+
+  for (const localQueue of localQueues) {
+    const clusterQueueName = localQueue.spec.clusterQueue;
+    const namespace = localQueue.metadata?.namespace;
+    if (!clusterQueueName || !namespace) {
+      continue;
+    }
+
+    const namespaces = index.get(clusterQueueName) ?? new Set<string>();
+    namespaces.add(namespace);
+    index.set(clusterQueueName, namespaces);
+  }
+
+  return index;
+};
+
+/** Union of namespaces (from the LocalQueue index) relevant to any of the given cluster queues. */
+export const getNamespacesForClusterQueues = (
+  clusterQueueNames: string[],
+  index: LocalQueueClusterQueueIndex,
+): Set<string> => {
+  const namespaces = new Set<string>();
+  for (const clusterQueueName of clusterQueueNames) {
+    for (const namespace of index.get(clusterQueueName) ?? []) {
+      namespaces.add(namespace);
+    }
+  }
+  return namespaces;
 };
 
 export const buildLocalQueueByName = (localQueues: LocalQueueKind[]): Map<string, LocalQueueKind> =>
@@ -171,17 +466,25 @@ export const isKueueManagedWorkload = (
   return true;
 };
 
+const EXCLUDED_KUEUE_STATUSES_FOR_CQ_TABLE = new Set([
+  KueueWorkloadStatus.Complete,
+  KueueWorkloadStatus.Failed,
+]);
+
+/** Default CQ table scope: active workloads only — excludes Complete and Failed. */
+export const isActiveQuotaUsageClusterQueueWorkload = (workload: WorkloadKind): boolean => {
+  const { status } = getKueueWorkloadStatusWithMessage(workload);
+  return !EXCLUDED_KUEUE_STATUSES_FOR_CQ_TABLE.has(status);
+};
+
 export const isQuotaUsageClusterQueueWorkload = (
   workload: WorkloadKind,
   pods: PodKind[],
   localQueueByName: Map<string, LocalQueueKind>,
 ): boolean =>
-  isGpuAwareWorkload(workload) && isKueueManagedWorkload(workload, pods, localQueueByName);
-
-export const isActiveWorkload = (workload: WorkloadKind): boolean => {
-  const { status } = getKueueWorkloadStatusWithMessage(workload);
-  return !TERMINAL_KUEUE_STATUSES.has(status);
-};
+  isGpuAwareWorkload(workload) &&
+  isKueueManagedWorkload(workload, pods, localQueueByName) &&
+  isActiveQuotaUsageClusterQueueWorkload(workload);
 
 /**
  * Notebook-style workbench workloads carry the job-name label and a supported owner ref.
@@ -203,9 +506,7 @@ export const isWorkbenchWorkload = (workload: WorkloadKind): boolean => {
     return true;
   }
 
-  return (workload.metadata?.ownerReferences ?? []).some(
-    (ownerRef) => ownerRef.kind.toLowerCase() === WorkloadOwnerType.StatefulSet.toLowerCase(),
-  );
+  return findStatefulSetOwnerName(workload) != null;
 };
 
 export const isRayClusterWorkload = (workload: WorkloadKind): boolean =>
@@ -265,10 +566,81 @@ const findOwnerRefByKind = (workload: WorkloadKind, kind: string) =>
     (ownerRef) => ownerRef.kind.toLowerCase() === kind.toLowerCase(),
   );
 
+const parseKueueJobOwnerKind = (ownerGvk: string): string | undefined => {
+  const match = ownerGvk.match(/Kind=([^,\s]+)/i);
+  return match?.[1];
+};
+
+/**
+ * StatefulSet-backed group workloads (e.g. ODH workbenches) may omit ownerReferences on the
+ * Workload CR and instead stamp `kueue.x-k8s.io/job-owner-name` / `job-owner-gvk`.
+ */
+const findStatefulSetOwnerName = (workload: WorkloadKind): string | undefined => {
+  const statefulSetRef = findOwnerRefByKind(workload, WorkloadOwnerType.StatefulSet);
+  if (statefulSetRef?.name) {
+    return statefulSetRef.name;
+  }
+
+  const ownerName = workload.metadata?.annotations?.[KUEUE_JOB_OWNER_NAME_ANNOTATION]?.trim();
+  const ownerGvk = workload.metadata?.annotations?.[KUEUE_JOB_OWNER_GVK_ANNOTATION];
+  if (!ownerName || !ownerGvk) {
+    return undefined;
+  }
+
+  const ownerKind = parseKueueJobOwnerKind(ownerGvk);
+  if (ownerKind?.toLowerCase() !== WorkloadOwnerType.StatefulSet.toLowerCase()) {
+    return undefined;
+  }
+
+  return ownerName;
+};
+
 const findPodsOwnedBy = (pods: PodKind[], ownerUid: string): PodKind[] =>
   pods.filter((pod) =>
     (pod.metadata.ownerReferences ?? []).some((ownerRef) => ownerRef.uid === ownerUid),
   );
+
+/** Multi-pod pod-groups (e.g. StatefulSet/Job-based notebooks and training jobs) label each Pod with the owning Workload's name. */
+const findPodsByGroupName = (pods: PodKind[], workloadName: string): PodKind[] =>
+  pods.filter((pod) => pod.metadata.labels?.[KUEUE_POD_GROUP_NAME_LABEL] === workloadName);
+
+/**
+ * Resolves the Pod(s) belonging to a workload, across pod-group (grouped, e.g. notebooks/training
+ * jobs) and single-pod (serving) shapes. Used to read dashboard-stamped Pod annotations (e.g. the
+ * hardware profile annotation) for a given Kueue Workload.
+ */
+export const findWorkloadPods = (workload: WorkloadKind, pods: PodKind[]): PodKind[] => {
+  const workloadName = workload.metadata?.name;
+  const groupPods = workloadName ? findPodsByGroupName(pods, workloadName) : [];
+  if (groupPods.length > 0) {
+    return groupPods;
+  }
+  return findServingWorkloadPods(workload, pods);
+};
+
+/**
+ * Annotation sources for hardware-profile resolution: running Pods first, then the owning
+ * StatefulSet pod template (stopped workbenches), then the Workload podSet template.
+ */
+export const getWorkloadHardwareProfileAnnotationSources = (
+  workload: WorkloadKind,
+  pods: PodKind[],
+  statefulSetsByName: Map<string, K8sResourceCommon>,
+): Array<Record<string, string> | undefined> => {
+  const sources = findWorkloadPods(workload, pods).map((pod) => pod.metadata.annotations);
+
+  const statefulSetOwnerName = findStatefulSetOwnerName(workload);
+  if (statefulSetOwnerName) {
+    const statefulSet = statefulSetsByName.get(statefulSetOwnerName);
+    sources.push(getPodTemplateAnnotations(statefulSet));
+  }
+
+  for (const podSet of workload.spec.podSets) {
+    sources.push(podSet.template.metadata?.annotations);
+  }
+
+  return sources;
+};
 
 /** Resolves serving Pods via direct Pod owner or descendant Pods for RS/LWS owners. */
 const findServingWorkloadPods = (workload: WorkloadKind, pods: PodKind[]): PodKind[] => {
@@ -289,6 +661,44 @@ const findServingWorkloadPods = (workload: WorkloadKind, pods: PodKind[]): PodKi
 
   const pod = pods.find((candidate) => candidate.metadata.uid === podRef.uid);
   return pod ? [pod] : [];
+};
+
+/**
+ * Local queue for Visibility API — same source as workbench/model-serving Kueue status:
+ * `kueue.x-k8s.io/queue-name` on owner (StatefulSet / InferenceService) or Pod, then workload spec.
+ */
+export const resolveWorkloadLocalQueueName = (
+  workload: WorkloadKind,
+  pods: PodKind[],
+  statefulSetsByName: Map<string, K8sResourceCommon>,
+  inferenceServicesByName: Map<string, WorkloadInferenceService>,
+): string => {
+  const statefulSetOwnerName = findStatefulSetOwnerName(workload);
+  if (statefulSetOwnerName) {
+    const queueFromStatefulSet =
+      statefulSetsByName.get(statefulSetOwnerName)?.metadata?.labels?.[KUEUE_QUEUE_LABEL];
+    if (queueFromStatefulSet) {
+      return queueFromStatefulSet;
+    }
+  }
+
+  const inferenceServiceName = resolveInferenceServiceNameForWorkload(workload, pods);
+  if (inferenceServiceName) {
+    const queueFromInferenceService =
+      inferenceServicesByName.get(inferenceServiceName)?.metadata?.labels?.[KUEUE_QUEUE_LABEL];
+    if (queueFromInferenceService) {
+      return queueFromInferenceService;
+    }
+  }
+
+  for (const pod of findWorkloadPods(workload, pods)) {
+    const queueFromPod = pod.metadata.labels?.[KUEUE_QUEUE_LABEL];
+    if (queueFromPod) {
+      return queueFromPod;
+    }
+  }
+
+  return workload.spec.queueName?.trim() ?? '';
 };
 
 /**
@@ -339,11 +749,12 @@ export const resolveWorkloadType = (
   }
 
   const jobKind = getWorkloadJobKind(workload, jobKindByUid);
-  if (jobKind === 'RayJob') {
-    return QuotaUsageWorkloadTypes.RayJob;
-  }
-  if (jobKind === 'TrainJob') {
+  if (jobKind === 'RayJob' || jobKind === 'TrainJob') {
     return QuotaUsageWorkloadTypes.Train;
+  }
+
+  if (isTrainingJobWorkload(workload)) {
+    return QuotaUsageWorkloadTypes.Batch;
   }
 
   return QuotaUsageWorkloadTypes.Unknown;
@@ -369,6 +780,14 @@ export const mapKueueStatusToQuotaUsageStatus = (
   kueueStatus: KueueWorkloadStatus,
 ): QuotaUsageWorkloadStatus => KUEUE_TO_QUOTA_USAGE_STATUS[kueueStatus];
 
+/** UXD status from Kueue Workload CR conditions only (no pod/runtime overlay). */
+export const resolveQuotaUsageWorkloadStatus = (
+  workload: WorkloadKind,
+): QuotaUsageWorkloadStatus => {
+  const { status: kueueStatus } = getKueueWorkloadStatusWithMessage(workload);
+  return mapKueueStatusToQuotaUsageStatus(kueueStatus);
+};
+
 export const getWorkloadAcceleratorCount = (workload: WorkloadKind): number =>
   workload.spec.podSets.reduce((podSetTotal, podSet) => {
     const perPod = podSet.template.spec.containers.reduce((containerTotal, container) => {
@@ -392,6 +811,186 @@ export const getWorkloadAcceleratorCount = (workload: WorkloadKind): number =>
 export const isGpuAwareWorkload = (workload: WorkloadKind): boolean =>
   getWorkloadAcceleratorCount(workload) > 0;
 
+const getStatefulSet = async (
+  namespace: string,
+  name: string,
+): Promise<K8sResourceCommon | undefined> => {
+  try {
+    return await k8sGetResource<K8sResourceCommon>({
+      model: StatefulSetModel,
+      queryOptions: { ns: namespace, name },
+    });
+  } catch {
+    return undefined;
+  }
+};
+
+const fetchStatefulSetsByName = async (
+  namespace: string,
+  names: Iterable<string>,
+): Promise<K8sResourceCommon[]> => {
+  const results = await Promise.all(
+    [...names].map(async (name) => getStatefulSet(namespace, name)),
+  );
+  return results.filter((statefulSet): statefulSet is K8sResourceCommon => statefulSet != null);
+};
+
+const listPodsForWorkloadGroups = async (
+  namespace: string,
+  workloadNames: string[],
+): Promise<PodKind[]> => {
+  if (workloadNames.length === 0) {
+    return [];
+  }
+
+  const labelSelector = `${KUEUE_POD_GROUP_NAME_LABEL} in (${workloadNames.join(',')})`;
+  const response = await k8sListResource<PodKind>({
+    model: PodModel,
+    queryOptions: { ns: namespace, queryParams: { labelSelector } },
+  });
+  return response.items;
+};
+
+const getGpuWorkloadsForClusterQueues = (
+  workloads: WorkloadKind[],
+  localQueues: LocalQueueKind[],
+  clusterQueueNames: string[],
+): WorkloadKind[] => {
+  const localQueueByName = buildLocalQueueByName(localQueues);
+  return workloads.filter(
+    (workload) =>
+      isGpuAwareWorkload(workload) &&
+      clusterQueueNames.some((clusterQueueName) =>
+        workloadMatchesClusterQueue(workload, clusterQueueName, localQueueByName),
+      ),
+  );
+};
+
+const getGpuWorkloadsInNamespace = (workloads: WorkloadKind[]): WorkloadKind[] =>
+  workloads.filter(isGpuAwareWorkload);
+
+const collectEnrichmentTargets = (
+  workloads: WorkloadKind[],
+): {
+  statefulSetNames: Set<string>;
+  workloadNames: string[];
+  needsInferenceServices: boolean;
+  needsJobKindByUid: boolean;
+} => {
+  const statefulSetNames = new Set<string>();
+  const workloadNames: string[] = [];
+  let needsInferenceServices = false;
+  let needsJobKindByUid = false;
+
+  for (const workload of workloads) {
+    const statefulSetOwnerName = findStatefulSetOwnerName(workload);
+    if (statefulSetOwnerName) {
+      statefulSetNames.add(statefulSetOwnerName);
+    }
+
+    const workloadName = workload.metadata?.name;
+    if (workloadName) {
+      workloadNames.push(workloadName);
+    }
+
+    if (
+      hasOwnerKind(workload, WorkloadOwnerType.ReplicaSet) ||
+      hasOwnerKind(workload, WorkloadOwnerType.LeaderWorkerSet) ||
+      findOwnerRefByKind(workload, 'pod')
+    ) {
+      needsInferenceServices = true;
+    }
+
+    if (workload.metadata?.labels?.[KUEUE_JOB_UID_LABEL] && !getWorkloadJobKind(workload)) {
+      needsJobKindByUid = true;
+    }
+  }
+
+  return { statefulSetNames, workloadNames, needsInferenceServices, needsJobKindByUid };
+};
+
+/**
+ * Fetches pods, owner StatefulSets, InferenceServices, and job-kind index only for workloads
+ * relevant to the selected cluster queue(s). Skips all enrichment API calls when the namespace
+ * has no GPU workloads in those queues.
+ */
+export const enrichNamespaceWorkloadData = async (
+  base: NamespaceWorkloadBaseData,
+  clusterQueueNames: string[],
+): Promise<NamespaceWorkloadData> => {
+  const relevantWorkloads = getGpuWorkloadsForClusterQueues(
+    base.workloads,
+    base.localQueues,
+    clusterQueueNames,
+  );
+
+  if (relevantWorkloads.length === 0) {
+    return toNamespaceWorkloadData(base);
+  }
+
+  const { statefulSetNames, workloadNames, needsInferenceServices, needsJobKindByUid } =
+    collectEnrichmentTargets(relevantWorkloads);
+
+  const [groupPods, servingPods, statefulSets, inferenceServices, jobKindByUid] = await Promise.all(
+    [
+      listPodsForWorkloadGroups(base.namespace, workloadNames),
+      needsInferenceServices ? listServingPodsInNamespace(base.namespace) : Promise.resolve([]),
+      fetchStatefulSetsByName(base.namespace, statefulSetNames),
+      needsInferenceServices
+        ? listNamespaceInferenceServices(base.namespace)
+        : Promise.resolve(EMPTY_INFERENCE_SERVICES),
+      needsJobKindByUid ? buildJobKindByUid(base.namespace) : Promise.resolve(new Map()),
+    ],
+  );
+
+  return toNamespaceWorkloadData(base, {
+    pods: mergePodsByUid([groupPods, servingPods]),
+    statefulSets,
+    inferenceServices,
+    jobKindByUid,
+  });
+};
+
+/** Namespace-scoped tab: enrich all GPU workloads in the namespace. */
+export const enrichNamespaceWorkloadDataForNamespace = async (
+  base: NamespaceWorkloadBaseData,
+): Promise<NamespaceWorkloadData> => {
+  const relevantWorkloads = getGpuWorkloadsInNamespace(base.workloads);
+
+  if (relevantWorkloads.length === 0) {
+    return toNamespaceWorkloadData(base);
+  }
+
+  const { statefulSetNames, workloadNames, needsInferenceServices, needsJobKindByUid } =
+    collectEnrichmentTargets(relevantWorkloads);
+
+  const [groupPods, servingPods, statefulSets, inferenceServices, jobKindByUid] = await Promise.all(
+    [
+      listPodsForWorkloadGroups(base.namespace, workloadNames),
+      needsInferenceServices ? listServingPodsInNamespace(base.namespace) : Promise.resolve([]),
+      fetchStatefulSetsByName(base.namespace, statefulSetNames),
+      needsInferenceServices
+        ? listNamespaceInferenceServices(base.namespace)
+        : Promise.resolve(EMPTY_INFERENCE_SERVICES),
+      needsJobKindByUid ? buildJobKindByUid(base.namespace) : Promise.resolve(new Map()),
+    ],
+  );
+
+  return toNamespaceWorkloadData(base, {
+    pods: mergePodsByUid([groupPods, servingPods]),
+    statefulSets,
+    inferenceServices,
+    jobKindByUid,
+  });
+};
+
+export const fetchNamespaceWorkloadData = async (
+  namespace: string,
+): Promise<NamespaceWorkloadData> => {
+  const base = await fetchNamespaceWorkloadBaseData(namespace);
+  return enrichNamespaceWorkloadDataForNamespace(base);
+};
+
 export const getProjectDisplayName = (project: ProjectKind): string =>
   project.metadata.annotations?.['openshift.io/display-name'] ?? project.metadata.name;
 
@@ -412,19 +1011,27 @@ export const resolveWorkloadClusterQueue = (
   return localQueueByName.get(localQueueName)?.spec.clusterQueue ?? '';
 };
 
+/** Lowercase words from WorkloadPriorityClass metadata.name, e.g. "on-demand" → "on demand". */
+export const formatPriorityClassLabel = (priorityClassName: string): string =>
+  priorityClassName
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.toLowerCase())
+    .join(' ');
+
+/** UXD format from Workload spec: "Critical (2000)" when both set; numeric priority alone as fallback. */
 export const formatWorkloadPriority = (workload: WorkloadKind): string | undefined => {
-  const priorityClassName = workload.spec.priorityClassRef?.name;
+  const priorityClassName = workload.spec.priorityClassRef?.name.trim();
   const { priority } = workload.spec;
 
   if (priorityClassName && priority != null) {
-    return `${priorityClassName} (${priority})`;
+    return `${formatPriorityClassLabel(priorityClassName)} (${priority})`;
   }
-  if (priorityClassName) {
-    return priorityClassName;
-  }
+
   if (priority != null) {
     return String(priority);
   }
+
   return undefined;
 };
 
@@ -437,22 +1044,52 @@ export const mapWorkloadToRow = (
   resourceFlavorByName: Map<string, ResourceFlavorKind>,
   jobKindByUid: ReadonlyMap<string, WorkloadJobKind> = new Map(),
   clusterQueueName?: string,
+  hardwareProfileByKey: HardwareProfileByKey = new Map(),
+  statefulSetsByName: Map<string, K8sResourceCommon> = new Map(),
+  inferenceServicesByName: Map<string, WorkloadInferenceService> = new Map(),
+  hardwareProfilesForMatching: HardwareProfileKind[] = [],
 ): ClusterQueueWorkloadRow => {
-  const kueueStatus = getKueueWorkloadStatusWithMessage(workload);
-  const status = mapKueueStatusToQuotaUsageStatus(kueueStatus.status);
+  const workloadType = resolveWorkloadType(workload, pods, jobKindByUid);
+  const inferenceServiceName = resolveInferenceServiceNameForWorkload(workload, pods);
+  const inferenceService = inferenceServiceName
+    ? inferenceServicesByName.get(inferenceServiceName)
+    : undefined;
+  const status = resolveQuotaUsageWorkloadStatus(workload);
+  const annotationSources = getWorkloadHardwareProfileAnnotationSources(
+    workload,
+    pods,
+    statefulSetsByName,
+  );
+  if (inferenceService?.metadata?.annotations) {
+    annotationSources.push(inferenceService.metadata.annotations);
+  }
+  const hardwareProfileInfo = resolveWorkloadHardwareProfileForRow(workload, {
+    annotationSources,
+    inferenceService,
+    hardwareProfileByKey,
+    hardwareProfilesForMatching,
+    resourceFlavorByName,
+    workloadType,
+  });
 
   return {
     name: workload.metadata?.name ?? 'Unnamed',
     namespace,
     project: projectDisplayName,
     clusterQueue: clusterQueueName ?? resolveWorkloadClusterQueue(workload, localQueueByName),
-    type: resolveWorkloadType(workload, pods, jobKindByUid),
+    type: workloadType,
     status,
-    localQueue: workload.spec.queueName ?? '',
+    localQueue: resolveWorkloadLocalQueueName(
+      workload,
+      pods,
+      statefulSetsByName,
+      inferenceServicesByName,
+    ),
     accelerators: getWorkloadAcceleratorCount(workload),
     queuePosition: undefined,
     priority: formatWorkloadPriority(workload),
-    hardwareProfile: resolveWorkloadHardwareProfile(workload, resourceFlavorByName),
+    hardwareProfile: hardwareProfileInfo?.displayName,
+    hardwareProfileResourceType: hardwareProfileInfo?.acceleratorIdentifier,
   };
 };
 
@@ -461,58 +1098,88 @@ export const filterAndMapClusterQueueWorkloads = (
   namespaceData: NamespaceWorkloadData[],
   projectDisplayNames: Map<string, string>,
   resourceFlavorByName: Map<string, ResourceFlavorKind>,
-  includeTerminal = false,
+  hardwareProfileByKey: HardwareProfileByKey = new Map(),
+  hardwareProfilesForMatching: HardwareProfileKind[] = [],
 ): ClusterQueueWorkloadRow[] =>
-  namespaceData.flatMap(({ namespace, workloads, localQueues, pods, jobKindByUid }) => {
-    const localQueueByName = buildLocalQueueByName(localQueues);
-    const projectDisplayName = projectDisplayNames.get(namespace) ?? namespace;
+  namespaceData.flatMap(
+    ({
+      namespace,
+      workloads,
+      localQueues,
+      pods,
+      statefulSets,
+      inferenceServices,
+      jobKindByUid,
+    }) => {
+      const localQueueByName = buildLocalQueueByName(localQueues);
+      const projectDisplayName = projectDisplayNames.get(namespace) ?? namespace;
+      const statefulSetsByName = buildStatefulSetsByName(statefulSets);
+      const inferenceServicesByName = buildInferenceServicesByName(inferenceServices);
 
-    return workloads
-      .filter(
-        (workload) =>
-          workloadMatchesClusterQueue(workload, clusterQueueName, localQueueByName) &&
-          isQuotaUsageClusterQueueWorkload(workload, pods, localQueueByName) &&
-          (includeTerminal || isActiveWorkload(workload)),
-      )
-      .map((workload) =>
-        mapWorkloadToRow(
-          workload,
-          namespace,
-          projectDisplayName,
-          pods,
-          localQueueByName,
-          resourceFlavorByName,
-          jobKindByUid,
-          clusterQueueName,
-        ),
-      );
-  });
+      return workloads
+        .filter(
+          (workload) =>
+            workloadMatchesClusterQueue(workload, clusterQueueName, localQueueByName) &&
+            isQuotaUsageClusterQueueWorkload(workload, pods, localQueueByName),
+        )
+        .map((workload) =>
+          mapWorkloadToRow(
+            workload,
+            namespace,
+            projectDisplayName,
+            pods,
+            localQueueByName,
+            resourceFlavorByName,
+            jobKindByUid,
+            clusterQueueName,
+            hardwareProfileByKey,
+            statefulSetsByName,
+            inferenceServicesByName,
+            hardwareProfilesForMatching,
+          ),
+        );
+    },
+  );
 
 /** All workloads in a namespace, regardless of cluster queue. */
 export const filterAndMapNamespaceWorkloads = (
-  { namespace, workloads, localQueues, pods, jobKindByUid }: NamespaceWorkloadData,
+  {
+    namespace,
+    workloads,
+    localQueues,
+    pods,
+    statefulSets,
+    inferenceServices,
+    jobKindByUid,
+  }: NamespaceWorkloadData,
   projectDisplayName: string,
   resourceFlavorByName: Map<string, ResourceFlavorKind>,
-  includeTerminal = false,
+  hardwareProfileByKey: HardwareProfileByKey = new Map(),
+  hardwareProfilesForMatching: HardwareProfileKind[] = [],
 ): ClusterQueueWorkloadRow[] => {
   const localQueueByName = buildLocalQueueByName(localQueues);
+  const statefulSetsByName = buildStatefulSetsByName(statefulSets);
+  const inferenceServicesByName = buildInferenceServicesByName(inferenceServices);
 
-  return workloads
-    .filter((workload) => includeTerminal || isActiveWorkload(workload))
-    .map((workload) =>
-      mapWorkloadToRow(
-        workload,
-        namespace,
-        projectDisplayName,
-        pods,
-        localQueueByName,
-        resourceFlavorByName,
-        jobKindByUid,
-      ),
-    );
+  return workloads.map((workload) =>
+    mapWorkloadToRow(
+      workload,
+      namespace,
+      projectDisplayName,
+      pods,
+      localQueueByName,
+      resourceFlavorByName,
+      jobKindByUid,
+      undefined,
+      hardwareProfileByKey,
+      statefulSetsByName,
+      inferenceServicesByName,
+      hardwareProfilesForMatching,
+    ),
+  );
 };
 
-type QueuePositionKey = `${string}/${string}`;
+export type QueuePositionKey = `${string}/${string}`;
 
 export const buildQueuePositionKey = (namespace: string, workloadName: string): QueuePositionKey =>
   `${namespace}/${workloadName}`;
@@ -574,14 +1241,33 @@ export const applyQueuePositions = (
     return position == null ? row : { ...row, queuePosition: position };
   });
 
-export const fetchWorkloadsForClusterQueues = async (
-  clusterQueueNames: string[],
+/**
+ * UXD display statuses: Kueue "Queued" without a visibility position → Pending;
+ * with position → Queued. Other statuses are unchanged.
+ */
+export const applyDisplayStatuses = (rows: ClusterQueueWorkloadRow[]): ClusterQueueWorkloadRow[] =>
+  rows.map((row) => {
+    if (row.status !== QuotaUsageWorkloadStatuses.Queued) {
+      return row;
+    }
+    if (row.queuePosition != null) {
+      return row;
+    }
+    return { ...row, status: QuotaUsageWorkloadStatuses.Pending };
+  });
+
+/** Fetches workload-related K8s data for all Kueue-managed namespaces (shared cache for CQ filtering). */
+export const fetchKueueNamespaceWorkloadCache = async (
   namespaces: string[],
-  projectDisplayNames: Map<string, string>,
-  includeTerminal = false,
-): Promise<Map<string, ClusterQueueWorkloadRow[]>> => {
-  if (namespaces.length === 0 || clusterQueueNames.length === 0) {
-    return new Map();
+  dashboardNamespace = '',
+): Promise<KueueNamespaceWorkloadCache> => {
+  if (namespaces.length === 0) {
+    return {
+      namespaceData: [],
+      resourceFlavorByName: new Map(),
+      hardwareProfileByKey: new Map(),
+      hardwareProfilesForMatching: [],
+    };
   }
 
   const [namespaceResults, resourceFlavors] = await Promise.all([
@@ -596,10 +1282,38 @@ export const fetchWorkloadsForClusterQueues = async (
     ),
     listResourceFlavors(),
   ]);
+
   const namespaceData = namespaceResults.filter(
     (result): result is NamespaceWorkloadData => result != null,
   );
-  const resourceFlavorByName = buildResourceFlavorByName(resourceFlavors);
+  const [hardwareProfileByKey, hardwareProfilesForMatching] = await Promise.all([
+    fetchHardwareProfilesByKey(collectHardwareProfileRefs(namespaceData)),
+    fetchHardwareProfilesForMatching(namespaceData, dashboardNamespace),
+  ]);
+
+  return {
+    namespaceData,
+    resourceFlavorByName: buildResourceFlavorByName(resourceFlavors),
+    hardwareProfileByKey,
+    hardwareProfilesForMatching,
+  };
+};
+
+/**
+ * Maps cached namespace workload data to cluster-queue table rows, synchronously — no queue
+ * position lookup. Lets the table render immediately; callers enrich with queue positions
+ * separately (see `fetchQueuePositions` + `applyQueuePositionsToMap`) so Visibility API latency
+ * does not block first paint.
+ */
+export const mapWorkloadsForClusterQueuesSync = (
+  clusterQueueNames: string[],
+  cache: KueueNamespaceWorkloadCache,
+  projectDisplayNames: Map<string, string>,
+): Map<string, ClusterQueueWorkloadRow[]> => {
+  if (clusterQueueNames.length === 0) {
+    return new Map();
+  }
+
   const workloadsByClusterQueue = new Map<string, ClusterQueueWorkloadRow[]>();
 
   for (const clusterQueueName of clusterQueueNames) {
@@ -607,28 +1321,74 @@ export const fetchWorkloadsForClusterQueues = async (
       clusterQueueName,
       filterAndMapClusterQueueWorkloads(
         clusterQueueName,
-        namespaceData,
+        cache.namespaceData,
         projectDisplayNames,
-        resourceFlavorByName,
-        includeTerminal,
+        cache.resourceFlavorByName,
+        cache.hardwareProfileByKey,
+        cache.hardwareProfilesForMatching,
       ),
     );
-  }
-
-  const allRows = [...workloadsByClusterQueue.values()].flat();
-  const positions = await fetchQueuePositions(allRows);
-
-  for (const [clusterQueueName, rows] of workloadsByClusterQueue) {
-    workloadsByClusterQueue.set(clusterQueueName, applyQueuePositions(rows, positions));
   }
 
   return workloadsByClusterQueue;
 };
 
+/** Applies fetched queue positions (or an empty map, for the pre-enrichment render) and re-derives display statuses. */
+export const applyQueuePositionsToMap = (
+  workloadsByClusterQueue: Map<string, ClusterQueueWorkloadRow[]>,
+  positions: Map<QueuePositionKey, number>,
+  applyDisplayStatusConversion = true,
+): Map<string, ClusterQueueWorkloadRow[]> => {
+  const result = new Map<string, ClusterQueueWorkloadRow[]>();
+  for (const [clusterQueueName, rows] of workloadsByClusterQueue) {
+    const rowsWithPositions = applyQueuePositions(rows, positions);
+    result.set(
+      clusterQueueName,
+      applyDisplayStatusConversion ? applyDisplayStatuses(rowsWithPositions) : rowsWithPositions,
+    );
+  }
+  return result;
+};
+
+/** Maps cached namespace workload data to cluster-queue table rows (includes queue positions). */
+export const mapWorkloadsForClusterQueues = async (
+  clusterQueueNames: string[],
+  cache: KueueNamespaceWorkloadCache,
+  projectDisplayNames: Map<string, string>,
+): Promise<Map<string, ClusterQueueWorkloadRow[]>> => {
+  const workloadsByClusterQueue = mapWorkloadsForClusterQueuesSync(
+    clusterQueueNames,
+    cache,
+    projectDisplayNames,
+  );
+
+  if (workloadsByClusterQueue.size === 0) {
+    return workloadsByClusterQueue;
+  }
+
+  const allRows = [...workloadsByClusterQueue.values()].flat();
+  const positions = await fetchQueuePositions(allRows);
+
+  return applyQueuePositionsToMap(workloadsByClusterQueue, positions);
+};
+
+export const fetchWorkloadsForClusterQueues = async (
+  clusterQueueNames: string[],
+  namespaces: string[],
+  projectDisplayNames: Map<string, string>,
+): Promise<Map<string, ClusterQueueWorkloadRow[]>> => {
+  if (namespaces.length === 0 || clusterQueueNames.length === 0) {
+    return new Map();
+  }
+
+  const cache = await fetchKueueNamespaceWorkloadCache(namespaces);
+  return mapWorkloadsForClusterQueues(clusterQueueNames, cache, projectDisplayNames);
+};
+
 export const fetchNamespaceWorkloads = async (
   namespace: string,
   projectDisplayName: string,
-  includeTerminal = false,
+  dashboardNamespace = '',
 ): Promise<ClusterQueueWorkloadRow[]> => {
   if (!namespace) {
     return [];
@@ -639,21 +1399,25 @@ export const fetchNamespaceWorkloads = async (
     listResourceFlavors(),
   ]);
   const resourceFlavorByName = buildResourceFlavorByName(resourceFlavors);
+  const [hardwareProfileByKey, hardwareProfilesForMatching] = await Promise.all([
+    fetchHardwareProfilesByKey(collectHardwareProfileRefs([namespaceData])),
+    fetchHardwareProfilesForMatching([namespaceData], dashboardNamespace),
+  ]);
   const rows = filterAndMapNamespaceWorkloads(
     namespaceData,
     projectDisplayName,
     resourceFlavorByName,
-    includeTerminal,
+    hardwareProfileByKey,
+    hardwareProfilesForMatching,
   );
   const positions = await fetchQueuePositions(rows);
-  return applyQueuePositions(rows, positions);
+  return applyDisplayStatuses(applyQueuePositions(rows, positions));
 };
 
 export const fetchClusterQueueWorkloads = async (
   clusterQueueName: string,
   namespaces: string[],
   projectDisplayNames: Map<string, string>,
-  includeTerminal = false,
 ): Promise<ClusterQueueWorkloadRow[]> => {
   if (!clusterQueueName || namespaces.length === 0) {
     return [];
@@ -663,7 +1427,6 @@ export const fetchClusterQueueWorkloads = async (
     [clusterQueueName],
     namespaces,
     projectDisplayNames,
-    includeTerminal,
   );
 
   return workloadsByClusterQueue.get(clusterQueueName) ?? [];

--- a/packages/gpuaas/src/utils/clusterQueueWorkloadsTableUtils.ts
+++ b/packages/gpuaas/src/utils/clusterQueueWorkloadsTableUtils.ts
@@ -1,0 +1,38 @@
+import type { ClusterQueueWorkloadsFilterDataType } from '../components/clusterQueueWorkloads/ClusterQueueWorkloadsToolbar';
+import type { ClusterQueueWorkloadRow } from '../types';
+
+const getFilterSelectValue = (
+  filter?: string | { label: string; value: string },
+): string | undefined => (typeof filter === 'string' ? filter : filter?.value);
+
+export const hasActiveWorkloadFilters = (
+  filterData: ClusterQueueWorkloadsFilterDataType,
+): boolean =>
+  Boolean(
+    filterData.name?.trim() ||
+      getFilterSelectValue(filterData.status) ||
+      getFilterSelectValue(filterData.priority) ||
+      getFilterSelectValue(filterData.hardwareProfile),
+  );
+
+export const filterClusterQueueWorkloads = (
+  workloads: ClusterQueueWorkloadRow[],
+  filterData: ClusterQueueWorkloadsFilterDataType,
+): ClusterQueueWorkloadRow[] => {
+  const nameFilter = filterData.name?.trim().toLowerCase();
+  const statusValue = getFilterSelectValue(filterData.status);
+  const priorityValue = getFilterSelectValue(filterData.priority);
+  const hardwareProfileValue = getFilterSelectValue(filterData.hardwareProfile);
+
+  return workloads.filter((workload) => {
+    const matchesName =
+      !nameFilter ||
+      workload.name.toLowerCase().includes(nameFilter) ||
+      workload.project.toLowerCase().includes(nameFilter);
+    const matchesStatus = !statusValue || workload.status === statusValue;
+    const matchesPriority = !priorityValue || workload.priority === priorityValue;
+    const matchesHardwareProfile =
+      !hardwareProfileValue || workload.hardwareProfile === hardwareProfileValue;
+    return matchesName && matchesStatus && matchesPriority && matchesHardwareProfile;
+  });
+};

--- a/packages/gpuaas/src/utils/extractWorkloadPodSpecOptions.ts
+++ b/packages/gpuaas/src/utils/extractWorkloadPodSpecOptions.ts
@@ -27,19 +27,25 @@ const mapWorkloadTolerations = (
     return undefined;
   }
 
-  return tolerations.flatMap((toleration) =>
-    toleration.key
-      ? [
-          {
-            key: toleration.key,
-            operator: isTolerationOperator(toleration.operator) ? toleration.operator : undefined,
-            value: toleration.value,
-            effect: isTolerationEffect(toleration.effect) ? toleration.effect : undefined,
-            tolerationSeconds: toleration.tolerationSeconds,
-          },
-        ]
-      : [],
-  );
+  return tolerations.flatMap((toleration) => {
+    const operator = isTolerationOperator(toleration.operator) ? toleration.operator : undefined;
+
+    // Kubernetes permits an empty key for an Exists toleration; it matches taints regardless of
+    // key and must not be discarded before hardware-profile matching.
+    if (!toleration.key && operator !== TolerationOperator.EXISTS) {
+      return [];
+    }
+
+    return [
+      {
+        key: toleration.key ?? '',
+        operator,
+        value: toleration.value,
+        effect: isTolerationEffect(toleration.effect) ? toleration.effect : undefined,
+        tolerationSeconds: toleration.tolerationSeconds,
+      },
+    ];
+  });
 };
 
 /** Pod spec options extracted from the first Kueue Workload podSet (same shape Model Serving passes to profile matching). */

--- a/packages/gpuaas/src/utils/extractWorkloadPodSpecOptions.ts
+++ b/packages/gpuaas/src/utils/extractWorkloadPodSpecOptions.ts
@@ -1,0 +1,96 @@
+import {
+  TolerationEffect,
+  TolerationOperator,
+  type ContainerResources,
+  type NodeSelector,
+  type Toleration,
+  type WorkloadKind,
+} from '@odh-dashboard/k8s-core';
+import { isAcceleratorResource } from './clusterQueueUtils';
+
+type WorkloadPodToleration = NonNullable<
+  WorkloadKind['spec']['podSets'][number]['template']['spec']['tolerations']
+>[number];
+
+const isTolerationOperator = (value?: string): value is TolerationOperator =>
+  value === TolerationOperator.EXISTS || value === TolerationOperator.EQUAL;
+
+const isTolerationEffect = (value?: string): value is TolerationEffect =>
+  value === TolerationEffect.NO_SCHEDULE ||
+  value === TolerationEffect.PREFER_NO_SCHEDULE ||
+  value === TolerationEffect.NO_EXECUTE;
+
+const mapWorkloadTolerations = (
+  tolerations?: WorkloadPodToleration[],
+): Toleration[] | undefined => {
+  if (!tolerations) {
+    return undefined;
+  }
+
+  return tolerations.flatMap((toleration) =>
+    toleration.key
+      ? [
+          {
+            key: toleration.key,
+            operator: isTolerationOperator(toleration.operator) ? toleration.operator : undefined,
+            value: toleration.value,
+            effect: isTolerationEffect(toleration.effect) ? toleration.effect : undefined,
+            tolerationSeconds: toleration.tolerationSeconds,
+          },
+        ]
+      : [],
+  );
+};
+
+/** Pod spec options extracted from the first Kueue Workload podSet (same shape Model Serving passes to profile matching). */
+export type WorkloadPodSpecOptions = {
+  resources?: ContainerResources;
+  tolerations?: Toleration[];
+  nodeSelector?: NodeSelector;
+};
+
+/**
+ * Reads container resources, tolerations, and node selector from a Workload's primary podSet
+ * template — the workload-native equivalent of `extractHardwareProfileConfigFromInferenceService`.
+ */
+export const extractWorkloadPodSpecOptions = (workload: WorkloadKind): WorkloadPodSpecOptions => {
+  if (workload.spec.podSets.length === 0) {
+    return {};
+  }
+
+  const podSet = workload.spec.podSets[0];
+
+  const { spec } = podSet.template;
+  const container =
+    spec.containers.find((candidate) => {
+      const requests = candidate.resources?.requests ?? {};
+      const limits = candidate.resources?.limits ?? {};
+      return [...Object.keys(requests), ...Object.keys(limits)].some((name) =>
+        isAcceleratorResource(name),
+      );
+    }) ?? spec.containers[0];
+
+  return {
+    resources: container.resources,
+    tolerations: mapWorkloadTolerations(spec.tolerations),
+    nodeSelector: spec.nodeSelector,
+  };
+};
+
+/** Primary accelerator resource name from Workload podSet containers (e.g. nvidia.com/gpu). */
+export const getWorkloadPrimaryAcceleratorIdentifier = (
+  workload: WorkloadKind,
+): string | undefined => {
+  for (const podSet of workload.spec.podSets) {
+    for (const container of podSet.template.spec.containers) {
+      const requests = container.resources?.requests ?? {};
+      const limits = container.resources?.limits ?? {};
+      for (const name of new Set([...Object.keys(requests), ...Object.keys(limits)])) {
+        if (isAcceleratorResource(name)) {
+          return name;
+        }
+      }
+    }
+  }
+  return undefined;
+};

--- a/packages/gpuaas/src/utils/hardwareModels.ts
+++ b/packages/gpuaas/src/utils/hardwareModels.ts
@@ -1,4 +1,11 @@
-import { ClusterQueueKind, ResourceFlavorKind, type WorkloadKind } from '@odh-dashboard/k8s-core';
+import {
+  ClusterQueueKind,
+  type HardwareProfileKind,
+  IdentifierResourceType,
+  type PodKind,
+  ResourceFlavorKind,
+  type WorkloadKind,
+} from '@odh-dashboard/k8s-core';
 import parseK8sQuantity from './parseK8sQuantity';
 import { ACCELERATOR_RESOURCE_REGEX } from '../const';
 
@@ -9,6 +16,73 @@ const GPU_PRODUCT_LABELS = [
   'amd.com/gpu.product',
   'intel.com/gpu.product',
 ] as const;
+
+/** Same annotation pair the dashboard stamps on notebook Pod templates when a HardwareProfile is assigned. */
+export const HARDWARE_PROFILE_NAME_ANNOTATION = 'opendatahub.io/hardware-profile-name';
+export const HARDWARE_PROFILE_NAMESPACE_ANNOTATION = 'opendatahub.io/hardware-profile-namespace';
+
+export type HardwareProfileRef = { name: string; namespace: string };
+
+export const buildHardwareProfileKey = ({ name, namespace }: HardwareProfileRef): string =>
+  `${namespace}/${name}`;
+
+/** Reads the dashboard's hardware-profile annotation pair from any annotation map. */
+export const getHardwareProfileRefFromAnnotations = (
+  annotations?: Record<string, string>,
+): HardwareProfileRef | undefined => {
+  const name = annotations?.[HARDWARE_PROFILE_NAME_ANNOTATION];
+  const namespace = annotations?.[HARDWARE_PROFILE_NAMESPACE_ANNOTATION];
+  return name && namespace ? { name, namespace } : undefined;
+};
+
+/** Reads the dashboard's hardware-profile annotation pair off a Pod, if present. */
+export const getHardwareProfileRefFromPod = (pod: PodKind): HardwareProfileRef | undefined =>
+  getHardwareProfileRefFromAnnotations(pod.metadata.annotations);
+
+/** The accelerator resource identifier (e.g. "nvidia.com/gpu") on a HardwareProfile, if any. */
+export const getHardwareProfileAcceleratorIdentifier = (
+  hardwareProfile: HardwareProfileKind,
+): string | undefined =>
+  hardwareProfile.spec.identifiers?.find(
+    (identifier) => identifier.resourceType === IdentifierResourceType.ACCELERATOR,
+  )?.identifier;
+
+/** Mirrors the dashboard-wide HardwareProfile display-name convention (name falls back to metadata.name). */
+export const getHardwareProfileDisplayName = (hardwareProfile: HardwareProfileKind): string =>
+  hardwareProfile.metadata.annotations?.['opendatahub.io/display-name'] ||
+  hardwareProfile.metadata.name;
+
+/** HardwareProfile CRs referenced by workload Pods, keyed by `${namespace}/${name}`. */
+export type HardwareProfileByKey = Map<string, HardwareProfileKind>;
+
+export type WorkloadHardwareProfileInfo = {
+  displayName: string;
+  acceleratorIdentifier?: string;
+};
+
+/**
+ * Resolves a workload's hardware profile from the real HardwareProfile CR referenced by a
+ * `opendatahub.io/hardware-profile-name` annotation (the same mechanism Notebooks use), when present.
+ */
+export const resolveWorkloadHardwareProfileFromAnnotation = (
+  annotationSources: Array<Record<string, string> | undefined>,
+  hardwareProfileByKey: Map<string, HardwareProfileKind>,
+): WorkloadHardwareProfileInfo | undefined => {
+  for (const annotations of annotationSources) {
+    const ref = getHardwareProfileRefFromAnnotations(annotations);
+    if (!ref) {
+      continue;
+    }
+    const hardwareProfile = hardwareProfileByKey.get(buildHardwareProfileKey(ref));
+    if (hardwareProfile) {
+      return {
+        displayName: getHardwareProfileDisplayName(hardwareProfile),
+        acceleratorIdentifier: getHardwareProfileAcceleratorIdentifier(hardwareProfile),
+      };
+    }
+  }
+  return undefined;
+};
 
 export const buildResourceFlavorByName = (
   resourceFlavors: ResourceFlavorKind[],

--- a/packages/gpuaas/src/utils/hardwareModels.ts
+++ b/packages/gpuaas/src/utils/hardwareModels.ts
@@ -4,7 +4,6 @@ import {
   IdentifierResourceType,
   type PodKind,
   ResourceFlavorKind,
-  type WorkloadKind,
 } from '@odh-dashboard/k8s-core';
 import parseK8sQuantity from './parseK8sQuantity';
 import { ACCELERATOR_RESOURCE_REGEX } from '../const';
@@ -82,45 +81,6 @@ export const resolveWorkloadHardwareProfileFromAnnotation = (
     }
   }
   return undefined;
-};
-
-export const buildResourceFlavorByName = (
-  resourceFlavors: ResourceFlavorKind[],
-): Map<string, ResourceFlavorKind> =>
-  new Map(
-    resourceFlavors.flatMap((resourceFlavor) => {
-      const name = resourceFlavor.metadata?.name;
-      return name ? [[name, resourceFlavor] as const] : [];
-    }),
-  );
-
-/** Resolves admitted ResourceFlavor assignments to GPU product names. */
-export const resolveWorkloadHardwareProfile = (
-  workload: WorkloadKind,
-  resourceFlavorByName: Map<string, ResourceFlavorKind>,
-): string | undefined => {
-  const models = new Set<string>();
-
-  for (const assignment of workload.status?.admission?.podSetAssignments ?? []) {
-    for (const flavorName of Object.values(assignment.flavors ?? {})) {
-      const resourceFlavor = resourceFlavorByName.get(flavorName);
-      if (!resourceFlavor?.spec.nodeLabels) {
-        continue;
-      }
-      for (const label of GPU_PRODUCT_LABELS) {
-        const value = resourceFlavor.spec.nodeLabels[label];
-        if (value) {
-          models.add(value);
-        }
-      }
-    }
-  }
-
-  if (models.size === 0) {
-    return undefined;
-  }
-
-  return [...models].toSorted((a, b) => a.localeCompare(b)).join(', ');
 };
 
 export type ModelGpuCount = {

--- a/packages/gpuaas/src/utils/loadWorkloadCache.ts
+++ b/packages/gpuaas/src/utils/loadWorkloadCache.ts
@@ -1,0 +1,243 @@
+import { NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetch';
+import {
+  collectHardwareProfileRefs,
+  enrichNamespaceWorkloadData,
+  fetchHardwareProfilesByKey,
+  fetchHardwareProfilesForMatching,
+  fetchLocalQueueClusterQueueIndex,
+  fetchNamespaceWorkloadBaseData,
+  getNamespacesForClusterQueues,
+  toNamespaceWorkloadData,
+  type HardwareProfileByKey,
+  type KueueNamespaceWorkloadCache,
+  type LocalQueueClusterQueueIndex,
+  type NamespaceWorkloadBaseData,
+} from './clusterQueueWorkloads';
+import {
+  applyNamespaceEnrichment,
+  createNamespaceBundleState,
+  toDisplayBundle,
+  type NamespaceBundleState,
+  type NamespaceWorkloadEnrichment,
+} from './namespaceBundleState';
+
+const buildNamespaceLoadError = (failures: { namespace: string; error: Error }[]): Error =>
+  new Error(
+    `Failed to load workloads for: ${failures
+      .map(({ namespace, error }) => `${namespace} (${error.message})`)
+      .join('; ')}`,
+  );
+
+/** Mutable session state for namespace bundles, HW profile cache, and fetch generations. */
+export class WorkloadCacheSession {
+  namespaceBundleState = new Map<string, NamespaceBundleState>();
+
+  hardwareProfileByKey: HardwareProfileByKey = new Map();
+
+  hardwareProfilesForMatching: KueueNamespaceWorkloadCache['hardwareProfilesForMatching'] = [];
+
+  baseFetchGeneration = 0;
+
+  enrichedFetchGeneration = 0;
+
+  clearForRefresh(): void {
+    this.namespaceBundleState.clear();
+    this.hardwareProfileByKey.clear();
+    this.hardwareProfilesForMatching = [];
+    this.enrichedFetchGeneration = 0;
+  }
+
+  /** Drop enrichment when the selected cluster queue set changes; keep fetched base per namespace. */
+  stripEnrichmentOnClusterQueueSwitch(): void {
+    for (const [namespace, state] of this.namespaceBundleState) {
+      this.namespaceBundleState.set(namespace, { base: state.base });
+    }
+    this.hardwareProfileByKey.clear();
+    this.hardwareProfilesForMatching = [];
+    this.enrichedFetchGeneration = 0;
+  }
+
+  bumpBaseGeneration(): number {
+    this.baseFetchGeneration += 1;
+    return this.baseFetchGeneration;
+  }
+
+  markEnrichedForCurrentBase(): void {
+    this.enrichedFetchGeneration = this.baseFetchGeneration;
+  }
+
+  setHardwareProfilesForMatching(
+    hardwareProfilesForMatching: KueueNamespaceWorkloadCache['hardwareProfilesForMatching'],
+  ): void {
+    this.hardwareProfilesForMatching = hardwareProfilesForMatching;
+  }
+}
+
+export type WorkloadCacheMutableStore = WorkloadCacheSession;
+
+export const createWorkloadCacheStore = (): WorkloadCacheSession => new WorkloadCacheSession();
+
+export const clearWorkloadCacheStore = (store: WorkloadCacheSession): void => {
+  store.clearForRefresh();
+};
+
+export const stripEnrichmentOnClusterQueueSwitch = (store: WorkloadCacheSession): void => {
+  store.stripEnrichmentOnClusterQueueSwitch();
+};
+
+export type LoadWorkloadCacheParams = {
+  clusterQueueNames: string[];
+  kueueNamespaceSet: Set<string>;
+  dashboardNamespace: string;
+  store: WorkloadCacheSession;
+  /** When true, refetch base data for every namespace (manual refresh / interval). */
+  invalidateBundles: boolean;
+  onBaseCache?: (cache: KueueNamespaceWorkloadCache) => void;
+};
+
+const fetchBaseCache = async (
+  index: LocalQueueClusterQueueIndex,
+  params: LoadWorkloadCacheParams,
+  pendingBaseGeneration: number,
+): Promise<KueueNamespaceWorkloadCache> => {
+  const { clusterQueueNames, kueueNamespaceSet, store, invalidateBundles } = params;
+
+  const relevantNamespaces = [...getNamespacesForClusterQueues(clusterQueueNames, index)].filter(
+    (namespace) => kueueNamespaceSet.has(namespace),
+  );
+
+  const fetchResults = await Promise.all(
+    relevantNamespaces.map(async (namespace) => {
+      try {
+        const previousState = store.namespaceBundleState.get(namespace);
+        let baseData = previousState?.base;
+        if (!baseData || invalidateBundles) {
+          baseData = await fetchNamespaceWorkloadBaseData(namespace);
+        }
+        const nextState = createNamespaceBundleState(baseData, previousState);
+        if (pendingBaseGeneration === store.baseFetchGeneration) {
+          store.namespaceBundleState.set(namespace, nextState);
+        }
+        return { namespace, error: undefined };
+      } catch (error) {
+        return {
+          namespace,
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+    }),
+  );
+
+  if (pendingBaseGeneration !== store.baseFetchGeneration) {
+    throw new NotReadyError('Base generation advanced during base fetch');
+  }
+
+  const failures = fetchResults.flatMap((result) =>
+    result.error ? [{ namespace: result.namespace, error: result.error }] : [],
+  );
+
+  const namespaceData = relevantNamespaces.flatMap((namespace) => {
+    const state = store.namespaceBundleState.get(namespace);
+    return state ? [toDisplayBundle(state, pendingBaseGeneration, true)] : [];
+  });
+
+  return {
+    namespaceData,
+    hardwareProfileByKey: new Map(store.hardwareProfileByKey),
+    hardwareProfilesForMatching: store.hardwareProfilesForMatching,
+    namespaceLoadError: failures.length > 0 ? buildNamespaceLoadError(failures) : undefined,
+  };
+};
+
+const enrichCache = async (
+  baseCache: KueueNamespaceWorkloadCache,
+  params: LoadWorkloadCacheParams,
+): Promise<KueueNamespaceWorkloadCache> => {
+  const { clusterQueueNames, dashboardNamespace, store } = params;
+  const baseGeneration = store.baseFetchGeneration;
+
+  const enrichResultsWithErrors = await Promise.all(
+    baseCache.namespaceData.map(async (baseBundle) => {
+      const state = store.namespaceBundleState.get(baseBundle.namespace);
+      const base: NamespaceWorkloadBaseData = state?.base ?? {
+        namespace: baseBundle.namespace,
+        workloads: baseBundle.workloads,
+        localQueues: baseBundle.localQueues,
+      };
+      try {
+        const enriched = await enrichNamespaceWorkloadData(base, clusterQueueNames);
+        const enrichment: NamespaceWorkloadEnrichment = {
+          pods: enriched.pods,
+          statefulSets: enriched.statefulSets,
+          inferenceServices: enriched.inferenceServices,
+          jobKindByUid: enriched.jobKindByUid,
+        };
+        const updatedState = applyNamespaceEnrichment(
+          state ?? { base },
+          enrichment,
+          baseGeneration,
+        );
+        if (baseGeneration === store.baseFetchGeneration) {
+          store.namespaceBundleState.set(base.namespace, updatedState);
+        }
+        return { data: toDisplayBundle(updatedState, baseGeneration), error: undefined };
+      } catch (error) {
+        return {
+          data: toNamespaceWorkloadData(base),
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+    }),
+  );
+
+  const enrichmentFailures = enrichResultsWithErrors.flatMap(({ data, error }) =>
+    error ? [{ namespace: data.namespace, error }] : [],
+  );
+  const enrichResults = enrichResultsWithErrors.map(({ data }) => data);
+
+  const [fetchedHardwareProfiles, hardwareProfilesForMatching] = await Promise.all([
+    fetchHardwareProfilesByKey(collectHardwareProfileRefs(enrichResults)),
+    fetchHardwareProfilesForMatching(enrichResults, dashboardNamespace),
+  ]);
+  if (baseGeneration !== store.baseFetchGeneration) {
+    throw new NotReadyError('Base generation advanced during enrichment');
+  }
+  for (const [key, hardwareProfile] of fetchedHardwareProfiles) {
+    store.hardwareProfileByKey.set(key, hardwareProfile);
+  }
+  store.setHardwareProfilesForMatching(hardwareProfilesForMatching);
+  store.markEnrichedForCurrentBase();
+
+  return {
+    namespaceData: enrichResults,
+    hardwareProfileByKey: new Map(store.hardwareProfileByKey),
+    hardwareProfilesForMatching,
+    namespaceLoadError:
+      baseCache.namespaceLoadError || enrichmentFailures.length > 0
+        ? buildNamespaceLoadError([
+            ...(baseCache.namespaceLoadError
+              ? [{ namespace: 'base data', error: baseCache.namespaceLoadError }]
+              : []),
+            ...enrichmentFailures,
+          ])
+        : undefined,
+  };
+};
+
+/**
+ * Cluster-wide LocalQueue index, scoped namespace base fetch, then enrichment (pods, ISVC, HW).
+ */
+export const loadWorkloadCache = async (
+  params: LoadWorkloadCacheParams,
+): Promise<KueueNamespaceWorkloadCache> => {
+  const pendingBaseGeneration = params.store.bumpBaseGeneration();
+  const index = await fetchLocalQueueClusterQueueIndex();
+  const baseCache = await fetchBaseCache(index, params, pendingBaseGeneration);
+  params.onBaseCache?.(baseCache);
+
+  if (baseCache.namespaceData.length === 0) {
+    return baseCache;
+  }
+
+  return enrichCache(baseCache, params);
+};

--- a/packages/gpuaas/src/utils/matchToHardwareProfile.ts
+++ b/packages/gpuaas/src/utils/matchToHardwareProfile.ts
@@ -13,15 +13,19 @@ const normalizeTolerationOperator = (operator?: Toleration['operator']): Tolerat
 const tolerationEffectsMatch = (
   workloadEffect?: Toleration['effect'],
   profileEffect?: Toleration['effect'],
-): boolean => !workloadEffect || workloadEffect === profileEffect;
+): boolean => !workloadEffect || !profileEffect || workloadEffect === profileEffect;
 
-const tolerationsMatchPair = (workload: Toleration, profile: Toleration): boolean =>
-  workload.key === profile.key &&
-  workload.value === profile.value &&
-  normalizeTolerationOperator(workload.operator) ===
-    normalizeTolerationOperator(profile.operator) &&
-  tolerationEffectsMatch(workload.effect, profile.effect) &&
-  workload.tolerationSeconds === profile.tolerationSeconds;
+const tolerationsMatchPair = (workload: Toleration, profile: Toleration): boolean => {
+  const workloadOperator = normalizeTolerationOperator(workload.operator);
+  const profileOperator = normalizeTolerationOperator(profile.operator);
+
+  return (
+    workload.key === profile.key &&
+    workloadOperator === profileOperator &&
+    (workloadOperator === TolerationOperator.EXISTS || workload.value === profile.value) &&
+    tolerationEffectsMatch(workload.effect, profile.effect)
+  );
+};
 
 /**
  * Gpuaas-local copy of `matchToHardwareProfile` from `useHardwareProfileConfig` — same logic
@@ -74,7 +78,7 @@ export const matchToHardwareProfile = (
       );
     });
 
-    const tolerationsMatch = profile.spec.scheduling?.node?.tolerations?.every(
+    const tolerationsMatch = (profile.spec.scheduling?.node?.tolerations ?? []).every(
       (profileToleration) =>
         tolerations.some((workloadToleration) =>
           tolerationsMatchPair(workloadToleration, profileToleration),

--- a/packages/gpuaas/src/utils/matchToHardwareProfile.ts
+++ b/packages/gpuaas/src/utils/matchToHardwareProfile.ts
@@ -1,0 +1,92 @@
+import {
+  TolerationOperator,
+  type ContainerResources,
+  type HardwareProfileKind,
+  type NodeSelector,
+  type Toleration,
+} from '@odh-dashboard/k8s-core';
+import { isCpuLimitLarger, isMemoryLimitLarger } from '@odh-dashboard/ui-core/utilities/valueUnits';
+
+const normalizeTolerationOperator = (operator?: Toleration['operator']): TolerationOperator =>
+  operator ?? TolerationOperator.EQUAL;
+
+const tolerationEffectsMatch = (
+  workloadEffect?: Toleration['effect'],
+  profileEffect?: Toleration['effect'],
+): boolean => !workloadEffect || workloadEffect === profileEffect;
+
+const tolerationsMatchPair = (workload: Toleration, profile: Toleration): boolean =>
+  workload.key === profile.key &&
+  workload.value === profile.value &&
+  normalizeTolerationOperator(workload.operator) ===
+    normalizeTolerationOperator(profile.operator) &&
+  tolerationEffectsMatch(workload.effect, profile.effect) &&
+  workload.tolerationSeconds === profile.tolerationSeconds;
+
+/**
+ * Gpuaas-local copy of `matchToHardwareProfile` from `useHardwareProfileConfig` — same logic
+ * workbench and model serving use today. Kept here so Quota usage display stays gpuaas-scoped;
+ * extract to `@odh-dashboard/hardware-profiles` (and fix tolerations matching) in follow-up.
+ */
+export const matchToHardwareProfile = (
+  hardwareProfiles: HardwareProfileKind[],
+  resources?: ContainerResources,
+  tolerations: Toleration[] = [],
+  nodeSelector: NodeSelector = {},
+): HardwareProfileKind | undefined => {
+  if (!resources) {
+    return undefined;
+  }
+
+  const matchingProfiles = hardwareProfiles.filter((profile) => {
+    const identifiersMatch = profile.spec.identifiers?.every((identifier) => {
+      const requestValue = resources.requests?.[identifier.identifier];
+      const limitValue = resources.limits?.[identifier.identifier];
+
+      if (!requestValue || !limitValue) {
+        return false;
+      }
+
+      if (identifier.identifier === 'cpu') {
+        return (
+          isCpuLimitLarger(requestValue, identifier.maxCount, true) &&
+          isCpuLimitLarger(limitValue, identifier.maxCount, true) &&
+          isCpuLimitLarger(identifier.minCount, requestValue, true) &&
+          isCpuLimitLarger(identifier.minCount, limitValue, true)
+        );
+      }
+
+      if (identifier.identifier === 'memory') {
+        return (
+          (!identifier.maxCount ||
+            (isMemoryLimitLarger(requestValue.toString(), identifier.maxCount.toString(), true) &&
+              isMemoryLimitLarger(limitValue.toString(), identifier.maxCount.toString(), true))) &&
+          isMemoryLimitLarger(identifier.minCount.toString(), requestValue.toString(), true) &&
+          isMemoryLimitLarger(identifier.minCount.toString(), limitValue.toString(), true)
+        );
+      }
+
+      return (
+        Number(identifier.minCount) <= Number(requestValue) &&
+        Number(identifier.minCount) <= Number(limitValue) &&
+        Number(identifier.maxCount) >= Number(requestValue) &&
+        Number(identifier.maxCount) >= Number(limitValue)
+      );
+    });
+
+    const tolerationsMatch = profile.spec.scheduling?.node?.tolerations?.every(
+      (profileToleration) =>
+        tolerations.some((workloadToleration) =>
+          tolerationsMatchPair(workloadToleration, profileToleration),
+        ),
+    );
+
+    const nodeSelectorMatch = Object.entries(
+      profile.spec.scheduling?.node?.nodeSelector || {},
+    ).every(([key, value]) => nodeSelector[key] === value);
+
+    return identifiersMatch && tolerationsMatch && nodeSelectorMatch;
+  });
+
+  return matchingProfiles.length > 0 ? matchingProfiles[0] : undefined;
+};

--- a/packages/gpuaas/src/utils/namespaceBundleState.ts
+++ b/packages/gpuaas/src/utils/namespaceBundleState.ts
@@ -1,0 +1,88 @@
+import type { WorkloadKind } from '@odh-dashboard/k8s-core';
+import {
+  emptyNamespaceEnrichment,
+  toNamespaceWorkloadData,
+  type NamespaceWorkloadBaseData,
+  type NamespaceWorkloadData,
+} from './clusterQueueWorkloads';
+
+export type NamespaceWorkloadEnrichment = Pick<
+  NamespaceWorkloadData,
+  'pods' | 'statefulSets' | 'inferenceServices' | 'jobKindByUid'
+>;
+
+/** Per-namespace snapshot with generation-tracked enrichment validity. */
+export type NamespaceBundleState = {
+  base: NamespaceWorkloadBaseData;
+  enrichment?: NamespaceWorkloadEnrichment;
+  /** Matches the global base fetch generation when enrichment is confirmed for the current base. */
+  enrichedForBaseGeneration?: number;
+};
+
+export const hasNamespaceEnrichmentData = (enrichment?: NamespaceWorkloadEnrichment): boolean =>
+  !!enrichment &&
+  (enrichment.pods.length > 0 ||
+    enrichment.inferenceServices.length > 0 ||
+    enrichment.statefulSets.length > 0 ||
+    enrichment.jobKindByUid.size > 0);
+
+const workloadIdentityKey = (workloads: WorkloadKind[]): string =>
+  workloads
+    .map((workload) => workload.metadata?.uid ?? workload.metadata?.name ?? '')
+    .filter(Boolean)
+    .toSorted((a, b) => a.localeCompare(b))
+    .join('\0');
+
+/** Reuse enrichment only when the underlying workload set is unchanged. */
+export const canPreserveNamespaceEnrichment = (
+  previous: NamespaceBundleState | undefined,
+  base: NamespaceWorkloadBaseData,
+): previous is NamespaceBundleState & { enrichment: NamespaceWorkloadEnrichment } =>
+  !!previous?.enrichment &&
+  hasNamespaceEnrichmentData(previous.enrichment) &&
+  workloadIdentityKey(previous.base.workloads) === workloadIdentityKey(base.workloads);
+
+export const createNamespaceBundleState = (
+  base: NamespaceWorkloadBaseData,
+  previous?: NamespaceBundleState,
+): NamespaceBundleState => {
+  if (!previous || !canPreserveNamespaceEnrichment(previous, base)) {
+    return { base };
+  }
+
+  return {
+    base,
+    enrichment: previous.enrichment,
+    enrichedForBaseGeneration: previous.enrichedForBaseGeneration,
+  };
+};
+
+export const applyNamespaceEnrichment = (
+  state: NamespaceBundleState,
+  enrichment: NamespaceWorkloadEnrichment,
+  baseGeneration: number,
+): NamespaceBundleState => ({
+  ...state,
+  enrichment,
+  enrichedForBaseGeneration: baseGeneration,
+});
+
+/**
+ * Builds the namespace bundle for display. When `optimisticWhileEnriching` is true, stale
+ * enrichment may be shown during B2 if workload identities still match (CQ switch UX).
+ */
+export const toDisplayBundle = (
+  state: NamespaceBundleState,
+  baseGeneration: number,
+  optimisticWhileEnriching = false,
+): NamespaceWorkloadData => {
+  const enrichmentMatchesGeneration = state.enrichedForBaseGeneration === baseGeneration;
+  const enrichment =
+    state.enrichment &&
+    (enrichmentMatchesGeneration || optimisticWhileEnriching) &&
+    hasNamespaceEnrichmentData(state.enrichment)
+      ? state.enrichment
+      : undefined;
+
+  return toNamespaceWorkloadData(state.base, enrichment ?? emptyNamespaceEnrichment());
+};

--- a/packages/gpuaas/src/utils/workloadHardwareProfileResolver.ts
+++ b/packages/gpuaas/src/utils/workloadHardwareProfileResolver.ts
@@ -1,0 +1,158 @@
+import {
+  type HardwareProfileKind,
+  HardwareProfileFeatureVisibility,
+  type ResourceFlavorKind,
+  type WorkloadKind,
+} from '@odh-dashboard/k8s-core';
+import { matchToHardwareProfile } from './matchToHardwareProfile';
+import {
+  extractWorkloadPodSpecOptions,
+  type WorkloadPodSpecOptions,
+} from './extractWorkloadPodSpecOptions';
+import {
+  getHardwareProfileAcceleratorIdentifier,
+  getHardwareProfileDisplayName,
+  resolveWorkloadHardwareProfile,
+  resolveWorkloadHardwareProfileFromAnnotation,
+  type HardwareProfileByKey,
+  type WorkloadHardwareProfileInfo,
+} from './hardwareModels';
+import type { WorkloadInferenceService } from '../types/inferenceService';
+import { QuotaUsageWorkloadTypes, type QuotaUsageWorkloadType } from '../types';
+
+const WORKBENCH_VISIBILITY = [HardwareProfileFeatureVisibility.WORKBENCH];
+const MODEL_SERVING_VISIBILITY = [HardwareProfileFeatureVisibility.MODEL_SERVING];
+
+const isHardwareProfileEnabled = (hardwareProfile: HardwareProfileKind): boolean =>
+  hardwareProfile.metadata.annotations?.['opendatahub.io/disabled'] === 'false' ||
+  hardwareProfile.metadata.annotations?.['opendatahub.io/disabled'] === undefined;
+
+/** Mirrors `filterHardwareProfileByFeatureVisibility` from hardware-profiles pages (no React hooks). */
+export const filterHardwareProfilesByVisibility = (
+  hardwareProfiles: HardwareProfileKind[],
+  visibility?: HardwareProfileFeatureVisibility[],
+): HardwareProfileKind[] =>
+  hardwareProfiles.filter((profile) => {
+    if (!isHardwareProfileEnabled(profile)) {
+      return false;
+    }
+    const visibilityAnnotation =
+      profile.metadata.annotations?.['opendatahub.io/dashboard-feature-visibility'];
+    if (!visibilityAnnotation) {
+      return true;
+    }
+    try {
+      const visibleIn: string[] = JSON.parse(visibilityAnnotation);
+      if (visibleIn.length === 0) {
+        return true;
+      }
+      return visibility ? visibility.some((entry) => visibleIn.includes(entry)) : true;
+    } catch {
+      return true;
+    }
+  });
+
+const visibilityForWorkloadType = (
+  workloadType: QuotaUsageWorkloadType,
+): HardwareProfileFeatureVisibility[] => {
+  if (workloadType === QuotaUsageWorkloadTypes.Serve) {
+    return MODEL_SERVING_VISIBILITY;
+  }
+  if (workloadType === QuotaUsageWorkloadTypes.Workbench) {
+    return WORKBENCH_VISIBILITY;
+  }
+  return [...WORKBENCH_VISIBILITY, ...MODEL_SERVING_VISIBILITY];
+};
+
+const toProfileInfo = (hardwareProfile: HardwareProfileKind): WorkloadHardwareProfileInfo => ({
+  displayName: getHardwareProfileDisplayName(hardwareProfile),
+  acceleratorIdentifier: getHardwareProfileAcceleratorIdentifier(hardwareProfile),
+});
+
+/**
+ * Model-serving pod spec options — same fields `extractHardwareProfileConfigFromInferenceService`
+ * passes into `useHardwareProfileConfig` for resource-based profile matching.
+ */
+export const extractInferenceServicePodSpecOptions = (
+  inferenceService: WorkloadInferenceService,
+): WorkloadPodSpecOptions => ({
+  resources: inferenceService.spec?.predictor?.model?.resources,
+  tolerations: inferenceService.spec?.predictor?.tolerations,
+  nodeSelector: inferenceService.spec?.predictor?.nodeSelector,
+});
+
+export type WorkloadHardwareProfileResolverContext = {
+  annotationSources: Array<Record<string, string> | undefined>;
+  inferenceService?: WorkloadInferenceService;
+  hardwareProfileByKey: HardwareProfileByKey;
+  hardwareProfilesForMatching: HardwareProfileKind[];
+  resourceFlavorByName: Map<string, ResourceFlavorKind>;
+  workloadType: QuotaUsageWorkloadType;
+};
+
+const matchProfileFromPodSpec = (
+  hardwareProfiles: HardwareProfileKind[],
+  visibility: HardwareProfileFeatureVisibility[],
+  podSpec: ReturnType<typeof extractWorkloadPodSpecOptions>,
+): HardwareProfileKind | undefined => {
+  const candidates = filterHardwareProfilesByVisibility(hardwareProfiles, visibility);
+  return matchToHardwareProfile(
+    candidates,
+    podSpec.resources,
+    podSpec.tolerations,
+    podSpec.nodeSelector,
+  );
+};
+
+/**
+ * Resolves hardware profile for a Quota usage workload row using the same strategies as Notebooks
+ * (annotation on owner pod template) and Model Serving (annotation on ISVC, else resource match).
+ */
+export const resolveWorkloadHardwareProfileForRow = (
+  workload: WorkloadKind,
+  {
+    annotationSources,
+    inferenceService,
+    hardwareProfileByKey,
+    hardwareProfilesForMatching,
+    resourceFlavorByName,
+    workloadType,
+  }: WorkloadHardwareProfileResolverContext,
+): WorkloadHardwareProfileInfo | undefined => {
+  const configuredProfile = resolveWorkloadHardwareProfileFromAnnotation(
+    annotationSources,
+    hardwareProfileByKey,
+  );
+  if (configuredProfile) {
+    return configuredProfile;
+  }
+
+  const visibility = visibilityForWorkloadType(workloadType);
+
+  if (inferenceService) {
+    const servingMatch = matchProfileFromPodSpec(
+      hardwareProfilesForMatching,
+      visibility,
+      extractInferenceServicePodSpecOptions(inferenceService),
+    );
+    if (servingMatch) {
+      return toProfileInfo(servingMatch);
+    }
+  }
+
+  const workloadMatch = matchProfileFromPodSpec(
+    hardwareProfilesForMatching,
+    visibility,
+    extractWorkloadPodSpecOptions(workload),
+  );
+  if (workloadMatch) {
+    return toProfileInfo(workloadMatch);
+  }
+
+  const flavorProduct = resolveWorkloadHardwareProfile(workload, resourceFlavorByName);
+  if (flavorProduct) {
+    return { displayName: flavorProduct };
+  }
+
+  return undefined;
+};

--- a/packages/gpuaas/src/utils/workloadHardwareProfileResolver.ts
+++ b/packages/gpuaas/src/utils/workloadHardwareProfileResolver.ts
@@ -1,7 +1,6 @@
 import {
   type HardwareProfileKind,
   HardwareProfileFeatureVisibility,
-  type ResourceFlavorKind,
   type WorkloadKind,
 } from '@odh-dashboard/k8s-core';
 import { matchToHardwareProfile } from './matchToHardwareProfile';
@@ -12,7 +11,6 @@ import {
 import {
   getHardwareProfileAcceleratorIdentifier,
   getHardwareProfileDisplayName,
-  resolveWorkloadHardwareProfile,
   resolveWorkloadHardwareProfileFromAnnotation,
   type HardwareProfileByKey,
   type WorkloadHardwareProfileInfo,
@@ -86,7 +84,6 @@ export type WorkloadHardwareProfileResolverContext = {
   inferenceService?: WorkloadInferenceService;
   hardwareProfileByKey: HardwareProfileByKey;
   hardwareProfilesForMatching: HardwareProfileKind[];
-  resourceFlavorByName: Map<string, ResourceFlavorKind>;
   workloadType: QuotaUsageWorkloadType;
 };
 
@@ -115,7 +112,6 @@ export const resolveWorkloadHardwareProfileForRow = (
     inferenceService,
     hardwareProfileByKey,
     hardwareProfilesForMatching,
-    resourceFlavorByName,
     workloadType,
   }: WorkloadHardwareProfileResolverContext,
 ): WorkloadHardwareProfileInfo | undefined => {
@@ -147,11 +143,6 @@ export const resolveWorkloadHardwareProfileForRow = (
   );
   if (workloadMatch) {
     return toProfileInfo(workloadMatch);
-  }
-
-  const flavorProduct = resolveWorkloadHardwareProfile(workload, resourceFlavorByName);
-  if (flavorProduct) {
-    return { displayName: flavorProduct };
   }
 
   return undefined;


### PR DESCRIPTION
## Description

Adds a **Workloads** table to the Infrastructure → Quota usage detail panel when a cluster queue is selected ([RHOAIENG-88168](https://redhat.atlassian.net/browse/RHOAIENG-88168)).

### What changed

https://github.com/user-attachments/assets/01fb6d01-d36f-4ead-bd73-37ae32e55717



- **UI**: Expandable workloads section with sortable/filterable/paginated table (Name, Project, Type, Status, Local queue, Accelerators, Queue position, Priority class, Hardware profile)
- **Data layer**: `KueueNamespaceWorkloadCacheProvider` with scoped namespace fetching (LocalQueue index → base workloads → async enrichment for pods/STS/InferenceServices/HW profiles)
- **Versioned bundle state** (`namespaceBundleState.ts`): generation-tracked enrichment validity; preserves base across CQ switches; clears enrichment on CQ switch/refresh
- **Workload taxonomy**: UXD status/type mapping, Serve pod discovery for KServe predictor pods, hardware profile resolution via annotations + resource matching
- **Refresh model**: Tiered polling — quota hierarchy 30s; workload cache manual; queue positions 30s when workloads section expanded; refresh badge wires hierarchy + workload cache

### Key files

| Area | Files |
|------|-------|
| Cache | `KueueNamespaceWorkloadCacheContext.tsx`, `namespaceBundleState.ts` |
| Rows | `useWorkloadRows.ts`, `clusterQueueWorkloads.ts` |
| UI | `ClusterQueueWorkloadsTable.tsx`, `QuotaUsageWorkloadsCollapsible.tsx` |
| Tests | Unit specs for cache, bundle state, status labels, table; Cypress mocked infra tests |

## How Has This Been Tested?

- `cd packages/gpuaas && npm run test-unit` — cache, workload rows, bundle state, status label, table utils, `clusterQueueWorkloads` specs
- Manual: select cluster queue on Quota usage → expand Workloads → verify Type/HW profile columns → refresh badge → verify data updates
- Cypress mocked: `packages/cypress/tests/mocked/gpuaas/infrastructure.cy.ts`

## Test Impact

- Added unit tests: `KueueNamespaceWorkloadCacheContext`, `namespaceBundleState`, `clusterQueueWorkloadStatusLabelUtils`, `ClusterQueueWorkloadsTable`, `clusterQueueWorkloadsTableUtils`, `workloadHardwareProfileResolver`
- Extended `clusterQueueWorkloads.spec.ts` and `useWorkloadRows.spec.ts`
- Extended Cypress mocked infrastructure tests for workloads table

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our Best Practices (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)

[RHOAIENG-88168]: https://redhat.atlassian.net/browse/RHOAIENG-88168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Workloads section for selected cluster queues in infrastructure views.
  * Workload tables display project, status, queue position, priority, accelerators, and hardware profile details.
  * Added filtering by name, status, priority, and hardware profile, plus sorting and pagination.
  * Added expandable workload details within quota usage panels.
  * Added loading, empty, and error states for workload data.
  * Workload information now refreshes with infrastructure data and improves hardware-profile identification.
  * Renamed the Utilization tab to Accelerator utilization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->