### PR TITLE
Edit nim pvc subpath

### DIFF
--- a/frontend/src/api/k8s/__tests__/pvcs.spec.ts
+++ b/frontend/src/api/k8s/__tests__/pvcs.spec.ts
@@ -249,6 +249,60 @@ describe('updatePvc', () => {
     });
   });
 
+  it('should update pvc and remove empty context type annotations', async () => {
+    const existingPvc = mockPVCK8sResource({
+      name: 'pvc',
+      namespace: 'namespace',
+      storage: '5Gi',
+      storageClassName: 'standard-csi',
+      displayName: 'Old Storage',
+      annotations: {
+        'dashboard.opendatahub.io/nim-subpath': 'models/foo',
+      },
+    });
+    const storageData: StorageData = {
+      name: 'pvc',
+      size: '5Gi',
+      contextTypeAnnotations: {
+        'dashboard.opendatahub.io/nim-subpath': '',
+      },
+    };
+
+    k8sUpdateResourceMock.mockResolvedValue(existingPvc);
+
+    await updatePvc(storageData, existingPvc, 'namespace');
+
+    const expectedPvc = {
+      ...existingPvc,
+      metadata: {
+        ...existingPvc.metadata,
+        annotations: {
+          'openshift.io/description': '',
+          'openshift.io/display-name': 'pvc',
+        },
+      },
+      spec: {
+        ...existingPvc.spec,
+        resources: {
+          requests: {
+            storage: '5Gi',
+          },
+        },
+      },
+      status: {
+        ...existingPvc.status,
+        phase: 'Pending',
+      },
+    };
+
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
+      model: PVCModel,
+      fetchOptions: { requestInit: {} },
+      queryOptions: { queryParams: {} },
+      resource: expectedPvc,
+    });
+  });
+
   it('should update pvc and add model annotations', async () => {
     const existingPvc = mockPVCK8sResource({
       name: 'pvc',

--- a/frontend/src/api/k8s/pvcs.ts
+++ b/frontend/src/api/k8s/pvcs.ts
@@ -154,13 +154,20 @@ export const updatePvc = (
     pvcResource.metadata.annotations['openshift.io/description'] = undefined;
   }
 
-  if (pvcResource.metadata.annotations) {
+  const { annotations } = pvcResource.metadata;
+  if (annotations) {
     if (!data.modelName) {
-      delete pvcResource.metadata.annotations[PvcModelAnnotation.MODEL_NAME];
+      delete annotations[PvcModelAnnotation.MODEL_NAME];
     }
     if (!data.modelPath) {
-      delete pvcResource.metadata.annotations[PvcModelAnnotation.MODEL_PATH];
+      delete annotations[PvcModelAnnotation.MODEL_PATH];
     }
+
+    Object.entries(data.contextTypeAnnotations ?? {}).forEach(([key, value]) => {
+      if (value === '') {
+        delete annotations[key];
+      }
+    });
   }
   return k8sUpdateResource<PersistentVolumeClaimKind>(
     applyK8sAPIOptions({ model: PVCModel, resource: pvcResource }, opts),

--- a/frontend/src/api/k8s/pvcs.ts
+++ b/frontend/src/api/k8s/pvcs.ts
@@ -37,6 +37,7 @@ export const assemblePvc = (
     accessMode,
     modelName,
     modelPath,
+    contextTypeAnnotations,
   } = data;
   const name = editName || data.k8sName || translateDisplayNameForK8s(pvcName);
 
@@ -45,6 +46,7 @@ export const assemblePvc = (
     ...(description && { 'openshift.io/description': description }),
     ...(modelName && { [PvcModelAnnotation.MODEL_NAME]: modelName }),
     ...(modelPath && { [PvcModelAnnotation.MODEL_PATH]: modelPath }),
+    ...(contextTypeAnnotations || {}),
     ...(additionalAnnotations || {}),
   };
 

--- a/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
@@ -15,6 +15,7 @@ import { useDefaultStorageClass } from '#~/pages/projects/screens/spawner/storag
 import { useCreateStorageObject } from '#~/pages/projects/screens/spawner/storage/utils';
 import { StorageData } from '#~/pages/projects/types';
 import { AccessMode } from '#~/pages/storageClasses/storageEnums';
+import { StorageContextType } from './useStorageContextType';
 
 type CreateStorageObjectData = Pick<
   StorageData,
@@ -33,6 +34,8 @@ export type BaseStorageModalProps = {
   existingData?: CreateStorageObjectData;
   existingPvc?: PersistentVolumeClaimKind;
   onClose: (submitted: boolean) => void;
+  storageContextTypes?: StorageContextType[];
+  storageContextTypesLoaded?: boolean;
 };
 
 const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
@@ -47,6 +50,8 @@ const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
   hasDuplicateName,
   onClose,
   onNameChange,
+  storageContextTypes,
+  storageContextTypesLoaded,
 }) => {
   const [defaultStorageClass] = useDefaultStorageClass();
   const [createData, setCreateData] = useCreateStorageObject(existingPvc, existingData);
@@ -102,6 +107,8 @@ const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
                 hasDuplicateName={hasDuplicateName}
                 disableStorageClassSelect={!!existingPvc}
                 editableK8sName={!existingPvc}
+                storageContextTypes={storageContextTypes}
+                storageContextTypesLoaded={storageContextTypesLoaded}
               />
             </StackItem>
             {children}

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
@@ -24,13 +24,21 @@ import {
 import useClusterStorageFormState from './useClusterStorageFormState';
 import ClusterStorageTable from './ClusterStorageTable';
 import { handleSubmit } from './submitUtils';
+import { StorageContextType } from './useStorageContextType';
 
 type ClusterStorageModalProps = {
   existingPvc?: PersistentVolumeClaimKind;
   onClose: (submit: boolean) => void;
+  storageContextTypes?: StorageContextType[];
+  storageContextTypesLoaded?: boolean;
 };
 
-const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, onClose }) => {
+const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({
+  existingPvc,
+  onClose,
+  storageContextTypes,
+  storageContextTypesLoaded,
+}) => {
   const {
     currentProject,
     notebooks: { data, loaded },
@@ -152,6 +160,8 @@ const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, 
       isValid={isValid}
       onClose={(submitted) => onClose(submitted)}
       existingPvc={existingPvc}
+      storageContextTypes={storageContextTypes}
+      storageContextTypesLoaded={storageContextTypesLoaded}
     >
       <>
         {workbenchEnabled && (

--- a/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
@@ -9,6 +9,7 @@ import DetailsSection from '#~/pages/projects/screens/detail/DetailsSection';
 import { ProjectObjectType, typedEmptyImage } from '#~/concepts/design/utils';
 import StorageTable from './StorageTable';
 import ClusterStorageModal from './ClusterStorageModal';
+import { useStorageContextType } from './useStorageContextType';
 
 const StorageList: React.FC = () => {
   const [isOpen, setOpen] = React.useState(false);
@@ -17,6 +18,8 @@ const StorageList: React.FC = () => {
     pvcs: { data: pvcs, loaded: pvcsLoaded, error: pvcsError, refresh: refreshPvcs },
   } = React.useContext(ProjectDetailsContext);
   const isPvcsEmpty = pvcs.length === 0;
+
+  const [storageContextTypes, storageContextTypesLoaded] = useStorageContextType();
 
   const refresh = () => {
     refreshPvcs();
@@ -72,7 +75,13 @@ const StorageList: React.FC = () => {
         }
       >
         {!isPvcsEmpty ? (
-          <StorageTable pvcs={pvcs} refresh={refresh} onAddPVC={() => setOpen(true)} />
+          <StorageTable
+            pvcs={pvcs}
+            refresh={refresh}
+            onAddPVC={() => setOpen(true)}
+            storageContextTypes={storageContextTypes}
+            storageContextTypesLoaded={storageContextTypesLoaded}
+          />
         ) : null}
       </DetailsSection>
       {isOpen ? (
@@ -83,6 +92,8 @@ const StorageList: React.FC = () => {
               refresh();
             }
           }}
+          storageContextTypes={storageContextTypes}
+          storageContextTypesLoaded={storageContextTypesLoaded}
         />
       ) : null}
     </>

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
@@ -11,21 +11,28 @@ import StorageTableRow from './StorageTableRow';
 import { columns } from './data';
 import { StorageTableData } from './types';
 import ClusterStorageModal from './ClusterStorageModal';
-import { useStorageContextType } from './useStorageContextType';
+import { StorageContextType } from './useStorageContextType';
 import { useClusterStorageConnectedResources } from './useClusterStorageConnectedResources';
 
 type StorageTableProps = {
   pvcs: PersistentVolumeClaimKind[];
   refresh: () => void;
   onAddPVC: () => void;
+  storageContextTypes?: StorageContextType[];
+  storageContextTypesLoaded?: boolean;
 };
 
-const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) => {
+const StorageTable: React.FC<StorageTableProps> = ({
+  pvcs,
+  refresh,
+  onAddPVC,
+  storageContextTypes,
+  storageContextTypesLoaded,
+}) => {
   const [deleteStorage, setDeleteStorage] = React.useState<PersistentVolumeClaimKind | undefined>();
   const [editPVC, setEditPVC] = React.useState<PersistentVolumeClaimKind | undefined>();
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
   const [storageClasses, storageClassesLoaded] = useStorageClasses();
-  const [storageContextTypes, storageContextTypesLoaded] = useStorageContextType();
   const [alertDismissed, setAlertDismissed] = React.useState<boolean>(false);
   const storageTableData: StorageTableData[] = pvcs.map((pvc) => ({
     pvc,
@@ -120,6 +127,8 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
             }
             setEditPVC(undefined);
           }}
+          storageContextTypes={storageContextTypes}
+          storageContextTypesLoaded={storageContextTypesLoaded}
         />
       ) : null}
       {deleteStorage ? (

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -32,7 +32,7 @@ type StorageTableRowProps = {
   rowIndex: number;
   obj: StorageTableData;
   storageContextTypes?: StorageContextType[];
-  storageContextTypesLoaded: boolean;
+  storageContextTypesLoaded?: boolean;
   storageClassesLoaded: boolean;
   showConnectedResources: boolean;
   additionalResourcesLoaded: boolean;

--- a/frontend/src/pages/projects/screens/detail/storage/__tests__/useStorageContextType.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/__tests__/useStorageContextType.spec.ts
@@ -27,7 +27,12 @@ const makeExtension = (
   type: 'app.cluster-storage/storage-context',
   uid: `ext-${title}`,
   pluginName: 'test',
-  properties: { title, description: `${title} desc`, isPVCUsingStorageContextType },
+  properties: {
+    title,
+    description: `${title} desc`,
+    isPVCUsingStorageContextType,
+    PVCStorageContextSettingsFields: { default: () => null },
+  },
 });
 
 const modelPVC = mockPVCK8sResource({

--- a/frontend/src/pages/projects/screens/detail/storage/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/__tests__/utils.spec.ts
@@ -1,0 +1,51 @@
+import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
+import type { StorageData } from '#~/pages/projects/types';
+import { isPvcUpdateRequired } from '#~/pages/projects/screens/detail/storage/utils';
+
+// Baseline StorageData that matches mockPVCK8sResource's defaults so only the
+// field under test differs from the existing PVC.
+const baseStorageData: StorageData = {
+  name: 'Test Storage',
+  description: '',
+  size: '5Gi',
+  storageClassName: 'gp3',
+};
+
+describe('isPvcUpdateRequired', () => {
+  it('should return false when nothing changed', () => {
+    expect(isPvcUpdateRequired(mockPVCK8sResource({}), baseStorageData)).toBe(false);
+  });
+
+  it('should return true when an additional annotation is added', () => {
+    expect(
+      isPvcUpdateRequired(mockPVCK8sResource({}), {
+        ...baseStorageData,
+        contextTypeAnnotations: { 'dashboard.opendatahub.io/nim-subpath': 'models/foo' },
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true when an existing additional annotation value changes', () => {
+    const existingPvc = mockPVCK8sResource({
+      annotations: { 'dashboard.opendatahub.io/nim-subpath': 'models/foo' },
+    });
+    expect(
+      isPvcUpdateRequired(existingPvc, {
+        ...baseStorageData,
+        contextTypeAnnotations: { 'dashboard.opendatahub.io/nim-subpath': 'models/bar' },
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false when the additional annotation matches the existing value', () => {
+    const existingPvc = mockPVCK8sResource({
+      annotations: { 'dashboard.opendatahub.io/nim-subpath': 'models/foo' },
+    });
+    expect(
+      isPvcUpdateRequired(existingPvc, {
+        ...baseStorageData,
+        contextTypeAnnotations: { 'dashboard.opendatahub.io/nim-subpath': 'models/foo' },
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/pages/projects/screens/detail/storage/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/__tests__/utils.spec.ts
@@ -37,6 +37,18 @@ describe('isPvcUpdateRequired', () => {
     ).toBe(true);
   });
 
+  it('should return true when an additional annotation is removed', () => {
+    const existingPvc = mockPVCK8sResource({
+      annotations: { 'dashboard.opendatahub.io/nim-subpath': 'models/foo' },
+    });
+    expect(
+      isPvcUpdateRequired(existingPvc, {
+        ...baseStorageData,
+        contextTypeAnnotations: { 'dashboard.opendatahub.io/nim-subpath': '' },
+      }),
+    ).toBe(true);
+  });
+
   it('should return false when the additional annotation matches the existing value', () => {
     const existingPvc = mockPVCK8sResource({
       annotations: { 'dashboard.opendatahub.io/nim-subpath': 'models/foo' },

--- a/frontend/src/pages/projects/screens/detail/storage/data.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/data.ts
@@ -6,7 +6,7 @@ import { StorageTableData } from './types';
 import { getContextStorageTypeExplanation, StorageContextType } from './useStorageContextType';
 
 export const columns = (data: {
-  storageContextTypes: StorageContextType[];
+  storageContextTypes?: StorageContextType[];
 }): SortableData<StorageTableData>[] => [
   {
     field: 'name',
@@ -48,7 +48,7 @@ export const columns = (data: {
     width: 15,
     sortable: false,
     info: {
-      popover: getContextStorageTypeExplanation(data.storageContextTypes),
+      popover: getContextStorageTypeExplanation(data.storageContextTypes ?? []),
       popoverProps: {
         showClose: true,
       },

--- a/frontend/src/pages/projects/screens/detail/storage/useStorageContextType.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/useStorageContextType.tsx
@@ -73,6 +73,8 @@ export const getPVCContextStorageType = (
 };
 
 export const getContextStorageTypeExplanation = (types: StorageContextType[]): string =>
-  `The context indicates the purpose of the storage: ${new Intl.ListFormat('en', {
-    type: 'disjunction',
-  }).format(types.map((value) => value.title.toLocaleLowerCase()))}.`;
+  types.length > 0
+    ? `The context indicates the purpose of the storage: ${new Intl.ListFormat('en', {
+        type: 'disjunction',
+      }).format(types.map((value) => value.title.toLocaleLowerCase()))}.`
+    : 'The context indicates the purpose of the storage.';

--- a/frontend/src/pages/projects/screens/detail/storage/useStorageContextType.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/useStorageContextType.tsx
@@ -5,12 +5,14 @@ import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import {
   ClusterStorageContextExtension,
   isClusterStorageContextExtension,
+  PVCStorageContextSettingsFieldsProps,
 } from '@odh-dashboard/plugin-core/extension-points';
 import { isModelStorage } from './utils';
 
 export type StorageContextType = {
   title: string;
   description?: string;
+  fields?: React.ComponentType<PVCStorageContextSettingsFieldsProps>;
 } & EitherNotBoth<
   { isPVCUsingStorageContextType: (pvc: PersistentVolumeClaimKind) => boolean },
   { isDefaultType: boolean }
@@ -46,6 +48,7 @@ export const useStorageContextType = (): [
             title: properties.title,
             description: properties.description,
             isPVCUsingStorageContextType: properties.isPVCUsingStorageContextType,
+            fields: properties.PVCStorageContextSettingsFields.default,
           }),
         )
         .toSorted((a, b) => a.title.localeCompare(b.title)),

--- a/frontend/src/pages/projects/screens/detail/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/utils.ts
@@ -35,6 +35,9 @@ export const isPvcUpdateRequired = (
     (existingAnnotations[PvcModelAnnotation.MODEL_NAME] || '') !== (storageData.modelName || '');
   const modelPathChanged =
     (existingAnnotations[PvcModelAnnotation.MODEL_PATH] || '') !== (storageData.modelPath || '');
+  const contextTypeAnnotationsChanged = Object.entries(
+    storageData.contextTypeAnnotations ?? {},
+  ).some(([key, value]) => (existingAnnotations[key] || '') !== (value || ''));
 
   return (
     getDisplayNameFromK8sResource(existingPvc) !== storageData.name ||
@@ -42,7 +45,8 @@ export const isPvcUpdateRequired = (
     existingPvc.spec.resources.requests.storage !== storageData.size ||
     existingPvc.spec.storageClassName !== storageData.storageClassName ||
     modelNameChanged ||
-    modelPathChanged
+    modelPathChanged ||
+    contextTypeAnnotationsChanged
   );
 };
 

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -14,7 +14,7 @@ import { StorageContextType } from '#~/pages/projects/screens/detail/storage/use
 import StorageClassSelect from './StorageClassSelect';
 import AccessModeField from './AccessModeField';
 import { useGetStorageClassConfig } from './useGetStorageClassConfig';
-import PVCContextField from './PVCContextField';
+import PVCContextField, { PVCContextFieldSkeleton } from './PVCContextField';
 
 type CreateNewStorageSectionProps<D extends StorageData> = {
   data: D;
@@ -42,6 +42,8 @@ const CreateNewStorageSection = <D extends StorageData>({
   setValid,
   hasDuplicateName,
   editableK8sName,
+  storageContextTypes,
+  storageContextTypesLoaded,
 }: CreateNewStorageSectionProps<D>): React.ReactNode => {
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
   const { data: clusterStorageNameDesc, onDataChange: setClusterNameDesc } =
@@ -127,14 +129,23 @@ const CreateNewStorageSection = <D extends StorageData>({
           />
         </>
       )}
-      <PVCContextField
-        modelName={data.modelName || ''}
-        modelPath={data.modelPath || ''}
-        setModelName={(name) => setData('modelName', name)}
-        setModelPath={(path) => setData('modelPath', path)}
-        setValid={setIsValidModelPath}
-        removeModelAnnotations={removeModelAnnotations}
-      />
+      {isContextTypeLoaded ? (
+        <PVCContextField
+          modelName={data.modelName || ''}
+          modelPath={data.modelPath || ''}
+          setModelName={(name) => setData('modelName', name)}
+          setModelPath={(path) => setData('modelPath', path)}
+          setValid={setIsValidModelPath}
+          removeModelAnnotations={removeModelAnnotations}
+          existingPvc={data.existingPvc}
+          storageContextTypes={storageContextTypes}
+          setContextTypeAnnotations={(annotations) =>
+            setData('contextTypeAnnotations', annotations)
+          }
+        />
+      ) : (
+        <PVCContextFieldSkeleton />
+      )}
 
       <PVSizeField
         fieldID="create-new-storage-size"

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -10,6 +10,7 @@ import K8sNameDescriptionField, {
 import type { UpdateObjectAtPropAndValue } from '@odh-dashboard/ui-core';
 import { StorageData } from '#~/pages/projects/types';
 import PVSizeField from '#~/pages/projects/components/PVSizeField';
+import { StorageContextType } from '#~/pages/projects/screens/detail/storage/useStorageContextType';
 import StorageClassSelect from './StorageClassSelect';
 import AccessModeField from './AccessModeField';
 import { useGetStorageClassConfig } from './useGetStorageClassConfig';
@@ -26,6 +27,8 @@ type CreateNewStorageSectionProps<D extends StorageData> = {
   setValid?: (isValid: boolean) => void;
   hasDuplicateName?: boolean;
   editableK8sName?: boolean;
+  storageContextTypes?: StorageContextType[];
+  storageContextTypesLoaded?: boolean;
 };
 
 const CreateNewStorageSection = <D extends StorageData>({
@@ -74,6 +77,10 @@ const CreateNewStorageSection = <D extends StorageData>({
     // only update if the name description changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clusterStorageNameDesc, isValidModelPath]);
+
+  // Not all consumers of this modal load extensions for dynamic context types (workbenches)
+  const isContextTypeLoaded =
+    storageContextTypes === undefined || storageContextTypesLoaded === true;
 
   return (
     <FormSection>

--- a/frontend/src/pages/projects/screens/spawner/storage/PVCContextField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/PVCContextField.tsx
@@ -6,13 +6,23 @@ import {
   HelperText,
   HelperTextItem,
   Radio,
+  Skeleton,
   TextInput,
 } from '@patternfly/react-core';
+import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import FieldGroupHelpLabelIcon from '@odh-dashboard/ui-core/components/FieldGroupHelpLabelIcon';
 import {
   GENERAL_PURPOSE_PVC_CONTEXT_TYPE,
+  getPVCContextStorageType,
   MODEL_STORAGE_PVC_CONTEXT_TYPE,
+  StorageContextType,
 } from '#~/pages/projects/screens/detail/storage/useStorageContextType';
+
+export const PVCContextFieldSkeleton: React.FC = () => (
+  <FormGroup label="Storage context" fieldId="storage-context">
+    <Skeleton height="80px" screenreaderText="Loading storage context options" />
+  </FormGroup>
+);
 
 type PVCContextFieldProps = {
   setModelName: (name: string) => void;
@@ -21,6 +31,9 @@ type PVCContextFieldProps = {
   modelPath: string;
   setValid: (isValid: boolean) => void;
   removeModelAnnotations: () => void;
+  existingPvc?: PersistentVolumeClaimKind;
+  storageContextTypes?: StorageContextType[];
+  setContextTypeAnnotations: (annotations: Record<string, string>) => void;
 };
 
 const PVCContextField: React.FC<PVCContextFieldProps> = ({
@@ -30,121 +43,163 @@ const PVCContextField: React.FC<PVCContextFieldProps> = ({
   modelPath,
   setValid,
   removeModelAnnotations,
+  existingPvc,
+  storageContextTypes,
+  setContextTypeAnnotations,
 }) => {
-  const [isGeneralPurpose, setIsGeneralPurpose] = useState(!modelName && !modelPath);
+  const [contextType, setContextType] = useState<StorageContextType>(() =>
+    existingPvc
+      ? getPVCContextStorageType(existingPvc, storageContextTypes)
+      : GENERAL_PURPOSE_PVC_CONTEXT_TYPE,
+  );
+
+  // Scope limitation: extension-provided context types (which use `fields`) only support editing and cannot change.
+  const existingExtensionContextType = existingPvc
+    ? storageContextTypes?.find(
+        (type) => type.fields && type.isPVCUsingStorageContextType?.(existingPvc),
+      )
+    : undefined;
+  const isLocked = !!(existingExtensionContextType && existingPvc);
 
   const validatePath = (path: string) => {
     const trimmedPath = path.trim();
     const pathRegex = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*\/?$/;
-    if (isGeneralPurpose || (trimmedPath && pathRegex.test(trimmedPath))) {
+    if (
+      contextType.title === GENERAL_PURPOSE_PVC_CONTEXT_TYPE.title ||
+      (trimmedPath && pathRegex.test(trimmedPath))
+    ) {
       setValid(true);
     } else {
       setValid(false);
     }
   };
 
+  const SettingsFields = existingExtensionContextType?.fields;
+
   return (
-    <>
-      <FormGroup
-        label="Storage context"
-        fieldId="storage-context"
-        labelHelp={
-          <FieldGroupHelpLabelIcon
-            content={
-              <p>
-                The context indicates the purpose of the storage: general purpose, or model storage.
-              </p>
-            }
-          />
-        }
-      >
-        <Radio
-          value="general-purpose"
-          name="storage-context-general-radio"
-          id="storage-context-general-radio"
-          data-testid="general-purpose-radio"
-          label={GENERAL_PURPOSE_PVC_CONTEXT_TYPE.title}
-          isChecked={isGeneralPurpose}
-          onChange={() => {
-            setIsGeneralPurpose(true);
-            setValid(true);
-            removeModelAnnotations();
-          }}
-          description={GENERAL_PURPOSE_PVC_CONTEXT_TYPE.description}
-        />
-        <br />
-        <Radio
-          value="model-storage"
-          name="storage-context-model-storage-radio"
-          id="storage-context-model-storage-radio"
-          data-testid="model-storage-radio"
-          label={MODEL_STORAGE_PVC_CONTEXT_TYPE.title}
-          isChecked={!isGeneralPurpose}
-          onChange={() => {
-            setIsGeneralPurpose(false);
-            if (!modelPath.trim()) {
-              setValid(false);
-            } else {
-              validatePath(modelPath);
-            }
-          }}
-          description={MODEL_STORAGE_PVC_CONTEXT_TYPE.description}
-          body={
-            !isGeneralPurpose && (
-              <FormSection title="Model details">
-                <FormGroup
-                  label="Model path"
-                  fieldId="storage-context-model-storage-model-path"
-                  isRequired
-                  labelHelp={
-                    <FieldGroupHelpLabelIcon
-                      content={
-                        <p>Enter the path to the model location within the cluster storage.</p>
-                      }
-                    />
-                  }
-                >
-                  <TextInput
-                    id="storage-context-model-storage-model-path"
-                    aria-label="Model path"
-                    data-testid="model-path-input"
-                    value={modelPath}
-                    onChange={(_, value) => {
-                      setModelPath(value.trim());
-                      validatePath(value);
-                    }}
-                    isRequired
-                  />
-                  <FormHelperText>
-                    <HelperText>
-                      <HelperTextItem>
-                        Enter a path to your model or a folder containing your model. The path
-                        cannot point to a root folder.
-                      </HelperTextItem>
-                    </HelperText>
-                  </FormHelperText>
-                </FormGroup>
-                <FormGroup
-                  label="Model name"
-                  fieldId="storage-context-model-storage-model-name"
-                  labelHelp={
-                    <FieldGroupHelpLabelIcon content={<p>Enter the name of the model.</p>} />
-                  }
-                >
-                  <TextInput
-                    id="storage-context-model-storage-model-name"
-                    aria-label="Model name"
-                    data-testid="model-name-input"
-                    value={modelName}
-                    onChange={(_, value) => setModelName(value.trim())}
-                  />
-                </FormGroup>
-              </FormSection>
-            )
+    <FormGroup
+      label="Storage context"
+      fieldId="storage-context"
+      labelHelp={
+        <FieldGroupHelpLabelIcon
+          content={
+            <p>
+              {isLocked
+                ? 'The context indicates the purpose of the storage. It cannot be changed.'
+                : 'The context indicates the purpose of the storage: general purpose, or model storage.'}
+            </p>
           }
         />
-      </FormGroup>
-    </>
+      }
+    >
+      <Radio
+        value="general-purpose"
+        name="storage-context-general-radio"
+        id="storage-context-general-radio"
+        data-testid="general-purpose-radio"
+        label={GENERAL_PURPOSE_PVC_CONTEXT_TYPE.title}
+        description={GENERAL_PURPOSE_PVC_CONTEXT_TYPE.description}
+        isChecked={contextType.title === GENERAL_PURPOSE_PVC_CONTEXT_TYPE.title}
+        isDisabled={isLocked}
+        onChange={() => {
+          setContextType(GENERAL_PURPOSE_PVC_CONTEXT_TYPE);
+          setValid(true);
+          removeModelAnnotations();
+        }}
+      />
+      <br />
+      <Radio
+        value="model-storage"
+        name="storage-context-model-storage-radio"
+        id="storage-context-model-storage-radio"
+        data-testid="model-storage-radio"
+        label={MODEL_STORAGE_PVC_CONTEXT_TYPE.title}
+        description={MODEL_STORAGE_PVC_CONTEXT_TYPE.description}
+        isChecked={contextType.title === MODEL_STORAGE_PVC_CONTEXT_TYPE.title}
+        isDisabled={isLocked}
+        onChange={() => {
+          setContextType(MODEL_STORAGE_PVC_CONTEXT_TYPE);
+          if (!modelPath.trim()) {
+            setValid(false);
+          } else {
+            validatePath(modelPath);
+          }
+        }}
+        body={
+          contextType.title === MODEL_STORAGE_PVC_CONTEXT_TYPE.title && (
+            <FormSection title="Model details">
+              <FormGroup
+                label="Model path"
+                fieldId="storage-context-model-storage-model-path"
+                isRequired
+                labelHelp={
+                  <FieldGroupHelpLabelIcon
+                    content={
+                      <p>Enter the path to the model location within the cluster storage.</p>
+                    }
+                  />
+                }
+              >
+                <TextInput
+                  id="storage-context-model-storage-model-path"
+                  aria-label="Model path"
+                  data-testid="model-path-input"
+                  value={modelPath}
+                  onChange={(_, value) => {
+                    setModelPath(value.trim());
+                    validatePath(value);
+                  }}
+                  isRequired
+                />
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem>
+                      Enter a path to your model or a folder containing your model. The path cannot
+                      point to a root folder.
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              </FormGroup>
+              <FormGroup
+                label="Model name"
+                fieldId="storage-context-model-storage-model-name"
+                labelHelp={
+                  <FieldGroupHelpLabelIcon content={<p>Enter the name of the model.</p>} />
+                }
+              >
+                <TextInput
+                  id="storage-context-model-storage-model-name"
+                  aria-label="Model name"
+                  data-testid="model-name-input"
+                  value={modelName}
+                  onChange={(_, value) => setModelName(value.trim())}
+                />
+              </FormGroup>
+            </FormSection>
+          )
+        }
+      />
+      {existingExtensionContextType && existingPvc ? (
+        <>
+          <br />
+          <Radio
+            value="extension-context"
+            name="storage-context-extension-radio"
+            id="storage-context-extension-radio"
+            data-testid="extension-context-radio"
+            label={existingExtensionContextType.title}
+            description={existingExtensionContextType.description}
+            isChecked={contextType.title === existingExtensionContextType.title}
+            isDisabled
+            body={
+              SettingsFields ? (
+                <SettingsFields existingPvc={existingPvc} onChange={setContextTypeAnnotations} />
+              ) : null
+            }
+          />
+        </>
+      ) : null}
+    </FormGroup>
   );
 };
 

--- a/frontend/src/pages/projects/screens/spawner/storage/PVCContextField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/PVCContextField.tsx
@@ -13,6 +13,7 @@ import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import FieldGroupHelpLabelIcon from '@odh-dashboard/ui-core/components/FieldGroupHelpLabelIcon';
 import {
   GENERAL_PURPOSE_PVC_CONTEXT_TYPE,
+  getContextStorageTypeExplanation,
   getPVCContextStorageType,
   MODEL_STORAGE_PVC_CONTEXT_TYPE,
   StorageContextType,
@@ -86,7 +87,12 @@ const PVCContextField: React.FC<PVCContextFieldProps> = ({
             <p>
               {isLocked
                 ? 'The context indicates the purpose of the storage. It cannot be changed.'
-                : 'The context indicates the purpose of the storage: general purpose, or model storage.'}
+                : getContextStorageTypeExplanation(
+                    storageContextTypes || [
+                      GENERAL_PURPOSE_PVC_CONTEXT_TYPE,
+                      MODEL_STORAGE_PVC_CONTEXT_TYPE,
+                    ],
+                  )}
             </p>
           }
         />

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -78,6 +78,7 @@ export type StorageData = {
   id?: number;
   modelName?: string;
   modelPath?: string;
+  contextTypeAnnotations?: Record<string, string>;
 };
 
 export type SecretKeyRefEnvVar = {

--- a/packages/cypress/cypress/pages/clusterStorage.ts
+++ b/packages/cypress/cypress/pages/clusterStorage.ts
@@ -233,6 +233,10 @@ class ClusterStorageModal extends Modal {
     return this.find().findByTestId('model-path-input');
   }
 
+  findNimSubpathInput() {
+    return this.find().findByTestId('nim-subpath-input');
+  }
+
   findGeneralPurposeRadio() {
     return this.find().findByTestId('general-purpose-radio');
   }

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -30,7 +30,10 @@ import {
   modelServingWizard,
   modelServingWizardEdit,
 } from '@odh-dashboard/cypress/cypress/pages/modelServing';
-import { clusterStorage } from '@odh-dashboard/cypress/cypress/pages/clusterStorage';
+import {
+  clusterStorage,
+  updateClusterStorageModal,
+} from '@odh-dashboard/cypress/cypress/pages/clusterStorage';
 import {
   ModelLocationSelectOption,
   ModelTypeLabel,
@@ -539,6 +542,9 @@ describe('NIM Models Deployments', () => {
         mockNimModelPVC({
           displayName: 'NIM Cache',
           name: 'nim-cache',
+          annotations: {
+            'dashboard.opendatahub.io/nim-subpath': 'arctic-embed-l',
+          },
         }),
       ]),
     );
@@ -562,6 +568,26 @@ describe('NIM Models Deployments', () => {
       .findConnectedResources()
       .should('contain.text', 'Test Name');
 
-    // TODO followup PR: can edit and update subpath
+    const storageRow = clusterStorage.getClusterStorageRow('NIM Cache');
+    storageRow.findKebabAction('Edit storage').click();
+    updateClusterStorageModal.findNimSubpathInput().should('have.value', 'arctic-embed-l');
+    updateClusterStorageModal.findNimSubpathInput().fill('new-model-path');
+
+    cy.interceptK8s('PUT', PVCModel, mockNimModelPVC({ name: 'nim-cache' })).as('updateNimStorage');
+    updateClusterStorageModal.findSubmitButton().click();
+
+    cy.wait('@updateNimStorage').then((interception) => {
+      expect(interception.request.url).to.include('?dryRun=All');
+      expect(interception.request.body).to.containSubset({
+        metadata: {
+          annotations: {
+            'dashboard.opendatahub.io/nim-pvc': 'true',
+            'dashboard.opendatahub.io/nim-subpath': 'new-model-path',
+          },
+          name: 'nim-cache',
+          namespace: 'test-project',
+        },
+      });
+    });
   });
 });

--- a/packages/nim-serving/extensions/cluster-storage.ts
+++ b/packages/nim-serving/extensions/cluster-storage.ts
@@ -11,6 +11,7 @@ const extensions: ClusterStorageContextExtension[] = [
         'Appropriate for caching NIM models. Enables you to define a subpath for the NIM image.',
       isPVCUsingStorageContextType: () =>
         import('../src/pages/clusterStorage/clusterStorage').then((m) => m.isNIMPVC),
+      PVCStorageContextSettingsFields: () => import('../src/pages/clusterStorage/clusterStorage'),
     },
     flags: {
       required: [SupportedArea.NIM_MODEL],

--- a/packages/nim-serving/src/pages/clusterStorage/__tests__/clusterStorage.spec.tsx
+++ b/packages/nim-serving/src/pages/clusterStorage/__tests__/clusterStorage.spec.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
+import Fields, {
+  isNIMPVC,
+  NIM_PVC_ANNOTATION,
+  NIM_PVC_SUBPATH_ANNOTATION,
+} from '../clusterStorage';
+
+describe('isNIMPVC', () => {
+  it('should identify a PVC with the NIM annotation', () => {
+    const pvc = mockPVCK8sResource({ annotations: { [NIM_PVC_ANNOTATION]: 'true' } });
+
+    expect(isNIMPVC(pvc)).toBe(true);
+  });
+
+  it('should reject a PVC without the NIM annotation', () => {
+    expect(isNIMPVC(mockPVCK8sResource({}))).toBe(false);
+  });
+});
+
+describe('NIM storage fields', () => {
+  it('should load and report the PVC subpath', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const pvc = mockPVCK8sResource({
+      annotations: {
+        [NIM_PVC_ANNOTATION]: 'true',
+        [NIM_PVC_SUBPATH_ANNOTATION]: 'arctic-embed-l',
+      },
+    });
+
+    render(<Fields existingPvc={pvc} onChange={onChange} />);
+
+    const input = screen.getByTestId('nim-subpath-input');
+    expect(input).toHaveValue('arctic-embed-l');
+
+    await user.clear(input);
+    await user.type(input, 'new-model-path');
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      [NIM_PVC_SUBPATH_ANNOTATION]: 'new-model-path',
+    });
+  });
+});

--- a/packages/nim-serving/src/pages/clusterStorage/__tests__/clusterStorage.spec.tsx
+++ b/packages/nim-serving/src/pages/clusterStorage/__tests__/clusterStorage.spec.tsx
@@ -38,6 +38,9 @@ describe('NIM storage fields', () => {
     expect(input).toHaveValue('arctic-embed-l');
 
     await user.clear(input);
+    expect(onChange).toHaveBeenLastCalledWith({
+      [NIM_PVC_SUBPATH_ANNOTATION]: '',
+    });
     await user.type(input, 'new-model-path');
 
     expect(onChange).toHaveBeenLastCalledWith({

--- a/packages/nim-serving/src/pages/clusterStorage/clusterStorage.ts
+++ b/packages/nim-serving/src/pages/clusterStorage/clusterStorage.ts
@@ -1,7 +1,0 @@
-import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
-
-export const NIM_PVC_ANNOTATION = 'dashboard.opendatahub.io/nim-pvc';
-export const NIM_PVC_SUBPATH_ANNOTATION = 'dashboard.opendatahub.io/nim-subpath';
-
-export const isNIMPVC = (pvc: PersistentVolumeClaimKind): boolean =>
-  !!pvc.metadata.annotations && Object.hasOwn(pvc.metadata.annotations, NIM_PVC_ANNOTATION);

--- a/packages/nim-serving/src/pages/clusterStorage/clusterStorage.tsx
+++ b/packages/nim-serving/src/pages/clusterStorage/clusterStorage.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+  FormGroup,
+  FormSection,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+} from '@patternfly/react-core';
+import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
+import type { PVCStorageContextSettingsFieldsProps } from '@odh-dashboard/plugin-core/extension-points';
+
+export const NIM_PVC_ANNOTATION = 'dashboard.opendatahub.io/nim-pvc';
+export const NIM_PVC_SUBPATH_ANNOTATION = 'dashboard.opendatahub.io/nim-subpath';
+
+export const isNIMPVC = (pvc: PersistentVolumeClaimKind): boolean =>
+  !!pvc.metadata.annotations && Object.hasOwn(pvc.metadata.annotations, NIM_PVC_ANNOTATION);
+
+const Fields: React.FC<PVCStorageContextSettingsFieldsProps> = ({ existingPvc, onChange }) => {
+  const [subPath, setSubPath] = React.useState(
+    existingPvc.metadata.annotations?.[NIM_PVC_SUBPATH_ANNOTATION] ?? '',
+  );
+
+  return (
+    <FormSection title="NIM details">
+      <FormGroup label="Subpath" fieldId="nim-subpath">
+        <TextInput
+          id="nim-subpath"
+          data-testid="nim-subpath-input"
+          value={subPath}
+          onChange={(_event, value) => {
+            setSubPath(value);
+            onChange({ [NIM_PVC_SUBPATH_ANNOTATION]: value });
+          }}
+          placeholder="/"
+        />
+        <HelperText>
+          <HelperTextItem>
+            Optional: Subdirectory within the PVC. Use this if you have multiple models stored in
+            the same PVC. Leave blank to use the root of the PVC.
+          </HelperTextItem>
+        </HelperText>
+      </FormGroup>
+    </FormSection>
+  );
+};
+
+export default Fields;

--- a/packages/nim-serving/src/pages/clusterStorage/clusterStorage.tsx
+++ b/packages/nim-serving/src/pages/clusterStorage/clusterStorage.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
-import {
-  FormGroup,
-  FormSection,
-  HelperText,
-  HelperTextItem,
-  TextInput,
-} from '@patternfly/react-core';
+import { FormSection } from '@patternfly/react-core';
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import type { PVCStorageContextSettingsFieldsProps } from '@odh-dashboard/plugin-core/extension-points';
+import { SubPathField } from '../deploymentWizard/fields/NIMPVCField';
 
 export const NIM_PVC_ANNOTATION = 'dashboard.opendatahub.io/nim-pvc';
 export const NIM_PVC_SUBPATH_ANNOTATION = 'dashboard.opendatahub.io/nim-subpath';
@@ -22,24 +17,17 @@ const Fields: React.FC<PVCStorageContextSettingsFieldsProps> = ({ existingPvc, o
 
   return (
     <FormSection title="NIM details">
-      <FormGroup label="Subpath" fieldId="nim-subpath">
-        <TextInput
-          id="nim-subpath"
-          data-testid="nim-subpath-input"
-          value={subPath}
-          onChange={(_event, value) => {
-            setSubPath(value);
-            onChange({ [NIM_PVC_SUBPATH_ANNOTATION]: value });
-          }}
-          placeholder="/"
-        />
-        <HelperText>
-          <HelperTextItem>
-            Optional: Subdirectory within the PVC. Use this if you have multiple models stored in
-            the same PVC. Leave blank to use the root of the PVC.
-          </HelperTextItem>
-        </HelperText>
-      </FormGroup>
+      <SubPathField
+        subPath={subPath}
+        onSubPathChange={(val: string) => {
+          setSubPath(val);
+          if (!val) {
+            onChange({ [NIM_PVC_SUBPATH_ANNOTATION]: '' });
+          } else {
+            onChange({ [NIM_PVC_SUBPATH_ANNOTATION]: val });
+          }
+        }}
+      />
     </FormSection>
   );
 };

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -165,7 +165,11 @@ type SubPathFieldProps = {
   isDisabled?: boolean;
 };
 
-const SubPathField: React.FC<SubPathFieldProps> = ({ subPath, onSubPathChange, isDisabled }) => (
+export const SubPathField: React.FC<SubPathFieldProps> = ({
+  subPath,
+  onSubPathChange,
+  isDisabled,
+}) => (
   <FormGroup label="Subpath" fieldId="nim-subpath">
     <TextInput
       id="nim-subpath"

--- a/packages/plugin-core/src/extension-points/cluster-storage.ts
+++ b/packages/plugin-core/src/extension-points/cluster-storage.ts
@@ -2,6 +2,17 @@ import type { PersistentVolumeClaimKind, ProjectKind } from '@odh-dashboard/k8s-
 import type { CodeRef, Extension } from '@openshift/dynamic-plugin-sdk';
 // eslint-disable-next-line no-restricted-syntax
 import { createExtensionGuard } from './utils';
+import type { ComponentCodeRef } from '../core';
+
+/**
+ * Props passed to a storage context's settings fields when editing an existing PVC of that type.
+ * The component reads its initial values from `existingPvc` (it owns its annotation keys) and
+ * reports the annotations to persist back to the host via `onChange`.
+ */
+export type PVCStorageContextSettingsFieldsProps = {
+  existingPvc: PersistentVolumeClaimKind;
+  onChange: (annotations: Record<string, string>) => void;
+};
 
 export type ClusterStorageContextProperties = {
   /** Display name of the storage context, shown in the storage table and the PVC form. */
@@ -10,6 +21,8 @@ export type ClusterStorageContextProperties = {
   description?: string;
   /** Returns `true` when the given PVC belongs to this storage context. */
   isPVCUsingStorageContextType: CodeRef<(pvc: PersistentVolumeClaimKind) => boolean>;
+  /** Settings fields shown when editing an existing PVC of this context type. */
+  PVCStorageContextSettingsFields: ComponentCodeRef<PVCStorageContextSettingsFieldsProps>;
 };
 
 /**


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-88011

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is a PR to support managing existing NIM PVCs without too much scope creep. It adds the "NIM Storage" radio option when editing a NIM PVC in the 'cluster storage' tab. 
- For simplicity, you can't change the context type
- You also can't create a new NIM storage, they only show up from being created in the wizard. 
- The extension is limited to only update annotations, which is fine since all context types just add different annotations

Note: There are 2 states. First is the PVC data object, 2nd is the the useState in the field. On initial render, technically the PVC data object doesn't have any value for the contextTypeAnnotations, instead the field state inits it by reading the existingPvc object directly. On save, if you didn't change anything, the value still remains even though the save function using the PVC data object, this is because it using _.merge with the old object, so the existing pvc annotations remains

<img width="447" height="539" alt="Screenshot 2026-09-09 at 2 02 51 PM" src="https://github.com/user-attachments/assets/e36481ea-f2e6-467e-bdd3-4d961f9d7f66" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**Regression checks**
1. Create a new PVC, the NIM option shouldn't show
2. Edit a General purpose PVC, the NIM option shouldn't show
3. Edit a model storage PVC, it too shouldn't show

**NIM flow**
1. Deploy a new NIM model, create a new storage
2. Go to the "Cluster storage" tab and edit it
3. You should be able to see the NIM radio option selected, and show the subpath of the PVC
4. Change the subpath, hit save. Verify the change persisted and the annotation is updated
5. If you create a new NIM model, and use that PVC, it should auto-populate the subpath with the new value.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
The cypress manage nim pvcs test has been expanded to assert the changing of the subpath and that it persists on save
I also added some simple jest unit tests for the field that is rendered and the isNIMPVC helper function.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
cc @justinxhale

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for storage context types when creating and editing persistent storage.
  - Extension-based storage settings now display read-only selections with extension-specific configuration fields.
  - Added loading placeholders while storage context options are retrieved.
  - NIM storage now supports editing its model subpath.

- **Bug Fixes**
  - Storage context annotations are preserved and updated when storage configurations change.
  - PVC update detection now recognizes added, removed, or changed context annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->