### PR TITLE
turn off rspack lazyCompilation for the main frontend application

### DIFF
--- a/frontend/config/rspack.dev.js
+++ b/frontend/config/rspack.dev.js
@@ -71,51 +71,7 @@ module.exports = merge(
   {
     mode: 'development',
     devtool: 'eval-source-map',
-    // Persist compile artifacts across `rspack dev` restarts. Default is
-    // memory-only, which forces a full cold rebuild every process start.
-    cache: {
-      type: 'persistent',
-      // CLI env / dotenv values are not auto-tracked. Digest vars that are
-      // inlined (DefinePlugin / EnvironmentPlugin) or that change the compile
-      // graph so CLI overrides bust the cache too.
-      version: JSON.stringify({
-        // frontend/src/utilities/const.ts (+ HtmlRspackPlugin branding)
-        APP_ENV: process.env.APP_ENV,
-        WS_HOSTNAME: process.env.WS_HOSTNAME,
-        POLL_INTERVAL: process.env.POLL_INTERVAL,
-        FAST_POLL_INTERVAL: process.env.FAST_POLL_INTERVAL,
-        SERVER_TIMEOUT: process.env.SERVER_TIMEOUT,
-        DOC_LINK: process.env.DOC_LINK,
-        COMMUNITY_LINK: process.env.COMMUNITY_LINK,
-        SUPPORT_LINK: process.env.SUPPORT_LINK,
-        ODH_LOGO: process.env.ODH_LOGO,
-        ODH_LOGO_DARK: process.env.ODH_LOGO_DARK,
-        ODH_PRODUCT_NAME: process.env.ODH_PRODUCT_NAME,
-        ODH_FAVICON: process.env.ODH_FAVICON,
-        DASHBOARD_CONFIG: process.env.DASHBOARD_CONFIG,
-        EXT_CLUSTER: process.env.EXT_CLUSTER,
-        INTERNAL_DASHBOARD_VERSION: process.env.INTERNAL_DASHBOARD_VERSION,
-        CONSOLE_LINK_DOMAIN: process.env.CONSOLE_LINK_DOMAIN,
-        // EnvironmentPlugin default / override (rspack.common.js)
-        MF_REMOTES: process.env.MF_REMOTES,
-        // Dotenv seeds that change entry/includes/output/publicPath (rspack.common.js)
-        ODH_SRC_DIR: process.env.ODH_SRC_DIR,
-        ODH_COMMON_DIR: process.env.ODH_COMMON_DIR,
-        ODH_DIST_DIR: process.env.ODH_DIST_DIR,
-        ODH_PUBLIC_PATH: process.env.ODH_PUBLIC_PATH,
-        ODH_IMAGES_DIRNAME: process.env.ODH_IMAGES_DIRNAME,
-        // Compile-graph toggles (loaders, MF, plugin discovery)
-        COVERAGE: process.env.COVERAGE,
-        MF_DEV: process.env.MF_DEV,
-        PLUGIN_PACKAGES: process.env.PLUGIN_PACKAGES,
-        MODULE_FEDERATION_CONFIG: process.env.MODULE_FEDERATION_CONFIG,
-        MF_UPDATE_TYPES: process.env.MF_UPDATE_TYPES,
-      }),
-      storage: {
-        type: 'filesystem',
-        directory: path.join(__dirname, '../node_modules/.cache/rspack'),
-      },
-    },
+    lazyCompilation: false,
     optimization: {
       // Module Federation embeds its runtime in the entry; a separate runtime
       // chunk races with shared consume factories (undefined.call) especially


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Turns off `lazyCompilation` for the `frontend/`. Note that `lazyCompilation` was already turned off everywhere else in the monorepo as it caused issues with federated modules. This is more than just alignment but it also serves to improve the performance of the development environment. While startup time for the dev server is increased, initial navigation of the application feels much snappier.  Startup time is already very fast that devs will feel the improved snappiness of navigating the dev app for the first time over the startup time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run start:dev` in both frontend and backend. 
Then navigate to the localhost dev page.

Repeat with `npm run start:dev:ext` in frontend.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Lazy compilation is now disabled in development builds.
  * Persistent filesystem caching and environment-based cache versioning have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->