### PR TITLE
fix(RHOAIENG-87447): support Markdown rendering and improve HTML visu…

### DIFF
--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/MarkdownCompare.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/MarkdownCompare.tsx
@@ -12,6 +12,8 @@ import { CompareRunsEmptyState } from '#~/concepts/pipelines/content/compareRuns
 import { PipelineRunArtifactSelect } from '#~/concepts/pipelines/content/compareRuns/metricsSection/PipelineRunArtifactSelect';
 import { PipelineRunKF } from '#~/concepts/pipelines/kfTypes';
 import { CompareRunsNoMetrics } from '#~/concepts/pipelines/content/compareRuns/CompareRunsNoMetrics';
+import MarkdownComponent from '#~/components/markdown/MarkdownComponent';
+import '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.scss';
 
 type MarkdownCompareProps = {
   configMap: Record<string, MarkdownAndTitle[]>;
@@ -24,6 +26,7 @@ export type MarkdownAndTitle = {
   title: string;
   config: string;
   fileSize?: number;
+  markdownContent?: string;
 };
 
 const MarkdownCompare: React.FC<MarkdownCompareProps> = ({
@@ -33,6 +36,7 @@ const MarkdownCompare: React.FC<MarkdownCompareProps> = ({
   isEmpty,
 }) => {
   const [expandedGraph, setExpandedGraph] = React.useState<MarkdownAndTitle | undefined>(undefined);
+
   if (!isLoaded) {
     return (
       <Bullseye>
@@ -52,7 +56,17 @@ const MarkdownCompare: React.FC<MarkdownCompareProps> = ({
   const renderMarkdownWithSize = (config: MarkdownAndTitle) => (
     <Stack hasGutter>
       <StackItem>
-        <iframe data-testid="markdown-compare" src={config.config} title="markdown view" />
+        {config.markdownContent ? (
+          <MarkdownComponent data={config.markdownContent} dataTestId="markdown-compare" />
+        ) : (
+          <iframe
+            className="odh-artifact-visualization__iframe pf-v6-u-w-100"
+            sandbox="allow-scripts"
+            data-testid="markdown-compare"
+            src={config.config}
+            title="markdown view"
+          />
+        )}
       </StackItem>
     </Stack>
   );

--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/useFetchMarkdownMaps.ts
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/useFetchMarkdownMaps.ts
@@ -7,6 +7,7 @@ import {
   getFullArtifactPaths,
 } from '#~/concepts/pipelines/content/compareRuns/metricsSection/utils';
 import { ArtifactType, PipelineRunKF } from '#~/concepts/pipelines/kfTypes';
+import { readBoundedText } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils';
 import { allSettledPromises } from '#~/utilities/allSettledPromises';
 
 const useFetchMarkdownMaps = (
@@ -17,7 +18,7 @@ const useFetchMarkdownMaps = (
   configsLoaded: boolean;
 } => {
   const [configsLoaded, setConfigsLoaded] = React.useState(false);
-  const { getStorageObjectRenderUrl } = useArtifactStorage();
+  const { getStorageObjectRenderUrl, getStorageObjectDownloadUrl } = useArtifactStorage();
 
   const [configMapBuilder, setConfigMapBuilder] = React.useState<
     Record<string, MarkdownAndTitle[]>
@@ -40,22 +41,39 @@ const useFetchMarkdownMaps = (
           const { run } = path;
           let sizeBytes: number | undefined;
           let url: string | undefined;
-          if (
-            path.linkedArtifact.artifact.getType() === ArtifactType.MARKDOWN ||
-            path.linkedArtifact.artifact.getType() === ArtifactType.HTML
-          ) {
+          let markdownContent: string | undefined;
+          const artifactType = path.linkedArtifact.artifact.getType();
+
+          if (artifactType === ArtifactType.MARKDOWN) {
+            try {
+              const downloadUrl = await getStorageObjectDownloadUrl(path.linkedArtifact.artifact);
+              if (downloadUrl) {
+                const response = await fetch(downloadUrl);
+                if (response.ok) {
+                  markdownContent = await readBoundedText(response);
+                }
+              }
+            } catch {
+              // Fall back to render URL for iframe display
+            }
+            if (!markdownContent) {
+              url = await getStorageObjectRenderUrl(path.linkedArtifact.artifact).catch(
+                () => undefined,
+              );
+            }
+          } else if (artifactType === ArtifactType.HTML) {
             url = await getStorageObjectRenderUrl(path.linkedArtifact.artifact).catch(
               () => undefined,
             );
           }
 
-          if (url === undefined) {
+          if (url === undefined && markdownContent === undefined) {
             return null;
           }
-          return { run, sizeBytes, url, path };
+          return { run, sizeBytes, url, markdownContent, path };
         }),
 
-    [fullArtifactPaths, getStorageObjectRenderUrl],
+    [fullArtifactPaths, getStorageObjectRenderUrl, getStorageObjectDownloadUrl],
   );
 
   React.useEffect(() => {
@@ -66,13 +84,14 @@ const useFetchMarkdownMaps = (
     allSettledPromises(fetchStorageObjectPromises).then(([successes]) => {
       successes.forEach((result) => {
         if (result.value) {
-          const { url, sizeBytes, run, path } = result.value;
+          const { url, markdownContent: mdContent, sizeBytes, run, path } = result.value;
           setRunMapBuilder((runMap) => ({ ...runMap, [run.run_id]: run }));
 
-          const config = {
+          const config: MarkdownAndTitle = {
             title: getFullArtifactPathLabel(path),
-            config: url,
+            config: url ?? '',
             fileSize: sizeBytes,
+            markdownContent: mdContent,
           };
 
           setConfigMapBuilder((configMap) => ({

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
@@ -8,6 +8,11 @@ import PipelineRunDrawerRightContent from '#~/concepts/pipelines/content/pipelin
 import { PipelineTask } from '#~/concepts/pipelines/topology';
 import { Artifact } from '#~/third_party/mlmd';
 
+jest.mock('#~/components/markdown/MarkdownComponent', () => ({
+  __esModule: true,
+  default: ({ data }: { data: string }) => <div data-testid="mock-markdown">{data}</div>,
+}));
+
 const artifactTask: PipelineTask = {
   type: 'artifact',
   name: 'metrics',

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.scss
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.scss
@@ -1,0 +1,16 @@
+.odh-artifact-visualization {
+  &__iframe {
+    min-height: 300px;
+    border: none;
+  }
+
+  &__iframe--fullscreen {
+    height: 75vh;
+    border: none;
+  }
+
+  &__markdown--fullscreen {
+    max-height: 75vh;
+    overflow: auto;
+  }
+}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
 
 import {
+  Button,
   Bullseye,
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
   Flex,
+  FlexItem,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- ContentModal adds a constrained body height that causes double scrollbars with the iframe/markdown scroll containers
+  Modal,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
+  ModalBody,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
+  ModalHeader,
   Spinner,
   Stack,
   StackItem,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
+import { ExpandIcon } from '@patternfly/react-icons';
 import { TableVariant, Td, Tr } from '@patternfly/react-table';
 
 import { Artifact } from '#~/third_party/mlmd';
@@ -27,7 +37,9 @@ import { isConfusionMatrix } from '#~/concepts/pipelines/content/compareRuns/met
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import { useArtifactStorage } from '#~/concepts/pipelines/apiHooks/useArtifactStorage';
 import { useDeepCompareMemoize } from '#~/utilities/useDeepCompareMemoize';
-import { getArtifactProperties } from './utils';
+import MarkdownComponent from '#~/components/markdown/MarkdownComponent';
+import { getArtifactProperties, readBoundedText } from './utils';
+import './ArtifactVisualization.scss';
 
 interface ArtifactVisualizationProps {
   artifact: Artifact;
@@ -35,29 +47,79 @@ interface ArtifactVisualizationProps {
 
 export const ArtifactVisualization: React.FC<ArtifactVisualizationProps> = ({ artifact }) => {
   const [renderUrl, setRenderUrl] = React.useState<string>();
+  const [markdownContent, setMarkdownContent] = React.useState<string>();
   const [loading, setLoading] = React.useState<boolean>(false);
+  const [isFullscreen, setIsFullscreen] = React.useState(false);
   const { namespace } = usePipelinesAPI();
-  const { getStorageObjectRenderUrl } = useArtifactStorage();
+  const { getStorageObjectRenderUrl, getStorageObjectDownloadUrl } = useArtifactStorage();
   const artifactType = artifact.getType();
 
   const memoizedArtifact = useDeepCompareMemoize(artifact);
 
   React.useEffect(() => {
-    if (artifactType === ArtifactType.MARKDOWN || artifactType === ArtifactType.HTML) {
-      const uri = memoizedArtifact.getUri();
-      if (uri) {
-        const renderArtifact = async () => {
-          await getStorageObjectRenderUrl(memoizedArtifact)
-            .then((url) => setRenderUrl(url))
-            .catch(() => null);
-          setLoading(false);
-        };
-        setLoading(true);
-        setRenderUrl(undefined);
-        renderArtifact();
-      }
+    if (artifactType !== ArtifactType.MARKDOWN && artifactType !== ArtifactType.HTML) {
+      return undefined;
     }
-  }, [memoizedArtifact, getStorageObjectRenderUrl, artifactType, namespace]);
+    const uri = memoizedArtifact.getUri();
+    if (!uri) {
+      return undefined;
+    }
+
+    const abortController = new AbortController();
+    const { signal } = abortController;
+
+    setLoading(true);
+    setRenderUrl(undefined);
+    setMarkdownContent(undefined);
+
+    const renderArtifact = async () => {
+      if (artifactType === ArtifactType.MARKDOWN) {
+        let content: string | undefined;
+        try {
+          const url = await getStorageObjectDownloadUrl(memoizedArtifact);
+          if (url && !signal.aborted) {
+            const response = await fetch(url, { signal });
+            if (response.ok) {
+              content = await readBoundedText(response);
+            }
+          }
+        } catch {
+          // Fall through to render URL fallback
+        }
+        if (!signal.aborted) {
+          if (content) {
+            setMarkdownContent(content);
+          } else {
+            const url = await getStorageObjectRenderUrl(memoizedArtifact).catch(() => undefined);
+            setRenderUrl(url);
+          }
+        }
+      } else if (!signal.aborted) {
+        await getStorageObjectRenderUrl(memoizedArtifact)
+          .then((url) => {
+            if (!signal.aborted) {
+              setRenderUrl(url);
+            }
+          })
+          .catch(() => null);
+      }
+      if (!signal.aborted) {
+        setLoading(false);
+      }
+    };
+
+    renderArtifact();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [
+    memoizedArtifact,
+    getStorageObjectRenderUrl,
+    getStorageObjectDownloadUrl,
+    artifactType,
+    namespace,
+  ]);
 
   if (artifactType === ArtifactType.CLASSIFICATION_METRICS) {
     const confusionMatrix = artifact.getCustomPropertiesMap().get('confusionMatrix');
@@ -154,15 +216,73 @@ export const ArtifactVisualization: React.FC<ArtifactVisualizationProps> = ({ ar
         </Bullseye>
       );
     }
-    if (renderUrl) {
+
+    const hasContent = markdownContent || renderUrl;
+    if (hasContent) {
+      const visualizationContent = markdownContent ? (
+        <MarkdownComponent data={markdownContent} dataTestId="artifact-visualization" />
+      ) : (
+        <iframe
+          className="odh-artifact-visualization__iframe pf-v6-u-w-100"
+          sandbox="allow-scripts"
+          src={renderUrl}
+          data-testid="artifact-visualization"
+          title="Artifact details"
+        />
+      );
+
+      const fullscreenContent = markdownContent ? (
+        <div className="odh-artifact-visualization__markdown--fullscreen">
+          <MarkdownComponent
+            data={markdownContent}
+            dataTestId="artifact-visualization-fullscreen"
+          />
+        </div>
+      ) : (
+        <iframe
+          className="odh-artifact-visualization__iframe--fullscreen pf-v6-u-w-100"
+          sandbox="allow-scripts"
+          src={renderUrl}
+          data-testid="artifact-visualization-fullscreen"
+          title="Artifact details"
+        />
+      );
+
       return (
         <Stack className="pf-v6-u-pt-lg pf-v6-u-pb-lg" hasGutter>
           <StackItem>
-            <Title headingLevel="h3">Artifact details</Title>
+            <Flex
+              justifyContent={{ default: 'justifyContentSpaceBetween' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+            >
+              <FlexItem>
+                <Title headingLevel="h3">Artifact details</Title>
+              </FlexItem>
+              <FlexItem>
+                <Tooltip content="Expand">
+                  <Button
+                    variant="plain"
+                    aria-label="Expand visualization"
+                    onClick={() => setIsFullscreen(true)}
+                    data-testid="artifact-visualization-expand"
+                    icon={<ExpandIcon />}
+                  />
+                </Tooltip>
+              </FlexItem>
+            </Flex>
           </StackItem>
-          <StackItem>
-            <iframe src={renderUrl} data-testid="artifact-visualization" title="Artifact details" />
-          </StackItem>
+          <StackItem>{visualizationContent}</StackItem>
+          {isFullscreen && (
+            <Modal
+              isOpen
+              onClose={() => setIsFullscreen(false)}
+              variant="large"
+              aria-label="Artifact visualization expanded"
+            >
+              <ModalHeader title="Artifact visualization" />
+              <ModalBody>{fullscreenContent}</ModalBody>
+            </Modal>
+          )}
         </Stack>
       );
     }

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
@@ -2,13 +2,26 @@ import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import { Drawer } from '@patternfly/react-core';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { act } from 'react';
 import { PipelineTask } from '#~/concepts/pipelines/topology';
 import { Artifact, Value } from '#~/third_party/mlmd';
 import { ArtifactNodeDrawerContent } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent';
+
+jest.mock('#~/components/markdown/MarkdownComponent', () => ({
+  __esModule: true,
+  default: ({ data }: { data: string }) => <div data-testid="mock-markdown">{data}</div>,
+}));
+
+const mockReadBoundedText = jest.fn();
+jest.mock('#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils', () => ({
+  ...jest.requireActual(
+    '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils',
+  ),
+  readBoundedText: (...args: unknown[]) => mockReadBoundedText(...args),
+}));
 
 const task: PipelineTask = {
   type: 'artifact',
@@ -26,7 +39,6 @@ jest.mock('#~/concepts/pipelines/content/compareRuns/metricsSection/roc/utils', 
   isConfidenceMetric: jest.fn(() => true),
 }));
 
-// Mock the useDispatch hook
 jest.mock('#~/redux/hooks', () => ({
   useAppDispatch: jest.fn(),
 }));
@@ -73,7 +85,24 @@ jest.mock('#~/concepts/pipelines/context/PipelinesContext', () => ({
   })),
 }));
 
+const mockGetStorageObjectDownloadUrl = jest.fn();
+const mockGetStorageObjectRenderUrl = jest.fn();
+
+jest.mock('#~/concepts/pipelines/apiHooks/useArtifactStorage', () => ({
+  useArtifactStorage: () => ({
+    getStorageObjectSize: jest.fn(),
+    getStorageObjectDownloadUrl: mockGetStorageObjectDownloadUrl,
+    getStorageObjectRenderUrl: mockGetStorageObjectRenderUrl,
+  }),
+}));
+
 describe('ArtifactNodeDrawerContent', () => {
+  beforeEach(() => {
+    mockGetStorageObjectDownloadUrl.mockReset();
+    mockGetStorageObjectRenderUrl.mockReset();
+    mockReadBoundedText.mockReset();
+  });
+
   it('renders artifact drawer content', async () => {
     await act(async () =>
       render(
@@ -230,6 +259,62 @@ describe('ArtifactNodeDrawerContent', () => {
     );
 
     expect(screen.queryByRole('tab', { name: 'Visualization' })).toBeNull();
+  });
+
+  it('renders markdown visualization natively when fetch succeeds', async () => {
+    mockGetStorageObjectDownloadUrl.mockResolvedValue('https://example.com/md');
+    mockReadBoundedText.mockResolvedValue('# Hello Markdown');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+
+    const user = userEvent.setup();
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={{
+              ...task,
+              metadata: createArtifact('system.Markdown'),
+            }}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Visualization' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-markdown')).toHaveTextContent('# Hello Markdown');
+    });
+    expect(screen.queryByTestId('artifact-visualization')).toBeNull();
+    expect(screen.getByTestId('artifact-visualization-expand')).toBeInTheDocument();
+  });
+
+  it('falls back to iframe when markdown fetch fails', async () => {
+    mockGetStorageObjectDownloadUrl.mockRejectedValue(new Error('CORS'));
+    mockGetStorageObjectRenderUrl.mockResolvedValue('https://example.com/render');
+
+    const user = userEvent.setup();
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={{
+              ...task,
+              metadata: createArtifact('system.Markdown'),
+            }}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Visualization' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('artifact-visualization')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('mock-markdown')).toBeNull();
   });
 });
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
@@ -36,6 +36,47 @@ export const getArtifactProperties = (artifact: Artifact): ArtifactProperty[] =>
   return result;
 };
 
+const MAX_MARKDOWN_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Read a Response body as text with a byte-size cap (5 MB).
+ * Returns undefined when the artifact exceeds the limit, letting
+ * callers fall back to an iframe.
+ *
+ * When Content-Length is available and within limits, uses response.text().
+ * When Content-Length is missing, streams the body and aborts if the
+ * limit is exceeded — prevents unbounded memory consumption (CWE-400).
+ */
+export const readBoundedText = async (response: Response): Promise<string | undefined> => {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return undefined;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_MARKDOWN_BYTES) {
+      await reader.cancel();
+      return undefined;
+    }
+    chunks.push(value);
+  }
+
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+};
+
 export const isMetricsArtifactType = (artifactType?: string): boolean =>
   artifactType === ArtifactType.METRICS ||
   artifactType === ArtifactType.CLASSIFICATION_METRICS ||


### PR DESCRIPTION
…alization in artifact drawer (#9439)

Markdown artifacts were rendered as plain text in an unsized iframe. HTML artifacts (e.g. AutoML leaderboards) were unreadable due to missing iframe dimensions. Both now have an expand button that opens a fullscreen modal.

- Render system.Markdown artifacts natively via MarkdownComponent (react-markdown + remark-gfm + rehype-sanitize) instead of iframe
- Add proper iframe sizing for system.HTML artifacts
- Add expand-to-fullscreen modal for both artifact types
- Apply the same fixes to the compare-runs markdown view

(cherry picked from commit 568e592a0ee63f996b03573654004972d22858ec)

Ticket: https://github.com/opendatahub-io/odh-dashboard/pull/9740

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
