### PR TITLE
fix(e2e): stabilize serving runtime row lookup (RHOAIENG-93297)

### DIFF
--- a/packages/cypress/cypress/pages/servingRuntimes.ts
+++ b/packages/cypress/cypress/pages/servingRuntimes.ts
@@ -58,6 +58,14 @@ class ServingRuntimeRow {
     this.findEnabledToggleInput().should(enabled ? 'be.checked' : 'not.be.checked');
     return this;
   }
+
+  findKebabToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByLabelText('Kebab toggle');
+  }
+
+  findDeleteButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findKebabAction('Delete');
+  }
 }
 
 class ServingRuntimes {

--- a/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
@@ -72,14 +72,10 @@ describe('Verify Admins Can Import and Delete a Custom Single-Model Serving Runt
 
       // Edit the created model serving platform and delete
       cy.step(`Verify the model ${modelServingSingleName} has been created`);
-      cy.contains(metadataSingleDisplayName).should('be.visible');
-      servingRuntimes
-        .getRowById(modelServingSingleName)
-        .find()
-        .within(() => {
-          servingRuntimes.findEditModel().click();
-        });
-      servingRuntimes.findDeleteModel().click();
+      const runtimeRow = servingRuntimes.getRowById(modelServingSingleName);
+      runtimeRow.find().should('exist');
+      runtimeRow.findKebabToggle().click();
+      runtimeRow.findDeleteButton().click();
 
       servingRuntimes.findDeleteModal().should('be.visible').type(metadataSingleDisplayName);
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-93297

## Description

Backport the serving-runtime delete flow from https://github.com/opendatahub-io/odh-dashboard/pull/9579 to `v3.5.0-fixes`.

After creating a custom runtime, `testSingleServingRuntimeCreation.cy.ts` asserted `cy.contains(displayName).should('be.visible')` and used page-level kebab/delete selectors. On Jenkins clusters with many OOTB runtimes, the new row is in the DOM but clipped by page overflow, so Cypress treats it as hidden even though creation succeeded.

This change:
- Asserts the created row exists via `data-testid` instead of viewport visibility
- Deletes via the row kebab menu (scoped `findKebabToggle` / `findDeleteButton` on `ServingRuntimeRow`)

The project-list stabilization from #9579 is already present on `v3.5.0-fixes`; only the serving-runtime portion was missing.

## How Has This Been Tested?

- Lint-staged (eslint) passed on the changed Cypress files.
- Serving-runtime visibility failure was observed on Jenkins (`dash-e2e-odh`); locally the shorter runtime list does not reproduce it.
- Full E2E rerun on Jenkins still needed after merge.

## Test Impact

Cypress E2E only. No new specs.

- `testSingleServingRuntimeCreation.cy.ts` — assert row existence instead of viewport visibility; delete from row kebab.
- `servingRuntimes.ts` — add row-scoped kebab/delete helpers.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)