### PR TITLE
E2E: Add Workbench Kueue Queued scenario

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
@@ -8,7 +8,7 @@ hardwareProfileDisplayName: "Kueue Lifecycle Profile"
 sectionTab: "workbenches"
 notebookImage: "code-server-notebook"
 
-# Zero quota → Inadmissible (RHOAIENG-90198)
+# Zero quota → Inadmissible
 cpuQuota: 0
 memoryQuota: 0
 exceededQuotaMessage: "Exceeded quota"

--- a/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
@@ -1,15 +1,21 @@
 # Kueue workbench lifecycle test data
-# Uses zero quota to force Inadmissible state, then updates quota to allow admission
 projectName: "kueue-lifecycle-project"
 flavorName: "lifecycle-flavor"
 clusterQueueName: "lifecycle-cluster-queue"
 localQueueName: "lifecycle-queue"
 hardwareProfileName: "kueue-lifecycle-hp"
 hardwareProfileDisplayName: "Kueue Lifecycle Profile"
-cpuQuota: 0
-memoryQuota: 0
-updatedCpuQuota: 4
-updatedMemoryQuota: 8
 sectionTab: "workbenches"
 notebookImage: "code-server-notebook"
+
+# Zero quota → Inadmissible (RHOAIENG-90198)
+cpuQuota: 0
+memoryQuota: 0
 exceededQuotaMessage: "Exceeded quota"
