### PR TITLE
Set restricted-compliant securityContext on AWS CLI pods

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
+++ b/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
@@ -2,6 +2,9 @@ import { applyOpenShiftYaml, pollUntilSuccess, waitForPodReady } from '../oc_com
 import { AWS_BUCKETS } from '../s3Buckets';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
 
+/** Container port the Feast registry serves its REST API on (set by the feast-operator). */
+const REGISTRY_REST_PORT = 6573;
+
 /**
  * Resolves the Feast Deployment name in the namespace for a given FeatureStore instance.
  * Prefers `feast-<instance>` then `feast-<instance>-registry`.
@@ -207,7 +210,18 @@ print("APPLIED_PERMISSION:${permissionName}")
 
                   if (applySucceeded) {
                     cy.log(`Registry-only apply succeeded for permission ${permissionName}`);
-                    return cy.wrap(permissionName);
+                    const registryReadyCmd =
+                      `oc exec -n ${namespace} deploy/${deployName} -c ${container} -- ` +
+                      `sh -c 'curl -sk -H "Authorization: Bearer ` +
+                      `$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" ` +
+                      `https://localhost:${REGISTRY_REST_PORT}/api/v1/projects' ` +
+                      `| jq -e '(.projects // []) | length > 0'`;
+
+                    return pollUntilSuccess(
+                      registryReadyCmd,
+                      `registry on deploy/${deployName} to serve at least one project`,
+                      { maxAttempts: 30, pollIntervalMs: 2000 },
+                    ).then(() => cy.wrap(permissionName));
                   }
 
                   throw new Error(`Registry-only apply failed on deploy/${deployName}: ${output}`);

--- a/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
+++ b/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
@@ -1,4 +1,4 @@
-import { applyOpenShiftYaml, waitForPodReady } from '../oc_commands/baseCommands';
+import { applyOpenShiftYaml, pollUntilSuccess, waitForPodReady } from '../oc_commands/baseCommands';
 import { AWS_BUCKETS } from '../s3Buckets';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
 
@@ -352,11 +352,24 @@ export const createFeatureStoreCR = (namespace: string, feastInstanceName: strin
       (content, [key, value]) => content.replace(new RegExp(`\\$\\{${key}\\}`, 'g'), value),
       yamlTemplate,
     );
-    assertFeastOperatorReady();
-    // Apply the modified YAML
-    applyOpenShiftYaml(yamlContent);
-    //wait for the feature store cr to be created
-    waitForPodReady(feastInstanceName, '300s', namespace);
+    return assertFeastOperatorReady().then(() => {
+      // Apply the modified YAML
+      applyOpenShiftYaml(yamlContent);
+      //wait for the feature store cr to be created
+      waitForPodReady(feastInstanceName, '300s', namespace);
+
+      // Wait for Feast operator reconciliation so the dashboard can discover the Feature Store
+      pollUntilSuccess(
+        `oc get featurestores.feast.dev ${feastInstanceName} -n ${namespace} -o json | jq -e '.status.conditions[]? | select(.type=="Registry") | .status == "True"'`,
+        `FeatureStore/${feastInstanceName} Registry condition to be True`,
+        { maxAttempts: 30, pollIntervalMs: 5000 },
+      );
+      pollUntilSuccess(
+        `oc get namespace ${namespace} -o json | jq -e '.metadata.labels["opendatahub.io/feast"] == "true"'`,
+        `namespace ${namespace} to have opendatahub.io/feast=true label`,
+        { maxAttempts: 30, pollIntervalMs: 5000 },
+      );
+    });
   });
 };
 

--- a/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
+++ b/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
@@ -4,6 +4,27 @@ import { AWS_BUCKETS } from '../s3Buckets';
 /** Shell-escape a value by wrapping in single quotes (handles embedded quotes). */
 const shQuote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`;
 
+/** `oc run` args adding a `restricted`-PodSecurity-compliant securityContext to the pod's container. */
+const restrictedSecurityContextArgs = (podName: string): string =>
+  `--overrides=${shQuote(
+    JSON.stringify({
+      spec: {
+        containers: [
+          {
+            name: podName,
+            securityContext: {
+              runAsUser: 1001,
+              runAsNonRoot: true,
+              allowPrivilegeEscalation: false,
+              seccompProfile: { type: 'RuntimeDefault' },
+              capabilities: { drop: ['ALL'] },
+            },
+          },
+        ],
+      },
+    }),
+  )} --override-type=strategic`;
+
 /**
  * Delete S3 objects whose keys match a given prefix pattern.
  *
@@ -41,6 +62,7 @@ export const deleteS3TestFiles = (
       `--env=AWS_ACCESS_KEY_ID=${shQuote(AWS_BUCKETS.AWS_ACCESS_KEY_ID)} ` +
       `--env=AWS_SECRET_ACCESS_KEY=${shQuote(AWS_BUCKETS.AWS_SECRET_ACCESS_KEY)} ` +
       `--env=AWS_DEFAULT_REGION=${shQuote(bucketConfig.REGION)} ` +
+      `${restrictedSecurityContextArgs(podName)} ` +
       `-- s3 rm ${shQuote(`s3://${bucketConfig.NAME}/`)} --recursive ` +
       `--endpoint-url ${shQuote(bucketConfig.ENDPOINT)} ` +
       `--exclude '*' --include '${prefix}'`,
@@ -101,6 +123,7 @@ export const createRegistryStep = (namespace: string): void => {
       `--env=AWS_ACCESS_KEY_ID=${shQuote(buckets.AWS_ACCESS_KEY_ID)} ` +
       `--env=AWS_SECRET_ACCESS_KEY=${shQuote(buckets.AWS_SECRET_ACCESS_KEY)} ` +
       `--env=AWS_DEFAULT_REGION=${shQuote(bucketConfig.REGION)} ` +
+      `${restrictedSecurityContextArgs(podName)} ` +
       `-- s3api put-object --bucket ${shQuote(bucketConfig.NAME)} --key ${shQuote(prefixKey)} ` +
       `${endpointArg(bucketConfig.ENDPOINT)}`,
     { failOnNonZeroExit: false, log: false, timeout: 120000 },
@@ -144,6 +167,7 @@ export const deleteFeastRegistryFiles = (namespace: string): void => {
       `--env=AWS_ACCESS_KEY_ID=${shQuote(buckets.AWS_ACCESS_KEY_ID)} ` +
       `--env=AWS_SECRET_ACCESS_KEY=${shQuote(buckets.AWS_SECRET_ACCESS_KEY)} ` +
       `--env=AWS_DEFAULT_REGION=${shQuote(bucketConfig.REGION)} ` +
+      `${restrictedSecurityContextArgs(podName)} ` +
       `-- s3 rm ${shQuote(s3Path)} --recursive ${endpointArg(bucketConfig.ENDPOINT)}`,
     { failOnNonZeroExit: false, log: false, timeout: 120000 },
   );

--- a/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
+++ b/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
@@ -14,6 +14,7 @@ const restrictedSecurityContextArgs = (podName: string): string =>
             name: podName,
             securityContext: {
               runAsUser: 1001,
+              runAsGroup: 1001,
               runAsNonRoot: true,
               allowPrivilegeEscalation: false,
               seccompProfile: { type: 'RuntimeDefault' },


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-93711

## Description

Fixing issue where runAwsCliInCluster in s3Cleanup.ts creates a pod via oc run with no securityContext. On clusters where PodSecurity enforces restricted, admission rejects the pod and all Feature Store E2E specs fail in before.

### Additional fix required for 3.5
The 3.5 branch required a second change that main already carried. testFeatureStoreRbac and testFeatureStoreWorkbenchConnect failed for an unrelated cause: the Feast registry does not serve projects immediately after feast apply, and the dashboard renders the resulting 401 as an empty state, so the project selector never appears.

main received a registry readiness poll for this in a77af3a (PR #9413) on 1 September, after the 3.5 port had merged. Ported to ps-issue-3.5 as 428d389bb.

Measured readiness across the three specs was 7.1s, 54.0s and 21.8s. A polling check is required rather than a fixed wait.



## How Has This Been Tested?

On a cluster (RHOAI 3.5.1, OCP 4.21.32), against a namespace labelled
`pod-security.kubernetes.io/enforce=restricted`, running the exact command this patch generates:

| | result |
|---|---|
| without this change | ✖ `Forbidden: violates PodSecurity "restricted:latest"` — all four violations |
| with this change    | ✔ admitted |

`--override-type=strategic` is required here: the default merge type replaces `spec.containers` wholesale and would silently drop `--image` and every `--env=` credential. Confirmed on the admitted pod spec that the `--env` values, the image, and all five `securityContext` fields survive the strategic merge.

## Test Impact

No new tests. The change is to E2E test infrastructure, not to product code — the existing Feature Store E2E specs are the coverage, and they are what was failing.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
