### PR TITLE
feat(autorag): add Milvus and PGVector vector database connections

### DIFF
--- a/packages/autorag/bff/internal/repositories/k8s_test.go
+++ b/packages/autorag/bff/internal/repositories/k8s_test.go
@@ -165,6 +165,29 @@ func TestDetectType(t *testing.T) {
 		}
 	})
 
+	t.Run("vector-db filter returns milvus from MILVUS_URI", func(t *testing.T) {
+		secret := milvusSecret("s")
+		if got := detectType(secret, "vector-db"); got != "milvus" {
+			t.Errorf("got %q, want milvus", got)
+		}
+	})
+
+	t.Run("vector-db filter returns pgvector from PGVECTOR_HOST", func(t *testing.T) {
+		secret := pgvectorSecret("s")
+		if got := detectType(secret, "vector-db"); got != "pgvector" {
+			t.Errorf("got %q, want pgvector", got)
+		}
+	})
+
+	t.Run("vector-db filter matches lowercase keys", func(t *testing.T) {
+		secret := kubernetes.SecretInfo{
+			Data: map[string]string{"milvus_uri": "http://milvus:19530"},
+		}
+		if got := detectType(secret, "vector-db"); got != "milvus" {
+			t.Errorf("got %q, want milvus", got)
+		}
+	})
+
 	t.Run("storage filter falls back to key-based s3", func(t *testing.T) {
 		secret := s3Secret("s")
 		if got := detectType(secret, "storage"); got != "s3" {

--- a/packages/autorag/frontend/src/__mocks__/mockSecretListItem.ts
+++ b/packages/autorag/frontend/src/__mocks__/mockSecretListItem.ts
@@ -64,3 +64,13 @@ export const mockVectorDbSecret = (overrides: MockSecretListItemOptions = {}): S
     },
     ...overrides,
   });
+
+export const mockMilvusSecret = (overrides: MockSecretListItemOptions = {}): SecretListItem =>
+  mockSecretListItem({
+    type: 'milvus',
+    data: {
+      MILVUS_URI: '[REDACTED]',
+      MILVUS_TOKEN: '[REDACTED]',
+    },
+    ...overrides,
+  });

--- a/packages/autorag/frontend/src/__tests__/cypress/cypress/pages/vectorDbConnection.ts
+++ b/packages/autorag/frontend/src/__tests__/cypress/cypress/pages/vectorDbConnection.ts
@@ -1,0 +1,75 @@
+class VectorDbConnection {
+  findFormGroup() {
+    return cy.findByTestId('configure-form-group-vector-database-connection');
+  }
+
+  findDescription() {
+    return cy.findByTestId('configure-form-group-description-vector-database-connection');
+  }
+
+  findSelector() {
+    return cy.findByTestId('vector-store-select-toggle');
+  }
+
+  findEmptyMessage() {
+    return this.findFormGroup().contains('There are no secrets in the selected namespace');
+  }
+
+  findSplitButton() {
+    return cy.findByTestId('add-vector-db-split-button');
+  }
+
+  findAddMilvusButton() {
+    return cy.findByTestId('add-milvus-connection-button');
+  }
+
+  findAddMilvusMenuItem() {
+    return cy.findByRole('menuitem', { name: 'Add Milvus' });
+  }
+
+  findAddPgvectorButton() {
+    return cy.findByRole('menuitem', { name: 'Add PGVector' });
+  }
+
+  findModal() {
+    return cy.findByTestId('vector-db-connection-modal');
+  }
+
+  findMilvusUri() {
+    return this.findModal().findByTestId('vector-db-milvus-uri');
+  }
+
+  findMilvusToken() {
+    return this.findModal().findByTestId('vector-db-milvus-token');
+  }
+
+  findMilvusServerCert() {
+    return this.findModal().findByTestId('vector-db-milvus-server-cert');
+  }
+
+  findPgvectorHost() {
+    return this.findModal().findByTestId('vector-db-pgvector-host');
+  }
+
+  findPgvectorPort() {
+    return this.findModal().findByTestId('vector-db-pgvector-port');
+  }
+
+  findPgvectorDb() {
+    return this.findModal().findByTestId('vector-db-pgvector-db');
+  }
+
+  findPgvectorUser() {
+    return this.findModal().findByTestId('vector-db-pgvector-user');
+  }
+
+  findPgvectorPassword() {
+    return this.findModal().findByTestId('vector-db-pgvector-password');
+  }
+
+  findModalSubmit() {
+    return this.findModal().findByRole('button', { name: 'Add connection' });
+  }
+}
+
+export const vectorDbConnection = new VectorDbConnection();

