### PR TITLE
remove latest pg-image env variable

### DIFF
--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -84,6 +84,7 @@ relatedImages:
   RELATED_IMAGE_ODH_AUTOML_IMAGE: ""
   RELATED_IMAGE_ODH_AUTORAG_IMAGE: ""
   RELATED_IMAGE_ODH_CORE_BFF_IMAGE: ""
+  RELATED_IMAGE_POSTGRESQL_16_IMAGE: ""
 
 config:
   name: odh-dashboard-config

--- a/dashboard-operator/internal/controller/support.go
+++ b/dashboard-operator/internal/controller/support.go
@@ -32,6 +32,7 @@ var imagesMap = map[string]string{
 	"automl-pipeline-runtime-image":  "RELATED_IMAGE_ODH_AUTOML_IMAGE",
 	"autorag-pipeline-runtime-image": "RELATED_IMAGE_ODH_AUTORAG_IMAGE",
 	"core-bff-image":                 "RELATED_IMAGE_ODH_CORE_BFF_IMAGE",
+	"pgvector-image":                 "RELATED_IMAGE_POSTGRESQL_16_IMAGE",
 }
 
 func init() {

--- a/dashboard-operator/internal/controller/support_test.go
+++ b/dashboard-operator/internal/controller/support_test.go
@@ -260,12 +260,14 @@ func TestResolveImageParams(t *testing.T) {
 		t.Setenv("RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE", "quay.io/mr:v1")
 		t.Setenv("RELATED_IMAGE_ODH_AUTOML_IMAGE", "quay.io/automl-runtime:v2")
 		t.Setenv("RELATED_IMAGE_ODH_AUTORAG_IMAGE", "quay.io/autorag-runtime:v3")
+		t.Setenv("RELATED_IMAGE_POSTGRESQL_16_IMAGE", "registry.redhat.io/rhel9/postgresql-16@sha256:abc123")
 
 		got := resolveImageParams()
 		assert.Equal(t, "quay.io/dashboard:latest", got["odh-dashboard-image"])
 		assert.Equal(t, "quay.io/mr:v1", got["model-registry-ui-image"])
 		assert.Equal(t, "quay.io/automl-runtime:v2", got["automl-pipeline-runtime-image"])
 		assert.Equal(t, "quay.io/autorag-runtime:v3", got["autorag-pipeline-runtime-image"])
+		assert.Equal(t, "registry.redhat.io/rhel9/postgresql-16@sha256:abc123", got["pgvector-image"])
 		assert.NotContains(t, got, "gen-ai-ui-image", "unset env vars should not appear")
 	})
 

--- a/manifests/modules/gen-ai/params.env
+++ b/manifests/modules/gen-ai/params.env
@@ -1,4 +1,4 @@
 # Injected variables from the Operator
 gen-ai-ui-image=quay.io/opendatahub/odh-mod-arch-gen-ai:main
-pgvector-image=registry.redhat.io/rhel9/postgresql-16
+pgvector-image=
 gateway-domain=


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-93842

## Description

Fix the pgvector image resolution for disconnected environments.

- map `pgvector-image` to the centrally managed `RELATED_IMAGE_POSTGRESQL_16_IMAGE` release value
- remove the untagged Postgres fallback, which could resolve to `latest` and bypass digest-based mirror rules
- add coverage that verifies the PostgreSQL digest is forwarded into the module params

## How Has This Been Tested?

- ran `go test ./internal/controller` in `dashboard-operator`
- built and deployed a custom dashboard-operator image to a development RHOAI cluster
- verified the custom operator receives the release-pinned PostgreSQL image:

  `registry.redhat.io/rhel9/postgresql-16@sha256:435ba5c1d3f686cf8a45ae525b4d169ced6b33753bcfab99a1498bd9e6e99817`

- verified the operator reconciles that same digest into the `gen-ai-ui` Deployment as `RELATED_IMAGE_POSTGRESQL_16_IMAGE`

This validates the dashboard-operator wiring. The full disconnected-environment validation will happen once this is merged to `main` and included in the shipped release image.

## Test Impact

Added a unit assertion for the `pgvector-image` to `RELATED_IMAGE_POSTGRESQL_16_IMAGE` mapping.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] N/A, no UI changes.
- [x] N/A, no UI changes.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added support for configuring the PostgreSQL 16 image used by the dashboard’s vector database capabilities.
  * The image can now be supplied through deployment image settings, including digest-based overrides.

* **Deployment Updates**
  * Removed the previous built-in PostgreSQL image default, allowing deployments to explicitly provide the appropriate image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->