### PR TITLE
fix(maas-consumer-portal): preserve portal path after logout

### DIFF
--- a/distributions/maas-consumer-portal/src/components/UserDropdown.tsx
+++ b/distributions/maas-consumer-portal/src/components/UserDropdown.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import { Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
 import { useSettings } from 'mod-arch-core';
 
+import { PORTAL_BASE_PATH } from '../portalPaths';
+
 // Logout via oauth2-proxy's GET sign-out endpoint, matching the main dashboard
 // (frontend/src/app/appUtils.ts). GET is CSRF-able but the only impact is an
 // unwanted logout; POST hardening would require oauth2-proxy support.
-export const PORTAL_SIGN_OUT_PATH = '/oauth2/sign_out';
+export const PORTAL_SIGN_OUT_PATH = `/oauth2/sign_out?rd=${encodeURIComponent(
+  `${PORTAL_BASE_PATH}/`,
+)}`;
 
 const navigateTo = (path: string): void => {
   window.location.href = path;

--- a/distributions/maas-consumer-portal/src/components/__tests__/UserDropdown.spec.tsx
+++ b/distributions/maas-consumer-portal/src/components/__tests__/UserDropdown.spec.tsx
@@ -9,11 +9,11 @@ describe('portalLogout', () => {
     jest.clearAllMocks();
   });
 
-  it('should redirect through the gateway-supported sign-out endpoint', () => {
+  it('should redirect through the gateway-supported sign-out endpoint to the portal', () => {
     const redirect = jest.fn();
 
     portalLogout(redirect);
 
-    expect(redirect).toHaveBeenCalledWith('/oauth2/sign_out');
+    expect(redirect).toHaveBeenCalledWith('/oauth2/sign_out?rd=%2Fmaas-consumer-portal%2F');
   });
 });


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-94167

## Description

Updates MaaS Consumer Portal logout to include a URL-encoded, relative `rd` return path. After gateway sign-in, users return to `/maas-consumer-portal/` instead of the main dashboard root.

The relative `rd` flow was validated against the gateway. The change does not hardcode a gateway hostname.

## How Has This Been Tested?

Run the portal checks:

```bash
npm run test-unit --workspace @odh-dashboard/maas-consumer-portal-distribution -- --runInBand
npm run type-check --workspace @odh-dashboard/maas-consumer-portal-distribution
npm run lint --workspace @odh-dashboard/maas-consumer-portal-distribution
```

Manual tests on a real cluster.

## Test Impact

- Updated `UserDropdown` unit coverage to assert the complete gateway sign-out URL.
- Portal unit tests, type-check, and lint pass.
- Repository-wide type-check, lint, and unit-test commands have unrelated existing failures in backend and MLflow code.

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:

- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signing out now redirects users back to the portal homepage after authentication logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->