--- a/packages/autorag/frontend/src/__tests__/cypress/cypress/tests/mocked/vectorDbConnection.cy.ts
+++ b/packages/autorag/frontend/src/__tests__/cypress/cypress/tests/mocked/vectorDbConnection.cy.ts
@@ -1,0 +1,111 @@
+import { fileExplorer } from '~/__tests__/cypress/cypress/pages/evaluationFileCreator';
+import { vectorDbConnection } from '~/__tests__/cypress/cypress/pages/vectorDbConnection';
+
+const NAMESPACE = 'my-project';
+const MAAS_SECRET = 'maas';
+const STORAGE_SECRET = 'data-connection';
+const VECTOR_DB_SECRET = 'vector-db';
+const DOCUMENTS_FOLDER_NAME = 'documents';
+const DOCUMENT_NAME = 'all_bank_policies.pdf';
+
+const initIntercepts = () => {
+  cy.intercept({ method: 'GET', pathname: '**/api/connection-types' }, { body: { items: [] } });
+};
+
+const navigateToConfigure = () => {
+  cy.visit(`/gen-ai-studio/autorag/configure/${NAMESPACE}`);
+  cy.findByTestId('autorag-name-input').should('be.visible');
+  cy.testA11y();
+};
+
+const advanceToConfigureDetails = () => {
+  cy.findByTestId('autorag-name-input').type('Vector DB Experiment');
+  cy.findByTestId('maas-secret-selector').click();
+  cy.findByRole('option', { name: new RegExp(MAAS_SECRET, 'i') }).click();
+  cy.findByTestId('autorag-next-button').click();
+  cy.findByTestId('configure-step-subtitle').should('be.visible');
+
+  cy.findByTestId('aws-secret-selector').should('exist');
+  cy.findByTestId('aws-secret-selector').click();
+  cy.findByTestId('aws-secret-selector').find('input').type(STORAGE_SECRET);
+  cy.findByRole('option', { name: new RegExp(STORAGE_SECRET, 'i') })
+    .should('be.visible')
+    .click();
+
+  fileExplorer.findBrowseBucketButton().click();
+  fileExplorer.find().should('be.visible');
+  fileExplorer.navigateIntoFolder('autorag input data');
+  fileExplorer.navigateIntoFolder('pdf');
+  fileExplorer.navigateIntoFolder('bank_policies_pdf');
+  fileExplorer.navigateIntoFolder(DOCUMENTS_FOLDER_NAME);
+  fileExplorer.findRow(DOCUMENT_NAME).click();
+  fileExplorer.findSelectButton().click();
+
+  vectorDbConnection.findFormGroup().should('be.visible');
+};
+
+describe('Vector database connection', () => {
+  beforeEach(() => {
+    initIntercepts();
+  });
+
+  it('should show the vector database selector and existing secrets', () => {
+    navigateToConfigure();
+    advanceToConfigureDetails();
+
+    vectorDbConnection.findDescription().should('contain.text', 'MILVUS_* or PGVECTOR_*');
+    vectorDbConnection.findSelector().should('exist');
+    vectorDbConnection.findSelector().click();
+    cy.findByRole('option', { name: new RegExp(VECTOR_DB_SECRET, 'i') }).should('be.visible');
+    cy.findByRole('option', { name: new RegExp(VECTOR_DB_SECRET, 'i') }).click();
+    vectorDbConnection.findSelector().should('contain.text', VECTOR_DB_SECRET);
+  });
+
+  it('should show the empty secret message and split actions', () => {
+    cy.intercept('GET', '**/autorag/api/v1/secrets*', (req) => {
+      const type = new URL(req.url, 'http://localhost').searchParams.get('type');
+      if (type === 'vector-db') {
+        req.reply({ body: { data: [] } });
+        return;
+      }
+      req.continue();
+    }).as('emptyVectorDbSecrets');
+
+    navigateToConfigure();
+    advanceToConfigureDetails();
+    cy.wait('@emptyVectorDbSecrets');
+
+    vectorDbConnection.findEmptyMessage().should('be.visible');
+    vectorDbConnection.findAddMilvusButton().should('be.visible');
+    vectorDbConnection.findSplitButton().click();
+    vectorDbConnection.findAddMilvusMenuItem().should('be.visible');
+    vectorDbConnection.findAddPgvectorButton().should('be.visible');
+  });
+
+  it('should open the Milvus connection modal from the split action', () => {
+    navigateToConfigure();
+    advanceToConfigureDetails();
+
+    vectorDbConnection.findAddMilvusButton().click();
+    vectorDbConnection.findModal().should('be.visible');
+    cy.testA11y();
+    vectorDbConnection.findMilvusUri().should('be.visible');
+    vectorDbConnection.findMilvusToken().should('be.visible');
+    vectorDbConnection.findMilvusServerCert().should('be.visible');
+    vectorDbConnection.findModalSubmit().should('be.disabled');
+  });
+
+  it('should switch the modal to the PGVector schema', () => {
+    navigateToConfigure();
+    advanceToConfigureDetails();
+
+    vectorDbConnection.findSplitButton().click();
+    vectorDbConnection.findAddPgvectorButton().click();
+    vectorDbConnection.findModal().should('be.visible');
+    vectorDbConnection.findPgvectorHost().should('be.visible');
+    vectorDbConnection.findPgvectorPort().should('be.visible');
+    vectorDbConnection.findPgvectorDb().should('be.visible');
+    vectorDbConnection.findPgvectorUser().should('be.visible');
+    vectorDbConnection.findPgvectorPassword().should('be.visible');
+  });
+});

