### PR TITLE
fix(e2e): stop manifest URL validation from timing out on large downloads

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
@@ -1,7 +1,8 @@
 # testManifestLinks.cy.ts Test Data #
 #
 # This test validates URLs found in manifest YAML files.
-# It uses tiered timeouts:
+# Reachability checks status/redirects only (no response body download).
+# Per-request timeouts:
 #   - Internal domains (*.redhat.com): 5s
 #   - Normal external URLs: 15s
 #   - Known slow domains (catalog.redhat.com, etc.): 30s

--- a/packages/cypress/cypress/utils/manifestUrlValidator.ts
+++ b/packages/cypress/cypress/utils/manifestUrlValidator.ts
@@ -32,6 +32,42 @@ interface FormatError {
   locations: UrlLocation[];
 }
 
+const isUrlLocation = (value: unknown): value is UrlLocation => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const loc = value as Record<string, unknown>;
+  return (
+    typeof loc.url === 'string' &&
+    loc.url.length > 0 &&
+    typeof loc.file === 'string' &&
+    loc.file.length > 0 &&
+    typeof loc.line === 'number'
+  );
+};
+
+const parseUrlLocations = (value: unknown): UrlLocation[] => {
+  if (!Array.isArray(value) || !value.every(isUrlLocation)) {
+    throw new Error('Invalid URL location format from extractor task');
+  }
+  return value;
+};
+
+const isUrlValidationResult = (value: unknown): value is UrlValidationResult => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const result = value as Record<string, unknown>;
+  return typeof result.url === 'string' && typeof result.status === 'number';
+};
+
+const parseUrlValidationResults = (value: unknown): UrlValidationResult[] => {
+  if (!Array.isArray(value) || !value.every(isUrlValidationResult)) {
+    throw new Error('Invalid validation result format from validateHttpsUrls task');
+  }
+  return value;
+};
+
 /**
  * Extract and filter URLs from manifest directory
  */