+updatedCpuQuota: 4
+updatedMemoryQuota: 8
+
+# Partial quota → Queued when consumed by first workbench (includes kube-rbac-proxy overhead)
+queuedCpuQuota: 2
+queuedMemoryQuota: 3
+waitingForQuotaMessage: "Waiting for quota"

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
@@ -208,10 +208,7 @@ describe('Workbench Kueue Lifecycle Tests', () => {
 
         openWorkbenchesTab(projectCtx);
         createWorkbench(projectCtx, firstWorkbenchName);
-        pollUntilWorkloadAdmitted(projectCtx.projectName, {
-          maxAttempts: 120,
-          pollIntervalMs: 5000,
-        });
+        pollUntilWorkloadAdmitted(projectCtx.projectName);
 
         createWorkbench(projectCtx, secondWorkbenchName);
         pollUntilAnyWorkloadMessageMatches(projectCtx.projectName, QUEUED_MESSAGE);

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
@@ -3,7 +3,7 @@ import {
   deleteOpenShiftProject,
   createOpenShiftProject,
 } from '../../../../utils/oc_commands/project';
-import { retryableBefore } from '../../../../utils/retryableHooks';
+import { retryableBefore, wasSetupPerformed } from '../../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../../utils/uuidGenerator';
 import { loadKueueWorkbenchLifecycleFixture } from '../../../../utils/dataLoader';
 import {
@@ -28,181 +28,164 @@ import type { KueueWorkbenchLifecycleTestData } from '../../../../types';
 const QUEUE_POSITION_REGEX = /\d+(st|nd|rd|th) in/;
 const QUEUED_MESSAGE = /insufficient unused quota/i;
 
+type WorkbenchLifecycleContext = {
+  uuid: string;
+  testData: KueueWorkbenchConfig;
+  fixtureData: KueueWorkbenchLifecycleTestData;
+  projectName: string;
+  sectionTab: string;
+  notebookImage: string;
+};
+
+const buildKueueConfig = (
+  data: KueueWorkbenchLifecycleTestData,
+  uuid: string,
+  resourceSuffix: string,
+  cpuQuota: number,
+  memoryQuota: number,
+): KueueWorkbenchConfig => ({
+  flavorName: `${data.flavorName}${resourceSuffix}-${uuid}`,
+  clusterQueueName: `${data.clusterQueueName}${resourceSuffix}-${uuid}`,
+  localQueueName: `${data.localQueueName}${resourceSuffix}-${uuid}`,
+  hardwareProfileName: `${data.hardwareProfileName}${resourceSuffix}-${uuid}`,
+  hardwareProfileDisplayName: resourceSuffix
+    ? `${data.hardwareProfileDisplayName} Queued ${uuid}`
+    : `${data.hardwareProfileDisplayName} ${uuid}`,
+  cpuQuota,
+  memoryQuota,
+});
+
+const initLifecycleProject = (
+  data: KueueWorkbenchLifecycleTestData,
+  projectSuffix: string,
+  resourceSuffix: string,
+  cpuQuota: number,
+  memoryQuota: number,
+): Cypress.Chainable<WorkbenchLifecycleContext> => {
+  const uuid = generateTestUUID();
+  const ctx: WorkbenchLifecycleContext = {
+    uuid,
+    fixtureData: data,
+    projectName: `${data.projectName}${projectSuffix}-${uuid}`,
+    sectionTab: data.sectionTab,
+    notebookImage: data.notebookImage,
+    testData: buildKueueConfig(data, uuid, resourceSuffix, cpuQuota, memoryQuota),
+  };
+
+  return deleteOpenShiftProject(ctx.projectName, { wait: true, ignoreNotFound: true })
+    .then(() => createOpenShiftProject(ctx.projectName))
+    .then(() => setupKueueWorkbenchResources(ctx.testData, ctx.projectName))
+    .then(() => ctx);
+};
+
+const setupLifecycleProject = (
+  projectSuffix: string,
+  resourceSuffix: string,
+  useQueuedQuota: boolean,
+): Cypress.Chainable<WorkbenchLifecycleContext> =>
+  loadKueueWorkbenchLifecycleFixture('e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml').then(
+    (data) =>
+      initLifecycleProject(
+        data,
+        projectSuffix,
+        resourceSuffix,
+        useQueuedQuota ? data.queuedCpuQuota : data.cpuQuota,
+        useQueuedQuota ? data.queuedMemoryQuota : data.memoryQuota,
+      ),
+  );
+
+const openWorkbenchesTab = (ctx: WorkbenchLifecycleContext) => {
+  cy.visitWithLogin('/?devFeatureFlags=true', LDAP_ADMIN_USER);
+  projectListPage.navigate();
+  projectListPage.filterProjectByName(ctx.projectName);
+  projectListPage.findProjectLink(ctx.projectName).click();
+  projectDetails.findSectionTab(ctx.sectionTab).click();
+};
+
+const createWorkbench = (ctx: WorkbenchLifecycleContext, workbenchName: string) => {
+  workbenchPage.findCreateButton().click();
+  createSpawnerPage.getNameInput().fill(workbenchName);
+  selectNotebookImageWithBackendFallback(ctx.notebookImage, createSpawnerPage);
+  createSpawnerPage
+    .findHardwareProfileSelect()
+    .should('contain.text', ctx.testData.hardwareProfileDisplayName);
+  createSpawnerPage.findSubmitButton().click();
+  workbenchPage.findNotebookTable(30000).should('exist');
+};
+
+const verifyResourcesModal = (clusterQueueName: string) => {
+  workbenchStatusModal.find().should('be.visible');
+  workbenchStatusModal.findResourcesTab().click();
+  workbenchStatusModal.findClusterQueueSection().should('be.visible');
+  workbenchStatusModal.findQueueValue().should('contain.text', clusterQueueName);
+  workbenchStatusModal.findQuotasSection().should('be.visible');
+  workbenchStatusModal.getModalCloseButton().click();
+};
+
 describe('Workbench Kueue Lifecycle Tests', () => {
   describe('Inadmissible with zero quota', () => {
-    let testData: KueueWorkbenchConfig;
-    let fixtureData: KueueWorkbenchLifecycleTestData;
-    let projectName: string;
-    let sectionTab: string;
-    let notebookImage: string;
-    const uuid = generateTestUUID();
-    const workbenchName = `kueue-lifecycle-wb-${uuid}`;
+    let ctx: WorkbenchLifecycleContext | undefined;
 
     retryableBefore(() =>
-      loadKueueWorkbenchLifecycleFixture(
-        'e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml',
-      ).then((data) => {
-        fixtureData = data;
-        projectName = `${data.projectName}-${uuid}`;
-        sectionTab = data.sectionTab;
-        notebookImage = data.notebookImage;
-        testData = {
-          flavorName: `${data.flavorName}-${uuid}`,
-          clusterQueueName: `${data.clusterQueueName}-${uuid}`,
-          localQueueName: `${data.localQueueName}-${uuid}`,
-          hardwareProfileName: `${data.hardwareProfileName}-${uuid}`,
-          hardwareProfileDisplayName: `${data.hardwareProfileDisplayName} ${uuid}`,
-          cpuQuota: data.cpuQuota,
-          memoryQuota: data.memoryQuota,
-        };
-        return deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true })
-          .then(() => createOpenShiftProject(projectName))
-          .then(() => setupKueueWorkbenchResources(testData, projectName));
+      setupLifecycleProject('', '', false).then((projectCtx) => {
+        ctx = projectCtx;
       }),
     );
 
     after(() => {
-      cleanupKueueWorkbenchResources(testData, projectName);
-      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+      if (!wasSetupPerformed() || !ctx) {
+        return;
+      }
+      cleanupKueueWorkbenchResources(ctx.testData, ctx.projectName);
+      deleteOpenShiftProject(ctx.projectName, { wait: false, ignoreNotFound: true });
     });
 
     it(
       'Verify workbench Kueue lifecycle: Inadmissible → Ready after quota update',
       { tags: ['@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged'] },
       () => {
-        cy.step('Log into the application');
-        cy.visitWithLogin('/?devFeatureFlags=true', LDAP_ADMIN_USER);
+        const workbenchName = `kueue-lifecycle-wb-${ctx.uuid}`;
 
-        cy.step(`Navigate to workbenches tab of project ${projectName}`);
-        projectListPage.navigate();
-        projectListPage.filterProjectByName(projectName);
-        projectListPage.findProjectLink(projectName).click();
-        projectDetails.findSectionTab(sectionTab).click();
+        openWorkbenchesTab(ctx);
+        createWorkbench(ctx, workbenchName);
 
-        cy.step('Click Create workbench button');
-        workbenchPage.findCreateButton().click();
-
-        cy.step('Enter workbench name');
-        createSpawnerPage.getNameInput().fill(workbenchName);
-
-        cy.step('Select a notebook image');
-        selectNotebookImageWithBackendFallback(notebookImage, createSpawnerPage);
-
-        cy.step('Verify Kueue hardware profile is pre-selected');
-        createSpawnerPage
-          .findHardwareProfileSelect()
-          .should('contain.text', testData.hardwareProfileDisplayName);
-
-        cy.step('Submit the workbench creation');
-        createSpawnerPage.findSubmitButton().click();
-
-        cy.step('Wait for notebook table to appear');
-        workbenchPage.findNotebookTable(30000).should('exist');
-
-        cy.step('Verify workbench shows Inadmissible status');
         const notebookRow = workbenchPage.getNotebookRow(workbenchName);
         notebookRow.expectStatusLabelToBe('Inadmissible', 120000);
-
-        cy.step('Verify status subtitle shows exceeded quota message');
         notebookRow
           .findNotebookStatusSubtitle()
-          .should('contain.text', fixtureData.exceededQuotaMessage);
+          .should('contain.text', ctx.fixtureData.exceededQuotaMessage);
 
-        cy.step('Click on the Inadmissible status label to open the status modal');
         notebookRow.findHaveNotebookStatusText().click();
+        verifyResourcesModal(ctx.testData.clusterQueueName);
 
-        cy.step('Verify status modal is visible');
-        workbenchStatusModal.find().should('be.visible');
-
-        cy.step('Verify Resources tab is visible and click it');
-        workbenchStatusModal.findResourcesTab().should('be.visible');
-        workbenchStatusModal.findResourcesTab().click();
-
-        cy.step('Verify ClusterQueue section is visible with queue name');
-        workbenchStatusModal.findClusterQueueSection().should('be.visible');
-        workbenchStatusModal.findQueueValue().should('contain.text', testData.clusterQueueName);
-
-        cy.step('Verify quotas section is visible');
-        workbenchStatusModal.findQuotasSection().should('be.visible');
-
-        cy.step('Close the status modal');
-        workbenchStatusModal.getModalCloseButton().click();
-
-        cy.step('Update the ClusterQueue quota to allow the workbench');
         updateClusterQueueQuota(
-          testData.clusterQueueName,
-          fixtureData.updatedCpuQuota,
-          fixtureData.updatedMemoryQuota,
+          ctx.testData.clusterQueueName,
+          ctx.fixtureData.updatedCpuQuota,
+          ctx.fixtureData.updatedMemoryQuota,
         );
 
-        cy.step('Wait for workbench to transition to Ready status');
         notebookRow.expectStatusLabelToBe('Ready', 300000);
-
-        cy.step('Verify hardware profile is displayed after Ready');
-        notebookRow.shouldHaveHardwareProfile(testData.hardwareProfileDisplayName);
+        notebookRow.shouldHaveHardwareProfile(ctx.testData.hardwareProfileDisplayName);
       },
     );
   });
 
-  describe('Queued when quota is fully consumed', () => {
-    let testData: KueueWorkbenchConfig;
-    let fixtureData: KueueWorkbenchLifecycleTestData;
-    let projectName: string;
-    let sectionTab: string;
-    let notebookImage: string;
-    const uuid = generateTestUUID();
-    const firstWorkbenchName = `kueue-wb-q1-${uuid}`;
-    const secondWorkbenchName = `kueue-wb-q2-${uuid}`;
+  describe('Queued when ClusterQueue quota is partially consumed', () => {
+    let ctx: WorkbenchLifecycleContext | undefined;
 
     retryableBefore(() =>
-      loadKueueWorkbenchLifecycleFixture(
-        'e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml',
-      ).then((data) => {
-        fixtureData = data;
-        projectName = `${data.projectName}-q-${uuid}`;
-        sectionTab = data.sectionTab;
-        notebookImage = data.notebookImage;
-        testData = {
-          flavorName: `${data.flavorName}-queued-${uuid}`,
-          clusterQueueName: `${data.clusterQueueName}-queued-${uuid}`,
-          localQueueName: `${data.localQueueName}-queued-${uuid}`,
-          hardwareProfileName: `${data.hardwareProfileName}-queued-${uuid}`,
-          hardwareProfileDisplayName: `${data.hardwareProfileDisplayName} Queued ${uuid}`,
-          cpuQuota: data.queuedCpuQuota,
-          memoryQuota: data.queuedMemoryQuota,
-        };
-        return deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true })
-          .then(() => createOpenShiftProject(projectName))
-          .then(() => setupKueueWorkbenchResources(testData, projectName));
+      setupLifecycleProject('-q', '-queued', true).then((projectCtx) => {
+        ctx = projectCtx;
       }),
     );
 
     after(() => {
-      cleanupKueueWorkbenchResources(testData, projectName);
-      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+      if (!wasSetupPerformed() || !ctx) {
+        return;
+      }
+      cleanupKueueWorkbenchResources(ctx.testData, ctx.projectName);
+      deleteOpenShiftProject(ctx.projectName, { wait: false, ignoreNotFound: true });
     });
-
-    const createWorkbench = (workbenchName: string) => {
-      cy.step('Click Create workbench button');
-      workbenchPage.findCreateButton().click();
-
-      cy.step('Enter workbench name');
-      createSpawnerPage.getNameInput().fill(workbenchName);
-
-      cy.step('Select a notebook image');
-      selectNotebookImageWithBackendFallback(notebookImage, createSpawnerPage);
-
-      cy.step('Verify Kueue hardware profile is pre-selected');
-      createSpawnerPage
-        .findHardwareProfileSelect()
-        .should('contain.text', testData.hardwareProfileDisplayName);
-
-      cy.step('Submit the workbench creation');
-      createSpawnerPage.findSubmitButton().click();
-
-      cy.step('Wait for notebook table to appear');
-      workbenchPage.findNotebookTable(30000).should('exist');
-    };
 
     it(
       'Verify workbench shows Queued when ClusterQueue quota is consumed by another workbench',
@@ -210,54 +193,28 @@ describe('Workbench Kueue Lifecycle Tests', () => {
         tags: ['@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged', '@NonConcurrent'],
       },
       () => {
-        cy.step('Log into the application');
-        cy.visitWithLogin('/?devFeatureFlags=true', LDAP_ADMIN_USER);
+        const firstWorkbenchName = `kueue-wb-q1-${ctx.uuid}`;
+        const secondWorkbenchName = `kueue-wb-q2-${ctx.uuid}`;
 
-        cy.step(`Navigate to workbenches tab of project ${projectName}`);
-        projectListPage.navigate();
-        projectListPage.filterProjectByName(projectName);
-        projectListPage.findProjectLink(projectName).click();
-        projectDetails.findSectionTab(sectionTab).click();
+        openWorkbenchesTab(ctx);
+        createWorkbench(ctx, firstWorkbenchName);
+        pollUntilWorkloadAdmitted(ctx.projectName, { maxAttempts: 120, pollIntervalMs: 5000 });
 
-        cy.step('Create first workbench and wait for Kueue admission');
-        createWorkbench(firstWorkbenchName);
-        pollUntilWorkloadAdmitted(projectName, { maxAttempts: 120, pollIntervalMs: 5000 });
+        createWorkbench(ctx, secondWorkbenchName);
+        pollUntilAnyWorkloadMessageMatches(ctx.projectName, QUEUED_MESSAGE);
 
-        cy.step('Create second workbench that consumes remaining quota');
-        createWorkbench(secondWorkbenchName);
-        pollUntilAnyWorkloadMessageMatches(projectName, QUEUED_MESSAGE);
-
-        cy.step('Verify workbench shows Queued status');
         const notebookRow = workbenchPage.getNotebookRow(secondWorkbenchName);
         notebookRow.expectStatusLabelToBe('Queued', 120000);
-
-        cy.step('Verify status subtitle shows waiting for quota or queue position');
         notebookRow.findNotebookStatusSubtitle().should(($el) => {
           const text = $el.text();
           expect(
-            text.includes(fixtureData.waitingForQuotaMessage) || QUEUE_POSITION_REGEX.test(text),
+            text.includes(ctx.fixtureData.waitingForQuotaMessage) ||
+              QUEUE_POSITION_REGEX.test(text),
           ).to.eq(true);
         });
 
-        cy.step('Click on the Queued status label to open the status modal');
         notebookRow.findHaveNotebookStatusText().click();
-
-        cy.step('Verify status modal is visible');
-        workbenchStatusModal.find().should('be.visible');
-
-        cy.step('Verify Resources tab is visible and click it');
-        workbenchStatusModal.findResourcesTab().should('be.visible');
-        workbenchStatusModal.findResourcesTab().click();
-
-        cy.step('Verify ClusterQueue section is visible with queue name');
-        workbenchStatusModal.findClusterQueueSection().should('be.visible');
-        workbenchStatusModal.findQueueValue().should('contain.text', testData.clusterQueueName);
-
-        cy.step('Verify quotas section is visible');
-        workbenchStatusModal.findQuotasSection().should('be.visible');
-
-        cy.step('Close the status modal');
-        workbenchStatusModal.getModalCloseButton().click();
+        verifyResourcesModal(ctx.testData.clusterQueueName);
       },
     );
   });

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
@@ -144,28 +144,33 @@ describe('Workbench Kueue Lifecycle Tests', () => {
       'Verify workbench Kueue lifecycle: Inadmissible → Ready after quota update',
       { tags: ['@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged'] },
       () => {
-        const workbenchName = `kueue-lifecycle-wb-${ctx.uuid}`;
+        if (!ctx) {
+          throw new Error('Test setup did not complete');
+        }
+        const projectCtx = ctx;
 
-        openWorkbenchesTab(ctx);
-        createWorkbench(ctx, workbenchName);
+        const workbenchName = `kueue-lifecycle-wb-${projectCtx.uuid}`;
+
+        openWorkbenchesTab(projectCtx);
+        createWorkbench(projectCtx, workbenchName);
 
         const notebookRow = workbenchPage.getNotebookRow(workbenchName);
         notebookRow.expectStatusLabelToBe('Inadmissible', 120000);
         notebookRow
           .findNotebookStatusSubtitle()
-          .should('contain.text', ctx.fixtureData.exceededQuotaMessage);
+          .should('contain.text', projectCtx.fixtureData.exceededQuotaMessage);
 
         notebookRow.findHaveNotebookStatusText().click();
-        verifyResourcesModal(ctx.testData.clusterQueueName);
+        verifyResourcesModal(projectCtx.testData.clusterQueueName);
 
         updateClusterQueueQuota(
-          ctx.testData.clusterQueueName,
-          ctx.fixtureData.updatedCpuQuota,
-          ctx.fixtureData.updatedMemoryQuota,
+          projectCtx.testData.clusterQueueName,
+          projectCtx.fixtureData.updatedCpuQuota,
+          projectCtx.fixtureData.updatedMemoryQuota,
         );
 
         notebookRow.expectStatusLabelToBe('Ready', 300000);
-        notebookRow.shouldHaveHardwareProfile(ctx.testData.hardwareProfileDisplayName);
+        notebookRow.shouldHaveHardwareProfile(projectCtx.testData.hardwareProfileDisplayName);
       },
     );
   });
@@ -193,28 +198,36 @@ describe('Workbench Kueue Lifecycle Tests', () => {
         tags: ['@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged', '@NonConcurrent'],
       },
       () => {
-        const firstWorkbenchName = `kueue-wb-q1-${ctx.uuid}`;
-        const secondWorkbenchName = `kueue-wb-q2-${ctx.uuid}`;
+        if (!ctx) {
+          throw new Error('Test setup did not complete');
+        }
+        const projectCtx = ctx;
 
-        openWorkbenchesTab(ctx);
-        createWorkbench(ctx, firstWorkbenchName);
-        pollUntilWorkloadAdmitted(ctx.projectName, { maxAttempts: 120, pollIntervalMs: 5000 });
+        const firstWorkbenchName = `kueue-wb-q1-${projectCtx.uuid}`;
+        const secondWorkbenchName = `kueue-wb-q2-${projectCtx.uuid}`;
 
-        createWorkbench(ctx, secondWorkbenchName);
-        pollUntilAnyWorkloadMessageMatches(ctx.projectName, QUEUED_MESSAGE);
+        openWorkbenchesTab(projectCtx);
+        createWorkbench(projectCtx, firstWorkbenchName);
+        pollUntilWorkloadAdmitted(projectCtx.projectName, {
+          maxAttempts: 120,
+          pollIntervalMs: 5000,
+        });
+
+        createWorkbench(projectCtx, secondWorkbenchName);
+        pollUntilAnyWorkloadMessageMatches(projectCtx.projectName, QUEUED_MESSAGE);
 
         const notebookRow = workbenchPage.getNotebookRow(secondWorkbenchName);
         notebookRow.expectStatusLabelToBe('Queued', 120000);
         notebookRow.findNotebookStatusSubtitle().should(($el) => {
           const text = $el.text();
           expect(
-            text.includes(ctx.fixtureData.waitingForQuotaMessage) ||
+            text.includes(projectCtx.fixtureData.waitingForQuotaMessage) ||
               QUEUE_POSITION_REGEX.test(text),
           ).to.eq(true);
         });
 
         notebookRow.findHaveNotebookStatusText().click();
-        verifyResourcesModal(ctx.testData.clusterQueueName);
+        verifyResourcesModal(projectCtx.testData.clusterQueueName);
       },
     );
   });

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
@@ -12,6 +12,10 @@ import {
   updateClusterQueueQuota,
   type KueueWorkbenchConfig,
 } from '../../../../utils/oc_commands/kueueWorkbench';
+import {
+  pollUntilWorkloadAdmitted,
+  pollUntilAnyWorkloadMessageMatches,
+} from '../../../../utils/oc_commands/kueueModelDeployment';
 import { projectDetails, projectListPage } from '../../../../pages/projects';
 import {
   workbenchPage,
@@ -21,18 +25,23 @@ import {
 import { selectNotebookImageWithBackendFallback } from '../../../../utils/oc_commands/imageStreams';
 import type { KueueWorkbenchLifecycleTestData } from '../../../../types';
 
-describe('Workbench Kueue Lifecycle Tests', () => {
-  let testData: KueueWorkbenchConfig;
-  let fixtureData: KueueWorkbenchLifecycleTestData;
-  let projectName: string;
-  let sectionTab: string;
-  let notebookImage: string;
-  const uuid = generateTestUUID();
-  const workbenchName = `kueue-lifecycle-wb-${uuid}`;
+const QUEUE_POSITION_REGEX = /\d+(st|nd|rd|th) in/;
+const QUEUED_MESSAGE = /insufficient unused quota/i;
 
-  retryableBefore(() =>
-    loadKueueWorkbenchLifecycleFixture('e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml').then(
-      (data) => {
+describe('Workbench Kueue Lifecycle Tests', () => {
+  describe('Inadmissible with zero quota', () => {
+    let testData: KueueWorkbenchConfig;
+    let fixtureData: KueueWorkbenchLifecycleTestData;
+    let projectName: string;
+    let sectionTab: string;
+    let notebookImage: string;
+    const uuid = generateTestUUID();
+    const workbenchName = `kueue-lifecycle-wb-${uuid}`;
+
+    retryableBefore(() =>
+      loadKueueWorkbenchLifecycleFixture(
+        'e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml',
+      ).then((data) => {
         fixtureData = data;
         projectName = `${data.projectName}-${uuid}`;
         sectionTab = data.sectionTab;
@@ -49,28 +58,131 @@ describe('Workbench Kueue Lifecycle Tests', () => {
         return deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true })
           .then(() => createOpenShiftProject(projectName))
           .then(() => setupKueueWorkbenchResources(testData, projectName));
-      },
-    ),
-  );
+      }),
+    );
 
-  after(() => {
-    cleanupKueueWorkbenchResources(testData, projectName);
-    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+    after(() => {
+      cleanupKueueWorkbenchResources(testData, projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+    });
+
+    it(
+      'Verify workbench Kueue lifecycle: Inadmissible → Ready after quota update',
+      { tags: ['@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged'] },
+      () => {
+        cy.step('Log into the application');
+        cy.visitWithLogin('/?devFeatureFlags=true', LDAP_ADMIN_USER);
+
+        cy.step(`Navigate to workbenches tab of project ${projectName}`);
+        projectListPage.navigate();
+        projectListPage.filterProjectByName(projectName);
+        projectListPage.findProjectLink(projectName).click();
+        projectDetails.findSectionTab(sectionTab).click();
+
+        cy.step('Click Create workbench button');
+        workbenchPage.findCreateButton().click();
+
+        cy.step('Enter workbench name');
+        createSpawnerPage.getNameInput().fill(workbenchName);
+
+        cy.step('Select a notebook image');
+        selectNotebookImageWithBackendFallback(notebookImage, createSpawnerPage);
+
+        cy.step('Verify Kueue hardware profile is pre-selected');
+        createSpawnerPage
+          .findHardwareProfileSelect()
+          .should('contain.text', testData.hardwareProfileDisplayName);
+
+        cy.step('Submit the workbench creation');
+        createSpawnerPage.findSubmitButton().click();
+
+        cy.step('Wait for notebook table to appear');
+        workbenchPage.findNotebookTable(30000).should('exist');
+
+        cy.step('Verify workbench shows Inadmissible status');
+        const notebookRow = workbenchPage.getNotebookRow(workbenchName);
+        notebookRow.expectStatusLabelToBe('Inadmissible', 120000);
+
+        cy.step('Verify status subtitle shows exceeded quota message');
+        notebookRow
+          .findNotebookStatusSubtitle()
+          .should('contain.text', fixtureData.exceededQuotaMessage);
+
+        cy.step('Click on the Inadmissible status label to open the status modal');
+        notebookRow.findHaveNotebookStatusText().click();
+
+        cy.step('Verify status modal is visible');
+        workbenchStatusModal.find().should('be.visible');
+
+        cy.step('Verify Resources tab is visible and click it');
+        workbenchStatusModal.findResourcesTab().should('be.visible');
+        workbenchStatusModal.findResourcesTab().click();
+
+        cy.step('Verify ClusterQueue section is visible with queue name');
+        workbenchStatusModal.findClusterQueueSection().should('be.visible');
+        workbenchStatusModal.findQueueValue().should('contain.text', testData.clusterQueueName);
+
+        cy.step('Verify quotas section is visible');
+        workbenchStatusModal.findQuotasSection().should('be.visible');
+
+        cy.step('Close the status modal');
+        workbenchStatusModal.getModalCloseButton().click();
+
+        cy.step('Update the ClusterQueue quota to allow the workbench');
+        updateClusterQueueQuota(
+          testData.clusterQueueName,
+          fixtureData.updatedCpuQuota,
+          fixtureData.updatedMemoryQuota,
+        );
+
+        cy.step('Wait for workbench to transition to Ready status');
+        notebookRow.expectStatusLabelToBe('Ready', 300000);
+
+        cy.step('Verify hardware profile is displayed after Ready');
+        notebookRow.shouldHaveHardwareProfile(testData.hardwareProfileDisplayName);
+      },
+    );
   });
 
-  it(
-    'Verify workbench Kueue lifecycle: Inadmissible → Ready after quota update',
-    { tags: ['@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged'] },
-    () => {
-      cy.step('Log into the application');
-      cy.visitWithLogin('/?devFeatureFlags=true', LDAP_ADMIN_USER);
+  describe('Queued when quota is fully consumed', () => {
+    let testData: KueueWorkbenchConfig;
+    let fixtureData: KueueWorkbenchLifecycleTestData;
+    let projectName: string;
+    let sectionTab: string;
+    let notebookImage: string;
+    const uuid = generateTestUUID();
+    const firstWorkbenchName = `kueue-wb-q1-${uuid}`;
+    const secondWorkbenchName = `kueue-wb-q2-${uuid}`;
 
-      cy.step(`Navigate to workbenches tab of project ${projectName}`);
-      projectListPage.navigate();
-      projectListPage.filterProjectByName(projectName);
-      projectListPage.findProjectLink(projectName).click();
-      projectDetails.findSectionTab(sectionTab).click();
+    retryableBefore(() =>
+      loadKueueWorkbenchLifecycleFixture(
+        'e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml',
+      ).then((data) => {
+        fixtureData = data;
+        projectName = `${data.projectName}-q-${uuid}`;
+        sectionTab = data.sectionTab;
+        notebookImage = data.notebookImage;
+        testData = {
+          flavorName: `${data.flavorName}-queued-${uuid}`,
+          clusterQueueName: `${data.clusterQueueName}-queued-${uuid}`,
+          localQueueName: `${data.localQueueName}-queued-${uuid}`,
+          hardwareProfileName: `${data.hardwareProfileName}-queued-${uuid}`,
+          hardwareProfileDisplayName: `${data.hardwareProfileDisplayName} Queued ${uuid}`,
+          cpuQuota: data.queuedCpuQuota,
+          memoryQuota: data.queuedMemoryQuota,
+        };
+        return deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true })
+          .then(() => createOpenShiftProject(projectName))
+          .then(() => setupKueueWorkbenchResources(testData, projectName));
+      }),
+    );
 
+    after(() => {
+      cleanupKueueWorkbenchResources(testData, projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+    });
+
+    const createWorkbench = (workbenchName: string) => {
       cy.step('Click Create workbench button');
       workbenchPage.findCreateButton().click();
 
@@ -90,48 +202,63 @@ describe('Workbench Kueue Lifecycle Tests', () => {
 
       cy.step('Wait for notebook table to appear');
       workbenchPage.findNotebookTable(30000).should('exist');
+    };
 
-      cy.step('Verify workbench shows Inadmissible status');
-      const notebookRow = workbenchPage.getNotebookRow(workbenchName);
-      notebookRow.expectStatusLabelToBe('Inadmissible', 120000);
+    it(
+      'Verify workbench shows Queued when ClusterQueue quota is consumed by another workbench',
+      {
+        tags: ['@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged', '@NonConcurrent'],
+      },
+      () => {
+        cy.step('Log into the application');
+        cy.visitWithLogin('/?devFeatureFlags=true', LDAP_ADMIN_USER);
 
-      cy.step('Verify status subtitle shows exceeded quota message');
-      notebookRow
-        .findNotebookStatusSubtitle()
-        .should('contain.text', fixtureData.exceededQuotaMessage);
+        cy.step(`Navigate to workbenches tab of project ${projectName}`);
+        projectListPage.navigate();
+        projectListPage.filterProjectByName(projectName);
+        projectListPage.findProjectLink(projectName).click();
+        projectDetails.findSectionTab(sectionTab).click();
 
-      cy.step('Click on the Inadmissible status label to open the status modal');
-      notebookRow.findHaveNotebookStatusText().click();
+        cy.step('Create first workbench and wait for Kueue admission');
+        createWorkbench(firstWorkbenchName);
+        pollUntilWorkloadAdmitted(projectName, { maxAttempts: 120, pollIntervalMs: 5000 });
 
-      cy.step('Verify status modal is visible');
-      workbenchStatusModal.find().should('be.visible');
+        cy.step('Create second workbench that consumes remaining quota');
+        createWorkbench(secondWorkbenchName);
+        pollUntilAnyWorkloadMessageMatches(projectName, QUEUED_MESSAGE);
 
-      cy.step('Verify Resources tab is visible and click it');
-      workbenchStatusModal.findResourcesTab().should('be.visible');
-      workbenchStatusModal.findResourcesTab().click();
+        cy.step('Verify workbench shows Queued status');
+        const notebookRow = workbenchPage.getNotebookRow(secondWorkbenchName);
+        notebookRow.expectStatusLabelToBe('Queued', 120000);
 
-      cy.step('Verify ClusterQueue section is visible with queue name');
-      workbenchStatusModal.findClusterQueueSection().should('be.visible');
-      workbenchStatusModal.findQueueValue().should('contain.text', testData.clusterQueueName);
+        cy.step('Verify status subtitle shows waiting for quota or queue position');
+        notebookRow.findNotebookStatusSubtitle().should(($el) => {
+          const text = $el.text();
+          expect(
+            text.includes(fixtureData.waitingForQuotaMessage) || QUEUE_POSITION_REGEX.test(text),
+          ).to.eq(true);
+        });
 
-      cy.step('Verify quotas section is visible');
-      workbenchStatusModal.findQuotasSection().should('be.visible');
+        cy.step('Click on the Queued status label to open the status modal');
+        notebookRow.findHaveNotebookStatusText().click();
 
-      cy.step('Close the status modal');
-      workbenchStatusModal.getModalCloseButton().click();
+        cy.step('Verify status modal is visible');
+        workbenchStatusModal.find().should('be.visible');
 
-      cy.step('Update the ClusterQueue quota to allow the workbench');
-      updateClusterQueueQuota(
-        testData.clusterQueueName,
-        fixtureData.updatedCpuQuota,
-        fixtureData.updatedMemoryQuota,
-      );
+        cy.step('Verify Resources tab is visible and click it');
+        workbenchStatusModal.findResourcesTab().should('be.visible');
+        workbenchStatusModal.findResourcesTab().click();
 
-      cy.step('Wait for workbench to transition to Ready status');
-      notebookRow.expectStatusLabelToBe('Ready', 300000);
+        cy.step('Verify ClusterQueue section is visible with queue name');
+        workbenchStatusModal.findClusterQueueSection().should('be.visible');
+        workbenchStatusModal.findQueueValue().should('contain.text', testData.clusterQueueName);
 
-      cy.step('Verify hardware profile is displayed after Ready');
-      notebookRow.shouldHaveHardwareProfile(testData.hardwareProfileDisplayName);
-    },
-  );
+        cy.step('Verify quotas section is visible');
+        workbenchStatusModal.findQuotasSection().should('be.visible');
+
+        cy.step('Close the status modal');
+        workbenchStatusModal.getModalCloseButton().click();
+      },
+    );
+  });
 });

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -139,6 +139,9 @@ export type KueueWorkbenchLifecycleTestData = KueueWorkbenchTestData & {
   updatedCpuQuota: number;
   updatedMemoryQuota: number;
   exceededQuotaMessage: string;
+  queuedCpuQuota: number;
+  queuedMemoryQuota: number;
+  waitingForQuotaMessage: string;
 };
 
 export type WBControlSuiteTestData = {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-93223

## Description


Adds a Cypress E2E test for the **Queued workbench Kueue lifecycle**. When the ClusterQueue quota is fully consumed by one workbench, a second workbench shows **Queued** status, and the resources modal displays the relevant queue and quota context.

Extends the shared Kueue workbench lifecycle fixture and types to support the Queued scenario. The Queued test runs in a separate spec to avoid resource-name collisions with the existing Inadmissible test.

## How Has This Been Tested?

- Ran `testWorkbenchKueueQueuedLifecycle.cy.ts` on a Kueue-enabled cluster with `devFeatureFlags=true`.
- Verified the second workbench enters the **Queued** state when the available quota is fully consumed.
- Verified the resources modal displays the expected queue/quota information.

## Test Impact

- New E2E test: `testWorkbenchKueueQueuedLifecycle.cy.ts`
- Updated Kueue workbench lifecycle fixture/types to support queued quota values:
  - `queuedCpuQuota`
  - `queuedMemoryQuota`
  - etc.

## Request Review Criteria

### Self Checklist

- [x] The developer has manually tested the changes and verified that they work.
- [x] Testing instructions have been added in the PR body for changes that are not immediately obvious.
- [x] The developer has added tests or explained why testing cannot be added.
- [x] The code follows our Best Practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for workbench lifecycle behavior under different quota conditions.
  - Added validation for workbenches becoming queued when quota is partially available.
  - Improved checks for quota-related messaging, queue position, resource details, and readiness states.
  - Added isolated scenarios and cleanup to make lifecycle validation more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->