--- a/packages/autorag/frontend/src/app/components/common/SecretSelector.tsx
+++ b/packages/autorag/frontend/src/app/components/common/SecretSelector.tsx
@@ -103,7 +103,7 @@ const SecretSelector: React.FC<SecretSelectorProps> = ({
 
       const requiredKeysForType = additionalRequiredKeys[secret.type];
       // TypeScript thinks this check is unnecessary because additionalRequiredKeys is typed as { [type: string]: string[] }
-      // and secret.type is 's3' | 'maas' at this point (after the !secret.type check above).
+      // and secret.type is classified (s3, maas, milvus, pgvector, ...) after the !secret.type check above.
       // However, additionalRequiredKeys is optional and may not contain entries for all possible secret types,
       // so this runtime check is needed.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/packages/autorag/frontend/src/app/components/common/VectorDbConnectionModal.tsx
+++ b/packages/autorag/frontend/src/app/components/common/VectorDbConnectionModal.tsx
@@ -1,0 +1,289 @@
+import React from 'react';
+import {
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Radio,
+  TextArea,
+  TextInput,
+} from '@patternfly/react-core';
+import PasswordInput from '@odh-dashboard/internal/components/PasswordInput';
+import DashboardModalFooter from '@odh-dashboard/ui-core/components/DashboardModalFooter';
+import K8sNameDescriptionField, {
+  useK8sNameDescriptionFieldData,
+} from '@odh-dashboard/ui-core/components/K8sNameDescriptionField';
+import { createSecret } from '@odh-dashboard/k8s-core/api/secrets';
+import { isK8sNameDescriptionDataValid, KnownLabels } from '@odh-dashboard/k8s-core';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import {
+  buildVectorDbStringData,
+  isValidHttpUrl,
+  isValidPostgresPort,
+  isVectorDbFormValid,
+  type VectorDbBackend,
+  type VectorDbSecretInput,
+} from '~/app/utilities/vectorDbSecret';
+
+type Props = {
+  namespace: string;
+  onClose: () => void;
+  onSubmit: (secretName: string) => void | Promise<void>;
+  initialBackend?: VectorDbBackend;
+};
+
+const VectorDbConnectionModal: React.FC<Props> = ({
+  namespace,
+  onClose,
+  onSubmit,
+  initialBackend = 'milvus',
+}) => {
+  const { data: nameDescData, onDataChange: setNameDescData } = useK8sNameDescriptionFieldData();
+  const [backend, setBackend] = React.useState<VectorDbBackend>(initialBackend);
+  const [milvusUri, setMilvusUri] = React.useState('');
+  const [milvusToken, setMilvusToken] = React.useState('');
+  const [milvusServerCert, setMilvusServerCert] = React.useState('');
+  const [pgHost, setPgHost] = React.useState('');
+  const [pgPort, setPgPort] = React.useState('5432');
+  const [pgDatabase, setPgDatabase] = React.useState('');
+  const [pgUser, setPgUser] = React.useState('');
+  const [pgPassword, setPgPassword] = React.useState('');
+  const [submitError, setSubmitError] = React.useState<Error>();
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [milvusUriTouched, setMilvusUriTouched] = React.useState(false);
+  const [pgPortTouched, setPgPortTouched] = React.useState(false);
+
+  const milvusUriValid = isValidHttpUrl(milvusUri);
+  const showMilvusUriError = milvusUriTouched && milvusUri.trim() !== '' && !milvusUriValid;
+  const pgPortValid = isValidPostgresPort(pgPort);
+  const showPgPortError = pgPortTouched && pgPort.trim() !== '' && !pgPortValid;
+
+  const secretInput: VectorDbSecretInput =
+    backend === 'milvus'
+      ? {
+          backend: 'milvus',
+          fields: { uri: milvusUri, token: milvusToken, serverCert: milvusServerCert },
+        }
+      : {
+          backend: 'pgvector',
+          fields: {
+            host: pgHost,
+            port: pgPort,
+            database: pgDatabase,
+            user: pgUser,
+            password: pgPassword,
+          },
+        };
+
+  const isFormValid =
+    isK8sNameDescriptionDataValid(nameDescData) && isVectorDbFormValid(secretInput);
+
+  const handleSubmit = async () => {
+    setIsSaving(true);
+    setSubmitError(undefined);
+
+    const k8sName = nameDescData.k8sName.value;
+    const secret: SecretKind = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: k8sName,
+        namespace,
+        annotations: {
+          'openshift.io/display-name': nameDescData.name.trim(),
+          'opendatahub.io/connection-type': backend,
+        },
+        labels: {
+          [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        },
+      },
+      stringData: buildVectorDbStringData(secretInput),
+    };
+
+    try {
+      await createSecret(secret);
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e : new Error(String(e)));
+      setIsSaving(false);
+      return;
+    }
+
+    try {
+      await onSubmit(k8sName);
+      onClose();
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const title = backend === 'milvus' ? 'Add Milvus connection' : 'Add PGVector connection';
+
+  return (
+    <Modal isOpen onClose={isSaving ? undefined : onClose} variant="medium">
+      <ModalHeader
+        title={title}
+        description="Provide connection details for a vector database. The pipeline reads MILVUS_* or PGVECTOR_* keys from the created secret."
+      />
+      <ModalBody>
+        <Form data-testid="vector-db-connection-modal">
+          <FormGroup fieldId="vector-db-backend" label="Vector database type" isRequired>
+            <div role="radiogroup" aria-label="Vector database type">
+              <Radio
+                id="vector-db-backend-milvus"
+                data-testid="vector-db-backend-milvus"
+                name="vector-db-backend"
+                label="Milvus"
+                isChecked={backend === 'milvus'}
+                onChange={() => setBackend('milvus')}
+              />
+              <Radio
+                id="vector-db-backend-pgvector"
+                data-testid="vector-db-backend-pgvector"
+                name="vector-db-backend"
+                label="PGVector"
+                isChecked={backend === 'pgvector'}
+                onChange={() => setBackend('pgvector')}
+              />
+            </div>
+          </FormGroup>
+          <K8sNameDescriptionField
+            dataTestId="vector-db-connection"
+            data={nameDescData}
+            onDataChange={setNameDescData}
+            nameLabel="Connection name"
+            hideDescription
+          />
+          {backend === 'milvus' ? (
+            <>
+              <FormGroup fieldId="vector-db-milvus-uri" label="URI" isRequired>
+                <TextInput
+                  id="vector-db-milvus-uri"
+                  data-testid="vector-db-milvus-uri"
+                  value={milvusUri}
+                  onChange={(_e, val) => setMilvusUri(val)}
+                  onBlur={() => {
+                    setMilvusUriTouched(true);
+                    setMilvusUri((prev) => prev.trim());
+                  }}
+                  maxLength={2048}
+                  validated={showMilvusUriError ? 'error' : 'default'}
+                  isRequired
+                />
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem variant={showMilvusUriError ? 'error' : 'default'}>
+                      {showMilvusUriError
+                        ? 'Enter a valid URL (e.g. https://example.com).'
+                        : 'Connection URI to the Milvus instance.'}
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              </FormGroup>
+              <FormGroup fieldId="vector-db-milvus-token" label="Token">
+                <PasswordInput
+                  id="vector-db-milvus-token"
+                  data-testid="vector-db-milvus-token"
+                  value={milvusToken}
+                  onChange={(_e, val) => setMilvusToken(val)}
+                  ariaLabelShow="Show token"
+                  ariaLabelHide="Hide token"
+                />
+              </FormGroup>
+              <FormGroup fieldId="vector-db-milvus-server-cert" label="Server certificate">
+                <TextArea
+                  id="vector-db-milvus-server-cert"
+                  data-testid="vector-db-milvus-server-cert"
+                  value={milvusServerCert}
+                  onChange={(_e, val) => setMilvusServerCert(val)}
+                  resizeOrientation="vertical"
+                  rows={4}
+                />
+              </FormGroup>
+            </>
+          ) : (
+            <>
+              <FormGroup fieldId="vector-db-pgvector-host" label="Host" isRequired>
+                <TextInput
+                  id="vector-db-pgvector-host"
+                  data-testid="vector-db-pgvector-host"
+                  value={pgHost}
+                  onChange={(_e, val) => setPgHost(val)}
+                  isRequired
+                />
+              </FormGroup>
+              <FormGroup fieldId="vector-db-pgvector-port" label="Port" isRequired>
+                <TextInput
+                  id="vector-db-pgvector-port"
+                  data-testid="vector-db-pgvector-port"
+                  value={pgPort}
+                  onChange={(_e, val) => setPgPort(val)}
+                  onBlur={() => setPgPortTouched(true)}
+                  validated={showPgPortError ? 'error' : 'default'}
+                  isRequired
+                />
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem variant={showPgPortError ? 'error' : 'default'}>
+                      {showPgPortError
+                        ? 'Enter a port between 1 and 65535.'
+                        : 'PostgreSQL server port.'}
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              </FormGroup>
+              <FormGroup fieldId="vector-db-pgvector-db" label="Database" isRequired>
+                <TextInput
+                  id="vector-db-pgvector-db"
+                  data-testid="vector-db-pgvector-db"
+                  value={pgDatabase}
+                  onChange={(_e, val) => setPgDatabase(val)}
+                  isRequired
+                />
+              </FormGroup>
+              <FormGroup fieldId="vector-db-pgvector-user" label="User" isRequired>
+                <TextInput
+                  id="vector-db-pgvector-user"
+                  data-testid="vector-db-pgvector-user"
+                  value={pgUser}
+                  onChange={(_e, val) => setPgUser(val)}
+                  isRequired
+                />
+              </FormGroup>
+              <FormGroup fieldId="vector-db-pgvector-password" label="Password" isRequired>
+                <PasswordInput
+                  id="vector-db-pgvector-password"
+                  data-testid="vector-db-pgvector-password"
+                  value={pgPassword}
+                  onChange={(_e, val) => setPgPassword(val)}
+                  ariaLabelShow="Show password"
+                  ariaLabelHide="Hide password"
+                />
+              </FormGroup>
+            </>
+          )}
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <DashboardModalFooter
+          submitLabel="Add connection"
+          onCancel={onClose}
+          onSubmit={handleSubmit}
+          error={submitError}
+          isSubmitDisabled={!isFormValid || isSaving}
+          isCancelDisabled={isSaving}
+          isSubmitLoading={isSaving}
+          alertTitle="Failed to create connection"
+        />
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default VectorDbConnectionModal;

--- a/packages/autorag/frontend/src/app/components/common/__tests__/SecretSelector.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/__tests__/SecretSelector.spec.tsx
@@ -371,6 +371,25 @@ describe('SecretSelector', () => {
       expect(toggle).toHaveTextContent('Select a secret');
     });
 
+    it('should show empty namespace helper text when no secrets are available', () => {
+      mockUseFetchState.mockReturnValue([[], true, undefined, mockRefresh]);
+
+      render(
+        <SecretSelector
+          namespace={defaultNamespace}
+          type="vector-db"
+          value={undefined}
+          onChange={mockOnChange}
+          dataTestId="test-selector"
+          placeholder="Select vector database secret"
+        />,
+      );
+
+      expect(
+        screen.getByText('There are no secrets in the selected namespace'),
+      ).toBeInTheDocument();
+    });
+
     it('should not open dropdown when clicked and no secrets available', () => {
       mockUseFetchState.mockReturnValue([[], true, undefined, mockRefresh]);
 
@@ -565,6 +584,36 @@ describe('SecretSelector', () => {
         mockUseFetchState.mock.calls[mockUseFetchState.mock.calls.length - 1][0];
 
       // The callbacks should be different because type changed
+      expect(secondCallback).not.toBe(firstCallback);
+    });
+
+    it('should refetch when type changes to vector-db', () => {
+      mockUseFetchState.mockReturnValue([[], true, undefined, mockRefresh]);
+
+      const { rerender } = render(
+        <SecretSelector
+          namespace={defaultNamespace}
+          type="maas"
+          value={undefined}
+          onChange={mockOnChange}
+          dataTestId="test-selector"
+        />,
+      );
+
+      const firstCallback = mockUseFetchState.mock.calls[0][0];
+
+      rerender(
+        <SecretSelector
+          namespace={defaultNamespace}
+          type="vector-db"
+          value={undefined}
+          onChange={mockOnChange}
+          dataTestId="test-selector"
+        />,
+      );
+
+      const secondCallback =
+        mockUseFetchState.mock.calls[mockUseFetchState.mock.calls.length - 1][0];
       expect(secondCallback).not.toBe(firstCallback);
     });
   });

--- a/packages/autorag/frontend/src/app/components/common/__tests__/VectorDbConnectionModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/__tests__/VectorDbConnectionModal.spec.tsx
@@ -1,0 +1,275 @@
+import * as secretsApi from '@odh-dashboard/k8s-core/api/secrets';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { act } from 'react';
+import { KnownLabels } from '@odh-dashboard/k8s-core';
+import VectorDbConnectionModal from '~/app/components/common/VectorDbConnectionModal';
+
+const TEST_NAMESPACE = 'my-namespace';
+
+jest.mock('@odh-dashboard/k8s-core/api/secrets', () => ({
+  createSecret: jest.fn(),
+}));
+
+const createSecretMock = jest.mocked(secretsApi.createSecret);
+
+describe('VectorDbConnectionModal', () => {
+  const onCloseMock = jest.fn();
+  const onSubmitMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createSecretMock.mockResolvedValue({} as Awaited<ReturnType<typeof createSecretMock>>);
+  });
+
+  it('should render Milvus fields by default', () => {
+    render(
+      <VectorDbConnectionModal
+        namespace={TEST_NAMESPACE}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Add Milvus connection' })).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-connection-name')).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-milvus-uri')).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-milvus-token')).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-milvus-server-cert')).toBeInTheDocument();
+    expect(screen.queryByTestId('vector-db-pgvector-host')).not.toBeInTheDocument();
+  });
+
+  it('should render PGVector fields when initialBackend is pgvector', () => {
+    render(
+      <VectorDbConnectionModal
+        namespace={TEST_NAMESPACE}
+        initialBackend="pgvector"
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Add PGVector connection' })).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-pgvector-host')).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-pgvector-port')).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-pgvector-db')).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-pgvector-user')).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-pgvector-password')).toBeInTheDocument();
+    expect(screen.queryByTestId('vector-db-milvus-uri')).not.toBeInTheDocument();
+  });
+
+  it('should switch schemas when the backend radio changes', async () => {
+    render(
+      <VectorDbConnectionModal
+        namespace={TEST_NAMESPACE}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('vector-db-backend-pgvector'));
+    });
+
+    expect(screen.getByRole('heading', { name: 'Add PGVector connection' })).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-pgvector-host')).toBeInTheDocument();
+  });
+
+  it('should have Add connection button disabled initially', () => {
+    render(
+      <VectorDbConnectionModal
+        namespace={TEST_NAMESPACE}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Add connection' })).toBeDisabled();
+  });
+
+  it('should create a Milvus secret with required URI and optional token', async () => {
+    render(
+      <VectorDbConnectionModal
+        namespace={TEST_NAMESPACE}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('vector-db-connection-name'), {
+        target: { value: 'My Milvus' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-milvus-uri'), {
+        target: { value: 'http://milvus:19530' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-milvus-token'), {
+        target: { value: 'token-123' },
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Add connection' })).toBeEnabled();
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add connection' }).click();
+    });
+
+    expect(createSecretMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          name: 'my-milvus',
+          namespace: TEST_NAMESPACE,
+          annotations: expect.objectContaining({
+            'openshift.io/display-name': 'My Milvus',
+            'opendatahub.io/connection-type': 'milvus',
+          }),
+          labels: expect.objectContaining({
+            [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+          }),
+        }),
+        stringData: {
+          MILVUS_URI: 'http://milvus:19530',
+          MILVUS_TOKEN: 'token-123',
+        },
+      }),
+    );
+    expect(onSubmitMock).toHaveBeenCalledWith('my-milvus');
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it('should create a PGVector secret with all required keys', async () => {
+    render(
+      <VectorDbConnectionModal
+        namespace={TEST_NAMESPACE}
+        initialBackend="pgvector"
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('vector-db-connection-name'), {
+        target: { value: 'My PGVector' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-host'), {
+        target: { value: 'pg.example.com' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-port'), {
+        target: { value: '5432' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-db'), {
+        target: { value: 'testdb' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-user'), {
+        target: { value: 'testuser' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-password'), {
+        target: { value: 'secret' },
+      });
+    });
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add connection' }).click();
+    });
+
+    expect(createSecretMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          name: 'my-pgvector',
+          annotations: expect.objectContaining({
+            'opendatahub.io/connection-type': 'pgvector',
+          }),
+        }),
+        stringData: {
+          PGVECTOR_HOST: 'pg.example.com',
+          PGVECTOR_PORT: '5432',
+          PGVECTOR_DB: 'testdb',
+          PGVECTOR_USER: 'testuser',
+          PGVECTOR_PASSWORD: 'secret',
+        },
+      }),
+    );
+    expect(onSubmitMock).toHaveBeenCalledWith('my-pgvector');
+  });
+
+  it('should keep submit disabled when PGVector port is invalid', async () => {
+    render(
+      <VectorDbConnectionModal
+        namespace={TEST_NAMESPACE}
+        initialBackend="pgvector"
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('vector-db-connection-name'), {
+        target: { value: 'My PGVector' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-host'), {
+        target: { value: 'pg.example.com' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-port'), {
+        target: { value: '99999' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-db'), {
+        target: { value: 'testdb' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-user'), {
+        target: { value: 'testuser' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-pgvector-password'), {
+        target: { value: 'secret' },
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Add connection' })).toBeDisabled();
+  });
+
+  it('should not call onSubmit when createSecret rejects', async () => {
+    createSecretMock.mockRejectedValueOnce(new Error('API error'));
+
+    render(
+      <VectorDbConnectionModal
+        namespace={TEST_NAMESPACE}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('vector-db-connection-name'), {
+        target: { value: 'My Milvus' },
+      });
+      fireEvent.change(screen.getByTestId('vector-db-milvus-uri'), {
+        target: { value: 'http://milvus:19530' },
+      });
+    });
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add connection' }).click();
+    });
+
+    expect(createSecretMock).toHaveBeenCalled();
+    expect(onSubmitMock).not.toHaveBeenCalled();
+    expect(onCloseMock).not.toHaveBeenCalled();
+    const alert = await screen.findByTestId('error-message-alert');
+    expect(alert).toHaveTextContent('Failed to create connection');
+  });
+
+  it('should call onClose when cancel is clicked', async () => {
+    render(
+      <VectorDbConnectionModal
+        namespace={TEST_NAMESPACE}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+      />,
+    );
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Cancel' }).click();
+    });
+
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+});

--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -817,6 +817,7 @@ function AutoragConfigure({
                     <FlexItem>
                       <ConfigureFormGroup
                         label="Vector database connection"
+                        isRequired
                         description="Select the Kubernetes secret for Milvus or PGVector. The pipeline reads MILVUS_* or PGVECTOR_* keys from that secret."
                       >
                         <AutoragVectorStoreSelector initialSecret={initialVectorDbSecret} />

--- a/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
@@ -1,14 +1,26 @@
 import React from 'react';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleAction,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
 import { useController, useFormContext } from 'react-hook-form';
 import { useParams } from 'react-router';
 import SecretSelector, { SecretSelection } from '~/app/components/common/SecretSelector';
+import VectorDbConnectionModal from '~/app/components/common/VectorDbConnectionModal';
 import { ConfigureSchema } from '~/app/schemas/configure.schema';
 import { useRunTriggeredTracking } from '~/app/context/RunTriggeredTrackingContext';
+import { SecretListItem } from '~/app/types';
 import {
   fireAutoragVectorStoreConfigured,
   toVectorStoreProviderTypeFromSecret,
   TrackingOutcome,
 } from '~/app/utilities/tracking';
+import type { VectorDbBackend } from '~/app/utilities/vectorDbSecret';
 
 type AutoragVectorStoreSelectorProps = {
   initialSecret?: SecretSelection;
@@ -21,9 +33,15 @@ const AutoragVectorStoreSelector: React.FC<AutoragVectorStoreSelectorProps> = ({
   const { onVectorStoreConfigured } = useRunTriggeredTracking();
   const {
     formState: { isSubmitting },
+    setValue,
   } = useFormContext<ConfigureSchema>();
   const [selectedSecret, setSelectedSecret] = React.useState<SecretSelection | undefined>(
     initialSecret,
+  );
+  const [isAddDropdownOpen, setIsAddDropdownOpen] = React.useState(false);
+  const [modalBackend, setModalBackend] = React.useState<VectorDbBackend | null>(null);
+  const secretsRefreshRef = React.useRef<(() => Promise<SecretListItem[] | undefined>) | null>(
+    null,
   );
 
   const {
@@ -32,29 +50,114 @@ const AutoragVectorStoreSelector: React.FC<AutoragVectorStoreSelectorProps> = ({
     name: 'vector_db_secret_name',
   });
 
+  const applySecret = React.useCallback(
+    (secret: SecretSelection | undefined) => {
+      setSelectedSecret(secret);
+      fieldOnChange(!secret || secret.invalid ? '' : secret.name);
+      const providerType = toVectorStoreProviderTypeFromSecret(secret?.type);
+      if (secret && !secret.invalid && providerType) {
+        fireAutoragVectorStoreConfigured({
+          providerType,
+          countOfCompatibleProviders: 1,
+          outcome: TrackingOutcome.submit,
+          success: true,
+        });
+        onVectorStoreConfigured(providerType);
+      }
+    },
+    [fieldOnChange, onVectorStoreConfigured],
+  );
+
+  const openCreateModal = (backend: VectorDbBackend) => {
+    setIsAddDropdownOpen(false);
+    setModalBackend(backend);
+  };
+
   return (
-    <SecretSelector
-      dataTestId="vector-store-select-toggle"
-      placeholder="Select vector database secret"
-      type="vector-db"
-      namespace={namespace}
-      value={selectedSecret?.uuid}
-      isDisabled={isSubmitting}
-      onChange={(secret) => {
-        setSelectedSecret(secret);
-        fieldOnChange(!secret || secret.invalid ? '' : secret.name);
-        const providerType = toVectorStoreProviderTypeFromSecret(secret?.type);
-        if (secret && !secret.invalid && providerType) {
-          fireAutoragVectorStoreConfigured({
-            providerType,
-            countOfCompatibleProviders: 1,
-            outcome: TrackingOutcome.submit,
-            success: true,
-          });
-          onVectorStoreConfigured(providerType);
-        }
-      }}
-    />
+    <>
+      <Split hasGutter isWrappable>
+        <SplitItem isFilled>
+          <SecretSelector
+            dataTestId="vector-store-select-toggle"
+            placeholder="Select vector database secret"
+            type="vector-db"
+            namespace={namespace}
+            value={selectedSecret?.uuid}
+            isDisabled={isSubmitting}
+            showType
+            onChange={applySecret}
+            onRefreshReady={(refresh) => {
+              secretsRefreshRef.current = refresh;
+            }}
+          />
+        </SplitItem>
+        <SplitItem>
+          <Dropdown
+            isOpen={isAddDropdownOpen}
+            onSelect={() => setIsAddDropdownOpen(false)}
+            onOpenChange={(isOpen) => setIsAddDropdownOpen(isOpen)}
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                variant="secondary"
+                onClick={() => setIsAddDropdownOpen(!isAddDropdownOpen)}
+                isExpanded={isAddDropdownOpen}
+                isDisabled={isSubmitting}
+                splitButtonItems={[
+                  <MenuToggleAction
+                    id="add-milvus-connection-button"
+                    key="add-milvus-connection-button"
+                    data-testid="add-milvus-connection-button"
+                    aria-label="Add new connection"
+                    onClick={() => openCreateModal('milvus')}
+                  >
+                    Add new connection
+                  </MenuToggleAction>,
+                ]}
+                aria-label="Add new connection, Milvus, or PGVector"
+                data-testid="add-vector-db-split-button"
+              />
+            )}
+          >
+            <DropdownList>
+              <DropdownItem
+                key="add-milvus"
+                data-testid="add-milvus-dropdown-item"
+                onClick={() => openCreateModal('milvus')}
+              >
+                Add Milvus
+              </DropdownItem>
+              <DropdownItem
+                key="add-pgvector"
+                data-testid="add-pgvector-connection-button"
+                onClick={() => openCreateModal('pgvector')}
+              >
+                Add PGVector
+              </DropdownItem>
+            </DropdownList>
+          </Dropdown>
+        </SplitItem>
+      </Split>
+      {modalBackend ? (
+        <VectorDbConnectionModal
+          namespace={namespace}
+          initialBackend={modalBackend}
+          onClose={() => setModalBackend(null)}
+          onSubmit={async (secretName) => {
+            const refresh = secretsRefreshRef.current;
+            if (!refresh) {
+              return;
+            }
+            const list = await refresh();
+            const secret = list?.find((s) => s.name === secretName);
+            if (secret) {
+              applySecret({ ...secret, invalid: false });
+              setValue('vector_db_secret_name', secret.name, { shouldValidate: true });
+            }
+          }}
+        />
+      ) : null}
+    </>
   );
 };
 

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
@@ -39,7 +39,15 @@ jest.mock('~/app/components/common/SecretSelector', () => ({
     namespace?: string;
     value?: string;
     isDisabled?: boolean;
+    onRefreshReady?: (refresh: () => Promise<SecretSelection[] | undefined>) => void;
   }) => {
+    props.onRefreshReady?.(async () => [
+      mockSecretListItem({
+        uuid: 'uid-created',
+        name: 'created-milvus',
+        type: 'milvus',
+      }),
+    ]);
     Object.assign(secretSelectorState.props, props);
     secretSelectorState.emit = props.onChange;
     return (
@@ -60,6 +68,33 @@ jest.mock('~/app/components/common/SecretSelector', () => ({
       </button>
     );
   },
+}));
+
+jest.mock('~/app/components/common/VectorDbConnectionModal', () => ({
+  __esModule: true,
+  default: ({
+    initialBackend,
+    onClose,
+    onSubmit,
+  }: {
+    initialBackend?: string;
+    onClose: () => void;
+    onSubmit: (name: string) => void | Promise<void>;
+  }) => (
+    <div data-testid="vector-db-connection-modal">
+      <span data-testid="vector-db-modal-backend">{initialBackend}</span>
+      <button
+        type="button"
+        data-testid="vector-db-modal-submit"
+        onClick={() => onSubmit('created-milvus')}
+      >
+        Submit modal
+      </button>
+      <button type="button" data-testid="vector-db-modal-close" onClick={onClose}>
+        Close modal
+      </button>
+    </div>
+  ),
 }));
 
 const configureSchema = createConfigureSchema();
@@ -137,6 +172,7 @@ describe('AutoragVectorStoreSelector', () => {
     expect(secretSelectorState.props).toMatchObject({
       type: 'vector-db',
       namespace: 'test-namespace',
+      showType: true,
     });
   });
 
@@ -242,5 +278,73 @@ describe('AutoragVectorStoreSelector', () => {
       </FormWrapper>,
     );
     expect(screen.getByTestId('vector-store-select-toggle')).toBeInTheDocument();
+  });
+
+  it('should open the Milvus modal from the split action', () => {
+    render(
+      <FormWrapper>
+        <AutoragVectorStoreSelector />
+      </FormWrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('add-milvus-connection-button'));
+    expect(screen.getByTestId('vector-db-connection-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('vector-db-modal-backend')).toHaveTextContent('milvus');
+  });
+
+  it('should open the PGVector modal from the split dropdown', () => {
+    render(
+      <FormWrapper>
+        <AutoragVectorStoreSelector />
+      </FormWrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('add-vector-db-split-button'));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add PGVector' }));
+    expect(screen.getByTestId('vector-db-modal-backend')).toHaveTextContent('pgvector');
+  });
+
+  it('should open the Milvus modal from the split dropdown', () => {
+    render(
+      <FormWrapper>
+        <AutoragVectorStoreSelector />
+      </FormWrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('add-vector-db-split-button'));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add Milvus' }));
+    expect(screen.getByTestId('vector-db-modal-backend')).toHaveTextContent('milvus');
+  });
+
+  it('should select the created secret after the modal submits', async () => {
+    /* eslint-disable camelcase */
+    const onFormChange = jest.fn();
+    const Wrapper: React.FC = () => {
+      const form = useForm({
+        mode: 'onChange',
+        resolver: zodResolver(configureSchema.full),
+        defaultValues: configureSchema.defaults,
+      });
+      React.useEffect(() => {
+        const sub = form.watch((values) => onFormChange(values));
+        return () => sub.unsubscribe();
+      }, [form]);
+      return (
+        <FormProvider {...form}>
+          <AutoragVectorStoreSelector />
+        </FormProvider>
+      );
+    };
+
+    render(<Wrapper />);
+    fireEvent.click(screen.getByTestId('add-milvus-connection-button'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('vector-db-modal-submit'));
+    });
+
+    expect(onFormChange).toHaveBeenCalledWith(
+      expect.objectContaining({ vector_db_secret_name: 'created-milvus' }),
+    );
+    /* eslint-enable camelcase */
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/vectorDbSecret.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/vectorDbSecret.spec.ts
@@ -1,0 +1,113 @@
+import {
+  buildVectorDbStringData,
+  isValidHttpUrl,
+  isValidPostgresPort,
+  isVectorDbFormValid,
+} from '~/app/utilities/vectorDbSecret';
+
+describe('isValidHttpUrl', () => {
+  it('should accept http and https URLs', () => {
+    expect(isValidHttpUrl('http://milvus:19530')).toBe(true);
+    expect(isValidHttpUrl('https://milvus.example.com')).toBe(true);
+  });
+
+  it('should reject empty, non-http, and invalid values', () => {
+    expect(isValidHttpUrl('')).toBe(false);
+    expect(isValidHttpUrl('ftp://milvus')).toBe(false);
+    expect(isValidHttpUrl('not-a-url')).toBe(false);
+  });
+});
+
+describe('isValidPostgresPort', () => {
+  it('should accept ports from 1 to 65535', () => {
+    expect(isValidPostgresPort('1')).toBe(true);
+    expect(isValidPostgresPort('5432')).toBe(true);
+    expect(isValidPostgresPort('65535')).toBe(true);
+  });
+
+  it('should reject empty, non-numeric, and out-of-range values', () => {
+    expect(isValidPostgresPort('')).toBe(false);
+    expect(isValidPostgresPort('0')).toBe(false);
+    expect(isValidPostgresPort('65536')).toBe(false);
+    expect(isValidPostgresPort('54.32')).toBe(false);
+    expect(isValidPostgresPort('abc')).toBe(false);
+  });
+});
+
+describe('buildVectorDbStringData', () => {
+  it('should include required Milvus URI and omit empty optional keys', () => {
+    expect(
+      buildVectorDbStringData({
+        backend: 'milvus',
+        fields: { uri: ' http://milvus:19530 ', token: '  ', serverCert: '' },
+      }),
+    ).toEqual({ MILVUS_URI: 'http://milvus:19530' });
+  });
+
+  it('should include optional Milvus token and certificate when set', () => {
+    expect(
+      buildVectorDbStringData({
+        backend: 'milvus',
+        fields: {
+          uri: 'https://milvus.example.com',
+          token: 'secret-token',
+          serverCert: '-----BEGIN CERTIFICATE-----',
+        },
+      }),
+    ).toEqual({
+      MILVUS_URI: 'https://milvus.example.com',
+      MILVUS_TOKEN: 'secret-token',
+      MILVUS_SERVER_CERT: '-----BEGIN CERTIFICATE-----',
+    });
+  });
+
+  it('should include all PGVector keys', () => {
+    expect(
+      buildVectorDbStringData({
+        backend: 'pgvector',
+        fields: {
+          host: ' pg.example.com ',
+          port: '5432',
+          database: 'testdb',
+          user: 'testuser',
+          password: 'testpassword',
+        },
+      }),
+    ).toEqual({
+      PGVECTOR_HOST: 'pg.example.com',
+      PGVECTOR_PORT: '5432',
+      PGVECTOR_DB: 'testdb',
+      PGVECTOR_USER: 'testuser',
+      PGVECTOR_PASSWORD: 'testpassword',
+    });
+  });
+});
+
+describe('isVectorDbFormValid', () => {
+  it('should require a valid Milvus URI', () => {
+    expect(isVectorDbFormValid({ backend: 'milvus', fields: { uri: 'http://milvus:19530' } })).toBe(
+      true,
+    );
+    expect(isVectorDbFormValid({ backend: 'milvus', fields: { uri: 'bad' } })).toBe(false);
+  });
+
+  it('should require all PGVector fields and a valid port', () => {
+    const fields = {
+      host: 'pg',
+      port: '5432',
+      database: 'db',
+      user: 'user',
+      password: 'pass',
+    };
+    expect(isVectorDbFormValid({ backend: 'pgvector', fields })).toBe(true);
+    expect(isVectorDbFormValid({ backend: 'pgvector', fields: { ...fields, host: '' } })).toBe(
+      false,
+    );
+    expect(isVectorDbFormValid({ backend: 'pgvector', fields: { ...fields, port: '0' } })).toBe(
+      false,
+    );
+    expect(isVectorDbFormValid({ backend: 'pgvector', fields: { ...fields, password: '' } })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/autorag/frontend/src/app/utilities/vectorDbSecret.ts
+++ b/packages/autorag/frontend/src/app/utilities/vectorDbSecret.ts
@@ -1,0 +1,75 @@
+export type VectorDbBackend = 'milvus' | 'pgvector';
+
+export type MilvusSecretFields = {
+  uri: string;
+  token?: string;
+  serverCert?: string;
+};
+
+export type PgVectorSecretFields = {
+  host: string;
+  port: string;
+  database: string;
+  user: string;
+  password: string;
+};
+
+export type VectorDbSecretInput =
+  | { backend: 'milvus'; fields: MilvusSecretFields }
+  | { backend: 'pgvector'; fields: PgVectorSecretFields };
+
+export const isValidHttpUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const isValidPostgresPort = (port: string): boolean => {
+  const trimmed = port.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return false;
+  }
+  const value = Number(trimmed);
+  return value >= 1 && value <= 65535;
+};
+
+export const buildVectorDbStringData = (input: VectorDbSecretInput): Record<string, string> => {
+  if (input.backend === 'milvus') {
+    const data: Record<string, string> = {
+      MILVUS_URI: input.fields.uri.trim(),
+    };
+    const token = input.fields.token?.trim();
+    if (token) {
+      data.MILVUS_TOKEN = token;
+    }
+    const cert = input.fields.serverCert?.trim();
+    if (cert) {
+      data.MILVUS_SERVER_CERT = cert;
+    }
+    return data;
+  }
+
+  return {
+    PGVECTOR_HOST: input.fields.host.trim(),
+    PGVECTOR_PORT: input.fields.port.trim(),
+    PGVECTOR_DB: input.fields.database.trim(),
+    PGVECTOR_USER: input.fields.user.trim(),
+    PGVECTOR_PASSWORD: input.fields.password.trim(),
+  };
+};
+
+export const isVectorDbFormValid = (input: VectorDbSecretInput): boolean => {
+  if (input.backend === 'milvus') {
+    return isValidHttpUrl(input.fields.uri);
+  }
+  return (
+    input.fields.host.trim() !== '' &&
+    isValidPostgresPort(input.fields.port) &&
+    input.fields.database.trim() !== '' &&
+    input.fields.user.trim() !== '' &&
+    input.fields.password.trim() !== ''
+  );
+};


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-89372

## Description
Require a vector DB secret (`vector_db_secret_name`) on AutoRAG configure. Users can pick an existing Milvus/PGVector secret or create one (Add new connection / Add Milvus / Add PGVector). Backend is detected from `MILVUS_*` or `PGVECTOR_*` keys. Submit is blocked until a secret is selected.

<img width="1420" height="505" alt="Screenshot 2026-09-10 at 4 21 05 PM" src="https://github.com/user-attachments/assets/8f31748a-0fbc-4a9c-92c5-2a71e98f3420" />


<img width="1390" height="452" alt="Screenshot 2026-09-10 at 4 21 16 PM" src="https://github.com/user-attachments/assets/c9714417-e201-4c04-a3ec-4916c65bc00c" />

<img width="1303" height="1015" alt="Screenshot 2026-09-10 at 12 43 21 PM" src="https://github.com/user-attachments/assets/215c08db-bad1-4b81-9488-ea6fe99e2908" />


<img width="1101" height="1016" alt="Screenshot 2026-09-10 at 12 43 33 PM" src="https://github.com/user-attachments/assets/76003e6f-9c12-47e7-9bf1-7d16f9fcd73f" />


## How Has This Been Tested?
Jest (modal, selector, SecretSelector, helpers) and BFF `k8s` unit tests. 
Manual check with `make dev-start-mock` in `packages/autorag` (fake secrets). 
Cypress specs added but not run here. 

## Test Impact
Unit tests + Cypress mocked tests for selector, empty state, and both connection schemas. BFF tests for vector-db classification.


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
