### PR TITLE
fix: added individual nested scrolling for tree view section for quota usage tab

### DIFF
--- a/packages/gpuaas/src/components/QuotaUsageSection.scss
+++ b/packages/gpuaas/src/components/QuotaUsageSection.scss
@@ -1,5 +1,78 @@
-// Prototype match: collapsed toggle points right, expanded points down (PF default caret is down/up).
 .gpuaas-quota-usage-section {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+
+  > .pf-v6-c-drawer {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .pf-v6-c-drawer,
+  .pf-v6-c-drawer__main {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .pf-v6-c-drawer {
+    overflow: hidden;
+  }
+
+  .pf-v6-c-drawer__main {
+    align-items: stretch;
+  }
+
+  .pf-v6-c-drawer__content,
+  .pf-v6-c-drawer__panel {
+    min-height: 0;
+    min-width: 0;
+  }
+
+  // Left column: toolbar pinned, tree scrolls.
+  .pf-v6-c-drawer__content {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .gpuaas-quota-usage-nav {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  // Right column: detail header pinned, body scrolls (resizable panel is row + splitter).
+  .gpuaas-quota-usage-detail-drawer {
+    height: 100%;
+    max-height: 100%;
+    overflow: hidden;
+
+    > .pf-v6-c-drawer__panel-main {
+      display: flex;
+      flex: 1 1 auto;
+      flex-direction: column;
+      height: 100%;
+      min-height: 0;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    .pf-v6-c-drawer__head {
+      flex-shrink: 0;
+    }
+
+    .pf-v6-c-drawer__body {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-y: auto;
+    }
+  }
+
   .gpuaas-quota-usage-tree {
     --pf-v6-c-tree-view__node-toggle-icon--base--Rotate: -90deg;
     --pf-v6-c-tree-view__list-item--m-expanded__node-toggle-icon--Rotate: 0deg;

--- a/packages/gpuaas/src/components/QuotaUsageSection.tsx
+++ b/packages/gpuaas/src/components/QuotaUsageSection.tsx
@@ -143,13 +143,11 @@ const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({
       clusterQueueNames={selection?.type === 'clusterQueue' ? [selection.clusterQueueName] : []}
     >
       <QuotaUsageWorkloadRefreshBridge onRegister={onRegisterWorkloadRefresh} />
-      <Flex
-        direction={{ default: 'column' }}
-        grow={{ default: 'grow' }}
-        className="gpuaas-quota-usage-section"
+      <div
+        className="gpuaas-quota-usage-section pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-flex-fill pf-v6-u-min-height-0"
         data-testid="quota-usage-section"
       >
-        <Drawer isExpanded isInline>
+        <Drawer isExpanded isInline className="pf-v6-u-flex-fill pf-v6-u-min-height-0">
           <DrawerContent
             panelContent={
               <DrawerPanelContent
@@ -158,6 +156,7 @@ const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({
                 defaultSize="75%"
                 minSize="60%"
                 maxSize="85%"
+                className="gpuaas-quota-usage-detail-drawer"
                 data-testid="quota-usage-detail-drawer"
               >
                 <QuotaUsageDetailPanel
@@ -171,7 +170,11 @@ const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({
               </DrawerPanelContent>
             }
           >
-            <DrawerContentBody style={drawerNavBodyStyle}>
+            <DrawerContentBody
+              className="gpuaas-quota-usage-nav"
+              style={drawerNavBodyStyle}
+              data-testid="quota-usage-nav-panel"
+            >
               <QuotaUsageNavPanel
                 tree={tree}
                 selection={selection}
@@ -180,7 +183,7 @@ const QuotaUsageSection: React.FC<QuotaUsageSectionProps> = ({
             </DrawerContentBody>
           </DrawerContent>
         </Drawer>
-      </Flex>
+      </div>
     </KueueNamespaceWorkloadCacheProvider>
   );
 };

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.scss
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.scss
@@ -1,0 +1,9 @@
+.gpuaas-quota-usage-nav-panel__toolbar {
+  flex-shrink: 0;
+}
+
+.gpuaas-quota-usage-nav-panel__tree {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}

--- a/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.tsx
+++ b/packages/gpuaas/src/components/quotaUsage/QuotaUsageNavPanel.tsx
@@ -9,6 +9,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import QuotaUsageTreeView from './QuotaUsageTreeView';
+import './QuotaUsageNavPanel.scss';
 import { QuotaSelection, QuotaTreeNode } from '../../types';
 import {
   collectAllExpandableNodeIds,
@@ -147,6 +148,7 @@ const QuotaUsageNavPanel: React.FC<QuotaUsageNavPanelProps> = ({
 
   const navToolbar = (
     <Toolbar
+      className="gpuaas-quota-usage-nav-panel__toolbar"
       inset={{ default: 'insetNone' }}
       style={toolbarInsetStyle}
       aria-label="Cohort hierarchy filters"
@@ -180,24 +182,26 @@ const QuotaUsageNavPanel: React.FC<QuotaUsageNavPanelProps> = ({
   return (
     <>
       {navToolbar}
-      <QuotaUsageTreeView
-        expandStateKey={treeExpandKey}
-        nodes={filteredTree}
-        selectedNodeId={selectedNodeId}
-        expandedNodeIds={mergedExpandedIds}
-        allExpanded={allExpanded}
-        onSelectNode={handleSelectNode}
-        onExpand={handleExpand}
-        onCollapse={handleCollapse}
-      />
-      {filteredTree.length === 0 && (
-        <EmptyState
-          headingLevel="h4"
-          titleText="No results found"
-          variant={EmptyStateVariant.sm}
-          data-testid="quota-usage-nav-search-empty"
+      <div className="gpuaas-quota-usage-nav-panel__tree">
+        <QuotaUsageTreeView
+          expandStateKey={treeExpandKey}
+          nodes={filteredTree}
+          selectedNodeId={selectedNodeId}
+          expandedNodeIds={mergedExpandedIds}
+          allExpanded={allExpanded}
+          onSelectNode={handleSelectNode}
+          onExpand={handleExpand}
+          onCollapse={handleCollapse}
         />
-      )}
+        {filteredTree.length === 0 && (
+          <EmptyState
+            headingLevel="h4"
+            titleText="No results found"
+            variant={EmptyStateVariant.sm}
+            data-testid="quota-usage-nav-search-empty"
+          />
+        )}
+      </div>
     </>
   );
 };

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -56,11 +56,12 @@ export const PROMETHEUS_CLUSTER_QUERY_PATH = '/api/prometheus/cluster/query';
 export const PROMETHEUS_CLUSTER_QUERY_RANGE_PATH = '/api/prometheus/cluster/queryRange';
 
 export const INFRASTRUCTURE_TABS = [
-  { id: 'utilization', title: 'Accelerator utilization' },
-  { id: 'quota-usage', title: 'Quota usage' },
+  { id: 'utilization', title: 'Accelerator utilization', layout: 'page' },
+  { id: 'quota-usage', title: 'Quota usage', layout: 'viewport' },
 ] as const;
 
 export type InfrastructureTabId = (typeof INFRASTRUCTURE_TABS)[number]['id'];
+export type InfrastructureTabLayout = (typeof INFRASTRUCTURE_TABS)[number]['layout'];
 
 export const QUOTA_USAGE_DESCRIPTION =
   'View quota usage across cluster queues, which are entry points for workloads to access defined pools of hardware resources. Cluster queues organized into cohorts can borrow accelerators from the defined pool.';
@@ -166,7 +167,7 @@ export const INFRASTRUCTURE_SECTIONS = [
     title: 'Summary',
     description: 'Cluster-wide accelerator allocation and average compute and memory consumption.',
     isPlain: true,
-    refreshBadgeTestId: undefined,
+    refreshBadgeTestId: 'infrastructure-refresh-badge',
     showKueueHelpLink: false,
   },
   {

--- a/packages/gpuaas/src/pages/InfrastructurePage.scss
+++ b/packages/gpuaas/src/pages/InfrastructurePage.scss
@@ -7,7 +7,7 @@
   flex-direction: column;
   height: calc(100dvh - var(--gpuaas-infrastructure-viewport-chrome-offset));
   max-height: calc(100dvh - var(--gpuaas-infrastructure-viewport-chrome-offset));
-  min-height: 28.4375rem;
+  min-height: min(28.4375rem, calc(100dvh - var(--gpuaas-infrastructure-viewport-chrome-offset)));
   overflow: hidden;
 
   .gpuaas-quota-usage-tab__header {

--- a/packages/gpuaas/src/pages/InfrastructurePage.scss
+++ b/packages/gpuaas/src/pages/InfrastructurePage.scss
@@ -1,0 +1,33 @@
+// Viewport tabs: bounded height below masthead + infra sticky header — no page scroll.
+.gpuaas-infrastructure-tab--viewport {
+  // Masthead + infra title/tabs above this panel. Tune if drawer clips or page scrolls.
+  --gpuaas-infrastructure-viewport-chrome-offset: 18rem;
+
+  display: flex;
+  flex-direction: column;
+  height: calc(100dvh - var(--gpuaas-infrastructure-viewport-chrome-offset));
+  max-height: calc(100dvh - var(--gpuaas-infrastructure-viewport-chrome-offset));
+  min-height: 28.4375rem;
+  overflow: hidden;
+
+  .gpuaas-quota-usage-tab__header {
+    flex-shrink: 0;
+    padding-block-end: var(--pf-t--global--spacer--md);
+    background-color: var(--pf-t--global--background--color--default);
+    border-block-end: var(--pf-t--global--border--width--regular) solid
+      var(--pf-t--global--border--color--default);
+  }
+
+  .gpuaas-quota-usage-tab__body {
+    display: flex;
+    flex: 1 1 0;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+
+    > .gpuaas-quota-usage-section {
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+  }
+}

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -38,6 +38,7 @@ import BorrowingLendingSection from '../components/BorrowingLendingSection';
 import QuotaUsageSection from '../components/QuotaUsageSection';
 import useInfrastructureMetrics from '../hooks/useInfrastructureMetrics';
 import useQuotaHierarchy from '../hooks/useQuotaHierarchy';
+import './InfrastructurePage.scss';
 
 type SectionId = (typeof INFRASTRUCTURE_SECTIONS)[number]['id'];
 type InfrastructureSection = (typeof INFRASTRUCTURE_SECTIONS)[number];
@@ -54,35 +55,45 @@ type SectionRenderOptions = {
   descriptionAddon?: React.ReactNode;
 };
 
-const renderInfrastructureSection = (
-  { id, title, description, isPlain }: InfrastructureSection,
-  section: React.ReactNode,
+const renderSectionHeader = (
+  { id, title, description }: InfrastructureSection,
   { headerAction, descriptionAddon }: SectionRenderOptions = {},
 ): React.ReactNode => (
-  <StackItem key={id}>
+  <>
+    <Flex
+      alignItems={{ default: 'alignItemsCenter' }}
+      justifyContent={{ default: 'justifyContentSpaceBetween' }}
+      flexWrap={{ default: 'wrap' }}
+      gap={{ default: 'gapMd' }}
+    >
+      <FlexItem>
+        <Title headingLevel="h2" data-testid={`infrastructure-${id}-title`}>
+          {title}
+        </Title>
+      </FlexItem>
+      {headerAction && <FlexItem>{headerAction}</FlexItem>}
+    </Flex>
+    <Content component="p" data-testid={`infrastructure-${id}-description`}>
+      {description}
+      {descriptionAddon && <> {descriptionAddon}</>}
+    </Content>
+  </>
+);
+
+const renderInfrastructureSection = (
+  infrastructureSection: InfrastructureSection,
+  section: React.ReactNode,
+  options: SectionRenderOptions = {},
+): React.ReactNode => (
+  <StackItem key={infrastructureSection.id}>
     <Stack hasGutter>
+      <StackItem>{renderSectionHeader(infrastructureSection, options)}</StackItem>
       <StackItem>
-        <Flex
-          alignItems={{ default: 'alignItemsCenter' }}
-          justifyContent={{ default: 'justifyContentSpaceBetween' }}
-          flexWrap={{ default: 'wrap' }}
-          gap={{ default: 'gapMd' }}
+        <Card
+          isPlain={infrastructureSection.isPlain}
+          data-testid={`infrastructure-${infrastructureSection.id}-section`}
         >
-          <FlexItem>
-            <Title headingLevel="h2" data-testid={`infrastructure-${id}-title`}>
-              {title}
-            </Title>
-          </FlexItem>
-          {headerAction && <FlexItem>{headerAction}</FlexItem>}
-        </Flex>
-        <Content component="p" data-testid={`infrastructure-${id}-description`}>
-          {description}
-          {descriptionAddon && <> {descriptionAddon}</>}
-        </Content>
-      </StackItem>
-      <StackItem>
-        <Card isPlain={isPlain} data-testid={`infrastructure-${id}-section`}>
-          {isPlain ? section : <CardBody>{section}</CardBody>}
+          {infrastructureSection.isPlain ? section : <CardBody>{section}</CardBody>}
         </Card>
       </StackItem>
     </Stack>
@@ -211,21 +222,50 @@ const InfrastructurePage: React.FC = () => {
       </Flex>
     ) : null;
 
-  const lastUpdatedBadge = renderRefreshBadge(handleRefresh);
-
   const getSectionRenderOptions = (section: InfrastructureSection): SectionRenderOptions => ({
     headerAction: section.refreshBadgeTestId
-      ? renderRefreshBadge(handleQuotaRefresh, section.refreshBadgeTestId)
+      ? renderRefreshBadge(
+          section.id === 'quota-usage' ? handleQuotaRefresh : handleRefresh,
+          section.refreshBadgeTestId,
+        )
       : undefined,
     descriptionAddon: section.showKueueHelpLink ? <InfrastructureKueueHelpLink /> : undefined,
   });
 
+  const renderQuotaUsageTab = (): React.ReactNode => {
+    const section = INFRASTRUCTURE_SECTIONS.find((entry) => entry.id === 'quota-usage');
+    if (!section) {
+      return null;
+    }
+
+    const options = getSectionRenderOptions(section);
+
+    return (
+      <>
+        <div className="gpuaas-quota-usage-tab__header">
+          {renderSectionHeader(section, options)}
+        </div>
+        <Card
+          isPlain={section.isPlain}
+          data-testid="infrastructure-quota-usage-section"
+          className="gpuaas-quota-usage-tab__body pf-v6-u-h-100 pf-v6-u-min-height-0"
+        >
+          {sectionComponents['quota-usage']}
+        </Card>
+      </>
+    );
+  };
+
   const renderTabPanel = (tabId: InfrastructureTabId): React.ReactNode => {
+    const tabInfo = INFRASTRUCTURE_TABS.find((entry) => entry.id === tabId);
+    if (tabInfo?.layout === 'viewport') {
+      return renderQuotaUsageTab();
+    }
+
     const tabSections = INFRASTRUCTURE_SECTIONS.filter((section) => section.tab === tabId);
 
     return (
       <Stack hasGutter>
-        {tabId === 'utilization' && lastUpdatedBadge && <StackItem>{lastUpdatedBadge}</StackItem>}
         {tabSections.map((section) =>
           renderInfrastructureSection(
             section,
@@ -282,10 +322,19 @@ const InfrastructurePage: React.FC = () => {
           </Stack>
         </PageSection>
       </PageGroup>
-      <PageSection isFilled className="pf-v6-u-pt-0" id="infrastructure-hub-content">
+      <PageSection
+        isFilled
+        hasBodyWrapper={false}
+        className="pf-v6-u-pt-0"
+        id="infrastructure-hub-content"
+      >
         {INFRASTRUCTURE_TABS.map((tabInfo) => (
           <TabContent
-            className="pf-v6-u-px-lg"
+            className={
+              tabInfo.layout === 'viewport'
+                ? 'pf-v6-u-px-lg gpuaas-infrastructure-tab--viewport'
+                : 'pf-v6-u-px-lg'
+            }
             key={tabInfo.id}
             id={getTabPanelId(tabInfo.id)}
             eventKey={tabInfo.id}


### PR DESCRIPTION


<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes the scroll issue for quota usage tab as per UX feedback from show and tell as per this [slack thread](https://redhat-internal.slack.com/archives/C09PD4PF58W/p1789133032252809)


https://github.com/user-attachments/assets/b939b5b9-8d52-4003-adb8-a2b0c2c42d17


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
UI changes there are no code related to functionality changes

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Infrastructure page layouts for full-height views, reducing unwanted page scrolling.
  * Enhanced quota usage navigation with independently scrolling content and a fixed detail header.
  * Improved handling of large quota hierarchies and detail panels within the available screen space.
  * Updated refresh behavior so quota usage refreshes its hierarchy and details independently from other infrastructure metrics.
  * Applied layout-specific behavior to infrastructure tabs for more consistent viewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->