@@ -39,37 +75,16 @@ const extractAndFilterUrls = (
   manifestsDir: string,
   excludedSubstrings: string[],
 ): Cypress.Chainable<UrlExtractionResult> => {
-  return cy.task<UrlLocation[]>('extractHttpsUrls', manifestsDir).then((urlLocations) => {
-    // Validate payload shape
-    if (!Array.isArray(urlLocations)) {
-      throw new Error('Failed to extract URLs from manifests directory');
-    }
-    // Runtime validation - task could return wrong shape despite types
-    /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-    if (
-      urlLocations.length > 0 &&
-      !urlLocations.every(
-        (loc) =>
-          typeof loc === 'object' &&
-          loc !== null &&
-          typeof loc.url === 'string' &&
-          loc.url.length > 0 &&
-          typeof loc.file === 'string' &&
-          loc.file.length > 0 &&
-          typeof loc.line === 'number',
-      )
-    ) {
-      throw new Error('Invalid URL location format from extractor task');
-    }
-    /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+  return cy.task<unknown>('extractHttpsUrls', manifestsDir).then((urlLocations) => {
+    const parsedUrlLocations = parseUrlLocations(urlLocations);
 
-    const filteredUrlLocations = urlLocations.filter(
+    const filteredUrlLocations = parsedUrlLocations.filter(
       (urlLocation) => urlLocation.url && !isUrlExcluded(urlLocation.url, excludedSubstrings),
     );
 
     const uniqueUrls = [...new Set(filteredUrlLocations.map((loc) => loc.url))];
 
-    return { urlLocations, filteredUrlLocations, uniqueUrls };
+    return { urlLocations: parsedUrlLocations, filteredUrlLocations, uniqueUrls };
   });
 };
 
@@ -200,42 +215,33 @@ export const validateManifestUrlReachability = (
           )}\n\nURLs to verify:\n${formatUrlLocationsByFile(filteredUrlLocations)}`,
         );
 
-        return cy.task<UrlValidationResult[]>('validateHttpsUrls', uniqueUrls).then((results) => {
-          // Validate results payload immediately - task could return wrong shape despite types
-          if (!Array.isArray(results)) {
-            throw new Error('validateHttpsUrls task did not return an array');
-          }
-          /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-          if (
-            results.length > 0 &&
-            !results.every(
-              (r) =>
-                typeof r === 'object' &&
-                r !== null &&
-                typeof r.url === 'string' &&
-                typeof r.status === 'number',
-            )
-          ) {
-            throw new Error('Invalid validation result format from validateHttpsUrls task');
-          }
-          /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+        // Default cy.task timeout is 60s; retries on slow domains can exceed that
+        // even after we stop downloading bodies.
+        return cy
+          .task<unknown>('validateHttpsUrls', uniqueUrls, { timeout: 180000 })
+          .then((results) => {
+            const parsedResults = parseUrlValidationResults(results);
 
-          const resultsWithLocation: UrlValidationResultWithLocation[] = results.map((result) => {
-            // Use originalUrl for location lookup (in case of redirects), fall back to url
-            const finalUrlLocations =
-              urlToLocationsMap.get(result.originalUrl || result.url) ||
-              urlToLocationsMap.get(result.url);
-            const location =
-              finalUrlLocations && finalUrlLocations.length > 0 ? finalUrlLocations[0] : undefined;
+            const resultsWithLocation: UrlValidationResultWithLocation[] = parsedResults.map(
+              (result) => {
+                // Use originalUrl for location lookup (in case of redirects), fall back to url
+                const finalUrlLocations =
+                  urlToLocationsMap.get(result.originalUrl || result.url) ||
+                  urlToLocationsMap.get(result.url);
+                const location =
+                  finalUrlLocations && finalUrlLocations.length > 0
+                    ? finalUrlLocations[0]
+                    : undefined;
 
-            return {
-              ...result,
-              location,
-            };
+                return {
+                  ...result,
+                  location,
+                };
+              },
+            );
+
+            return { resultsWithLocation, urlToLocationsMap };
           });
-
-          return { resultsWithLocation, urlToLocationsMap };
-        });
       })
       .then(({ resultsWithLocation, urlToLocationsMap }): void => {
         // Process and validate all results (categorize, log, assert)

--- a/packages/cypress/cypress/utils/urlValidator.ts
+++ b/packages/cypress/cypress/utils/urlValidator.ts
@@ -10,6 +10,7 @@
 
 import * as http from 'http';
 import * as https from 'https';
+import { logToConsole, LogLevel } from './logger';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const HttpsProxyAgent: new (options: string | object) => https.Agent = require('https-proxy-agent');
 
@@ -113,6 +114,63 @@ const isRetryableError = (error: Error & { code?: string }): boolean => {
 const isRetryableStatusCode = (statusCode: number): boolean =>
   statusCode >= 500 && statusCode < 600;
 
+type HeaderResult = {
+  statusCode: number;
+  location?: string;
+};
+
+const headerLocation = (location: string | string[] | undefined): string | undefined =>
+  Array.isArray(location) ? location[0] : location;
+
+/**
+ * GET a URL and return only status / Location. Do not download the body.
+ * Manifests include GitHub release assets (tens of MB); waiting for `end` on
+ * those (or a stalled stream after headers) exceeds Cypress's 60s `cy.task` timeout.
+ */
+const fetchStatus = (
+  urlToTest: string,
+  options: http.RequestOptions,
+  protocol: typeof http | typeof https,
+  requestTimeout: number,
+): Promise<HeaderResult> =>
+  new Promise((resolve, reject) => {
+    let settled = false;
+    const timeoutState: { timer?: ReturnType<typeof setTimeout> } = {};
+
+    const settle = (cb: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutState.timer) {
+        clearTimeout(timeoutState.timer);
+      }
+      cb();
+    };
+
+    const req = protocol.get(urlToTest, options, (res) => {
+      const statusCode = res.statusCode || 0;
+      const location = headerLocation(res.headers.location);
+      // Resolve before destroy() so a sync ECONNRESET from abort is ignored.
+      settle(() => resolve({ statusCode, location }));
+      res.resume();
+      req.destroy();
+    });
+
+    timeoutState.timer = setTimeout(() => {
+      req.destroy();
+      settle(() => reject(new Error(`Request timed out after ${requestTimeout}ms`)));
+    }, requestTimeout);
+
+    req.on('error', (err) => {
+      settle(() => reject(err));
+    });
+    req.on('timeout', () => {
+      req.destroy();
+      settle(() => reject(new Error(`Request timed out after ${requestTimeout}ms`)));
+    });
+  });
+
 // Make HTTP/HTTPS request with retry logic, redirect handling, and proxy support
 const makeRequest = async (
   urlToTest: string,
@@ -154,24 +212,12 @@ const makeRequest = async (
   const options: http.RequestOptions = { timeout: requestTimeout, headers: commonHeaders, agent };
 
   try {
-    // Make the HTTP request with timeout handling
-    const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
-      const req = protocol.get(urlToTest, options, resolve);
-      req.on('error', reject);
-      req.on('timeout', () => {
-        req.destroy();
-        reject(new Error(`Request timed out after ${requestTimeout}ms`));
-      });
-    });
-
-    const statusCode = response.statusCode || 0;
-    const { location } = response.headers;
-
-    // Consume response data to properly close the connection
-    await new Promise<void>((resolve) => {
-      response.on('data', () => undefined);
-      response.on('end', resolve);
-    });
+    const { statusCode, location } = await fetchStatus(
+      urlToTest,
+      options,
+      protocol,
+      requestTimeout,
+    );
 
     // Handle HTTP redirects (3xx status codes)
     if (statusCode >= 300 && statusCode < 400 && location) {
@@ -248,10 +294,23 @@ export async function validateHttpsUrls(
   const uniqueUrls = [...new Set(urls)];
   const results: UrlValidationResult[] = [];
 
+  const batchCount = Math.ceil(uniqueUrls.length / CONCURRENCY_LIMIT);
+  logToConsole(
+    LogLevel.INFO,
+    `validateHttpsUrls: ${uniqueUrls.length} URLs in ${batchCount} batch(es) of ${CONCURRENCY_LIMIT}`,
+  );
+
   for (let i = 0; i < uniqueUrls.length; i += CONCURRENCY_LIMIT) {
     const batch = uniqueUrls.slice(i, i + CONCURRENCY_LIMIT);
+    const batchStart = Date.now();
     const batchResults = await Promise.all(batch.map((url) => makeRequest(url, proxyUrlFromTask)));
     results.push(...batchResults);
+    logToConsole(
+      LogLevel.INFO,
+      `validateHttpsUrls: batch ${i / CONCURRENCY_LIMIT + 1}/${batchCount} finished in ${
+        Date.now() - batchStart
+      }ms`,
+    );
   }
 
   return results;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-94319

## Description

`testManifestLinks.cy.ts` (`Checks URL reachability with tolerance for transient errors`) was failing locally and in CI with:

```
CypressError: cy.task('validateHttpsUrls') timed out after waiting 60000ms
```

**Root cause:** `validateHttpsUrls` performed GET requests and waited for the full response body to finish streaming. Manifests include links such as the Pachyderm `pachctl` GitHub release tarball (~24MB after redirect). On slower networks or when other URLs retry, the Node task exceeded Cypress's default 60s `cy.task` timeout even though the links themselves are valid.

**Fix:**
- Check HTTP status and redirects only (`fetchStatus`) — abort the socket after headers instead of downloading bodies
- Raise `cy.task('validateHttpsUrls')` timeout to 180s as a backstop for slow-domain retries
- Add batch timing logs in the plugin task for easier debugging
- Replace `eslint-disable` runtime checks with `unknown` type guards for `cy.task` payloads
- Update fixture comment to document header-only reachability checks

## How Has This Been Tested?

- `npx eslint cypress/utils/urlValidator.ts cypress/utils/manifestUrlValidator.ts`
- `npx tsc --noEmit` (packages/cypress)
- `npx cypress run --spec cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts` — **2 passing** (~17s, reachability case ~17s)
- /dashboard-e2e-tests/2879/ /dashboard-e2e-tests/2880/ /dashboard-e2e-tests/2881/

## Test Impact

No new tests added. The existing `testManifestLinks.cy.ts` spec covers this path; verified it passes with the fix applied.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


## Summary by CodeRabbit

- **Bug Fixes**
  - Improved manifest URL validation by checking response status and redirects without downloading full response bodies.
  - Added safer handling for request timeouts and redirects, reducing the risk of stalled or duplicate validations.
  - Improved validation reliability through stricter response checks and clearer failure reporting.

- **Documentation**
  - Clarified that reachability checks inspect status and redirects only, with timeouts applied per request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->