### PR TITLE
Add error states for gated models

### DIFF
--- a/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
+++ b/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
@@ -17,6 +17,22 @@ class ModelDetailsPage {
     return cy.findByTestId('deploy-button');
   }
 
+  findGatedAccessRequiredState() {
+    return cy.findByTestId('model-gated-access-required');
+  }
+
+  findGatedAccessRequestLink() {
+    return cy.findByTestId('model-gated-access-request-link');
+  }
+
+  findWhosMyAdministratorLink() {
+    return cy.findByTestId('whos-my-admin-link');
+  }
+
+  findAccessLabelGatedDenied() {
+    return cy.findByTestId('model-catalog-access-label-gated-denied');
+  }
+
   findTuneModelButton() {
     return cy.findByTestId('tune-model-button');
   }

--- a/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
@@ -77,12 +77,6 @@ const setupGatedAccessIntercepts = () => {
     },
   );
 
-  cy.interceptOdh(
-    'GET /model-registry/api/:apiVersion/model_registry',
-    { path: { apiVersion: API_VERSION } },
-    { data: [{ name: 'modelregistry-sample', displayName: 'Model Registry Sample' }] },
-  );
-
   cy.intercept(
     'GET',
     `**/model-registry/api/${API_VERSION}/model_catalog/sources/${SOURCE_ID}/models/**`,

--- a/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
@@ -2,6 +2,7 @@
 import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { ModelRegistryMetadataType } from '@odh-dashboard/model-registry/types/types';
 import { asClusterAdminUser, asProjectEditUser } from '../../../utils/mockUsers';
 import { modelDetailsPage } from '../../../pages/modelCatalog/modelDetailsPage';
 import { API_VERSION, setupModelCatalogIntercepts } from '../catalogHelpers';
@@ -22,11 +23,11 @@ const gatedDeniedModel = {
   customProperties: {
     hf_access_type: {
       string_value: 'gated_auto',
-      metadataType: 'MetadataString',
+      metadataType: ModelRegistryMetadataType.STRING,
     },
     hf_gated_access_granted: {
       string_value: 'false',
-      metadataType: 'MetadataString',
+      metadataType: ModelRegistryMetadataType.STRING,
     },
   },
 };
@@ -81,7 +82,7 @@ const setupGatedAccessIntercepts = () => {
     'GET',
     `**/model-registry/api/${API_VERSION}/model_catalog/sources/${SOURCE_ID}/models/**`,
     { body: { data: gatedDeniedModel } },
-  );
+  ).as('getGatedModel');
 
   cy.intercept(
     'GET',
@@ -101,6 +102,7 @@ const setupGatedAccessIntercepts = () => {
 
 const visitGatedModelDetails = () => {
   cy.visitWithLogin(`/ai-hub/models/catalog/${SOURCE_ID}/${ENCODED_MODEL_NAME}/overview`);
+  cy.wait('@getGatedModel');
   modelDetailsPage.findPageTitle().should('exist');
 };
 

--- a/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
@@ -1,0 +1,145 @@
+/* eslint-disable camelcase */
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { asClusterAdminUser, asProjectEditUser } from '../../../utils/mockUsers';
+import { modelDetailsPage } from '../../../pages/modelCatalog/modelDetailsPage';
+import { API_VERSION, setupModelCatalogIntercepts } from '../catalogHelpers';
+
+const SOURCE_ID = 'hugging_face_source';
+const MODEL_NAME = 'meta-llama/Llama-3.1-8B-Instruct-INT8';
+const ENCODED_MODEL_NAME = 'meta-llama%2FLlama-3.1-8B-Instruct-INT8';
+const REGISTRIES_NAMESPACE = 'odh-model-registries';
+
+const gatedDeniedModel = {
+  source_id: SOURCE_ID,
+  name: MODEL_NAME,
+  description: '',
+  readme: '',
+  provider: 'Meta',
+  license: 'apache-2.0',
+  tasks: ['text-generation'],
+  customProperties: {
+    hf_access_type: {
+      string_value: 'gated_auto',
+      metadataType: 'MetadataString',
+    },
+    hf_gated_access_granted: {
+      string_value: 'false',
+      metadataType: 'MetadataString',
+    },
+  },
+};
+
+const setupGatedAccessIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableModelCatalog: false,
+      disableModelRegistry: false,
+      disableModelServing: false,
+    }),
+  );
+
+  setupModelCatalogIntercepts();
+
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.MODEL_REGISTRY]: {
+          managementState: 'Managed',
+          registriesNamespace: REGISTRIES_NAMESPACE,
+        },
+        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+      },
+    }),
+  );
+
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/model_catalog/sources',
+    { path: { apiVersion: API_VERSION } },
+    {
+      data: {
+        items: [
+          {
+            id: SOURCE_ID,
+            name: 'Hugging Face',
+            enabled: true,
+            labels: ['Community'],
+            status: 'available',
+          },
+        ],
+        size: 1,
+        pageSize: 10,
+        nextPageToken: '',
+      },
+    },
+  );
+
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/model_registry',
+    { path: { apiVersion: API_VERSION } },
+    { data: [{ name: 'modelregistry-sample', displayName: 'Model Registry Sample' }] },
+  );
+
+  cy.intercept(
+    'GET',
+    `**/model-registry/api/${API_VERSION}/model_catalog/sources/${SOURCE_ID}/models/**`,
+    { body: { data: gatedDeniedModel } },
+  );
+
+  cy.intercept(
+    'GET',
+    `**/model-registry/api/${API_VERSION}/model_catalog/sources/${SOURCE_ID}/artifacts/**`,
+    {
+      body: {
+        data: {
+          items: [],
+          size: 0,
+          pageSize: 10,
+          nextPageToken: '',
+        },
+      },
+    },
+  );
+};
+
+const visitGatedModelDetails = () => {
+  cy.visitWithLogin(`/ai-hub/models/catalog/${SOURCE_ID}/${ENCODED_MODEL_NAME}/overview`);
+  modelDetailsPage.findPageTitle().should('exist');
+};
+
+describe('Model Catalog Details Page - Gated access denied', () => {
+  it('non-admin sees gated empty state with disabled deploy and register actions', () => {
+    asProjectEditUser();
+    setupGatedAccessIntercepts();
+    visitGatedModelDetails();
+
+    modelDetailsPage.findGatedAccessRequiredState().should('be.visible');
+    modelDetailsPage
+      .findGatedAccessRequiredState()
+      .should('contain.text', 'To request access, contact your administrator.');
+    modelDetailsPage.findWhosMyAdministratorLink().should('be.visible');
+    modelDetailsPage.findGatedAccessRequestLink().should('not.exist');
+    modelDetailsPage.findModelCardMarkdown().should('not.exist');
+    modelDetailsPage.findAccessLabelGatedDenied().should('be.visible');
+    modelDetailsPage.findDeployModelButton().should('have.attr', 'aria-disabled', 'true');
+    modelDetailsPage.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
+  });
+
+  it('admin sees Hugging Face request link with disabled deploy and register actions', () => {
+    asClusterAdminUser();
+    setupGatedAccessIntercepts();
+    visitGatedModelDetails();
+
+    modelDetailsPage.findGatedAccessRequiredState().should('be.visible');
+    modelDetailsPage
+      .findGatedAccessRequiredState()
+      .should('contain.text', 'Go to Hugging Face to request permission for this model.');
+    modelDetailsPage.findGatedAccessRequestLink().should('be.visible');
+    modelDetailsPage.findWhosMyAdministratorLink().should('not.exist');
+    modelDetailsPage.findDeployModelButton().should('have.attr', 'aria-disabled', 'true');
+    modelDetailsPage.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
+  });
+});

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -604,10 +604,6 @@ class ModelCatalog {
     return cy.findByTestId('register-model-button');
   }
 
