### PR TITLE
fix(playground): address agent profile UX debt

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -79,7 +79,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
             {!isCompareMode && (
               <ToolbarItem>
                 {profileApplied ? (
-                  <Tooltip content="Comparison mode is not available when an agent is loaded.">
+                  <Tooltip content="Side-by-side chat comparison isn't available for saved agents.">
                     <Button
                       variant="link"
                       aria-label="Compare chat (disabled)"

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ChatbotHeaderActions from '~/app/Chatbot/ChatbotHeaderActions';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
@@ -132,6 +132,34 @@ describe('ChatbotHeaderActions', () => {
 
       const button = screen.getByTestId('compare-chat-button');
       expect(button).toHaveAttribute('aria-label', 'Compare chat');
+    });
+
+    it('shows the saved agent comparison limitation tooltip', async () => {
+      mockUseChatbotConfigStore.mockImplementation((selector: unknown) => {
+        if (typeof selector === 'function') {
+          return selector({
+            configurations: { default: { selectedModel: 'test-model' } },
+            configIds: ['default'],
+            profileApplied: true,
+          });
+        }
+        return undefined;
+      });
+
+      const user = userEvent.setup();
+      render(
+        <TestWrapper contextValue={createContextValue()}>
+          <ChatbotHeaderActions {...defaultProps} isCompareMode={false} />
+        </TestWrapper>,
+      );
+
+      await user.hover(screen.getByTestId('compare-chat-button'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Side-by-side chat comparison isn't available for saved agents."),
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotPaneHeader.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotPaneHeader.tsx
@@ -62,175 +62,184 @@ const ChatbotPaneHeader: React.FC<ChatbotPaneHeaderProps> = ({
   }
 
   return (
-    <div
-      style={{
-        backgroundColor: isDarkMode
-          ? 'var(--pf-t--global--dark--background--color--100)'
-          : 'var(--pf-t--global--background--color--100)',
-        padding: '1rem 1.5rem',
-      }}
-    >
-      <ChatbotHeaderMain>
-        <Flex
-          justifyContent={{ default: 'justifyContentSpaceBetween' }}
-          alignItems={{ default: 'alignItemsCenter' }}
-          fullWidth={{ default: 'fullWidth' }}
-        >
-          {/* Compare mode: just the label */}
-          {label && !agentName && (
-            <FlexItem>
-              <span
-                style={{
-                  fontWeight: 600,
-                  whiteSpace: 'nowrap',
-                  color:
-                    isSettingsOpen && isActiveConfig
-                      ? 'var(--pf-t--global--color--brand--default)'
-                      : undefined,
-                }}
-              >
-                {label}
-              </span>
-            </FlexItem>
-          )}
+    <>
+      <div
+        style={{
+          backgroundColor: isDarkMode
+            ? 'var(--pf-t--global--dark--background--color--100)'
+            : 'var(--pf-t--global--background--color--100)',
+          padding: '1rem 1.5rem 0',
+        }}
+      >
+        <ChatbotHeaderMain>
+          <Flex
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+            fullWidth={{ default: 'fullWidth' }}
+          >
+            {/* Compare mode: just the label */}
+            {label && !agentName && (
+              <FlexItem>
+                <span
+                  style={{
+                    fontWeight: 600,
+                    whiteSpace: 'nowrap',
+                    color:
+                      isSettingsOpen && isActiveConfig
+                        ? 'var(--pf-t--global--color--brand--default)'
+                        : undefined,
+                  }}
+                >
+                  {label}
+                </span>
+              </FlexItem>
+            )}
 
-          {/* Agent loaded (single mode or compare mode with agent) */}
-          {agentName && (
+            {/* Agent loaded (single mode or compare mode with agent) */}
+            {agentName && (
+              <FlexItem>
+                <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+                  {label && (
+                    <>
+                      <FlexItem style={{ fontWeight: 600 }}>{label}</FlexItem>
+                      <Divider
+                        orientation={{ default: 'vertical' }}
+                        style={{ height: '1em', alignSelf: 'center' }}
+                      />
+                    </>
+                  )}
+                  <FlexItem style={{ fontWeight: 600 }}>Agent</FlexItem>
+                  <FlexItem>
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        borderRadius: '50%',
+                        backgroundColor: 'var(--pf-t--color--teal--10)',
+                        padding: 'var(--pf-t--global--spacer--xs)',
+                      }}
+                    >
+                      <AiChatbotIcon />
+                    </span>
+                  </FlexItem>
+                  <FlexItem>
+                    <Title
+                      headingLevel="h4"
+                      size="md"
+                      style={{ whiteSpace: 'nowrap' }}
+                      data-testid="agent-name-title"
+                    >
+                      {agentName}
+                    </Title>
+                  </FlexItem>
+                  <FlexItem>
+                    <Popover
+                      headerContent="Agent"
+                      bodyContent="This agent includes model settings, prompts, knowledge sources, and guardrails."
+                    >
+                      <Button
+                        variant="plain"
+                        aria-label="Agent information"
+                        icon={<OutlinedQuestionCircleIcon />}
+                        data-testid="agent-info-button"
+                      />
+                    </Popover>
+                  </FlexItem>
+                  {isProfileDirty && (
+                    <FlexItem>
+                      <Content
+                        component="small"
+                        className="pf-v6-u-color-200"
+                        data-testid="agent-unsaved-indicator"
+                      >
+                        <i>(Unsaved)</i>
+                      </Content>
+                    </FlexItem>
+                  )}
+                </Flex>
+              </FlexItem>
+            )}
+
             <FlexItem>
               <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
-                {label && (
-                  <>
-                    <FlexItem style={{ fontWeight: 600 }}>{label}</FlexItem>
-                    <Divider
-                      orientation={{ default: 'vertical' }}
-                      style={{ height: '1em', alignSelf: 'center' }}
-                    />
-                  </>
+                {agentName && onClearAgent && (
+                  <FlexItem>
+                    <Button variant="link" onClick={onClearAgent} data-testid="agent-clear-button">
+                      Clear agent
+                    </Button>
+                  </FlexItem>
                 )}
-                <FlexItem style={{ fontWeight: 600 }}>Agent</FlexItem>
-                <FlexItem>
-                  <span
-                    style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      borderRadius: '50%',
-                      backgroundColor: 'var(--pf-t--color--teal--10)',
-                      padding: 'var(--pf-t--global--spacer--xs)',
-                    }}
-                  >
-                    <AiChatbotIcon />
-                  </span>
-                </FlexItem>
-                <FlexItem>
-                  <Title
-                    headingLevel="h4"
-                    size="md"
-                    style={{ whiteSpace: 'nowrap' }}
-                    data-testid="agent-name-title"
-                  >
-                    {agentName}
-                  </Title>
-                </FlexItem>
-                <FlexItem>
-                  <Popover
-                    headerContent="Agent"
-                    bodyContent="This agent includes model settings, prompts, knowledge sources, and guardrails."
-                  >
+                {onCloseClick && (
+                  <FlexItem>
                     <Button
                       variant="plain"
-                      aria-label="Agent information"
-                      icon={<OutlinedQuestionCircleIcon />}
-                      data-testid="agent-info-button"
+                      aria-label="Close pane"
+                      icon={<TimesIcon />}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onCloseClick();
+                      }}
+                      data-testid={`${testIdPrefix}-close-button`}
                     />
-                  </Popover>
-                </FlexItem>
-                {isProfileDirty && (
-                  <FlexItem>
-                    <Content
-                      component="small"
-                      className="pf-v6-u-color-200"
-                      data-testid="agent-unsaved-indicator"
-                    >
-                      <i>(Unsaved)</i>
-                    </Content>
                   </FlexItem>
                 )}
               </Flex>
             </FlexItem>
-          )}
+          </Flex>
+        </ChatbotHeaderMain>
 
-          <FlexItem>
-            <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
-              {agentName && onClearAgent && (
-                <FlexItem>
-                  <Button variant="link" onClick={onClearAgent} data-testid="agent-clear-button">
-                    Clear agent
-                  </Button>
-                </FlexItem>
-              )}
-              {onCloseClick && (
-                <FlexItem>
-                  <Button
-                    variant="plain"
-                    aria-label="Close pane"
-                    icon={<TimesIcon />}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onCloseClick();
-                    }}
-                    data-testid={`${testIdPrefix}-close-button`}
-                  />
-                </FlexItem>
-              )}
-            </Flex>
-          </FlexItem>
-        </Flex>
-      </ChatbotHeaderMain>
-
-      {/* Response metrics row */}
-      {(metrics || isLoading) && (
-        <Flex gap={{ default: 'gapSm' }} style={{ marginTop: 'var(--pf-t--global--spacer--md)' }}>
-          {isLoading ? (
-            <FlexItem>
-              <Label variant="outline" isCompact data-testid={`${testIdPrefix}-loading`}>
-                <Spinner size="sm" aria-label="Loading" />
-              </Label>
-            </FlexItem>
-          ) : (
-            metrics && (
-              <>
-                <FlexItem>
-                  <Label variant="outline" isCompact data-testid={`${testIdPrefix}-latency-metric`}>
-                    {formatDuration(metrics.latency_ms)}
-                  </Label>
-                </FlexItem>
-                {metrics.usage && (
+        {/* Response metrics row */}
+        {(metrics || isLoading) && (
+          <Flex gap={{ default: 'gapSm' }} style={{ marginTop: 'var(--pf-t--global--spacer--md)' }}>
+            {isLoading ? (
+              <FlexItem>
+                <Label variant="outline" isCompact data-testid={`${testIdPrefix}-loading`}>
+                  <Spinner size="sm" aria-label="Loading" />
+                </Label>
+              </FlexItem>
+            ) : (
+              metrics && (
+                <>
                   <FlexItem>
                     <Label
                       variant="outline"
                       isCompact
-                      data-testid={`${testIdPrefix}-tokens-metric`}
+                      data-testid={`${testIdPrefix}-latency-metric`}
                     >
-                      T: {metrics.usage.total_tokens}
+                      {formatDuration(metrics.latency_ms)}
                     </Label>
                   </FlexItem>
-                )}
-                {metrics.time_to_first_token_ms !== undefined && (
-                  <FlexItem>
-                    <Label variant="outline" isCompact data-testid={`${testIdPrefix}-ttft-metric`}>
-                      TTFT: {formatDuration(metrics.time_to_first_token_ms)}
-                    </Label>
-                  </FlexItem>
-                )}
-              </>
-            )
-          )}
-        </Flex>
-      )}
-
-      {hasDivider && <Divider style={{ marginTop: 'var(--pf-t--global--spacer--md)' }} />}
-    </div>
+                  {metrics.usage && (
+                    <FlexItem>
+                      <Label
+                        variant="outline"
+                        isCompact
+                        data-testid={`${testIdPrefix}-tokens-metric`}
+                      >
+                        T: {metrics.usage.total_tokens}
+                      </Label>
+                    </FlexItem>
+                  )}
+                  {metrics.time_to_first_token_ms !== undefined && (
+                    <FlexItem>
+                      <Label
+                        variant="outline"
+                        isCompact
+                        data-testid={`${testIdPrefix}-ttft-metric`}
+                      >
+                        TTFT: {formatDuration(metrics.time_to_first_token_ms)}
+                      </Label>
+                    </FlexItem>
+                  )}
+                </>
+              )
+            )}
+          </Flex>
+        )}
+      </div>
+      {hasDivider && <Divider className="pf-v6-u-mt-md" />}
+    </>
   );
 };
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -289,7 +289,14 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
             ))}
           </ToggleGroup>
         )}
