### PR TITLE
fix: restrict NIM hardware profile Compatible badge to NVIDIA accelerators

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelServingHardwareProfileSection.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelServingHardwareProfileSection.tsx
@@ -14,12 +14,19 @@ type ModelServingHardwareProfileSectionComponentProps = {
   hardwareProfileConfig: UseHardwareProfileConfigResult;
   project?: string;
   isEditing?: boolean;
+  isHardwareProfileSupported?: (profile: HardwareProfileKind) => boolean;
   isHardwareProfilePreferred?: (profile: HardwareProfileKind) => boolean;
 };
 
 export const ModelServingHardwareProfileSection: React.FC<
   ModelServingHardwareProfileSectionComponentProps
-> = ({ hardwareProfileConfig, project, isEditing = false, isHardwareProfilePreferred }) => {
+> = ({
+  hardwareProfileConfig,
+  project,
+  isEditing = false,
+  isHardwareProfileSupported = () => true,
+  isHardwareProfilePreferred,
+}) => {
   const podSpecOptionsState: HardwarePodSpecOptionsState<PodSpecOptions> = React.useMemo(
     () => ({
       hardwareProfile: hardwareProfileConfig,
@@ -37,7 +44,7 @@ export const ModelServingHardwareProfileSection: React.FC<
       project={project}
       podSpecOptionsState={podSpecOptionsState}
       isEditing={isEditing}
-      isHardwareProfileSupported={() => true}
+      isHardwareProfileSupported={isHardwareProfileSupported}
       isHardwareProfilePreferred={isHardwareProfilePreferred}
       visibleIn={MODEL_SERVING_VISIBILITY}
     />

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -35,7 +35,7 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
   const hideHwp = isNonSingleNodeTopologyActive(wizardState.state);
   const preferredAccelerator = wizardState.computedOverrides.hardwareProfile?.preferredAccelerator;
 
-  const isHardwareProfilePreferred = React.useMemo(
+  const isHardwareProfileWithPreferredAccelerator = React.useMemo(
     (): ((profile: HardwareProfileKind) => boolean) | undefined =>
       preferredAccelerator
         ? (profile) => isHardwareProfileWithAcceleratorPrefix(profile, preferredAccelerator)
@@ -100,7 +100,8 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
             project={projectName}
             hardwareProfileConfig={wizardState.state.hardwareProfileConfig}
             isEditing={wizardState.initialData?.isEditing}
-            isHardwareProfilePreferred={isHardwareProfilePreferred}
+            isHardwareProfileSupported={isHardwareProfileWithPreferredAccelerator}
+            isHardwareProfilePreferred={isHardwareProfileWithPreferredAccelerator}
           />
         )}
         {wizardState.state.modelFormatState.isVisible && (


### PR DESCRIPTION
<!--- https://issues.redhat.com/browse/RHOAIENG-90397 -->

https://issues.redhat.com/browse/RHOAIENG-90397

## Description

Fixes a bug where the deployment wizard showed the **Compatible** badge on every hardware profile when deploying a NIM model, instead of only on profiles with an NVIDIA accelerator identifier (`nvidia.com/*`).

The model-serving wizard hardcoded `isHardwareProfileSupported={() => true}` in `ModelServingHardwareProfileSection`, so all profiles received the badge regardless of deployment type. NIM already sets `preferredAccelerator: 'nvidia.com/'` via `getNIMHardwareProfileFieldOverrides()` in the nim-serving spoke, but that override was only used for sorting profiles to the top — not for the Compatible label.

This change wires the existing `preferredAccelerator` override into `isHardwareProfileSupported` in `ModelDeploymentStep`, reusing `isHardwareProfileWithAcceleratorPrefix`. When no override is set (KServe, LLMD, etc.), behavior is unchanged — all profiles still show Compatible.

Applies to both NIM platforms (`nvidia-nim` and `nvidia-nim-service`). Badge-only change — profile selection, validation, and sorting logic are otherwise unchanged.

## How Has This Been Tested?

- ESLint on changed files: pass
- `npm run type-check` in `@odh-dashboard/model-serving`: pass
- `npm run test-unit` in `@odh-dashboard/model-serving`: 569/569 passed
- `npm run test-unit` in `@odh-dashboard/nim-serving`: 273/273 passed (includes `nimHardwareProfileOverrides.spec.ts`)
<img width="1420" height="567" alt="Screenshot 2026-09-09 at 5 09 57 PM" src="https://github.com/user-attachments/assets/aa83a440-8dcd-4377-a7f6-bf3849cd0a76" />

**Manual testing (cluster/local):**
1. Open the model deployment wizard and select a NIM model source.
2. On the Model deployment step, open the Hardware profile dropdown.
3. Verify only profiles with an `nvidia.com/` accelerator identifier show the **Compatible** badge.
4. Verify non-NVIDIA profiles (e.g. `default-profile`, Habana, test accelerators) do **not** show the badge but remain selectable.
5. Repeat with a non-NIM deployment type (e.g. KServe) and confirm all profiles still show **Compatible**.

## Test Impact

No new tests added. The NIM spoke already has unit coverage for `getNIMHardwareProfileFieldOverrides()` (`nimHardwareProfileOverrides.spec.ts`). This PR only connects that existing override to the Compatible badge in the hub — no new logic or extension points were introduced.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hardware profile selection now supports filtering profiles based on accelerator compatibility.
  * Deployment configuration applies preferred accelerator criteria when determining available and preferred hardware profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->