### PR TITLE
fixing pod security issue

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
+++ b/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
@@ -84,6 +84,7 @@ export const runAwsCliInCluster = ({
           envFrom: [{ secretRef: { name: secretName } }],
           securityContext: {
             runAsUser: 1001,
+            runAsGroup: 1001,
             runAsNonRoot: true,
             allowPrivilegeEscalation: false,
             seccompProfile: { type: 'RuntimeDefault' },

--- a/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
+++ b/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
@@ -82,6 +82,13 @@ export const runAwsCliInCluster = ({
           image: AWS_CLI_IMAGE,
           args: awsCliArgs,
           envFrom: [{ secretRef: { name: secretName } }],
+          securityContext: {
+            runAsUser: 1001,
+            runAsNonRoot: true,
+            allowPrivilegeEscalation: false,
+            seccompProfile: { type: 'RuntimeDefault' },
+            capabilities: { drop: ['ALL'] },
+          },
         },
       ],
     },


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-93189

## Description


Fixing issuw where runAwsCliInCluster in s3Cleanup.ts creates a pod via oc run with no securityContext. On clusters where PodSecurity enforces restricted, admission rejects the pod and all Feature Store E2E specs fail in before.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a cluster, running the real Cypress helper against a namespace labelled
  `pod-security.kubernetes.io/enforce=restricted`:

  | | result |
  |---|---|
  | without this change | ✖ 1 failing — `Forbidden: violates PodSecurity "restricted:latest"` |
  | with this change    | ✔ 1 passing (38s) |

  Nothing else differed between the two runs.

## Test Impact

No new tests. The change is to E2E test infrastructure, not to product code
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved security for AWS CLI cleanup tasks by running them as a non-root user.
  - Disabled privilege escalation, applied the default seccomp profile, and dropped Linux capabilities.
  - Enforced consistent user and group settings to reduce unnecessary container privileges and strengthen runtime isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->