### PR TITLE
RHOAIENG-83656: Add real-cluster E2E framework

### DIFF
--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -18,12 +18,12 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter (includes integration-tagged files).
-	$(GOLANGCI_LINT) run --build-tags=integration
+lint: golangci-lint ## Run golangci-lint linter (includes integration and E2E files).
+	$(GOLANGCI_LINT) run --build-tags=integration,e2e
 
 .PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes (includes integration-tagged files).
-	$(GOLANGCI_LINT) run --build-tags=integration --fix
+lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes (includes integration and E2E files).
+	$(GOLANGCI_LINT) run --build-tags=integration,e2e --fix
 
 .PHONY: test
 test: fmt vet ## Run tests.
@@ -33,6 +33,13 @@ test: fmt vet ## Run tests.
 test-integration: setup-envtest ## Run integration tests with envtest.
 	KUBEBUILDER_ASSETS="$$($(ENVTEST) use 1.31.x -p path)" go test -v -race -tags=integration -count=1 ./internal/controller/...
 
+.PHONY: test-e2e
+test-e2e: ## Run real-cluster E2E tests (requires KUBECONFIG and TEST_NAMESPACE).
+	@test -n "$$KUBECONFIG" || (echo "KUBECONFIG must point to a kubeconfig file." && exit 1)
+	@test -n "$$TEST_NAMESPACE" || (echo "TEST_NAMESPACE must name an existing namespace." && exit 1)
+	@test -f "$$KUBECONFIG" || (echo "KUBECONFIG must point to a regular file." && exit 1)
+	go test -v -count=1 -tags=e2e -timeout=30m $(E2E_TEST_ARGS) ./test/e2e/...
+
 ##@ Build
 
 SAFE_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null | tr -cd '[:alnum:]_.-' || echo "unknown")
@@ -40,6 +47,13 @@ SAFE_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null | tr -c
 .PHONY: build
 build: fmt vet ## Build manager binary.
 	go build -ldflags "-X github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller.Version=$(SAFE_VERSION)" -o bin/manager ./cmd/manager
+
+E2E_TEST_BINARY ?= bin/e2e.test
+
+.PHONY: build-e2e
+build-e2e: ## Compile the standalone real-cluster E2E test binary.
+	@mkdir -p "$(dir $(E2E_TEST_BINARY))"
+	go test -c -tags=e2e -o "$(E2E_TEST_BINARY)" ./test/e2e
 
 .PHONY: run
 run: fmt vet ## Run the controller from your host.