-        <DrawerActions style={{ gap: 'var(--pf-t--global--spacer--sm)' }}>
+        <DrawerActions
+          style={{
+            alignSelf: 'center',
+            alignItems: 'center',
+            marginBlockStart: 0,
+            gap: 'var(--pf-t--global--spacer--sm)',
+          }}
+        >
           {agentConfigManagementEnabled && !isCompareMode && (
             <Button
               variant="secondary"

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -290,12 +290,8 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
           </ToggleGroup>
         )}
         <DrawerActions
-          style={{
-            alignSelf: 'center',
-            alignItems: 'center',
-            marginBlockStart: 0,
-            gap: 'var(--pf-t--global--spacer--sm)',
-          }}
+          className="pf-v6-u-align-self-center pf-v6-u-align-items-center pf-v6-u-mt-0"
+          style={{ gap: 'var(--pf-t--global--spacer--sm)' }}
         >
           {agentConfigManagementEnabled && !isCompareMode && (
             <Button
@@ -312,7 +308,6 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
       </DrawerHead>
       <DrawerPanelBody
         style={{ flexGrow: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
-        hasNoPadding
       >
         <ToggleGroup
           isFill

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -148,7 +148,7 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
                   data-testid={`load-agent-profile-row-${profile.profileId}`}
                 >
                   <Td dataLabel="Name">
-                    {profile.displayName}
+                    <div className="pf-v6-u-font-weight-bold">{profile.displayName}</div>
                     {profile.description && (
                       <div className="pf-v6-u-text-color-subtle">{profile.description}</div>
                     )}

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -135,9 +135,7 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
                   <Td dataLabel="Name">
                     {profile.displayName}
                     {profile.description && (
-                      <div style={{ color: 'var(--pf-t--global--text--color--subtle)' }}>
-                        {profile.description}
-                      </div>
+                      <div className="pf-v6-u-text-color-subtle">{profile.description}</div>
                     )}
                   </Td>
                   <Td dataLabel="Last modified">{formatDate(profile.lastModified)}</Td>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -15,6 +15,7 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  Tooltip,
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
@@ -126,6 +127,20 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
           <Tbody>
             {paginatedProfiles.map((profile) => {
               const isLoaded = profile.profileId === loadedProfileId;
+              const loadButton = (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  isDisabled={isLoaded}
+                  onClick={() => {
+                    onSelect(profile.profileId);
+                    onClose();
+                  }}
+                  data-testid={`load-agent-profile-button-${profile.profileId}`}
+                >
+                  Load agent
+                </Button>
+              );
               return (
                 <Tr
                   key={profile.profileId}
@@ -140,18 +155,13 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
                   </Td>
                   <Td dataLabel="Last modified">{formatDate(profile.lastModified)}</Td>
                   <Td dataLabel="Actions" modifier="fitContent">
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      isDisabled={isLoaded}
-                      onClick={() => {
-                        onSelect(profile.profileId);
-                        onClose();
-                      }}
-                      data-testid={`load-agent-profile-button-${profile.profileId}`}
-                    >
-                      Load agent
-                    </Button>
+                    {isLoaded ? (
+                      <Tooltip content="This agent is already loaded.">
+                        <span>{loadButton}</span>
+                      </Tooltip>
+                    ) : (
+                      loadButton
+                    )}
                   </Td>
                 </Tr>
               );

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -115,11 +115,11 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
     }
     return (
       <>
-        <Table aria-label="Agents" variant="compact">
+        <Table aria-label="Agents">
           <Thead>
             <Tr>
               <Th>Name</Th>
-              <Th modifier="fitContent">Last modified</Th>
+              <Th>Last modified</Th>
               <Th modifier="fitContent" screenReaderText="Actions" />
             </Tr>
           </Thead>
@@ -133,19 +133,18 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
                   data-testid={`load-agent-profile-row-${profile.profileId}`}
                 >
                   <Td dataLabel="Name">
-                    <strong>{profile.displayName}</strong>
+                    {profile.displayName}
                     {profile.description && (
-                      <div className="pf-v6-u-font-size-sm pf-v6-u-color-200">
+                      <div style={{ color: 'var(--pf-t--global--text--color--subtle)' }}>
                         {profile.description}
                       </div>
                     )}
                   </Td>
-                  <Td dataLabel="Last modified" modifier="fitContent">
-                    {formatDate(profile.lastModified)}
-                  </Td>
+                  <Td dataLabel="Last modified">{formatDate(profile.lastModified)}</Td>
                   <Td dataLabel="Actions" modifier="fitContent">
                     <Button
                       variant="secondary"
+                      size="sm"
                       isDisabled={isLoaded}
                       onClick={() => {
                         onSelect(profile.profileId);
@@ -174,11 +173,18 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
       data-testid="load-agent-profile-modal"
     >
       <ModalHeader
-        title="Load agent"
+        title="Select agent configuration"
         labelId="load-agent-profile-modal-title"
-        description="Select a saved agent to load into the playground."
+        description="Select a saved agent configuration to load into the playground."
       />
       <ModalBody>
+        <Alert
+          variant="info"
+          isInline
+          isPlain
+          className="pf-v6-u-mb-md"
+          title="Side-by-side chat comparison isn't available for saved agents."
+        />
         <Toolbar
           inset={{ default: 'insetNone' }}
           style={{ marginBottom: 'var(--pf-t--global--spacer--md)' }}

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -132,6 +132,7 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
                   variant="secondary"
                   size="sm"
                   isDisabled={isLoaded}
+                  tabIndex={isLoaded ? -1 : undefined}
                   onClick={() => {
                     onSelect(profile.profileId);
                     onClose();
@@ -159,7 +160,9 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
                       <Tooltip content="This agent is already loaded.">
                         {/* Disabled buttons need a focusable wrapper for the tooltip. */}
                         {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-                        <span tabIndex={0}>{loadButton}</span>
+                        <span tabIndex={0} role="none">
+                          {loadButton}
+                        </span>
                       </Tooltip>
                     ) : (
                       loadButton

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -157,7 +157,9 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
                   <Td dataLabel="Actions" modifier="fitContent">
                     {isLoaded ? (
                       <Tooltip content="This agent is already loaded.">
-                        <span>{loadButton}</span>
+                        {/* Disabled buttons need a focusable wrapper for the tooltip. */}
+                        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+                        <span tabIndex={0}>{loadButton}</span>
                       </Tooltip>
                     ) : (
                       loadButton

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -450,8 +450,12 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
             <Alert
               variant="info"
               isInline
-              title="Playground guardrails will not be saved with this profile"
-            />
+              isPlain
+              title="Playground guardrails cannot be saved with this agent"
+            >
+              Guardrails cannot yet be saved individually and are not included when saving an agent.
+              Any guardrail settings configured here will need to be reapplied in future sessions.
+            </Alert>
           </FormGroup>
         </Form>
       </ModalBody>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -451,11 +451,8 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
               variant="info"
               isInline
               isPlain
-              title="Playground guardrails cannot be saved with this agent"
-            >
-              Guardrails cannot yet be saved individually and are not included when saving an agent.
-              Any guardrail settings configured here will need to be reapplied in future sessions.
-            </Alert>
+              title="Guardrails cannot yet be saved individually and are not included when saving an agent. Any guardrail settings configured here will need to be reapplied in future sessions."
+            />
           </FormGroup>
         </Form>
       </ModalBody>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
@@ -76,6 +76,33 @@ describe('LoadAgentProfileModal', () => {
     expect(screen.getByText('Coding assistant').tagName).not.toBe('STRONG');
   });
 
+  it('should explain why the loaded agent button is disabled', async () => {
+    useChatbotConfigStore.setState({ loadedProfileId: 'uuid-1' });
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [
+        {
+          profileId: 'uuid-1',
+          name: 'agent-profile-uuid-1',
+          displayName: 'Coding assistant',
+          description: 'Code review',
+          namespace: 'test-ns',
+          lastModified: '2026-06-15T10:00:00Z',
+        },
+      ],
+      totalCount: 1,
+    } as never);
+
+    const user = userEvent.setup();
+    renderModal();
+
+    const button = await screen.findByTestId('load-agent-profile-button-uuid-1');
+    await user.hover(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('This agent is already loaded.')).toBeInTheDocument();
+    });
+  });
+
   it('should show a spinner while loading', () => {
     jest
       .mocked(mockGenAiContextValue.apiState.api.listAgentProfiles)

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
@@ -73,7 +73,7 @@ describe('LoadAgentProfileModal', () => {
 
     expect(screen.getByTestId('load-agent-profile-button-uuid-1')).toHaveClass('pf-m-small');
     expect(screen.getByRole('grid')).not.toHaveClass('pf-m-compact');
-    expect(screen.getByText('Coding assistant').tagName).not.toBe('STRONG');
+    expect(screen.getByText('Coding assistant')).toHaveClass('pf-v6-u-font-weight-bold');
   });
 
   it('should explain why the loaded agent button is disabled', async () => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
@@ -3,6 +3,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LoadAgentProfileModal from '~/app/Chatbot/components/LoadAgentProfileModal';
 import { mockGenAiContextValue } from '~/__mocks__/mockGenAiContext';
+import { DEFAULT_CONFIG_ID, useChatbotConfigStore } from '~/app/Chatbot/store';
+import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
 
 jest.mock('~/app/hooks/useGenAiAPI', () => ({
   useGenAiAPI: jest.fn(() => ({
@@ -20,6 +22,12 @@ const renderModal = () =>
 describe('LoadAgentProfileModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useChatbotConfigStore.setState({
+      configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
+      configIds: [DEFAULT_CONFIG_ID],
+      profileApplied: false,
+      loadedProfileId: null,
+    });
   });
 
   it('should render the modal title and description', async () => {
@@ -30,10 +38,42 @@ describe('LoadAgentProfileModal', () => {
 
     renderModal();
 
-    expect(screen.getByText('Load agent')).toBeInTheDocument();
+    expect(screen.getByText('Select agent configuration')).toBeInTheDocument();
     expect(
-      screen.getByText('Select a saved agent to load into the playground.'),
+      screen.getByText('Select a saved agent configuration to load into the playground.'),
     ).toBeInTheDocument();
+  });
+
+  it('should always show the saved agent comparison warning', () => {
+    renderModal();
+
+    expect(
+      screen.getByText("Side-by-side chat comparison isn't available for saved agents."),
+    ).toBeInTheDocument();
+  });
+
+  it('should use the default table row sizing and small load buttons', async () => {
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [
+        {
+          profileId: 'uuid-1',
+          name: 'agent-profile-uuid-1',
+          displayName: 'Coding assistant',
+          description: 'Code review',
+          namespace: 'test-ns',
+          lastModified: '2026-06-15T10:00:00Z',
+        },
+      ],
+      totalCount: 1,
+    } as never);
+
+    renderModal();
+
+    await waitFor(() => screen.getByTestId('load-agent-profile-button-uuid-1'));
+
+    expect(screen.getByTestId('load-agent-profile-button-uuid-1')).toHaveClass('pf-m-small');
+    expect(screen.getByRole('grid')).not.toHaveClass('pf-m-compact');
+    expect(screen.getByText('Coding assistant').tagName).not.toBe('STRONG');
   });
 
   it('should show a spinner while loading', () => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
@@ -102,6 +102,8 @@ describe('LoadAgentProfileModal', () => {
 
     const button = await screen.findByTestId('load-agent-profile-button-uuid-1');
     expect(button.parentElement).toHaveAttribute('tabIndex', '0');
+    expect(button.parentElement).toHaveAttribute('role', 'none');
+    expect(button).toHaveAttribute('tabIndex', '-1');
     await user.hover(button);
 
     await waitFor(() => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
@@ -96,6 +96,7 @@ describe('LoadAgentProfileModal', () => {
     renderModal();
 
     const button = await screen.findByTestId('load-agent-profile-button-uuid-1');
+    expect(button.parentElement).toHaveAttribute('tabIndex', '0');
     await user.hover(button);
 
     await waitFor(() => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
@@ -45,6 +45,11 @@ describe('LoadAgentProfileModal', () => {
   });
 
   it('should always show the saved agent comparison warning', () => {
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [],
+      totalCount: 0,
+    } as never);
+
     renderModal();
 
     expect(

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -118,6 +118,19 @@ describe('SaveAgentProfileModal', () => {
       expect(screen.getByTestId('save-agent-profile-name-input')).toHaveValue('');
     });
 
+    it('should explain that guardrails are not saved with the agent', () => {
+      renderModal('save-as');
+
+      expect(
+        screen.getByText('Playground guardrails cannot be saved with this agent'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Guardrails cannot yet be saved individually and are not included when saving an agent. Any guardrail settings configured here will need to be reapplied in future sessions.',
+        ),
+      ).toBeInTheDocument();
+    });
+
     it('should show name required error only after blur', async () => {
       const user = userEvent.setup();
       renderModal('save-as');

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -122,9 +122,6 @@ describe('SaveAgentProfileModal', () => {
       renderModal('save-as');
 
       expect(
-        screen.getByText('Playground guardrails cannot be saved with this agent'),
-      ).toBeInTheDocument();
-      expect(
         screen.getByText(
           'Guardrails cannot yet be saved individually and are not included when saving an agent. Any guardrail settings configured here will need to be reapplied in future sessions.',
         ),


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-78237
https://redhat.atlassian.net/browse/RHOAIENG-78238
https://redhat.atlassian.net/browse/RHOAIENG-78239
https://redhat.atlassian.net/browse/RHOAIENG-78258
https://redhat.atlassian.net/browse/RHOAIENG-78288
https://redhat.atlassian.net/browse/RHOAIENG-78289

## Description

Address six related AI Playground agent-profile UX debt items:

- Extend the agent header divider across the full chat pane width.
- Align the Settings drawer actions, including the Load agent button, with the Settings heading.
- Update the Guardrails notification in the Save agent configuration modal with the approved explanation and borderless PatternFly styling.
- Update the Load agent modal to use default PatternFly table row sizing, standard typography, subtle description text, and small Load agent buttons.
- Update the Load agent modal title and description, add the approved side-by-side comparison guidance, and improve spacing around the filter control.
- Update the disabled Compare chat tooltip to explain that side-by-side chat comparison is unavailable for saved agents.
- Add a tooltip explaining why the Load agent button is disabled when that agent is already loaded.

The model column shown in the design was intentionally not added because it is not part of the current acceptance criteria.

## How Has This Been Tested?

From `packages/gen-ai/frontend`:

```bash
npm run test:unit -- --runInBand src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx src/app/Chatbot/components/__tests__/ChatbotSettingsPanel.spec.tsx src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
npm run test:type-check
npm run lint
```

Results:

- Focused unit tests: 87 passed across the affected component suites
- Type-check passed
- Lint passed
- The developer manually tested the updated Playground flows locally.

## Test Impact

Added coverage for:

- The Settings drawer and action layout behavior.
- The updated Guardrails alert copy.
- The Load agent modal title, description, comparison guidance, default table sizing, typography, and button size.
- The updated saved-agent comparison tooltip.
- The disabled Load agent button tooltip when the selected agent is already loaded.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change. Designs were provided in Jira/Figma, but no local screenshots were captured for the PR.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-78237]: https://redhat.atlassian.net/browse/RHOAIENG-78237
[RHOAIENG-78239]: https://redhat.atlassian.net/browse/RHOAIENG-78239
[RHOAIENG-78258]: https://redhat.atlassian.net/browse/RHOAIENG-78258
[RHOAIENG-78288]: https://redhat.atlassian.net/browse/RHOAIENG-78288
[RHOAIENG-78289]: https://redhat.atlassian.net/browse/RHOAIENG-78289




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Updates**
  - Clarified that side-by-side chat comparison is unavailable when using saved agents.
  - Added an informational notice when selecting a saved agent configuration.
  - Added guidance when attempting to load an agent that is already active.
  - Updated save-agent messaging to explain that guardrails aren’t saved and must be reapplied in future sessions.
  - Refined agent profile controls, chatbot header spacing, and settings panel layout.
  - Improved table sizing, button presentation, and contextual tooltips in agent profile dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->