### PR TITLE
Fix registry MCP tool discovery

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServerToolsModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServerToolsModal.tsx
@@ -66,7 +66,12 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
     toolsLoadError,
     toolsStatus,
     isLoading,
-  } = useMCPServerTools(server.connectionUrl, mcpBearerToken, isOpen);
+  } = useMCPServerTools(
+    server.connectionUrl,
+    mcpBearerToken,
+    server.source === 'registry' ? server.name : undefined,
+    isOpen,
+  );
 
   const [searchValue, setSearchValue] = React.useState('');
   const hasTrackedSearch = React.useRef(false);

--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/__tests__/useServerTools.spec.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/__tests__/useServerTools.spec.ts
@@ -103,6 +103,38 @@ describe('useServerTools', () => {
     );
   });
 
+  it('should use the registry server name when provided', async () => {
+    mockGetMCPServerTools.mockResolvedValue({
+      status: 'success',
+      // eslint-disable-next-line camelcase
+      tools_count: 14,
+    });
+
+    const { result } = renderHook(() =>
+      useServerTools({
+        api: mockApi,
+        apiAvailable: true,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.fetchToolsCount(
+        'https://kubernetes-mcp-server.example.com/mcp',
+        undefined,
+        'io.kubernetes/kubernetes-mcp-server',
+      );
+    });
+
+    expect(mockGetMCPServerTools).toHaveBeenCalledWith(
+      // eslint-disable-next-line camelcase
+      { server_name: 'io.kubernetes/kubernetes-mcp-server' },
+      { headers: {} },
+    );
+    expect(
+      result.current.serverToolsCount.get('https://kubernetes-mcp-server.example.com/mcp'),
+    ).toBe(14);
+  });
+
   it('should track fetching state', async () => {
     let resolvePromise: (
       value:

--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/useAutoUnlock.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/useAutoUnlock.ts
@@ -18,7 +18,7 @@ export interface UseAutoUnlockProps {
   initialServerStatuses?: Map<string, ServerStatusInfo>;
   getToken: (serverUrl: string) => TokenInfo | undefined;
   onTokenUpdate: (serverUrl: string, tokenInfo: TokenInfo) => void;
-  onFetchTools: (serverUrl: string, token: string) => Promise<void>;
+  onFetchTools: (serverUrl: string, token: string, serverName?: string) => Promise<void>;
 }
 
 /**
@@ -58,7 +58,11 @@ const useAutoUnlock = ({
             autoConnected: true,
           });
 
-          await onFetchTools(server.connectionUrl, '');
+          if (server.source === 'registry') {
+            await onFetchTools(server.connectionUrl, '', server.name);
+          } else {
+            await onFetchTools(server.connectionUrl, '');
+          }
         }
       } catch {
         // Silently fail

--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/useServerTools.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/useServerTools.ts
@@ -4,7 +4,7 @@ import { GenAiAPIs } from '~/app/types';
 export interface UseServerToolsReturn {
   serverToolsCount: Map<string, number>;
   fetchingToolsServers: Set<string>;
-  fetchToolsCount: (serverUrl: string, token?: string) => Promise<void>;
+  fetchToolsCount: (serverUrl: string, token?: string, serverName?: string) => Promise<void>;
 }
 
 export interface UseServerToolsProps {
@@ -24,7 +24,7 @@ const useServerTools = ({ api, apiAvailable }: UseServerToolsProps): UseServerTo
   const [fetchingToolsServers, setFetchingToolsServers] = React.useState<Set<string>>(new Set());
 
   const fetchToolsCount = React.useCallback(
-    async (serverUrl: string, token?: string) => {
+    async (serverUrl: string, token?: string, serverName?: string) => {
       if (!apiAvailable) {
         return;
       }
@@ -39,10 +39,15 @@ const useServerTools = ({ api, apiAvailable }: UseServerToolsProps): UseServerTo
         }
 
         const response = await api.getMCPServerTools(
-          {
-            // eslint-disable-next-line camelcase
-            server_url: serverUrl,
-          },
+          serverName
+            ? {
+                // eslint-disable-next-line camelcase
+                server_name: serverName,
+              }
+            : {
+                // eslint-disable-next-line camelcase
+                server_url: serverUrl,
+              },
           { headers },
         );
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/useTokenValidation.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/useTokenValidation.ts
@@ -32,7 +32,7 @@ export interface UseTokenValidationProps {
   ) => Promise<ServerStatusInfo>;
   onTokenUpdate: (serverUrl: string, tokenInfo: TokenInfo) => void;
   getToken: (serverUrl: string) => TokenInfo | undefined;
-  onFetchTools: (serverUrl: string, token: string) => Promise<void>;
+  onFetchTools: (serverUrl: string, token: string, serverName?: string) => Promise<void>;
   onConfigModalOpen: (server: MCPServer) => void;
   onConfigModalClose: () => void;
   onSuccessModalOpen: (server: MCPServer) => void;
@@ -108,9 +108,13 @@ const useTokenValidation = ({
             success: true,
           });
 
-          await onFetchTools(serverUrl, bearerToken);
-
           const server = transformedServers.find((s) => s.connectionUrl === serverUrl);
+          if (server?.source === 'registry') {
+            await onFetchTools(serverUrl, bearerToken, server.name);
+          } else {
+            await onFetchTools(serverUrl, bearerToken);
+          }
+
           if (server) {
             onConfigModalClose();
             onSuccessModalOpen(server);
@@ -195,7 +199,11 @@ const useTokenValidation = ({
             autoConnected: true,
           });
 
-          await onFetchTools(server.connectionUrl, '');
+          if (server.source === 'registry') {
+            await onFetchTools(server.connectionUrl, '', server.name);
+          } else {
+            await onFetchTools(server.connectionUrl, '');
+          }
           onSuccessModalOpen(server);
         } else {
           onConfigModalOpen(server);

--- a/packages/gen-ai/frontend/src/app/hooks/useMCPServerTools.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useMCPServerTools.ts
@@ -13,6 +13,7 @@ export type UseMCPServerToolsReturn = {
 export const useMCPServerTools = (
   serverUrl: string,
   mcpBearerToken?: string,
+  serverName?: string,
   enabled = true,
 ): UseMCPServerToolsReturn => {
   const [tools, setTools] = React.useState<MCPToolFromAPI[]>([]);
@@ -46,9 +47,13 @@ export const useMCPServerTools = (
       /* eslint-disable camelcase */
       const response = await api
         .getMCPServerTools(
-          {
-            server_url: serverUrl,
-          },
+          serverName
+            ? {
+                server_name: serverName,
+              }
+            : {
+                server_url: serverUrl,
+              },
           { headers },
         )
         .catch((error) => {
@@ -94,7 +99,7 @@ export const useMCPServerTools = (
       setToolsLoaded(true);
       setIsLoading(false);
     }
-  }, [serverUrl, enabled, mcpBearerToken, apiAvailable, api]);
+  }, [serverUrl, serverName, enabled, mcpBearerToken, apiAvailable, api]);
 
   React.useEffect(() => {
     fetchTools();


### PR DESCRIPTION
## Description

Fix MCP tool discovery for servers sourced from the MCP registry. Registry-backed servers must be looked up by their registry name (`server_name`) rather than their public endpoint URL (`server_url`).

This updates both the tool-count path used by the MCP server panel and the full tool-list path used by the tool selection modal. Manual/ConfigMap servers continue using `server_url`.

## How Has This Been Tested?

- `npm run test:jest --prefix packages/gen-ai/frontend -- --runInBand --silent src/app/Chatbot/mcp/hooks/__tests__/useServerTools.spec.ts src/app/Chatbot/mcp/hooks/__tests__/useAutoUnlock.spec.ts src/app/Chatbot/mcp/hooks/__tests__/useTokenValidation.spec.ts`
- `npx turbo run type-check lint --filter=@odh-dashboard/gen-ai`
- Added a regression test covering registry server-name lookup in `useServerTools`.

## Test Impact

The registry-specific tool-count request is covered by a new unit test. Existing manual-server behavior remains covered by the existing hook tests.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP server tool retrieval for registry-connected servers by using their registered server names when available.
  - Preserved URL-based retrieval for servers from other sources.
  - Ensured tool counts remain correctly associated with their server connections.

- **Tests**
  - Added coverage verifying registry server names are included in tool-count requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->