-  findDeployButton() {
-    return cy.findByTestId('deploy-button');
-  }
-
   findRegisterCatalogModelTooltip() {
     return cy.findByTestId('register-catalog-model-tooltip');
   }

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -262,6 +262,10 @@ class ModelCatalog {
     return cy.findByTestId('model-gated-access-request-link');
   }
 
+  findWhosMyAdministratorLink() {
+    return cy.findByTestId('whos-my-admin-link');
+  }
+
   visitModelDetails(sourceId: string, modelName: string) {
     cy.visit(catalogModelDetailsUrl(modelName, sourceId));
     cy.findByTestId('app-page-title').should('exist');
@@ -598,6 +602,10 @@ class ModelCatalog {
 
   findRegisterModelButton() {
     return cy.findByTestId('register-model-button');
+  }
+
+  findDeployButton() {
+    return cy.findByTestId('deploy-button');
   }
 
   findRegisterCatalogModelTooltip() {

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -573,10 +573,14 @@ describe('Model Catalog Details Page - Gated access denied', () => {
 
     modelCatalog.findGatedAccessRequiredState().should('be.visible');
     modelCatalog.findGatedAccessRequiredState().should('contain.text', 'Model access required');
-    modelCatalog.findGatedAccessRequestLink().should('be.visible');
+    modelCatalog
+      .findGatedAccessRequiredState()
+      .should('contain.text', 'To request access, contact your administrator.');
+    modelCatalog.findWhosMyAdministratorLink().should('be.visible');
+    modelCatalog.findGatedAccessRequestLink().should('not.exist');
     modelCatalog.findDetailsDescription().should('not.exist');
     modelCatalog.findModelCardMarkdown().should('not.exist');
-    modelCatalog.findRegisterModelButton().should('be.disabled');
+    modelCatalog.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
     modelCatalog.findAccessLabelGatedDenied().should('be.visible');
   });
 });

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/components/McpSourceDetailsSection.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/components/McpSourceDetailsSection.tsx
@@ -96,7 +96,7 @@ const McpSourceDetailsSection: React.FC<McpSourceDetailsSectionProps> = ({
 
       {isEditMode && formData.isDefault && serverCount !== undefined && (
         <FormGroup label={MCP_FORM_LABELS.MCP_SERVERS} fieldId="mcp-servers-count">
-          <Content component="p" data-testid="mcp-servers-count">
+          <Content component="p" id="mcp-servers-count" data-testid="mcp-servers-count">
             {serverCount} servers
           </Content>
         </FormGroup>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -39,7 +39,10 @@ import { CatalogModelDetailsParams } from '~/app/modelCatalogTypes';
 import { useCatalogModelArtifacts } from '~/app/hooks/modelCatalog/useCatalogModelArtifacts';
 import { modelCatalogUrl } from '~/app/routes/modelCatalog/catalogModel';
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
-import { MODEL_CATALOG_POPOVER_MESSAGES } from '~/concepts/modelCatalog/const';
+import {
+  MODEL_CATALOG_GATED_ACCESS_REQUIRED,
+  MODEL_CATALOG_POPOVER_MESSAGES,
+} from '~/concepts/modelCatalog/const';
 import { MODEL_CATALOG_TITLE } from '~/app/pages/modelCatalog/const';
 import { useUserInteraction } from '~/concepts/userInteraction';
 import { MODEL_CATALOG_EVENTS } from '~/app/pages/modelCatalog/tracking';
@@ -125,9 +128,11 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab, customNoRegist
   const registerModelButton = (variant: 'primary' | 'secondary' = 'primary') => {
     if (gatedAccessDenied) {
       return (
-        <Button variant={variant} isDisabled data-testid="register-model-button">
-          Register model
-        </Button>
+        <Tooltip content={MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_BUTTON_TOOLTIP}>
+          <Button variant={variant} isAriaDisabled data-testid="register-model-button">
+            Register model
+          </Button>
+        </Tooltip>
       );
     }
 
@@ -259,13 +264,17 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab, customNoRegist
           model && (
             <ActionList>
               <ActionListGroup>
-                {!gatedAccessDenied && (
-                  <ExtensibleActions
-                    actions={actionExtensions}
-                    group={MODEL_CATALOG_DEPLOY_GROUP}
-                    componentProps={catalogDeployProps}
-                  />
-                )}
+                <ExtensibleActions
+                  actions={actionExtensions}
+                  group={MODEL_CATALOG_DEPLOY_GROUP}
+                  componentProps={{
+                    ...catalogDeployProps,
+                    ...(gatedAccessDenied && {
+                      disabledTooltip:
+                        MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_BUTTON_TOOLTIP,
+                    }),
+                  }}
+                />
                 {registerModelButton(isDeployAvailable ? 'secondary' : 'primary')}
               </ActionListGroup>
             </ActionList>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
@@ -8,36 +8,55 @@ import {
   PageSection,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { useThemeContext } from 'mod-arch-kubeflow';
+import { KubeflowDocs, WhosMyAdministrator } from 'mod-arch-shared';
 import type { CatalogModel } from '~/app/modelCatalogTypes';
 import { getHuggingFaceModelUrl } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import ExternalLink from '~/app/shared/components/ExternalLink';
 import { MODEL_CATALOG_GATED_ACCESS_REQUIRED } from '~/concepts/modelCatalog/const';
+import { useAdminStatus } from '~/odh/context/AdminStatusContext';
 
 type ModelGatedAccessRequiredViewProps = {
   model: CatalogModel;
 };
 
-const ModelGatedAccessRequiredView: React.FC<ModelGatedAccessRequiredViewProps> = ({ model }) => (
-  <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
-    <EmptyState
-      headingLevel="h2"
-      icon={ExclamationTriangleIcon}
-      titleText={MODEL_CATALOG_GATED_ACCESS_REQUIRED.TITLE}
-      variant={EmptyStateVariant.lg}
-      data-testid="model-gated-access-required"
-    >
-      <EmptyStateBody>{MODEL_CATALOG_GATED_ACCESS_REQUIRED.DESCRIPTION}</EmptyStateBody>
-      <EmptyStateFooter>
-        <EmptyStateActions>
-          <ExternalLink
-            text={MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_LINK_TEXT}
-            to={getHuggingFaceModelUrl(model)}
-            testId="model-gated-access-request-link"
-          />
-        </EmptyStateActions>
-      </EmptyStateFooter>
-    </EmptyState>
-  </PageSection>
-);
+const ModelGatedAccessRequiredView: React.FC<ModelGatedAccessRequiredViewProps> = ({ model }) => {
+  const { isAdmin, loaded } = useAdminStatus();
+  const { isMUITheme } = useThemeContext();
+  const isAdminUser = loaded && isAdmin;
+
+  return (
+    <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
+      <EmptyState
+        headingLevel="h2"
+        icon={ExclamationTriangleIcon}
+        titleText={MODEL_CATALOG_GATED_ACCESS_REQUIRED.TITLE}
+        variant={EmptyStateVariant.lg}
+        data-testid="model-gated-access-required"
+      >
+        <EmptyStateBody>
+          {isAdminUser
+            ? MODEL_CATALOG_GATED_ACCESS_REQUIRED.DESCRIPTION_ADMIN
+            : MODEL_CATALOG_GATED_ACCESS_REQUIRED.DESCRIPTION_NON_ADMIN}
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            {isAdminUser ? (
+              <ExternalLink
+                text={MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_LINK_TEXT}
+                to={getHuggingFaceModelUrl(model)}
+                testId="model-gated-access-request-link"
+              />
+            ) : isMUITheme ? (
+              <KubeflowDocs />
+            ) : (
+              <WhosMyAdministrator linkTestId="whos-my-admin-link" />
+            )}
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    </PageSection>
+  );
+};
 
 export default ModelGatedAccessRequiredView;

--- a/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
+++ b/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
@@ -262,9 +262,12 @@ export enum ModelCatalogTensorType {
 
 export const MODEL_CATALOG_GATED_ACCESS_REQUIRED = {
   TITLE: 'Model access required',
-  DESCRIPTION:
+  DESCRIPTION_ADMIN:
     'You do not have access to this model, so it cannot be deployed or registered. Go to Hugging Face to request permission for this model.',
+  DESCRIPTION_NON_ADMIN:
+    'You do not have access to this model, so it cannot be deployed or registered. To request access, contact your administrator.',
   REQUEST_ACCESS_LINK_TEXT: 'Request access on Hugging Face',
+  REQUEST_ACCESS_BUTTON_TOOLTIP: 'Model access is required to deploy or register this model.',
 } as const;
 
 export const HUGGING_FACE_BASE_URL = 'https://huggingface.co';

--- a/packages/model-serving/modelRegistry/DeployPrefillAction.tsx
+++ b/packages/model-serving/modelRegistry/DeployPrefillAction.tsx
@@ -14,6 +14,7 @@ const DeployPrefillAction: React.FC<DeployPrefillActionProps> = ({
   deployPrefill,
   deployPrefillLoaded,
   deployPrefillError,
+  disabledTooltip,
 }) => {
   const availablePlatformIds = useAvailablePlatformIds();
   const navigateToWizard = useNavigateToDeploymentWizardWithData(deployPrefill);
@@ -26,15 +27,33 @@ const DeployPrefillAction: React.FC<DeployPrefillActionProps> = ({
   const canInitializeWizardNavigation = deployPrefillLoaded && !deployPrefillError;
   const isLoading = canInitializeWizardNavigation && navigateToWizard === null;
 
-  const buttonState =
-    platformIdButtonState.enabled && canInitializeWizardNavigation && navigateToWizard !== null
-      ? { enabled: true }
-      : {
-          enabled: false,
-          tooltip: isLoading
-            ? 'Loading deployment data...'
-            : platformIdButtonState.tooltip || 'Deployment wizard is not available',
-        };
+  const buttonState = React.useMemo(() => {
+    if (disabledTooltip) {
+      return { enabled: false, tooltip: disabledTooltip };
+    }
+
+    if (
+      platformIdButtonState.enabled &&
+      canInitializeWizardNavigation &&
+      navigateToWizard !== null
+    ) {
+      return { enabled: true };
+    }
+
+    return {
+      enabled: false,
+      tooltip: isLoading
+        ? 'Loading deployment data...'
+        : platformIdButtonState.tooltip || 'Deployment wizard is not available',
+    };
+  }, [
+    disabledTooltip,
+    platformIdButtonState.enabled,
+    platformIdButtonState.tooltip,
+    canInitializeWizardNavigation,
+    navigateToWizard,
+    isLoading,
+  ]);
 
   const deployButton = (
     <Button

--- a/packages/model-serving/src/shared/types/deploy-prefill.ts
+++ b/packages/model-serving/src/shared/types/deploy-prefill.ts
@@ -40,4 +40,6 @@ export type DeployPrefillActionProps = {
   deployPrefill: DeployPrefillData;
   deployPrefillLoaded: boolean;
   deployPrefillError?: Error;
+  /** When set, the deploy action is disabled and shows this tooltip (e.g. gated catalog access). */
+  disabledTooltip?: string;
 };


### PR DESCRIPTION
Closes: https://redhat.atlassian.net/browse/RHOAIENG-94189

## Description
This PR aims to add error stare for gated models for non-admins
<img width="1111" height="853" alt="Screenshot 2026-09-10 at 9 45 22 PM" src="https://github.com/user-attachments/assets/c52ba704-851f-4fc6-9085-4676f5b964c3" />
<img width="1143" height="828" alt="Screenshot 2026-09-10 at 9 45 43 PM" src="https://github.com/user-attachments/assets/5d2aaefe-2291-4294-9c18-f78cb10fd17c" />


## How Has This Been Tested?
Run the application green-3 
and check others section on model catalog to see the gated models and check both admin and non-admin error state

## Test Impact
Added cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Experience**
  - Deployment actions can display a helpful tooltip when unavailable.
  - Deployment buttons remain disabled when platform availability, wizard readiness, or loading status prevents deployment.
  - Existing enabled and disabled behavior is preserved when no tooltip is provided.
  - Gated model access states clearly indicate when administrator assistance or access requests are required.
  - Cluster administrators can access a direct link to request gated model access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->