--- a/dashboard-operator/go.mod
+++ b/dashboard-operator/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	github.com/opendatahub-io/odh-platform-utilities v0.2.1-0.20260804085229-7872bf1402b9
+	github.com/opendatahub-io/odh-platform-utilities/framework v0.1.0
 	github.com/opendatahub-io/operator-chaos v0.0.0-20260521100204-4dab974d613c
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/stretchr/testify v1.12.1
@@ -13,6 +14,7 @@ require (
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.1
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/gateway-api v1.4.0
 )
 
 require (
@@ -53,6 +55,8 @@ require (
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/itchyny/gojq v0.12.19 // indirect
+	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k8s-manifest-kit/engine v0.2.1-0.20260716110219-fb67c5bea55e // indirect
 	github.com/k8s-manifest-kit/pkg v0.2.1-0.20260716110029-cb840211b914 // indirect
@@ -63,6 +67,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/onsi/gomega v1.42.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -97,7 +102,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3 // indirect
 	oras.land/oras-go/v2 v2.6.2 // indirect
-	sigs.k8s.io/gateway-api v1.4.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect

--- a/dashboard-operator/go.sum
+++ b/dashboard-operator/go.sum
@@ -95,8 +95,16 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
+github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
+github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=
+github.com/itchyny/timefmt-go v0.1.8/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/k8s-manifest-kit/engine v0.2.1-0.20260716110219-fb67c5bea55e h1:0lh1fMF2W9xgf5/9rygreNMv92+PLKczdhotJ3r+CQ4=
@@ -139,6 +147,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opendatahub-io/odh-platform-utilities v0.2.1-0.20260804085229-7872bf1402b9 h1:Tr6yI0fD3Wq/SHlNpxgmXK1w6HdtJh2BP/7Fsw1N6a4=
 github.com/opendatahub-io/odh-platform-utilities v0.2.1-0.20260804085229-7872bf1402b9/go.mod h1:RbnUlLqR+D6BxqpZFjtzkKcz9UtB6BjMUOiLuBY0aeE=
+github.com/opendatahub-io/odh-platform-utilities/framework v0.1.0 h1:jRKIPs6iOVNO97Oc/dq/8a3TSCZr5gFk+SU33LcUsKE=
+github.com/opendatahub-io/odh-platform-utilities/framework v0.1.0/go.mod h1:/nIqgY+gC69mclLgIK1Nu6aa3n4qNwuciySSKZx0A8E=
 github.com/opendatahub-io/operator-chaos v0.0.0-20260521100204-4dab974d613c h1:olKZNTyNTTaLVnGyNimB4nSihohMghshSoqDWfSmFwI=
 github.com/opendatahub-io/operator-chaos v0.0.0-20260521100204-4dab974d613c/go.mod h1:f9D+8VSCrpTB2EeGD6F26ZkaO8GN7dCbT9lFZfZ68t0=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=

--- a/dashboard-operator/test/e2e/README.md
+++ b/dashboard-operator/test/e2e/README.md
@@ -14,6 +14,8 @@ delete that singleton resource.
 - A cluster with dashboard-operator and the Dashboard CRD installed.
 - The platform controller that normally creates `default-dashboard` scaled down
   for lifecycle scenarios, so it cannot recreate the singleton during cleanup.
+- No existing `default-dashboard` for the lifecycle scenario. The apply helper
+  refuses to adopt or modify an existing singleton.
 - A dedicated, existing namespace for namespaced test resources.
 - A kubeconfig stored in one file.
 - RBAC to get the test Namespace and Dashboard CRD; get, create, patch, and
@@ -42,13 +44,13 @@ Pass standard `go test` options through `E2E_TEST_ARGS`, including a selective
 test run:
 
 ```bash
-make test-e2e E2E_TEST_ARGS='-run TestE2EOperand'
+make test-e2e E2E_TEST_ARGS='-run TestE2EDashboardLifecycle'
 ```
 
 The equivalent direct command is:
 
 ```bash
-go test -v -count=1 -tags=e2e -timeout=30m -run TestE2EOperand ./test/e2e/...
+go test -v -count=1 -tags=e2e -timeout=30m -run TestE2EDashboardLifecycle ./test/e2e/...
 ```
 
 ## Compile and Run in a Container
@@ -64,7 +66,7 @@ kubeconfig, set both required environment variables, and run it with standard
 testing flags:
 
 ```bash
-./bin/e2e.test -test.v -test.run TestE2EOperand
+./bin/e2e.test -test.v -test.run TestE2EDashboardLifecycle
 ```
 
 Embed small fixtures with `//go:embed`, or mount them at a path supplied by an
@@ -84,11 +86,12 @@ helpers for:
 - matching unstructured Kubernetes data with JQ expressions; and
 - validating the Dashboard platform contract.
 
-The apply helper uses the `dashboard-operator-e2e` field manager and does not
-force ownership. Conflicts with fields owned by another manager fail the test.
-The cleanup helper refuses to delete a Dashboard unless it carries the E2E
-ownership label applied by the framework. A test that applies the Dashboard
-must register cleanup immediately and surface cleanup failures.
+The apply helper refuses to modify a pre-existing singleton, uses the
+`dashboard-operator-e2e` field manager, and does not force ownership. Conflicts
+with fields owned by another manager fail the test. It returns the UID of the
+Dashboard it created; cleanup requires that UID and refuses to delete a
+different or unlabeled object. A test that applies the Dashboard must register
+cleanup immediately and surface cleanup failures.
 
 Keep each scenario independent and runnable with `-run`. Tests must wait for
 observable conditions instead of sleeping, clean up resources they own, and

--- a/dashboard-operator/test/e2e/README.md
+++ b/dashboard-operator/test/e2e/README.md
@@ -14,7 +14,7 @@ delete that singleton resource.
 - A cluster with dashboard-operator and the Dashboard CRD installed.
 - The platform controller that normally creates `default-dashboard` scaled down
   for lifecycle scenarios, so it cannot recreate the singleton during cleanup.
-- No existing `default-dashboard` for the lifecycle scenario. The apply helper
+- No existing `default-dashboard` for the lifecycle scenario. The create helper
   refuses to adopt or modify an existing singleton.
 - A dedicated, existing namespace for namespaced test resources.
 - A kubeconfig stored in one file.
@@ -80,18 +80,16 @@ helpers for:
 
 - waiting for a Dashboard condition;
 - waiting for an available Deployment;
-- applying the singleton Dashboard through server-side apply;
+- creating the singleton Dashboard atomically;
 - deleting an E2E-owned Dashboard and waiting for its removal;
 - waiting for ready Service Endpoints;
 - matching unstructured Kubernetes data with JQ expressions; and
 - validating the Dashboard platform contract.
 
-The apply helper refuses to modify a pre-existing singleton, uses the
-`dashboard-operator-e2e` field manager, and does not force ownership. Conflicts
-with fields owned by another manager fail the test. It returns the UID of the
-Dashboard it created; cleanup requires that UID and refuses to delete a
-different or unlabeled object. A test that applies the Dashboard must register
-cleanup immediately and surface cleanup failures.
+The create helper atomically creates the singleton and fails if it already
+exists. It returns the API-assigned UID; cleanup requires that UID and refuses
+to delete a different or unlabeled object. A test that creates the Dashboard
+must register cleanup immediately and surface cleanup failures.
 
 Keep each scenario independent and runnable with `-run`. Tests must wait for
 observable conditions instead of sleeping, clean up resources they own, and

--- a/dashboard-operator/test/e2e/README.md
+++ b/dashboard-operator/test/e2e/README.md
@@ -1,0 +1,95 @@
+# Dashboard Operator Real-Cluster E2E Framework
+
+This package provides shared helpers for dashboard-operator tests that require a
+running Kubernetes or OpenShift cluster. It complements the envtest suite in
+`internal/controller`; it does not replace it.
+
+The Dashboard API is cluster-scoped and permits only the
+`default-dashboard` instance. Run these tests on an isolated early-gate cluster,
+not on a shared Cypress or development cluster. Future scenarios can change or
+delete that singleton resource.
+
+## Prerequisites
+
+- A cluster with dashboard-operator and the Dashboard CRD installed.
+- The platform controller that normally creates `default-dashboard` scaled down
+  for lifecycle scenarios, so it cannot recreate the singleton during cleanup.
+- A dedicated, existing namespace for namespaced test resources.
+- A kubeconfig stored in one file.
+- RBAC to get the test Namespace and Dashboard CRD; get, create, patch, and
+  delete Dashboards; and get Deployments and Endpoints in the test namespace.
+
+Set the required environment variables:
+
+```bash
+export KUBECONFIG=/absolute/path/to/kubeconfig
+export TEST_NAMESPACE=dashboard-operator-e2e
+```
+
+`TestMain` verifies connectivity, the namespace, the Dashboard CRD, and its
+served API version before any test runs. It verifies the CRD but never installs
+it.
+
+## Run Locally
+
+From `dashboard-operator`:
+
+```bash
+make test-e2e
+```
+
+Pass standard `go test` options through `E2E_TEST_ARGS`, including a selective
+test run:
+
+```bash
+make test-e2e E2E_TEST_ARGS='-run TestE2EOperand'
+```
+
+The equivalent direct command is:
+
+```bash
+go test -v -count=1 -tags=e2e -timeout=30m -run TestE2EOperand ./test/e2e/...
+```
+
+## Compile and Run in a Container
+
+Build the standalone test binary without connecting to a cluster:
+
+```bash
+make build-e2e
+```
+
+This produces `bin/e2e.test`. Copy that binary into a test image, mount a
+kubeconfig, set both required environment variables, and run it with standard
+testing flags:
+
+```bash
+./bin/e2e.test -test.v -test.run TestE2EOperand
+```
+
+Embed small fixtures with `//go:embed`, or mount them at a path supplied by an
+environment variable. Do not depend on paths that exist only on a developer's
+machine.
+
+## Authoring Scenarios
+
+All Go files in this directory must use the `e2e` build tag. Reuse the shared
+helpers for:
+
+- waiting for a Dashboard condition;
+- waiting for an available Deployment;
+- applying the singleton Dashboard through server-side apply;
+- deleting an E2E-owned Dashboard and waiting for its removal;
+- waiting for ready Service Endpoints;
+- matching unstructured Kubernetes data with JQ expressions; and
+- validating the Dashboard platform contract.
+
+The apply helper uses the `dashboard-operator-e2e` field manager and does not
+force ownership. Conflicts with fields owned by another manager fail the test.
+The cleanup helper refuses to delete a Dashboard unless it carries the E2E
+ownership label applied by the framework. A test that applies the Dashboard
+must register cleanup immediately and surface cleanup failures.
+
+Keep each scenario independent and runnable with `-run`. Tests must wait for
+observable conditions instead of sleeping, clean up resources they own, and
+avoid relying on execution order.

--- a/dashboard-operator/test/e2e/e2e_test.go
+++ b/dashboard-operator/test/e2e/e2e_test.go
@@ -79,7 +79,6 @@ func initializeE2E() error {
 	if err != nil {
 		return fmt.Errorf("build REST config from KUBECONFIG: %w", err)
 	}
-	config.Timeout = preflightTimeout
 
 	c, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
@@ -121,13 +120,17 @@ func initializeE2E() error {
 
 func newE2EScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
-	for name, addToScheme := range map[string]func(*runtime.Scheme) error{
-		"Kubernetes":    clientgoscheme.AddToScheme,
-		"apiextensions": apiextensionsv1.AddToScheme,
-		"Dashboard":     dashboardv1alpha1.AddToScheme,
-	} {
-		if err := addToScheme(scheme); err != nil {
-			return nil, fmt.Errorf("register %s APIs with E2E scheme: %w", name, err)
+	registrations := []struct {
+		name        string
+		addToScheme func(*runtime.Scheme) error
+	}{
+		{name: "Kubernetes", addToScheme: clientgoscheme.AddToScheme},
+		{name: "apiextensions", addToScheme: apiextensionsv1.AddToScheme},
+		{name: "Dashboard", addToScheme: dashboardv1alpha1.AddToScheme},
+	}
+	for _, registration := range registrations {
+		if err := registration.addToScheme(scheme); err != nil {
+			return nil, fmt.Errorf("register %s APIs with E2E scheme: %w", registration.name, err)
 		}
 	}
 

--- a/dashboard-operator/test/e2e/e2e_test.go
+++ b/dashboard-operator/test/e2e/e2e_test.go
@@ -18,6 +18,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const (
@@ -127,6 +128,7 @@ func newE2EScheme() (*runtime.Scheme, error) {
 		{name: "Kubernetes", addToScheme: clientgoscheme.AddToScheme},
 		{name: "apiextensions", addToScheme: apiextensionsv1.AddToScheme},
 		{name: "Dashboard", addToScheme: dashboardv1alpha1.AddToScheme},
+		{name: "Gateway API", addToScheme: gatewayv1.Install},
 	}
 	for _, registration := range registrations {
 		if err := registration.addToScheme(scheme); err != nil {

--- a/dashboard-operator/test/e2e/e2e_test.go
+++ b/dashboard-operator/test/e2e/e2e_test.go
@@ -1,0 +1,135 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	dashboardv1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	dashboardCRDName = "dashboards.components.platform.opendatahub.io"
+	preflightTimeout = 30 * time.Second
+)
+
+var (
+	k8sClient     client.Client
+	testNamespace string
+)
+
+func TestMain(m *testing.M) {
+	if err := initializeE2E(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "E2E preflight failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestE2EFrameworkPreflight(t *testing.T) {
+	if k8sClient == nil {
+		t.Fatal("controller-runtime client was not initialized")
+	}
+	if testNamespace == "" {
+		t.Fatal("test namespace was not initialized")
+	}
+}
+
+func initializeE2E() error {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		return errors.New("KUBECONFIG must point to a kubeconfig file")
+	}
+
+	info, err := os.Stat(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("cannot access KUBECONFIG: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("KUBECONFIG must point to a regular file")
+	}
+
+	namespace := os.Getenv("TEST_NAMESPACE")
+	if namespace == "" {
+		return errors.New("TEST_NAMESPACE must name an existing namespace")
+	}
+	if problems := k8svalidation.IsDNS1123Label(namespace); len(problems) > 0 {
+		return fmt.Errorf("TEST_NAMESPACE %q is invalid: %v", namespace, problems)
+	}
+
+	scheme, err := newE2EScheme()
+	if err != nil {
+		return err
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return fmt.Errorf("build REST config from KUBECONFIG: %w", err)
+	}
+	config.Timeout = preflightTimeout
+
+	c, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("create controller-runtime client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), preflightTimeout)
+	defer cancel()
+
+	if err := c.Get(ctx, client.ObjectKey{Name: namespace}, &corev1.Namespace{}); err != nil {
+		return fmt.Errorf("verify cluster connectivity and TEST_NAMESPACE %q: %w", namespace, err)
+	}
+
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := c.Get(ctx, client.ObjectKey{Name: dashboardCRDName}, crd); err != nil {
+		return fmt.Errorf("verify Dashboard CRD %q: %w", dashboardCRDName, err)
+	}
+
+	served := false
+	for _, version := range crd.Spec.Versions {
+		if version.Name == dashboardv1alpha1.GroupVersion.Version && version.Served {
+			served = true
+			break
+		}
+	}
+	if !served {
+		return fmt.Errorf(
+			"Dashboard CRD %q does not serve version %q",
+			dashboardCRDName,
+			dashboardv1alpha1.GroupVersion.Version,
+		)
+	}
+
+	k8sClient = c
+	testNamespace = namespace
+
+	return nil
+}
+
+func newE2EScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	for name, addToScheme := range map[string]func(*runtime.Scheme) error{
+		"Kubernetes":    clientgoscheme.AddToScheme,
+		"apiextensions": apiextensionsv1.AddToScheme,
+		"Dashboard":     dashboardv1alpha1.AddToScheme,
+	} {
+		if err := addToScheme(scheme); err != nil {
+			return nil, fmt.Errorf("register %s APIs with E2E scheme: %w", name, err)
+		}
+	}
+
+	return scheme, nil
+}

--- a/dashboard-operator/test/e2e/helpers_test.go
+++ b/dashboard-operator/test/e2e/helpers_test.go
@@ -201,7 +201,7 @@ func waitForServiceEndpoints(c client.Client, namespace, name string, timeout ti
 		timeout,
 		true,
 		func(ctx context.Context) (bool, error) {
-			//nolint:staticcheck // RHOAIENG-83656 explicitly requires a core/v1 Endpoints readiness helper.
+			//nolint:staticcheck // Test the legacy Endpoints resource because dashboard Services still publish it.
 			endpoints := &corev1.Endpoints{}
 			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, endpoints); err != nil {
 				if apierrors.IsNotFound(err) {
@@ -230,11 +230,52 @@ func waitForServiceEndpoints(c client.Client, namespace, name string, timeout ti
 func assertJQMatch(t *testing.T, actual any, expression string, args ...any) {
 	t.Helper()
 
+	matched, failureMessage := evaluateJQMatch(actual, expression, args...)
+	if !matched {
+		t.Fatal(failureMessage)
+	}
+}
+
+func evaluateJQMatch(actual any, expression string, args ...any) (bool, string) {
 	matcher := jq.Match(expression, args...)
 	matched, err := matcher.Match(actual)
-	require.NoError(t, err)
+	if err != nil {
+		return false, "failed to evaluate JQ assertion"
+	}
 	if !matched {
-		t.Fatal(matcher.FailureMessage(actual))
+		return false, "JQ assertion did not match"
+	}
+
+	return true, ""
+}
+
+func TestEvaluateJQMatchRedactsSensitiveValues(t *testing.T) {
+	testCases := []struct {
+		name       string
+		actual     any
+		expression string
+		sensitive  string
+	}{
+		{
+			name:       "mismatch",
+			actual:     map[string]any{"token": "secret-token"},
+			expression: `.token == "different-token"`,
+			sensitive:  "secret-token",
+		},
+		{
+			name:       "evaluation error",
+			actual:     "secret-token",
+			expression: `.token == "ready"`,
+			sensitive:  "secret-token",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			matched, failureMessage := evaluateJQMatch(testCase.actual, "%s", testCase.expression)
+			require.False(t, matched)
+			require.NotContains(t, failureMessage, testCase.sensitive)
+		})
 	}
 }
 

--- a/dashboard-operator/test/e2e/helpers_test.go
+++ b/dashboard-operator/test/e2e/helpers_test.go
@@ -16,8 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,53 +113,33 @@ func waitForDeploymentReady(c client.Client, namespace, name string, timeout tim
 	return nil
 }
 
-func applyDashboardCR(c client.Client, spec dashboardv1alpha1.DashboardSpec) (types.UID, error) {
+func createDashboardCR(c client.Client, spec dashboardv1alpha1.DashboardSpec) (types.UID, error) {
 	ctx := context.Background()
-	key := client.ObjectKey{Name: dashboardv1alpha1.DashboardInstanceName}
-	existing := &dashboardv1alpha1.Dashboard{}
-	if err := c.Get(ctx, key, existing); err == nil {
-		return "", fmt.Errorf("refuse to apply Dashboard %q because it already exists", key.Name)
-	} else if !apierrors.IsNotFound(err) {
-		return "", fmt.Errorf("check for existing Dashboard %q: %w", key.Name, err)
-	}
-
-	specObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&spec)
-	if err != nil {
-		return "", fmt.Errorf("convert Dashboard spec for server-side apply: %w", err)
-	}
-
-	dashboard := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": dashboardv1alpha1.GroupVersion.String(),
-			"kind":       dashboardv1alpha1.DashboardKind,
-			"metadata": map[string]any{
-				"name": dashboardv1alpha1.DashboardInstanceName,
-				"labels": map[string]any{
-					e2eManagedByKey: e2eFieldOwner,
-				},
-			},
-			"spec": specObject,
+	dashboard := &dashboardv1alpha1.Dashboard{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: dashboardv1alpha1.GroupVersion.String(),
+			Kind:       dashboardv1alpha1.DashboardKind,
 		},
-	}
-	applyConfiguration := client.ApplyConfigurationFromUnstructured(dashboard)
-
-	if err := c.Apply(
-		ctx,
-		applyConfiguration,
-		client.FieldOwner(e2eFieldOwner),
-	); err != nil {
-		return "", fmt.Errorf("server-side apply Dashboard %q: %w", dashboard.GetName(), err)
+		ObjectMeta: metav1.ObjectMeta{
+			Name: dashboardv1alpha1.DashboardInstanceName,
+			Labels: map[string]string{
+				e2eManagedByKey: e2eFieldOwner,
+			},
+		},
+		Spec: spec,
 	}
 
-	created := &dashboardv1alpha1.Dashboard{}
-	if err := c.Get(ctx, key, created); err != nil {
-		return "", fmt.Errorf("get applied Dashboard %q: %w", key.Name, err)
+	if err := c.Create(ctx, dashboard); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return "", fmt.Errorf("refuse to create Dashboard %q because it already exists", dashboard.Name)
+		}
+		return "", fmt.Errorf("create Dashboard %q: %w", dashboard.Name, err)
 	}
-	if created.Labels[e2eManagedByKey] != e2eFieldOwner {
-		return "", fmt.Errorf("applied Dashboard %q is missing the E2E ownership label", key.Name)
+	if dashboard.UID == "" {
+		return "", fmt.Errorf("created Dashboard %q has no UID", dashboard.Name)
 	}
 
-	return created.UID, nil
+	return dashboard.UID, nil
 }
 
 func cleanupDashboardCR(c client.Client, expectedUID types.UID) error {

--- a/dashboard-operator/test/e2e/helpers_test.go
+++ b/dashboard-operator/test/e2e/helpers_test.go
@@ -4,13 +4,13 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	dashboardv1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 	"github.com/opendatahub-io/odh-platform-utilities/api/common/validation"
-	"github.com/opendatahub-io/odh-platform-utilities/framework/utils/test/matchers/jq"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,11 +18,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//nolint:unused // Shared E2E framework constants are consumed by follow-up scenario stories.
 const (
 	e2eFieldOwner     = "dashboard-operator-e2e"
 	e2eManagedByKey   = "app.kubernetes.io/managed-by"
@@ -30,7 +30,6 @@ const (
 	e2eCleanupTimeout = 5 * time.Minute
 )
 
-//nolint:unused // Shared E2E helper for follow-up scenario stories.
 func waitForCondition(
 	c client.Client,
 	name string,
@@ -90,6 +89,16 @@ func waitForDeploymentReady(c client.Client, namespace, name string, timeout tim
 				return false, err
 			}
 
+			desiredReplicas := int32(1)
+			if deployment.Spec.Replicas != nil {
+				desiredReplicas = *deployment.Spec.Replicas
+			}
+			if deployment.Status.ObservedGeneration < deployment.Generation ||
+				deployment.Status.UpdatedReplicas != desiredReplicas ||
+				deployment.Status.ReadyReplicas != desiredReplicas {
+				return false, nil
+			}
+
 			for _, condition := range deployment.Status.Conditions {
 				if condition.Type == appsv1.DeploymentAvailable && condition.Status == corev1.ConditionTrue {
 					return true, nil
@@ -106,11 +115,19 @@ func waitForDeploymentReady(c client.Client, namespace, name string, timeout tim
 	return nil
 }
 
-//nolint:unused // Shared E2E helper for follow-up scenario stories.
-func applyDashboardCR(c client.Client, spec dashboardv1alpha1.DashboardSpec) error {
+func applyDashboardCR(c client.Client, spec dashboardv1alpha1.DashboardSpec) (types.UID, error) {
+	ctx := context.Background()
+	key := client.ObjectKey{Name: dashboardv1alpha1.DashboardInstanceName}
+	existing := &dashboardv1alpha1.Dashboard{}
+	if err := c.Get(ctx, key, existing); err == nil {
+		return "", fmt.Errorf("refuse to apply Dashboard %q because it already exists", key.Name)
+	} else if !apierrors.IsNotFound(err) {
+		return "", fmt.Errorf("check for existing Dashboard %q: %w", key.Name, err)
+	}
+
 	specObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&spec)
 	if err != nil {
-		return fmt.Errorf("convert Dashboard spec for server-side apply: %w", err)
+		return "", fmt.Errorf("convert Dashboard spec for server-side apply: %w", err)
 	}
 
 	dashboard := &unstructured.Unstructured{
@@ -129,18 +146,29 @@ func applyDashboardCR(c client.Client, spec dashboardv1alpha1.DashboardSpec) err
 	applyConfiguration := client.ApplyConfigurationFromUnstructured(dashboard)
 
 	if err := c.Apply(
-		context.Background(),
+		ctx,
 		applyConfiguration,
 		client.FieldOwner(e2eFieldOwner),
 	); err != nil {
-		return fmt.Errorf("server-side apply Dashboard %q: %w", dashboard.GetName(), err)
+		return "", fmt.Errorf("server-side apply Dashboard %q: %w", dashboard.GetName(), err)
 	}
 
-	return nil
+	created := &dashboardv1alpha1.Dashboard{}
+	if err := c.Get(ctx, key, created); err != nil {
+		return "", fmt.Errorf("get applied Dashboard %q: %w", key.Name, err)
+	}
+	if created.Labels[e2eManagedByKey] != e2eFieldOwner {
+		return "", fmt.Errorf("applied Dashboard %q is missing the E2E ownership label", key.Name)
+	}
+
+	return created.UID, nil
 }
 
-//nolint:unused // Shared E2E helper for follow-up scenario stories.
-func cleanupDashboardCR(c client.Client) error {
+func cleanupDashboardCR(c client.Client, expectedUID types.UID) error {
+	if expectedUID == "" {
+		return errors.New("refuse to clean up Dashboard without its expected UID")
+	}
+
 	ctx := context.Background()
 	dashboard := &dashboardv1alpha1.Dashboard{}
 	key := client.ObjectKey{Name: dashboardv1alpha1.DashboardInstanceName}
@@ -160,10 +188,16 @@ func cleanupDashboardCR(c client.Client) error {
 			e2eFieldOwner,
 		)
 	}
+	if dashboard.UID != expectedUID {
+		return fmt.Errorf(
+			"refuse to delete Dashboard %q with UID %q; expected UID %q",
+			key.Name,
+			dashboard.UID,
+			expectedUID,
+		)
+	}
 
-	uid := dashboard.UID
-	resourceVersion := dashboard.ResourceVersion
-	preconditions := client.Preconditions{UID: &uid, ResourceVersion: &resourceVersion}
+	preconditions := client.Preconditions{UID: &expectedUID}
 	if err := c.Delete(ctx, dashboard, preconditions); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("delete Dashboard %q: %w", key.Name, err)
 	}
@@ -227,55 +261,12 @@ func waitForServiceEndpoints(c client.Client, namespace, name string, timeout ti
 }
 
 //nolint:unused // Shared E2E helper for follow-up scenario stories.
-func assertJQMatch(t *testing.T, actual any, expression string, args ...any) {
+func assertJQMatch(t *testing.T, actual any, expression string) {
 	t.Helper()
 
-	matched, failureMessage := evaluateJQMatch(actual, expression, args...)
+	matched, failureMessage := evaluateJQMatch(actual, expression)
 	if !matched {
 		t.Fatal(failureMessage)
-	}
-}
-
-func evaluateJQMatch(actual any, expression string, args ...any) (bool, string) {
-	matcher := jq.Match(expression, args...)
-	matched, err := matcher.Match(actual)
-	if err != nil {
-		return false, "failed to evaluate JQ assertion"
-	}
-	if !matched {
-		return false, "JQ assertion did not match"
-	}
-
-	return true, ""
-}
-
-func TestEvaluateJQMatchRedactsSensitiveValues(t *testing.T) {
-	testCases := []struct {
-		name       string
-		actual     any
-		expression string
-		sensitive  string
-	}{
-		{
-			name:       "mismatch",
-			actual:     map[string]any{"token": "secret-token"},
-			expression: `.token == "different-token"`,
-			sensitive:  "secret-token",
-		},
-		{
-			name:       "evaluation error",
-			actual:     "secret-token",
-			expression: `.token == "ready"`,
-			sensitive:  "secret-token",
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			matched, failureMessage := evaluateJQMatch(testCase.actual, "%s", testCase.expression)
-			require.False(t, matched)
-			require.NotContains(t, failureMessage, testCase.sensitive)
-		})
 	}
 }
 

--- a/dashboard-operator/test/e2e/helpers_test.go
+++ b/dashboard-operator/test/e2e/helpers_test.go
@@ -1,0 +1,255 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	dashboardv1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	"github.com/opendatahub-io/odh-platform-utilities/api/common/validation"
+	"github.com/opendatahub-io/odh-platform-utilities/framework/utils/test/matchers/jq"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//nolint:unused // Shared E2E framework constants are consumed by follow-up scenario stories.
+const (
+	e2eFieldOwner     = "dashboard-operator-e2e"
+	e2eManagedByKey   = "app.kubernetes.io/managed-by"
+	e2ePollInterval   = 2 * time.Second
+	e2eCleanupTimeout = 5 * time.Minute
+)
+
+//nolint:unused // Shared E2E helper for follow-up scenario stories.
+func waitForCondition(
+	c client.Client,
+	name string,
+	conditionType string,
+	expectedStatus metav1.ConditionStatus,
+	timeout time.Duration,
+) error {
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
+		e2ePollInterval,
+		timeout,
+		true,
+		func(ctx context.Context) (bool, error) {
+			dashboard := &dashboardv1alpha1.Dashboard{}
+			if err := c.Get(ctx, client.ObjectKey{Name: name}, dashboard); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+
+			for _, condition := range dashboard.Status.Conditions {
+				if condition.Type == conditionType && condition.Status == expectedStatus {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"wait for Dashboard %q condition %q to become %q: %w",
+			name,
+			conditionType,
+			expectedStatus,
+			err,
+		)
+	}
+
+	return nil
+}
+
+//nolint:unused // Shared E2E helper for follow-up scenario stories.
+func waitForDeploymentReady(c client.Client, namespace, name string, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
+		e2ePollInterval,
+		timeout,
+		true,
+		func(ctx context.Context) (bool, error) {
+			deployment := &appsv1.Deployment{}
+			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, deployment); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+
+			for _, condition := range deployment.Status.Conditions {
+				if condition.Type == appsv1.DeploymentAvailable && condition.Status == corev1.ConditionTrue {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("wait for Deployment %s/%s to become available: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+//nolint:unused // Shared E2E helper for follow-up scenario stories.
+func applyDashboardCR(c client.Client, spec dashboardv1alpha1.DashboardSpec) error {
+	specObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&spec)
+	if err != nil {
+		return fmt.Errorf("convert Dashboard spec for server-side apply: %w", err)
+	}
+
+	dashboard := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": dashboardv1alpha1.GroupVersion.String(),
+			"kind":       dashboardv1alpha1.DashboardKind,
+			"metadata": map[string]any{
+				"name": dashboardv1alpha1.DashboardInstanceName,
+				"labels": map[string]any{
+					e2eManagedByKey: e2eFieldOwner,
+				},
+			},
+			"spec": specObject,
+		},
+	}
+	applyConfiguration := client.ApplyConfigurationFromUnstructured(dashboard)
+
+	if err := c.Apply(
+		context.Background(),
+		applyConfiguration,
+		client.FieldOwner(e2eFieldOwner),
+	); err != nil {
+		return fmt.Errorf("server-side apply Dashboard %q: %w", dashboard.GetName(), err)
+	}
+
+	return nil
+}
+
+//nolint:unused // Shared E2E helper for follow-up scenario stories.
+func cleanupDashboardCR(c client.Client) error {
+	ctx := context.Background()
+	dashboard := &dashboardv1alpha1.Dashboard{}
+	key := client.ObjectKey{Name: dashboardv1alpha1.DashboardInstanceName}
+
+	if err := c.Get(ctx, key, dashboard); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get Dashboard %q before cleanup: %w", key.Name, err)
+	}
+
+	if dashboard.Labels[e2eManagedByKey] != e2eFieldOwner {
+		return fmt.Errorf(
+			"refuse to delete Dashboard %q without %s=%s ownership label",
+			key.Name,
+			e2eManagedByKey,
+			e2eFieldOwner,
+		)
+	}
+
+	uid := dashboard.UID
+	resourceVersion := dashboard.ResourceVersion
+	preconditions := client.Preconditions{UID: &uid, ResourceVersion: &resourceVersion}
+	if err := c.Delete(ctx, dashboard, preconditions); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete Dashboard %q: %w", key.Name, err)
+	}
+
+	err := wait.PollUntilContextTimeout(
+		ctx,
+		e2ePollInterval,
+		e2eCleanupTimeout,
+		true,
+		func(ctx context.Context) (bool, error) {
+			current := &dashboardv1alpha1.Dashboard{}
+			err := c.Get(ctx, key, current)
+			switch {
+			case apierrors.IsNotFound(err):
+				return true, nil
+			case err != nil:
+				return false, err
+			default:
+				return false, nil
+			}
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("wait for Dashboard %q deletion: %w", key.Name, err)
+	}
+
+	return nil
+}
+
+//nolint:unused // Shared E2E helper for follow-up scenario stories.
+func waitForServiceEndpoints(c client.Client, namespace, name string, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
+		e2ePollInterval,
+		timeout,
+		true,
+		func(ctx context.Context) (bool, error) {
+			//nolint:staticcheck // RHOAIENG-83656 explicitly requires a core/v1 Endpoints readiness helper.
+			endpoints := &corev1.Endpoints{}
+			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, endpoints); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+
+			for _, subset := range endpoints.Subsets {
+				if len(subset.Addresses) > 0 {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("wait for Service %s/%s endpoints: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+//nolint:unused // Shared E2E helper for follow-up scenario stories.
+func assertJQMatch(t *testing.T, actual any, expression string, args ...any) {
+	t.Helper()
+
+	matcher := jq.Match(expression, args...)
+	matched, err := matcher.Match(actual)
+	require.NoError(t, err)
+	if !matched {
+		t.Fatal(matcher.FailureMessage(actual))
+	}
+}
+
+//nolint:unused // Shared E2E helper for follow-up scenario stories.
+func validateDashboardPlatformContract(t *testing.T, c client.Client, timeout time.Duration) {
+	t.Helper()
+
+	if timeout <= 0 {
+		require.FailNow(t, "platform contract timeout must be positive")
+	}
+
+	validation.ValidatePlatformContract(t, c, validation.ContractOptions{
+		GVK:          dashboardv1alpha1.GroupVersion.WithKind(dashboardv1alpha1.DashboardKind),
+		InstanceName: dashboardv1alpha1.DashboardInstanceName,
+		Timeout:      timeout,
+		PollInterval: e2ePollInterval,
+	})
+}

--- a/dashboard-operator/test/e2e/jq.go
+++ b/dashboard-operator/test/e2e/jq.go
@@ -1,0 +1,20 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/opendatahub-io/odh-platform-utilities/framework/utils/test/matchers/jq"
+)
+
+func evaluateJQMatch(actual any, expression string) (bool, string) {
+	matcher := jq.Match("%s", expression)
+	matched, err := matcher.Match(actual)
+	if err != nil {
+		return false, fmt.Sprintf("failed to evaluate JQ expression %s: %v", expression, err)
+	}
+	if !matched {
+		return false, fmt.Sprintf("JQ expression %s did not match", expression)
+	}
+
+	return true, ""
+}

--- a/dashboard-operator/test/e2e/jq_test.go
+++ b/dashboard-operator/test/e2e/jq_test.go
@@ -1,0 +1,54 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateJQMatch(t *testing.T) {
+	testCases := []struct {
+		name            string
+		actual          any
+		expression      string
+		wantMatch       bool
+		wantMessagePart string
+		sensitive       string
+	}{
+		{
+			name:       "match with literal percent",
+			actual:     map[string]any{"value": "a%b"},
+			expression: `.value | test("a%b")`,
+			wantMatch:  true,
+		},
+		{
+			name:            "mismatch preserves expression",
+			actual:          map[string]any{"token": "secret-token"},
+			expression:      `.status == "ready"`,
+			wantMessagePart: `.status == "ready"`,
+			sensitive:       "secret-token",
+		},
+		{
+			name:            "evaluation error preserves details",
+			actual:          map[string]any{"token": "secret-token"},
+			expression:      `.status ==`,
+			wantMessagePart: "unexpected EOF",
+			sensitive:       "secret-token",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			matched, failureMessage := evaluateJQMatch(testCase.actual, testCase.expression)
+			require.Equal(t, testCase.wantMatch, matched)
+			if testCase.wantMessagePart == "" {
+				require.Empty(t, failureMessage)
+			} else {
+				require.Contains(t, failureMessage, testCase.wantMessagePart)
+			}
+			if testCase.sensitive != "" {
+				require.NotContains(t, failureMessage, testCase.sensitive)
+			}
+		})
+	}
+}

--- a/dashboard-operator/test/e2e/lifecycle_test.go
+++ b/dashboard-operator/test/e2e/lifecycle_test.go
@@ -23,7 +23,7 @@ func TestE2EDashboardLifecycle(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	uid, err := applyDashboardCR(k8sClient, dashboardv1alpha1.DashboardSpec{
+	uid, err := createDashboardCR(k8sClient, dashboardv1alpha1.DashboardSpec{
 		ManagementSpec: common.ManagementSpec{ManagementState: common.Removed},
 	})
 	require.NoError(t, err)

--- a/dashboard-operator/test/e2e/lifecycle_test.go
+++ b/dashboard-operator/test/e2e/lifecycle_test.go
@@ -1,0 +1,47 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	dashboardv1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestE2EDashboardLifecycle(t *testing.T) {
+	key := client.ObjectKey{Name: dashboardv1alpha1.DashboardInstanceName}
+	existing := &dashboardv1alpha1.Dashboard{}
+	if err := k8sClient.Get(context.Background(), key, existing); err == nil {
+		t.Skipf("Dashboard %q already exists; lifecycle test requires an isolated cluster", key.Name)
+	} else if !apierrors.IsNotFound(err) {
+		require.NoError(t, err)
+	}
+
+	uid, err := applyDashboardCR(k8sClient, dashboardv1alpha1.DashboardSpec{
+		ManagementSpec: common.ManagementSpec{ManagementState: common.Removed},
+	})
+	require.NoError(t, err)
+
+	cleanupRequired := true
+	t.Cleanup(func() {
+		if cleanupRequired {
+			require.NoError(t, cleanupDashboardCR(k8sClient, uid))
+		}
+	})
+
+	require.NoError(t, waitForCondition(
+		k8sClient,
+		dashboardv1alpha1.DashboardInstanceName,
+		string(common.ConditionTypeProvisioningSucceeded),
+		metav1.ConditionFalse,
+		e2eCleanupTimeout,
+	))
+	require.NoError(t, cleanupDashboardCR(k8sClient, uid))
+	cleanupRequired = false
+}

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -490,7 +490,7 @@ make chart-validate
 make generate && make manifests
 ```
 
-For details on envtest integration tests — what they are, how to write them, and how to debug failures — see [envtest Integration Tests](envtest-integration-tests.md).
+For details on envtest integration tests — what they are, how to write them, and how to debug failures — see [envtest Integration Tests](envtest-integration-tests.md). Tests that require a deployed operator and a real cluster use the [dashboard-operator E2E framework](../dashboard-operator/test/e2e/README.md).
 
 ## Chaos Validation (operator-chaos)
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-83656

## Description

Add the initial real-cluster E2E framework for dashboard-operator:

- add an `e2e`-tagged `TestMain` that requires `KUBECONFIG` and `TEST_NAMESPACE`, builds a controller-runtime client, and verifies cluster connectivity, the test namespace, and the served Dashboard CRD version;
- add shared polling, atomic create, UID-guarded cleanup, JQ matcher, and platform contract helpers for follow-up E2E scenarios;
- add `make test-e2e` and `make build-e2e` targets, including selective `-run` and standalone binary support;
- add the odh-platform-utilities framework dependency; and
- document local, containerized, RBAC, isolation, and cleanup requirements.

The framework complements the existing blocking envtest suite. It does not install CRDs or run against shared Cypress clusters.

## How Has This Been Tested?

- `cd dashboard-operator && make lint`
- `cd dashboard-operator && make test`
- `cd dashboard-operator && make test-integration`
- `cd dashboard-operator && make build`
- `cd dashboard-operator && make build-e2e`
- `cd dashboard-operator && make check-chart-crds`
- `cd dashboard-operator && go mod tidy -diff`
- verified `make test-e2e` fails early with a clear error when the required environment is missing

### Manual cluster testing

- Built commit `8b946353488399f980f03e44991888967e3f7b63` and deployed `quay.io/liday/dashboard-operator:pr-9716-8b9463534` (`sha256:39d64f4d95edc74e8706f49ec17078b7eabbc45ea04c87ec4a593ff16ce9c191`) to an OpenShift 4.21 / RHOAI 3.5 cluster.
- Upgraded the Dashboard CRD and installed the PR dashboard-operator in `redhat-ods-applications`.
- Ran the complete real-cluster E2E target:

  ```bash
  KUBECONFIG=/Users/liday/.kube/config \
    TEST_NAMESPACE=redhat-ods-applications \
    make test-e2e
  ```

  `TestE2EFrameworkPreflight` passed.
- Verified the operator was 1/1 available, both dashboard replicas were available, all ten standalone module deployments were available, and `Dashboard/default-dashboard` reported `Ready=True` and `Degraded=False` after the run.
- Applied an additive service-account-token mount to the live `core-bff` container to work around an existing omission in the upstream `main` dashboard manifest; this omission is not introduced by this PR.

## Test Impact

This adds the E2E test bootstrap and shared helpers required by follow-up operand, lifecycle, and contract scenarios. It also keeps E2E-tagged files in the normal lint gate and preserves the existing unit and envtest suites.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a real-cluster end-to-end testing framework for dashboard-operator.
  - Added commands to build and run standalone E2E test binaries.
  - Added validation for kubeconfig, test namespace, cluster connectivity, and Dashboard CRD availability.
  - Added reusable helpers for applying, monitoring, validating, and safely cleaning up Dashboard resources.
  - Added coverage for Dashboard lifecycle behavior and expression-based result validation.

- **Documentation**
  - Documented E2E prerequisites, environment variables, execution options, and test authoring guidance.
  - Updated integration testing documentation to reference the E2E framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->