### PR TITLE
fix(ci): validate sync-stable target without pipefail grep pipeline

### DIFF
--- a/.github/workflows/sync-stable.yml
+++ b/.github/workflows/sync-stable.yml
@@ -84,8 +84,12 @@ jobs:
             exit 1
           fi
 
-          if ! git rev-list --first-parent origin/main | grep -Fxq "$TARGET_COMMIT"; then
-            echo "ERROR: target_commit $TARGET_COMMIT is not on main's first-parent history"
+          MAIN_TIP="$(git rev-parse origin/main)"
+          echo "origin/main tip: $MAIN_TIP"
+
+          # Do not use `rev-list | grep -q` with pipefail: grep exits early and rev-list gets SIGPIPE (141).
+          if ! git merge-base --is-ancestor "$TARGET_COMMIT" "$MAIN_TIP"; then
+            echo "ERROR: target_commit $TARGET_COMMIT is not an ancestor of origin/main ($MAIN_TIP)"
             exit 1
           fi
 


### PR DESCRIPTION
## Description

Fixes false failures in **Fast-forward main to stable** when `target_commit` is valid on `main` (e.g. [run 34535611979](https://github.com/opendatahub-io/odh-dashboard/actions/runs/34535611979/job/103066427426)).

The workflow step uses `set -o pipefail` and validates with:

```bash
git rev-list --first-parent origin/main | grep -Fxq "$TARGET_COMMIT"
```

When the SHA is on `main`, `grep -q` exits as soon as it matches, closes the pipe, and `rev-list` gets SIGPIPE (exit 141). With `pipefail`, the pipeline is treated as failed, so the job reports *"not on main's first-parent history"* even though the commit is on `main`.

Replace that check with `git merge-base --is-ancestor "$TARGET_COMMIT" "$(git rev-parse origin/main)"` and log `origin/main` tip for debugging. The explicit `git fetch origin +refs/heads/main:refs/remotes/origin/main` from #9676 is unchanged.

Related: [RHOAIENG-93248](https://redhat.atlassian.net/browse/RHOAIENG-93248)

## How Has This Been Tested?

Reproduced locally with `set -euo pipefail` on a clone of `main`: the old pipeline returns failure for SHAs on first-parent; the new `merge-base --is-ancestor` check passes for the same SHAs.

## Test Impact

Workflow-only change; no unit/Cypress impact.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)

[RHOAIENG-93248]: https://redhat.atlassian.net/browse/RHOAIENG-93248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stable-branch synchronization checks to recognize commits from any valid main-branch history path.
  * Prevented synchronization failures caused by pipeline behavior during commit verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->