### PR TITLE
Sync from kubeflow/model-registry 3e474bd

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
@@ -32,7 +32,11 @@ const gatedDeniedModel = {
   },
 };
 
-const setupGatedAccessIntercepts = () => {
+type GatedAccessInterceptOptions = {
+  hfUsername?: string;
+};
+
+const setupGatedAccessIntercepts = ({ hfUsername }: GatedAccessInterceptOptions = {}) => {
   cy.interceptOdh(
     'GET /api/config',
     mockDashboardConfig({
@@ -69,6 +73,7 @@ const setupGatedAccessIntercepts = () => {
             enabled: true,
             labels: ['Community'],
             status: 'available',
+            ...(hfUsername ? { hfUsername, hasApiKey: true, authenticated: true } : {}),
           },
         ],
         size: 1,
@@ -109,7 +114,7 @@ const visitGatedModelDetails = () => {
 describe('Model Catalog Details Page - Gated access denied', () => {
   it('non-admin sees gated empty state with disabled deploy and register actions', () => {
     asProjectEditUser();
-    setupGatedAccessIntercepts();
+    setupGatedAccessIntercepts({ hfUsername: 'alice' });
     visitGatedModelDetails();
 
     modelDetailsPage.findGatedAccessRequiredState().should('be.visible');
@@ -118,13 +123,33 @@ describe('Model Catalog Details Page - Gated access denied', () => {
       .should('contain.text', 'To request access, contact your administrator.');
     modelDetailsPage.findWhosMyAdministratorLink().should('be.visible');
     modelDetailsPage.findGatedAccessRequestLink().should('not.exist');
+    modelDetailsPage
+      .findGatedAccessRequiredState()
+      .should('not.contain.text', 'Log in to the Hugging Face account');
+    modelDetailsPage.findGatedAccessRequiredState().should('not.contain.text', 'alice');
     modelDetailsPage.findModelCardMarkdown().should('not.exist');
     modelDetailsPage.findAccessLabelGatedDenied().should('be.visible');
     modelDetailsPage.findDeployModelButton().should('have.attr', 'aria-disabled', 'true');
     modelDetailsPage.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
   });
 
-  it('admin sees Hugging Face request link with disabled deploy and register actions', () => {
+  it('admin sees Hugging Face username guidance with disabled deploy and register actions', () => {
+    asClusterAdminUser();
+    setupGatedAccessIntercepts({ hfUsername: 'alice' });
+    visitGatedModelDetails();
+
+    modelDetailsPage.findGatedAccessRequiredState().should('be.visible');
+    modelDetailsPage
+      .findGatedAccessRequiredState()
+      .should('contain.text', 'Log in to the Hugging Face account');
+    modelDetailsPage.findGatedAccessRequiredState().should('contain.text', 'alice');
+    modelDetailsPage.findGatedAccessRequestLink().should('be.visible');
+    modelDetailsPage.findWhosMyAdministratorLink().should('not.exist');
+    modelDetailsPage.findDeployModelButton().should('have.attr', 'aria-disabled', 'true');
+    modelDetailsPage.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
+  });
+
+  it('admin sees generic Hugging Face guidance when hfUsername is unavailable', () => {
     asClusterAdminUser();
     setupGatedAccessIntercepts();
     visitGatedModelDetails();
@@ -136,9 +161,10 @@ describe('Model Catalog Details Page - Gated access denied', () => {
         'contain.text',
         'This model is gated on Hugging Face. Request access on Hugging Face.',
       );
+    modelDetailsPage
+      .findGatedAccessRequiredState()
+      .should('not.contain.text', 'Log in to the Hugging Face account');
     modelDetailsPage.findGatedAccessRequestLink().should('be.visible');
     modelDetailsPage.findWhosMyAdministratorLink().should('not.exist');
-    modelDetailsPage.findDeployModelButton().should('have.attr', 'aria-disabled', 'true');
-    modelDetailsPage.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
   });
 });

--- a/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts
@@ -132,7 +132,10 @@ describe('Model Catalog Details Page - Gated access denied', () => {
     modelDetailsPage.findGatedAccessRequiredState().should('be.visible');
     modelDetailsPage
       .findGatedAccessRequiredState()
-      .should('contain.text', 'Go to Hugging Face to request permission for this model.');
+      .should(
+        'contain.text',
+        'This model is gated on Hugging Face. Request access on Hugging Face.',
+      );
     modelDetailsPage.findGatedAccessRequestLink().should('be.visible');
     modelDetailsPage.findWhosMyAdministratorLink().should('not.exist');
     modelDetailsPage.findDeployModelButton().should('have.attr', 'aria-disabled', 'true');

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "b15fb0f2621af86837c0599cb473e8aa2a22f98b"
+    "commit": "0ad4e38ae3310d156b1d9ebdb056912f0eae1980"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "fbcce8f5d2ae8fd9927fc971c1217322cde3f686"
+    "commit": "3e474bdda404121e2340f914c00cb330489c6c27"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "840d432572d25afb942e5efef82dff8a68f23088"
+    "commit": "fbcce8f5d2ae8fd9927fc971c1217322cde3f686"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "0ad4e38ae3310d156b1d9ebdb056912f0eae1980"
+    "commit": "840d432572d25afb942e5efef82dff8a68f23088"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/upstream/api/openapi/mod-arch.yaml
+++ b/packages/model-registry/upstream/api/openapi/mod-arch.yaml
@@ -2980,6 +2980,13 @@ components:
           type: boolean
           nullable: true
           readOnly: true
+        hfUsername:
+          description: |-
+            The Hugging Face username associated with the stored API token.
+            Null when no token exists or authentication failed.
+          type: string
+          nullable: true
+          readOnly: true
         assetType:
           $ref: "#/components/schemas/assetType"
           description: |-
@@ -3631,6 +3638,17 @@ components:
         included:
           type: boolean
           description: Whether this asset would be included based on the source configuration
+        hfAccessType:
+          type: string
+          description: |-
+            Hugging Face access type classification. Only present for Hugging Face sources.
+            Possible values: public, private, gated_auto, gated_manual.
+          example: gated_auto
+        hfGatedAccessGranted:
+          type: boolean
+          description: |-
+            Whether the configured API key has been granted access to this gated model.
+            Only present for gated Hugging Face models when the information is available.
     CatalogSourcePreviewModel:
       description: |-
         Deprecated alias for `CatalogSourcePreviewItem`. A model or asset with its inclusion status.

--- a/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
+++ b/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
@@ -338,6 +338,18 @@ func hfAccessCustomProperties(accessType string, gatedAccessGranted ...string) *
 	return &result
 }
 
+func hfPreviewModel(name string, included bool, accessType string, gatedAccessGranted ...bool) models.CatalogSourcePreviewModel {
+	model := models.CatalogSourcePreviewModel{
+		Name:         name,
+		Included:     included,
+		HfAccessType: stringToPointer(accessType),
+	}
+	if len(gatedAccessGranted) > 0 {
+		model.HfGatedAccessGranted = BoolPtr(gatedAccessGranted[0])
+	}
+	return model
+}
+
 func NewMockSessionContext(parent context.Context) context.Context {
 	if parent == nil {
 		parent = context.TODO()
@@ -1004,6 +1016,7 @@ func GetCatalogSourceMocks() []models.CatalogSource {
 			Labels:        []string{"Sample category 2", "Sample category"},
 			HasApiKey:     &hasApiKeyTrue,
 			Authenticated: &authenticatedTrue,
+			HfUsername:    "johndoe",
 			// Status is nil - represents "Starting" state (no status yet)
 			Status: nil,
 		},
@@ -1016,6 +1029,7 @@ func GetCatalogSourceMocks() []models.CatalogSource {
 			Error:         &invalidCredentialError,
 			HasApiKey:     &hasApiKeyTrue,
 			Authenticated: &authenticatedFalse,
+			HfUsername:    "bob",
 		},
 		{
 			Id:      "adminModel2",
@@ -1062,6 +1076,7 @@ func GetCatalogSourceMocks() []models.CatalogSource {
 			Error:         &partialAvailabilityError,
 			HasApiKey:     &hasApiKeyTrue,
 			Authenticated: &authenticatedTrue,
+			HfUsername:    "alice",
 		},
 	}
 }
@@ -2680,16 +2695,36 @@ func GetModelsWithInclusionStatusListMocks() []models.CatalogSourcePreviewModel 
 	// We want 45 included and 25 excluded = 70 total models
 	var allModels []models.CatalogSourcePreviewModel
 
-	// Add 45 included models
-	for i := 1; i <= 45; i++ {
+	// Hugging Face access preview matrix (hfAccessType / hfGatedAccessGranted):
+	//   public              — no hfGatedAccessGranted
+	//   private             — no hfGatedAccessGranted
+	//   gated_auto + true   — access granted
+	//   gated_auto + false  — access denied
+	//   gated_manual + true — access granted
+	//   gated_manual + false— access denied
+	allModels = append(allModels,
+		hfPreviewModel("hf-mock/public-model", true, "public"),
+		hfPreviewModel("my-org/private-model", true, "private"),
+		hfPreviewModel("meta-llama/gated-auto-granted", true, "gated_auto", true),
+		hfPreviewModel("meta-llama/gated-auto-denied", false, "gated_auto", false),
+		hfPreviewModel("hf-mock/gated-manual-granted", true, "gated_manual", true),
+		hfPreviewModel("hf-mock/gated-manual-denied", false, "gated_manual", false),
+	)
+
+	// Add remaining included models (first two are gated for preview icon testing)
+	allModels = append(allModels,
+		hfPreviewModel("sample-source/included-model-1", true, "gated_auto", true),
+		hfPreviewModel("sample-source/included-model-2", true, "gated_manual", false),
+	)
+	for i := 3; i <= 41; i++ {
 		allModels = append(allModels, models.CatalogSourcePreviewModel{
 			Name:     fmt.Sprintf("sample-source/included-model-%d", i),
 			Included: true,
 		})
 	}
 
-	// Add 25 excluded models
-	for i := 1; i <= 25; i++ {
+	// Add remaining excluded models
+	for i := 1; i <= 23; i++ {
 		allModels = append(allModels, models.CatalogSourcePreviewModel{
 			Name:     fmt.Sprintf("sample-source/excluded-model-%d", i),
 			Included: false,

--- a/packages/model-registry/upstream/bff/internal/models/catalog_source_list.go
+++ b/packages/model-registry/upstream/bff/internal/models/catalog_source_list.go
@@ -9,6 +9,7 @@ type CatalogSource struct {
 	Error         *string  `json:"error,omitempty"`
 	HasApiKey     *bool    `json:"hasApiKey,omitempty"`
 	Authenticated *bool    `json:"authenticated,omitempty"`
+	HfUsername    string   `json:"hfUsername,omitempty"`
 }
 
 type CatalogSourceList struct {

--- a/packages/model-registry/upstream/bff/internal/models/catalog_source_preview.go
+++ b/packages/model-registry/upstream/bff/internal/models/catalog_source_preview.go
@@ -11,8 +11,10 @@ type CatalogSourcePreviewRequest struct {
 }
 
 type CatalogSourcePreviewModel struct {
-	Name     string `json:"name"`
-	Included bool   `json:"included"`
+	Name                 string  `json:"name"`
+	Included             bool    `json:"included"`
+	HfAccessType         *string `json:"hfAccessType,omitempty"`
+	HfGatedAccessGranted *bool   `json:"hfGatedAccessGranted,omitempty"`
 }
 
 type CatalogSourcePreviewSummary struct {

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -505,6 +505,23 @@ class ManageSourcePage {
   findPreviewModelsIncludedSummary(count: number, total: number) {
     return cy.contains(`${count} of ${total} models included:`);
   }
+
+  findPreviewModelsExcludedSummary(count: number, total: number) {
+    return cy.contains(`${count} of ${total} models excluded:`);
+  }
+
+  clickPreviewExcludedTab() {
+    this.findPreviewPanel().contains('Models excluded').click();
+    return this;
+  }
+
+  findPreviewModelRow(modelName: string) {
+    return this.findPreviewPanel().contains('li', modelName);
+  }
+
+  findPreviewGatedAccessWarningIcon(modelName: string) {
+    return this.findPreviewModelRow(modelName).findByLabelText('Gated access warning');
+  }
 }
 
 export const modelCatalogSettings = new ModelCatalogSettings();

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -1,4 +1,3 @@
-import { TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
 import {
   addSourceUrl,
   catalogSettingsUrl,
@@ -158,13 +157,7 @@ class CatalogSourceStatusErrorModal extends Modal {
 }
 
 class ModelCatalogSettings {
-  visit({
-    wait = true,
-    enableTempDevCatalogHuggingFaceApiKeyFeature = false,
-  }: { wait?: boolean; enableTempDevCatalogHuggingFaceApiKeyFeature?: boolean } = {}) {
-    if (enableTempDevCatalogHuggingFaceApiKeyFeature) {
-      window.localStorage.setItem(TempDevFeature.CatalogHuggingFaceApiKey, 'true');
-    }
+  visit({ wait = true }: { wait?: boolean } = {}) {
     cy.visit(catalogSettingsUrl());
     if (wait) {
       this.wait();
@@ -248,29 +241,14 @@ class ModelCatalogSettings {
 }
 
 class ManageSourcePage {
-  visitAddSource({
-    wait = true,
-    enableTempDevCatalogHuggingFaceApiKeyFeature = false,
-  }: { wait?: boolean; enableTempDevCatalogHuggingFaceApiKeyFeature?: boolean } = {}) {
-    if (enableTempDevCatalogHuggingFaceApiKeyFeature) {
-      window.localStorage.setItem(TempDevFeature.CatalogHuggingFaceApiKey, 'true');
-    }
+  visitAddSource({ wait = true }: { wait?: boolean } = {}) {
     cy.visit(addSourceUrl());
     if (wait) {
       this.wait();
     }
   }
 
-  visitManageSource(
-    catalogSourceId: string,
-    {
-      wait = true,
-      enableTempDevCatalogHuggingFaceApiKeyFeature = false,
-    }: { wait?: boolean; enableTempDevCatalogHuggingFaceApiKeyFeature?: boolean } = {},
-  ) {
-    if (enableTempDevCatalogHuggingFaceApiKeyFeature) {
-      window.localStorage.setItem(TempDevFeature.CatalogHuggingFaceApiKey, 'true');
-    }
+  visitManageSource(catalogSourceId: string, { wait = true }: { wait?: boolean } = {}) {
     cy.visit(manageSourceUrl(catalogSourceId));
     if (wait) {
       this.wait();

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
@@ -590,6 +590,9 @@ export const setupHfAccessCardIntercepts = (models: CatalogModel[]): void => {
     id: 'hugging_face_source',
     name: 'Hugging face source',
     labels: [],
+    hfUsername: 'alice',
+    hasApiKey: true,
+    authenticated: true,
   });
 
   interceptSources([hfSource]);
@@ -613,4 +616,51 @@ export const setupHfAccessCardIntercepts = (models: CatalogModel[]): void => {
     },
     mockCatalogModelList({ items: models }),
   );
+};
+
+export const GATED_DENIED_DETAILS_SOURCE_ID = 'hugging_face_source';
+export const GATED_DENIED_DETAILS_MODEL_NAME = 'meta-llama/Llama-3.1-8B-Instruct-INT8';
+
+export type GatedDeniedDetailsInterceptOptions = {
+  hfUsername?: string;
+};
+
+export const createGatedDeniedDetailsModel = (): CatalogModel =>
+  mockCatalogModel({
+    name: GATED_DENIED_DETAILS_MODEL_NAME,
+    provider: 'Meta',
+    description: '',
+    readme: '',
+    source_id: GATED_DENIED_DETAILS_SOURCE_ID,
+    customProperties: buildHfAccessCustomProperties('gated_auto', 'false'),
+  });
+
+/**
+ * Sets up intercepts for gated-denied model details tests without relying on
+ * setupModelCatalogIntercepts override behavior.
+ */
+export const setupGatedDeniedDetailsIntercepts = (
+  options: GatedDeniedDetailsInterceptOptions = {},
+): void => {
+  const { hfUsername } = options;
+  const gatedDeniedModel = createGatedDeniedDetailsModel();
+
+  cy.intercept('GET', '/model-registry/api/v1/model_registry*', [
+    mockModelRegistry({ name: 'modelregistry-sample' }),
+  ]).as('getModelRegistries');
+
+  interceptSources([
+    ...defaultSources(),
+    mockCatalogSource({
+      id: GATED_DENIED_DETAILS_SOURCE_ID,
+      name: 'Hugging face source',
+      labels: [],
+      ...(hfUsername ? { hfUsername, hasApiKey: true, authenticated: true } : {}),
+    }),
+  ]);
+  interceptLabels();
+  interceptFilterOptions();
+  interceptSingleModel(GATED_DENIED_DETAILS_SOURCE_ID, gatedDeniedModel);
+  interceptSingleModelRegex(gatedDeniedModel);
+  interceptArtifactsList({ items: [], size: 0, pageSize: 10, nextPageToken: '' });
 };

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -4,9 +4,6 @@ import { modelCatalog } from '~/__tests__/cypress/cypress/pages/modelCatalog';
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
 import {
-  GATED_DENIED_DETAILS_MODEL_NAME,
-  GATED_DENIED_DETAILS_SOURCE_ID,
-  setupGatedDeniedDetailsIntercepts,
   setupModelCatalogIntercepts,
   setupValidatedModelIntercepts,
   interceptArtifactsList,
@@ -528,51 +525,5 @@ describe('Model Catalog Registration - Model Type Field', () => {
 
     modelCatalog.findModelTypeSelect().should('contain.text', 'Predictive Model');
     modelCatalog.findModelTypeSelect().should('be.disabled');
-  });
-});
-
-describe('Model Catalog Details Page - Gated access denied', () => {
-  it('shows admin gated access required state with Hugging Face username guidance', () => {
-    setupGatedDeniedDetailsIntercepts({ hfUsername: 'alice' });
-
-    modelCatalog.visitModelDetails(GATED_DENIED_DETAILS_SOURCE_ID, GATED_DENIED_DETAILS_MODEL_NAME);
-    appChrome.waitForA11y();
-
-    modelCatalog.findGatedAccessRequiredState().should('be.visible');
-    modelCatalog.findGatedAccessRequiredState().should('contain.text', 'Model access required');
-    modelCatalog
-      .findGatedAccessRequiredState()
-      .should('contain.text', 'Log in to the Hugging Face account');
-    modelCatalog.findGatedAccessRequiredState().should('contain.text', 'alice');
-    modelCatalog.findGatedAccessRequestLink().should('be.visible');
-    modelCatalog.findWhosMyAdministratorLink().should('not.exist');
-    modelCatalog.findDetailsDescription().should('not.exist');
-    modelCatalog.findModelCardMarkdown().should('not.exist');
-    modelCatalog.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
-    modelCatalog.findRegisterModelButton().trigger('mouseenter');
-    modelCatalog
-      .findRegisterCatalogModelTooltip()
-      .should('be.visible')
-      .and('contain.text', 'Model access is required to deploy or register this model.');
-    modelCatalog.findAccessLabelGatedDenied().should('be.visible');
-  });
-
-  it('shows admin generic gated access guidance when hfUsername is unavailable', () => {
-    setupGatedDeniedDetailsIntercepts();
-
-    modelCatalog.visitModelDetails(GATED_DENIED_DETAILS_SOURCE_ID, GATED_DENIED_DETAILS_MODEL_NAME);
-
-    modelCatalog.findGatedAccessRequiredState().should('be.visible');
-    modelCatalog
-      .findGatedAccessRequiredState()
-      .should(
-        'contain.text',
-        'This model is gated on Hugging Face. Request access on Hugging Face.',
-      );
-    modelCatalog
-      .findGatedAccessRequiredState()
-      .should('not.contain.text', 'Log in to the Hugging Face account');
-    modelCatalog.findGatedAccessRequestLink().should('be.visible');
-    modelCatalog.findWhosMyAdministratorLink().should('not.exist');
   });
 });

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -4,6 +4,9 @@ import { modelCatalog } from '~/__tests__/cypress/cypress/pages/modelCatalog';
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
 import {
+  GATED_DENIED_DETAILS_MODEL_NAME,
+  GATED_DENIED_DETAILS_SOURCE_ID,
+  setupGatedDeniedDetailsIntercepts,
   setupModelCatalogIntercepts,
   setupValidatedModelIntercepts,
   interceptArtifactsList,
@@ -529,58 +532,44 @@ describe('Model Catalog Registration - Model Type Field', () => {
 });
 
 describe('Model Catalog Details Page - Gated access denied', () => {
-  const gatedDeniedModel = mockCatalogModel({
-    name: 'meta-llama/Llama-3.1-8B-Instruct-INT8',
-    provider: 'Meta',
-    description: '',
-    readme: '',
-    source_id: 'hugging_face_source',
-    customProperties: {
-      hf_access_type: {
-        string_value: 'gated_auto',
-        metadataType: ModelRegistryMetadataType.STRING,
-      },
-      hf_gated_access_granted: {
-        string_value: 'false',
-        metadataType: ModelRegistryMetadataType.STRING,
-      },
-    },
-  });
-
-  beforeEach(() => {
-    cy.intercept('GET', '/model-registry/api/v1/model_registry*', [
-      mockModelRegistry({ name: 'modelregistry-sample' }),
-    ]).as('getModelRegistries');
-
-    setupModelCatalogIntercepts({});
-    cy.interceptApi(
-      `GET /api/:apiVersion/model_catalog/sources/:sourceId/models/:modelName`,
-      {
-        path: {
-          apiVersion: MODEL_CATALOG_API_VERSION,
-          sourceId: 'hugging_face_source',
-          modelName: 'meta-llama%2FLlama-3.1-8B-Instruct-INT8',
-        },
-      },
-      gatedDeniedModel,
-    );
-    interceptArtifactsList({ items: [], size: 0, pageSize: 10, nextPageToken: '' });
-  });
-
   it('shows gated access required state instead of model details', () => {
-    modelCatalog.visitModelDetails('hugging_face_source', 'meta-llama/Llama-3.1-8B-Instruct-INT8');
+    setupGatedDeniedDetailsIntercepts({ hfUsername: 'alice' });
+
+    modelCatalog.visitModelDetails(GATED_DENIED_DETAILS_SOURCE_ID, GATED_DENIED_DETAILS_MODEL_NAME);
     appChrome.waitForA11y();
 
     modelCatalog.findGatedAccessRequiredState().should('be.visible');
     modelCatalog.findGatedAccessRequiredState().should('contain.text', 'Model access required');
     modelCatalog
       .findGatedAccessRequiredState()
-      .should('contain.text', 'To request access, contact your administrator.');
-    modelCatalog.findWhosMyAdministratorLink().should('be.visible');
-    modelCatalog.findGatedAccessRequestLink().should('not.exist');
+      .should('contain.text', 'Log in to the Hugging Face account');
+    modelCatalog.findGatedAccessRequiredState().should('contain.text', 'alice');
+    modelCatalog.findGatedAccessRequestLink().should('be.visible');
     modelCatalog.findDetailsDescription().should('not.exist');
     modelCatalog.findModelCardMarkdown().should('not.exist');
     modelCatalog.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
+    modelCatalog.findRegisterModelButton().trigger('mouseenter');
+    modelCatalog
+      .findRegisterCatalogModelTooltip()
+      .should('be.visible')
+      .and('contain.text', 'Model access is required to deploy or register this model.');
     modelCatalog.findAccessLabelGatedDenied().should('be.visible');
+  });
+
+  it('shows generic gated access guidance when hfUsername is unavailable', () => {
+    setupGatedDeniedDetailsIntercepts();
+
+    modelCatalog.visitModelDetails(GATED_DENIED_DETAILS_SOURCE_ID, GATED_DENIED_DETAILS_MODEL_NAME);
+
+    modelCatalog.findGatedAccessRequiredState().should('be.visible');
+    modelCatalog
+      .findGatedAccessRequiredState()
+      .should(
+        'contain.text',
+        'This model is gated on Hugging Face. Request access on Hugging Face.',
+      );
+    modelCatalog
+      .findGatedAccessRequiredState()
+      .should('not.contain.text', 'Log in to the Hugging Face account');
   });
 });

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -532,7 +532,7 @@ describe('Model Catalog Registration - Model Type Field', () => {
 });
 
 describe('Model Catalog Details Page - Gated access denied', () => {
-  it('shows gated access required state instead of model details', () => {
+  it('shows admin gated access required state with Hugging Face username guidance', () => {
     setupGatedDeniedDetailsIntercepts({ hfUsername: 'alice' });
 
     modelCatalog.visitModelDetails(GATED_DENIED_DETAILS_SOURCE_ID, GATED_DENIED_DETAILS_MODEL_NAME);
@@ -545,6 +545,7 @@ describe('Model Catalog Details Page - Gated access denied', () => {
       .should('contain.text', 'Log in to the Hugging Face account');
     modelCatalog.findGatedAccessRequiredState().should('contain.text', 'alice');
     modelCatalog.findGatedAccessRequestLink().should('be.visible');
+    modelCatalog.findWhosMyAdministratorLink().should('not.exist');
     modelCatalog.findDetailsDescription().should('not.exist');
     modelCatalog.findModelCardMarkdown().should('not.exist');
     modelCatalog.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
@@ -556,7 +557,7 @@ describe('Model Catalog Details Page - Gated access denied', () => {
     modelCatalog.findAccessLabelGatedDenied().should('be.visible');
   });
 
-  it('shows generic gated access guidance when hfUsername is unavailable', () => {
+  it('shows admin generic gated access guidance when hfUsername is unavailable', () => {
     setupGatedDeniedDetailsIntercepts();
 
     modelCatalog.visitModelDetails(GATED_DENIED_DETAILS_SOURCE_ID, GATED_DENIED_DETAILS_MODEL_NAME);
@@ -571,5 +572,7 @@ describe('Model Catalog Details Page - Gated access denied', () => {
     modelCatalog
       .findGatedAccessRequiredState()
       .should('not.contain.text', 'Log in to the Hugging Face account');
+    modelCatalog.findGatedAccessRequestLink().should('be.visible');
+    modelCatalog.findWhosMyAdministratorLink().should('not.exist');
   });
 });

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -1013,6 +1013,57 @@ describe('Manage Source Page', () => {
       manageSourcePage.findPreviewPanelBodyButton().should('be.disabled');
     });
 
+    it('should show warning icon for gated models without access in preview tabs', () => {
+      cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_preview*', {
+        data: {
+          items: [
+            {
+              name: 'sample-source/included-model-1',
+              included: true,
+              hfAccessType: 'gated_auto',
+              hfGatedAccessGranted: true,
+            },
+            {
+              name: 'sample-source/included-model-2',
+              included: true,
+              hfAccessType: 'gated_manual',
+              hfGatedAccessGranted: false,
+            },
+            {
+              name: 'meta-llama/gated-auto-denied',
+              included: false,
+              hfAccessType: 'gated_auto',
+              hfGatedAccessGranted: false,
+            },
+          ],
+          summary: { totalModels: 3, includedModels: 2, excludedModels: 1 },
+          nextPageToken: '',
+          pageSize: 20,
+          size: 3,
+        },
+      }).as('previewGatedModels');
+
+      manageSourcePage.visitAddSource();
+      manageSourcePage.fillOrganization('Google');
+      manageSourcePage.findPreviewButton().click();
+      cy.wait('@previewGatedModels');
+
+      manageSourcePage.findPreviewModelsIncludedSummary(2, 3).should('exist');
+      manageSourcePage
+        .findPreviewModelRow('sample-source/included-model-1')
+        .findByLabelText('Included model')
+        .should('exist');
+      manageSourcePage
+        .findPreviewGatedAccessWarningIcon('sample-source/included-model-2')
+        .should('exist');
+
+      manageSourcePage.clickPreviewExcludedTab();
+      manageSourcePage.findPreviewModelsExcludedSummary(1, 3).should('exist');
+      manageSourcePage
+        .findPreviewGatedAccessWarningIcon('meta-llama/gated-auto-denied')
+        .should('exist');
+    });
+
     it('should show refresh alert with enabled link when token is typed after preview without token', () => {
       cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_preview*', {
         data: {
@@ -1630,9 +1681,7 @@ describe('HuggingFace Credentials Validation', () => {
         }),
       });
 
-      manageSourcePage.visitManageSource('hf-edit-locked', {
-        enableTempDevCatalogHuggingFaceApiKeyFeature: true,
-      });
+      manageSourcePage.visitManageSource('hf-edit-locked');
 
       manageSourcePage.findAccessTokenInput().should('be.disabled');
       manageSourcePage.findAccessTokenInput().should('have.value', '••••••••');
@@ -1664,9 +1713,7 @@ describe('HuggingFace Credentials Validation', () => {
         }),
       });
 
-      manageSourcePage.visitManageSource('hf-edit-clear-flow', {
-        enableTempDevCatalogHuggingFaceApiKeyFeature: true,
-      });
+      manageSourcePage.visitManageSource('hf-edit-clear-flow');
 
       manageSourcePage.findCredentialsSection().within(() => {
         cy.findByRole('button', { name: 'Clear' }).click();
@@ -1704,9 +1751,7 @@ describe('HuggingFace Credentials Validation', () => {
         }),
       });
 
-      manageSourcePage.visitManageSource('hf-edit-no-key', {
-        enableTempDevCatalogHuggingFaceApiKeyFeature: true,
-      });
+      manageSourcePage.visitManageSource('hf-edit-no-key');
 
       manageSourcePage.findAccessTokenInput().should('not.be.disabled');
       manageSourcePage.findAccessTokenHiddenHelper().should('not.exist');

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -751,7 +751,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should show Hugging Face fields by default', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.findSourceTypeHuggingFace().should('be.checked');
       manageSourcePage.findCredentialsSection().should('exist');
       manageSourcePage.findAccessTokenInput().should('exist');
@@ -786,7 +786,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should enable Add button when all required HF fields are filled', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillSourceName('Test Source');
       manageSourcePage.fillAccessToken('test-token-123');
       manageSourcePage.fillOrganization('Google');
@@ -794,7 +794,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should keep Preview disabled when HF credentials are filled but not validated', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillAccessToken('test-token-123');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('be.disabled');
@@ -813,7 +813,7 @@ describe('Manage Source Page', () => {
         },
       }).as('validateHfCredentials');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillAccessToken('test-token-123');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('be.disabled');
@@ -825,7 +825,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should enable Preview for HF when only organization is filled', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('not.be.disabled');
       manageSourcePage.findPreviewPanelHeaderButton().should('not.be.disabled');
@@ -925,7 +925,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should maintain form state when switching between source types', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
 
       // Fill name and HF fields
       manageSourcePage.fillSourceName('Test Source');
@@ -1005,7 +1005,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should keep all three preview buttons disabled when token is entered but not validated', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillAccessToken('test-token');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('be.disabled');
@@ -1024,7 +1024,7 @@ describe('Manage Source Page', () => {
         },
       }).as('previewSource');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('not.be.disabled');
       manageSourcePage.findPreviewButton().click();
@@ -1082,7 +1082,7 @@ describe('Manage Source Page', () => {
       cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_configs', {
         data: mockHuggingFaceCatalogSourceConfig({}),
       }).as('addSourcewithHuggingFaceType');
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.findNameInput().type('sample source');
       manageSourcePage.selectSourceType('huggingface');
       manageSourcePage.findSourceTypeHuggingFace().should('be.checked');
@@ -1317,9 +1317,7 @@ describe('Manage Source Page', () => {
       },
     ).as('manageSourcewithHuggingFaceType');
 
-    manageSourcePage.visitManageSource('huggingface_source_3', {
-      enableTempDevCatalogHuggingFaceApiKeyFeature: true,
-    });
+    manageSourcePage.visitManageSource('huggingface_source_3');
     manageSourcePage.findNameInput().should('have.value', 'Huggingface source 3');
 
     manageSourcePage.findAccessTokenInput().should('have.value', '••••••••');
@@ -1415,19 +1413,6 @@ describe('HuggingFace Credentials Validation', () => {
     setupMocks([], mockCatalogSourceConfigList({}));
   });
 
-  describe('Feature flag behavior', () => {
-    it('should show credentials section when flag is enabled', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
-      manageSourcePage.findCredentialsSection().should('exist');
-      manageSourcePage.findAccessTokenInput().should('exist');
-    });
-
-    it('should hide credentials section when flag is disabled', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: false });
-      manageSourcePage.findCredentialsSection().should('not.exist');
-    });
-  });
-
   describe('Validation success/fail (mocked with qwen)', () => {
     it('should show success alert when org and token are valid', () => {
       cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_preview*', {
@@ -1435,7 +1420,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewSuccessResponse,
       }).as('validateSuccess');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('valid-token-123');
 
@@ -1452,7 +1437,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewFailResponse,
       }).as('validateFail');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('qwen');
       manageSourcePage.fillAccessToken('any-token');
 
@@ -1468,7 +1453,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewFailResponse,
       }).as('validateFail');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('qwen');
       manageSourcePage.fillAccessToken('any-token');
 
@@ -1488,7 +1473,7 @@ describe('HuggingFace Credentials Validation', () => {
 
   describe('Eye/mask toggle behavior', () => {
     it('should toggle password visibility with eye button', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillAccessToken('my-secret-token');
 
       manageSourcePage.findAccessTokenInput().should('have.attr', 'type', 'password');
@@ -1506,7 +1491,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewSuccessResponse,
       }).as('validateSuccess');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('my-secret-token');
 
@@ -1529,7 +1514,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewSuccessResponse,
       }).as('validateSuccess');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('valid-token-123');
 
@@ -1547,7 +1532,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewSuccessResponse,
       }).as('validateSuccess');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('valid-token-123');
       manageSourcePage.clickValidate();
@@ -1588,7 +1573,7 @@ describe('HuggingFace Credentials Validation', () => {
         data: mockHuggingFaceCatalogSourceConfig({}),
       }).as('addSource');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillSourceName('My HF Source');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('my-secret-token');
@@ -1610,7 +1595,7 @@ describe('HuggingFace Credentials Validation', () => {
         data: mockHuggingFaceCatalogSourceConfig({}),
       }).as('addSource');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillSourceName('My HF Source');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('my-secret-token');

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -1628,4 +1628,106 @@ describe('HuggingFace Credentials Validation', () => {
       });
     });
   });
+
+  describe('Edit flow - existing access token (hasApiKey)', () => {
+    it('should show locked access token field when hasApiKey is true', () => {
+      setupMocks(
+        [mockCatalogSource({ id: 'hf-edit-locked', name: 'HF Edit Locked', hasApiKey: true })],
+        mockCatalogSourceConfigList({}),
+      );
+
+      cy.intercept('GET', '/model-registry/api/v1/settings/model_catalog/source_configs/**', {
+        data: mockHuggingFaceCatalogSourceConfig({
+          id: 'hf-edit-locked',
+          name: 'HF Edit Locked',
+          allowedOrganization: 'org1',
+          isDefault: false,
+        }),
+      });
+
+      manageSourcePage.visitManageSource('hf-edit-locked', {
+        enableTempDevCatalogHuggingFaceApiKeyFeature: true,
+      });
+
+      manageSourcePage.findAccessTokenInput().should('be.disabled');
+      manageSourcePage.findAccessTokenInput().should('have.value', '••••••••');
+      manageSourcePage.findAccessTokenHiddenHelper().should('exist');
+      manageSourcePage.findCredentialsSection().within(() => {
+        cy.findByRole('button', { name: 'Clear' }).should('exist');
+        cy.findByRole('button', { name: 'Validate' }).should('not.exist');
+      });
+    });
+
+    it('should unlock access token field after clearing when hasApiKey is true', () => {
+      setupMocks(
+        [
+          mockCatalogSource({
+            id: 'hf-edit-clear-flow',
+            name: 'HF Edit Clear Flow',
+            hasApiKey: true,
+          }),
+        ],
+        mockCatalogSourceConfigList({}),
+      );
+
+      cy.intercept('GET', '/model-registry/api/v1/settings/model_catalog/source_configs/**', {
+        data: mockHuggingFaceCatalogSourceConfig({
+          id: 'hf-edit-clear-flow',
+          name: 'HF Edit Clear Flow',
+          allowedOrganization: 'org1',
+          isDefault: false,
+        }),
+      });
+
+      manageSourcePage.visitManageSource('hf-edit-clear-flow', {
+        enableTempDevCatalogHuggingFaceApiKeyFeature: true,
+      });
+
+      manageSourcePage.findCredentialsSection().within(() => {
+        cy.findByRole('button', { name: 'Clear' }).click();
+      });
+      manageSourcePage.findClearAccessTokenModal().should('exist');
+      manageSourcePage.findClearAccessTokenConfirmButton().click();
+      manageSourcePage.findClearAccessTokenModal().should('not.exist');
+
+      manageSourcePage.findAccessTokenInput().should('not.be.disabled');
+      manageSourcePage.findAccessTokenInput().should('have.value', '');
+      manageSourcePage.findAccessTokenHiddenHelper().should('not.exist');
+      manageSourcePage.findCredentialsSection().within(() => {
+        cy.findByRole('button', { name: 'Validate' }).should('exist');
+      });
+    });
+
+    it('should show editable access token field when hasApiKey is false', () => {
+      setupMocks(
+        [
+          mockCatalogSource({
+            id: 'hf-edit-no-key',
+            name: 'HF Edit No Key',
+            hasApiKey: false,
+          }),
+        ],
+        mockCatalogSourceConfigList({}),
+      );
+
+      cy.intercept('GET', '/model-registry/api/v1/settings/model_catalog/source_configs/**', {
+        data: mockHuggingFaceCatalogSourceConfig({
+          id: 'hf-edit-no-key',
+          name: 'HF Edit No Key',
+          allowedOrganization: 'org1',
+          isDefault: false,
+        }),
+      });
+
+      manageSourcePage.visitManageSource('hf-edit-no-key', {
+        enableTempDevCatalogHuggingFaceApiKeyFeature: true,
+      });
+
+      manageSourcePage.findAccessTokenInput().should('not.be.disabled');
+      manageSourcePage.findAccessTokenHiddenHelper().should('not.exist');
+      manageSourcePage.findCredentialsSection().within(() => {
+        cy.findByRole('button', { name: 'Validate' }).should('exist');
+      });
+    });
+  });
 });

--- a/packages/model-registry/upstream/frontend/src/app/hooks/useTempDevFeatureAvailable.ts
+++ b/packages/model-registry/upstream/frontend/src/app/hooks/useTempDevFeatureAvailable.ts
@@ -3,7 +3,7 @@
  *
  * This hook provides a browser storage-backed feature flag that can be toggled
  * via the browser console using:
- *     window.setTempDevCatalogHuggingFaceApiKeyFeatureAvailable(true/false);
+ *     window.setTempFeatureFlagAvailable(true/false);
  * The state persists across page reloads using browser storage.
  *
  * Each TempDevFeature and corresponding window.set* here should be removed once that feature is ready.
@@ -18,7 +18,7 @@ import { useOdhDevFeatureFlagOverrides } from '~/odh/extension-points';
 
 declare global {
   interface Window {
-    setTempDevCatalogHuggingFaceApiKeyFeatureAvailable?: (enabled: boolean) => void;
+    setTempFeatureFlagAvailable?: (enabled: boolean) => void;
   }
 }
 
@@ -34,7 +34,8 @@ export const useTempDevFeatureAvailable = (feature: TempDevFeature): boolean => 
   const contextOverride = overrides?.[feature];
 
   React.useEffect(() => {
-    window.setTempDevCatalogHuggingFaceApiKeyFeatureAvailable = setIsAvailable;
+    // Placeholder console API for the temporary feature using this hook.
+    window.setTempFeatureFlagAvailable = setIsAvailable;
   }, [feature, setIsAvailable]);
 
   // Context override takes precedence, then localStorage

--- a/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
+++ b/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
@@ -488,6 +488,8 @@ export type CatalogSourcePreviewRequest = {
 export type CatalogSourcePreviewModel = {
   name: string;
   included: boolean;
+  hfAccessType?: string;
+  hfGatedAccessGranted?: boolean;
 };
 
 export type CatalogSourcePreviewSummary = {

--- a/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
+++ b/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
@@ -49,6 +49,7 @@ export type CatalogSource = {
   assetType?: CatalogAssetType;
   hasApiKey?: boolean;
   authenticated?: boolean;
+  hfUsername?: string;
 };
 
 export type CatalogSourceList = PaginationParams & { items?: CatalogSource[] };

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -27,11 +27,13 @@ import useCatalogDeployPrefillData from '~/odh/hooks/useCatalogDeployPrefillData
 import {
   decodeParams,
   getModelName,
+  getSourceFromSourceId,
   hasModelArtifacts,
   isModelValidated,
   isRedHatModel,
   getHfAccessLabelVariant,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { useCatalogModel } from '~/app/hooks/modelCatalog/useCatalogModel';
 import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 import { getRegisterCatalogModelRoute } from '~/app/routes/modelCatalog/catalogModelRegister';
@@ -74,6 +76,11 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab, customNoRegist
     () => actionExtensions.some((action) => action.properties.group === MODEL_CATALOG_DEPLOY_GROUP),
     [actionExtensions],
   );
+  const { catalogSources } = React.useContext(ModelCatalogContext);
+  const hfUsername = getSourceFromSourceId(
+    decodedParams.sourceId || '',
+    catalogSources,
+  )?.hfUsername;
 
   const [artifacts, artifactLoaded, artifactsLoadError] = useCatalogModelArtifacts(
     decodedParams.sourceId || '',
@@ -127,13 +134,7 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab, customNoRegist
 
   const registerModelButton = (variant: 'primary' | 'secondary' = 'primary') => {
     if (gatedAccessDenied) {
-      return (
-        <Tooltip content={MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_BUTTON_TOOLTIP}>
-          <Button variant={variant} isAriaDisabled data-testid="register-model-button">
-            Register model
-          </Button>
-        </Tooltip>
-      );
+      return registerButtonTooltip('', MODEL_CATALOG_GATED_ACCESS_REQUIRED.REGISTER_BUTTON_TOOLTIP);
     }
 
     if (!modelRegistriesLoaded || modelRegistriesLoadError) {
@@ -270,8 +271,7 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab, customNoRegist
                   componentProps={{
                     ...catalogDeployProps,
                     ...(gatedAccessDenied && {
-                      disabledTooltip:
-                        MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_BUTTON_TOOLTIP,
+                      disabledTooltip: MODEL_CATALOG_GATED_ACCESS_REQUIRED.REGISTER_BUTTON_TOOLTIP,
                     }),
                   }}
                 />
@@ -290,6 +290,7 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab, customNoRegist
             artifactLoaded={artifactLoaded}
             artifactsLoadError={artifactsLoadError}
             gatedAccessDenied={gatedAccessDenied}
+            hfUsername={hfUsername}
           />
         )}
       </ApplicationsPage>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsTabs.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsTabs.tsx
@@ -27,6 +27,7 @@ type ModelDetailsTabsProps = {
   artifactLoaded: boolean;
   artifactsLoadError: Error | undefined;
   gatedAccessDenied: boolean;
+  hfUsername?: string;
 };
 
 const ModelDetailsTabs = ({
@@ -37,11 +38,25 @@ const ModelDetailsTabs = ({
   artifactLoaded,
   artifactsLoadError,
   gatedAccessDenied,
+  hfUsername,
 }: ModelDetailsTabsProps): React.JSX.Element => {
   const navigate = useNavigate();
   const tabExtensions = useExtensions(isDetailTabExtension);
   const queryParams = useQueryParamNamespaces();
   const namespace = typeof queryParams.namespace === 'string' ? queryParams.namespace : undefined;
+
+  if (gatedAccessDenied) {
+    return (
+      <PageSection
+        hasBodyWrapper={false}
+        isFilled
+        data-testid="model-overview-tab-content"
+        padding={{ default: 'noPadding' }}
+      >
+        <ModelGatedAccessRequiredView model={model} hfUsername={hfUsername} />
+      </PageSection>
+    );
+  }
 
   const showValidatedInsights = shouldShowValidatedInsights(model, artifacts.items);
 
@@ -71,19 +86,6 @@ const ModelDetailsTabs = ({
 
     return tabs;
   }, [model, artifacts, artifactLoaded, artifactsLoadError, showValidatedInsights]);
-
-  if (gatedAccessDenied) {
-    return (
-      <PageSection
-        hasBodyWrapper={false}
-        isFilled
-        data-testid="model-overview-tab-content"
-        padding={{ default: 'noPadding' }}
-      >
-        <ModelGatedAccessRequiredView model={model} />
-      </PageSection>
-    );
-  }
 
   return (
     <ExtensibleDetailTabs

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsTabs.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsTabs.tsx
@@ -45,19 +45,6 @@ const ModelDetailsTabs = ({
   const queryParams = useQueryParamNamespaces();
   const namespace = typeof queryParams.namespace === 'string' ? queryParams.namespace : undefined;
 
-  if (gatedAccessDenied) {
-    return (
-      <PageSection
-        hasBodyWrapper={false}
-        isFilled
-        data-testid="model-overview-tab-content"
-        padding={{ default: 'noPadding' }}
-      >
-        <ModelGatedAccessRequiredView model={model} hfUsername={hfUsername} />
-      </PageSection>
-    );
-  }
-
   const showValidatedInsights = shouldShowValidatedInsights(model, artifacts.items);
 
   const staticTabs = React.useMemo(() => {
@@ -86,6 +73,19 @@ const ModelDetailsTabs = ({
 
     return tabs;
   }, [model, artifacts, artifactLoaded, artifactsLoadError, showValidatedInsights]);
+
+  if (gatedAccessDenied) {
+    return (
+      <PageSection
+        hasBodyWrapper={false}
+        isFilled
+        data-testid="model-overview-tab-content"
+        padding={{ default: 'noPadding' }}
+      >
+        <ModelGatedAccessRequiredView model={model} hfUsername={hfUsername} />
+      </PageSection>
+    );
+  }
 
   return (
     <ExtensibleDetailTabs

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
@@ -8,11 +8,14 @@ import {
   PageSection,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { useThemeContext } from 'mod-arch-kubeflow';
+import { KubeflowDocs, WhosMyAdministrator } from 'mod-arch-shared';
 import type { CatalogModel } from '~/app/modelCatalogTypes';
 import { renderGatedAccessRequiredDescription } from '~/app/pages/modelCatalog/utils/gatedAccessRequiredUtils';
 import { getHuggingFaceModelUrl } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import ExternalLink from '~/app/shared/components/ExternalLink';
 import { MODEL_CATALOG_GATED_ACCESS_REQUIRED } from '~/concepts/modelCatalog/const';
+import { useAdminStatus } from '~/odh/context/AdminStatusContext';
 
 type ModelGatedAccessRequiredViewProps = {
   model: CatalogModel;
@@ -22,27 +25,43 @@ type ModelGatedAccessRequiredViewProps = {
 const ModelGatedAccessRequiredView: React.FC<ModelGatedAccessRequiredViewProps> = ({
   model,
   hfUsername,
-}) => (
-  <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
-    <EmptyState
-      headingLevel="h2"
-      icon={ExclamationTriangleIcon}
-      titleText={MODEL_CATALOG_GATED_ACCESS_REQUIRED.TITLE}
-      variant={EmptyStateVariant.lg}
-      data-testid="model-gated-access-required"
-    >
-      <EmptyStateBody>{renderGatedAccessRequiredDescription(hfUsername)}</EmptyStateBody>
-      <EmptyStateFooter>
-        <EmptyStateActions>
-          <ExternalLink
-            text={MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_LINK_TEXT}
-            to={getHuggingFaceModelUrl(model)}
-            testId="model-gated-access-request-link"
-          />
-        </EmptyStateActions>
-      </EmptyStateFooter>
-    </EmptyState>
-  </PageSection>
-);
+}) => {
+  const { isAdmin, loaded } = useAdminStatus();
+  const { isMUITheme } = useThemeContext();
+  const isAdminUser = loaded && isAdmin;
+
+  return (
+    <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
+      <EmptyState
+        headingLevel="h2"
+        icon={ExclamationTriangleIcon}
+        titleText={MODEL_CATALOG_GATED_ACCESS_REQUIRED.TITLE}
+        variant={EmptyStateVariant.lg}
+        data-testid="model-gated-access-required"
+      >
+        <EmptyStateBody>
+          {isAdminUser
+            ? renderGatedAccessRequiredDescription(hfUsername)
+            : MODEL_CATALOG_GATED_ACCESS_REQUIRED.DESCRIPTION_NON_ADMIN}
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            {isAdminUser ? (
+              <ExternalLink
+                text={MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_LINK_TEXT}
+                to={getHuggingFaceModelUrl(model)}
+                testId="model-gated-access-request-link"
+              />
+            ) : isMUITheme ? (
+              <KubeflowDocs />
+            ) : (
+              <WhosMyAdministrator linkTestId="whos-my-admin-link" />
+            )}
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    </PageSection>
+  );
+};
 
 export default ModelGatedAccessRequiredView;

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
@@ -8,55 +8,41 @@ import {
   PageSection,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { useThemeContext } from 'mod-arch-kubeflow';
-import { KubeflowDocs, WhosMyAdministrator } from 'mod-arch-shared';
 import type { CatalogModel } from '~/app/modelCatalogTypes';
+import { renderGatedAccessRequiredDescription } from '~/app/pages/modelCatalog/utils/gatedAccessRequiredUtils';
 import { getHuggingFaceModelUrl } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import ExternalLink from '~/app/shared/components/ExternalLink';
 import { MODEL_CATALOG_GATED_ACCESS_REQUIRED } from '~/concepts/modelCatalog/const';
-import { useAdminStatus } from '~/odh/context/AdminStatusContext';
 
 type ModelGatedAccessRequiredViewProps = {
   model: CatalogModel;
+  hfUsername?: string;
 };
 
-const ModelGatedAccessRequiredView: React.FC<ModelGatedAccessRequiredViewProps> = ({ model }) => {
-  const { isAdmin, loaded } = useAdminStatus();
-  const { isMUITheme } = useThemeContext();
-  const isAdminUser = loaded && isAdmin;
-
-  return (
-    <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
-      <EmptyState
-        headingLevel="h2"
-        icon={ExclamationTriangleIcon}
-        titleText={MODEL_CATALOG_GATED_ACCESS_REQUIRED.TITLE}
-        variant={EmptyStateVariant.lg}
-        data-testid="model-gated-access-required"
-      >
-        <EmptyStateBody>
-          {isAdminUser
-            ? MODEL_CATALOG_GATED_ACCESS_REQUIRED.DESCRIPTION_ADMIN
-            : MODEL_CATALOG_GATED_ACCESS_REQUIRED.DESCRIPTION_NON_ADMIN}
-        </EmptyStateBody>
-        <EmptyStateFooter>
-          <EmptyStateActions>
-            {isAdminUser ? (
-              <ExternalLink
-                text={MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_LINK_TEXT}
-                to={getHuggingFaceModelUrl(model)}
-                testId="model-gated-access-request-link"
-              />
-            ) : isMUITheme ? (
-              <KubeflowDocs />
-            ) : (
-              <WhosMyAdministrator linkTestId="whos-my-admin-link" />
-            )}
-          </EmptyStateActions>
-        </EmptyStateFooter>
-      </EmptyState>
-    </PageSection>
-  );
-};
+const ModelGatedAccessRequiredView: React.FC<ModelGatedAccessRequiredViewProps> = ({
+  model,
+  hfUsername,
+}) => (
+  <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
+    <EmptyState
+      headingLevel="h2"
+      icon={ExclamationTriangleIcon}
+      titleText={MODEL_CATALOG_GATED_ACCESS_REQUIRED.TITLE}
+      variant={EmptyStateVariant.lg}
+      data-testid="model-gated-access-required"
+    >
+      <EmptyStateBody>{renderGatedAccessRequiredDescription(hfUsername)}</EmptyStateBody>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <ExternalLink
+            text={MODEL_CATALOG_GATED_ACCESS_REQUIRED.REQUEST_ACCESS_LINK_TEXT}
+            to={getHuggingFaceModelUrl(model)}
+            testId="model-gated-access-request-link"
+          />
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
+  </PageSection>
+);
 
 export default ModelGatedAccessRequiredView;

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/__tests__/ModelGatedAccessRequiredView.spec.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/__tests__/ModelGatedAccessRequiredView.spec.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useThemeContext } from 'mod-arch-kubeflow';
+import { mockCatalogModel } from '~/__mocks__';
+import ModelGatedAccessRequiredView from '~/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView';
+import { AdminStatusProvider } from '~/odh/context/AdminStatusContext';
+
+jest.mock('mod-arch-kubeflow', () => ({
+  useThemeContext: jest.fn(),
+}));
+
+jest.mock('mod-arch-shared', () => ({
+  KubeflowDocs: () => <div data-testid="kubeflow-docs" />,
+  WhosMyAdministrator: ({ linkTestId }: { linkTestId?: string }) => (
+    <button type="button" data-testid={linkTestId}>
+      Who&apos;s my administrator?
+    </button>
+  ),
+}));
+
+jest.mock('~/app/pages/modelCatalog/utils/modelCatalogUtils', () => ({
+  getHuggingFaceModelUrl: () => 'https://huggingface.co/meta-llama/test-model',
+}));
+
+const mockModel = mockCatalogModel({ name: 'meta-llama/test-model' });
+
+const renderView = ({
+  isAdmin,
+  loaded = true,
+  hfUsername,
+}: {
+  isAdmin: boolean;
+  loaded?: boolean;
+  hfUsername?: string;
+}) =>
+  render(
+    <AdminStatusProvider
+      isAdmin={isAdmin}
+      loaded={loaded}
+      settingsUrl="/settings"
+      settingsTitle="Settings"
+    >
+      <ModelGatedAccessRequiredView model={mockModel} hfUsername={hfUsername} />
+    </AdminStatusProvider>,
+  );
+
+describe('ModelGatedAccessRequiredView', () => {
+  beforeEach(() => {
+    (useThemeContext as jest.Mock).mockReturnValue({ isMUITheme: false });
+  });
+
+  it('shows non-admin guidance with Who is my administrator link', () => {
+    renderView({ isAdmin: false });
+
+    expect(
+      screen.getByText(
+        'You do not have access to this model, so it cannot be deployed or registered. To request access, contact your administrator.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('whos-my-admin-link')).toBeInTheDocument();
+    expect(screen.queryByTestId('model-gated-access-request-link')).not.toBeInTheDocument();
+  });
+
+  it('shows admin guidance with Hugging Face username and request link', () => {
+    renderView({ isAdmin: true, hfUsername: 'johndoe' });
+
+    expect(screen.getByText(/Log in to the Hugging Face account/)).toBeInTheDocument();
+    expect(screen.getByText('johndoe')).toBeInTheDocument();
+    expect(screen.getByTestId('model-gated-access-request-link')).toBeInTheDocument();
+    expect(screen.queryByTestId('whos-my-admin-link')).not.toBeInTheDocument();
+  });
+
+  it('shows Kubeflow docs for non-admin users in MUI theme', () => {
+    (useThemeContext as jest.Mock).mockReturnValue({ isMUITheme: true });
+    renderView({ isAdmin: false });
+
+    expect(screen.getByTestId('kubeflow-docs')).toBeInTheDocument();
+    expect(screen.queryByTestId('whos-my-admin-link')).not.toBeInTheDocument();
+  });
+});

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/hfAccessUtils.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/hfAccessUtils.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { render } from '@testing-library/react';
 import { CatalogModel } from '~/app/modelCatalogTypes';
 import { CatalogModelCustomPropertyKey, HfAccessType } from '~/concepts/modelCatalog/const';
 import { ModelRegistryMetadataType } from '~/app/types';
@@ -8,7 +9,13 @@ import {
   getHfGatedAccessGranted,
   getHuggingFaceModelUrl,
   isHfGatedAccessDenied,
+  isHfGatedAccessDeniedFromFields,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import {
+  getGatedAccessRequiredDescriptionText,
+  renderGatedAccessRequiredDescription,
+} from '~/app/pages/modelCatalog/utils/gatedAccessRequiredUtils';
+import { isPreviewModelGatedAccessDenied } from '~/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils';
 import { createHfAccessCatalogModel } from '~/__tests__/utils/createHfAccessModel';
 
 describe('HF access utilities', () => {
@@ -93,5 +100,60 @@ describe('HF access utilities', () => {
     expect(getHuggingFaceModelUrl(model)).toBe(
       'https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct-INT8',
     );
+  });
+});
+
+describe('isHfGatedAccessDeniedFromFields', () => {
+  it('returns true for gated models without granted access', () => {
+    expect(isHfGatedAccessDeniedFromFields('gated_auto', false)).toBe(true);
+    expect(isHfGatedAccessDeniedFromFields('gated_manual', undefined)).toBe(true);
+  });
+
+  it('returns false for gated models with granted access', () => {
+    expect(isHfGatedAccessDeniedFromFields('gated_auto', true)).toBe(false);
+  });
+
+  it('returns false for non-gated access types', () => {
+    expect(isHfGatedAccessDeniedFromFields('public', false)).toBe(false);
+    expect(isHfGatedAccessDeniedFromFields(undefined, false)).toBe(false);
+  });
+});
+
+describe('gated access required description', () => {
+  it('formats generic and personalized descriptions from shared copy', () => {
+    expect(getGatedAccessRequiredDescriptionText()).toBe(
+      'This model is gated on Hugging Face. Request access on Hugging Face. After access is granted on Hugging Face, it might take a few hours for this model to show as available in the catalog.',
+    );
+    expect(getGatedAccessRequiredDescriptionText('johndoe')).toBe(
+      'This model is gated on Hugging Face. Log in to the Hugging Face account johndoe and request access. After access is granted on Hugging Face, it might take a few hours for this model to show as available in the catalog.',
+    );
+  });
+
+  it('renders personalized description with bold username', () => {
+    const { container } = render(renderGatedAccessRequiredDescription('alice'));
+    expect(container.textContent).toContain('Log in to the Hugging Face account');
+    expect(container.querySelector('strong')?.textContent).toBe('alice');
+  });
+});
+
+describe('isPreviewModelGatedAccessDenied', () => {
+  it('uses the shared gated access rule for preview fields', () => {
+    expect(
+      isPreviewModelGatedAccessDenied({
+        name: 'sample-source/included-model-2',
+        included: true,
+        hfAccessType: 'gated_manual',
+        hfGatedAccessGranted: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isPreviewModelGatedAccessDenied({
+        name: 'sample-source/included-model-1',
+        included: true,
+        hfAccessType: 'gated_auto',
+        hfGatedAccessGranted: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/gatedAccessRequiredUtils.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/gatedAccessRequiredUtils.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY } from '~/concepts/modelCatalog/const';
+
+export const getGatedAccessRequiredDescriptionText = (hfUsername?: string): string => {
+  const { INTRO, GENERIC_ACTION, USERNAME_PROMPT, USERNAME_ACTION, OUTRO } =
+    MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY;
+
+  if (!hfUsername) {
+    return `${INTRO} ${GENERIC_ACTION} ${OUTRO}`;
+  }
+
+  return `${INTRO} ${USERNAME_PROMPT} ${hfUsername} ${USERNAME_ACTION} ${OUTRO}`;
+};
+
+export const renderGatedAccessRequiredDescription = (hfUsername?: string): React.ReactNode => {
+  const { INTRO, USERNAME_PROMPT, USERNAME_ACTION, OUTRO } =
+    MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY;
+
+  if (!hfUsername) {
+    return getGatedAccessRequiredDescriptionText();
+  }
+
+  return (
+    <>
+      {INTRO} {USERNAME_PROMPT} <strong>{hfUsername}</strong> {USERNAME_ACTION} {OUTRO}
+    </>
+  );
+};

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -181,7 +181,18 @@ export const hasPerformanceArtifacts = (artifacts: CatalogArtifacts[]): boolean 
 
 export type HfAccessLabelVariant = 'private' | 'gated' | 'gated-denied';
 
-const isGatedAccessType = (accessType: string): boolean => accessType.startsWith('gated');
+export const isGatedAccessType = (accessType: string): boolean => accessType.startsWith('gated');
+
+export const isHfGatedAccessDeniedFromFields = (
+  accessType?: string | null,
+  gatedAccessGranted?: boolean | null,
+): boolean => {
+  if (!accessType || !isGatedAccessType(accessType)) {
+    return false;
+  }
+
+  return gatedAccessGranted !== true;
+};
 
 export const getHfGatedAccessGranted = (model: CatalogModel): boolean => {
   if (!model.customProperties) {
@@ -227,15 +238,25 @@ export const getHfAccessLabelVariant = (model: CatalogModel): HfAccessLabelVaria
     return 'private';
   }
 
+  if (isHfGatedAccessDeniedFromFields(accessType, getHfGatedAccessGranted(model))) {
+    return 'gated-denied';
+  }
+
   if (isGatedAccessType(accessType)) {
-    return getHfGatedAccessGranted(model) ? 'gated' : 'gated-denied';
+    return 'gated';
   }
 
   return null;
 };
 
-export const isHfGatedAccessDenied = (model: CatalogModel): boolean =>
-  getHfAccessLabelVariant(model) === 'gated-denied';
+export const isHfGatedAccessDenied = (model: CatalogModel): boolean => {
+  const accessType = getHfAccessType(model);
+  if (!accessType) {
+    return false;
+  }
+
+  return isHfGatedAccessDeniedFromFields(accessType, getHfGatedAccessGranted(model));
+};
 
 // TODO: this needs to be updated with the customProperties of the model, where we will have the HF link
 export const getHuggingFaceModelUrl = (model: CatalogModel): string =>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -30,7 +30,6 @@ import {
   SUCCESS_MESSAGES,
   CLEAR_ACCESS_TOKEN_MODAL,
 } from '~/app/pages/modelCatalogSettings/constants';
-import { TempDevFeature, useTempDevFeatureAvailable } from '~/app/hooks/useTempDevFeatureAvailable';
 
 type CredentialsSectionProps = {
   formData: ManageSourceFormData;
@@ -83,53 +82,6 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
       setIsClearing(false);
     }
   }, [setData, onClearValidationSuccess, onClearCredentials]);
-
-  const accessTokenFeatureAvailable = useTempDevFeatureAvailable(
-    TempDevFeature.CatalogHuggingFaceApiKey,
-  );
-
-  if (!accessTokenFeatureAvailable) {
-    return (
-      <>
-        <ThemeAwareFormGroupWrapper
-          label={FORM_LABELS.ORGANIZATION}
-          fieldId="organization"
-          isRequired
-          hasError={isOrganizationTouched && !isOrganizationValid}
-          helperTextNode={
-            isOrganizationTouched && !isOrganizationValid ? (
-              <FormHelperText>
-                <HelperText>
-                  <HelperTextItem variant="error" data-testid="organization-error">
-                    {VALIDATION_MESSAGES.ORGANIZATION_REQUIRED}
-                  </HelperTextItem>
-                </HelperText>
-              </FormHelperText>
-            ) : undefined
-          }
-          popoverHelpText={DESCRIPTION_TEXT.ORGANIZATION}
-        >
-          <TextInput
-            isRequired
-            type="text"
-            id="organization"
-            name="organization"
-            data-testid="organization-input"
-            placeholder={PLACEHOLDERS.ORGANIZATION}
-            value={formData.organization}
-            onChange={(_event, value) => setData('organization', value)}
-            onBlur={() => setIsOrganizationTouched(true)}
-            validated={isOrganizationTouched && !isOrganizationValid ? 'error' : 'default'}
-          />
-        </ThemeAwareFormGroupWrapper>
-        <FormHelperText>
-          <HelperText>
-            <HelperTextItem>{HELPER_TEXT.ORGANIZATION_SLUG}</HelperTextItem>
-          </HelperText>
-        </FormHelperText>
-      </>
-    );
-  }
 
   const organizationInput = (
     <TextInput

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -12,6 +12,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalVariant,
+  Flex,
 } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue, ThemeAwareFormGroupWrapper } from 'mod-arch-shared';
@@ -146,23 +147,15 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
     />
   );
 
-  const organizationHelperTxtNode =
-    isOrganizationTouched && !isOrganizationValid ? (
-      <>
-        <FormHelperText>
-          <HelperText>
-            <HelperTextItem variant="error" data-testid="organization-error">
-              {VALIDATION_MESSAGES.ORGANIZATION_REQUIRED}
-            </HelperTextItem>
-          </HelperText>
-        </FormHelperText>
-      </>
-    ) : undefined;
-
-  const formGroupOrgHelpTextNode = (
+  const organizationHelperTxtNode = (
     <>
       <FormHelperText>
         <HelperText>
+          {isOrganizationTouched && !isOrganizationValid ? (
+            <HelperTextItem variant="error" data-testid="organization-error">
+              {VALIDATION_MESSAGES.ORGANIZATION_REQUIRED}
+            </HelperTextItem>
+          ) : undefined}
           <HelperTextItem>{HELPER_TEXT.ORGANIZATION_SLUG}</HelperTextItem>
         </HelperText>
       </FormHelperText>
@@ -175,13 +168,11 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
         label={FORM_LABELS.ORGANIZATION}
         fieldId="organization"
         isRequired
-        hasError={!!organizationHelperTxtNode}
         helperTextNode={organizationHelperTxtNode}
         popoverHelpText={DESCRIPTION_TEXT.ORGANIZATION}
       >
         {organizationInput}
       </ThemeAwareFormGroupWrapper>
-      {formGroupOrgHelpTextNode}
     </>
   );
 
@@ -254,29 +245,31 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
 
   const accessTokenFormGroup = (
     <>
-      <ThemeAwareFormGroupWrapper
-        label={FORM_LABELS.ACCESS_TOKEN}
-        fieldId="access-token"
-        helperTextNode={accessTokenHelperTxtNode}
-        popoverHelpText={DESCRIPTION_TEXT.ACCESS_TOKEN}
-      >
-        {accessTokenInput}
-      </ThemeAwareFormGroupWrapper>
-      {validationError && (
-        <Alert isInline variant="danger" title={ERROR_MESSAGES.VALIDATION_FAILED}>
-          {validationError.message}
-        </Alert>
-      )}
-      {isValidationSuccess && !isTokenLocked && (
-        <Alert isInline variant="success" title={SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL}>
-          {SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL_BODY}
-        </Alert>
-      )}
+      <Flex direction={{ default: 'column' }}>
+        <ThemeAwareFormGroupWrapper
+          label={FORM_LABELS.ACCESS_TOKEN}
+          fieldId="access-token"
+          helperTextNode={accessTokenHelperTxtNode}
+          popoverHelpText={DESCRIPTION_TEXT.ACCESS_TOKEN}
+        >
+          {accessTokenInput}
+        </ThemeAwareFormGroupWrapper>
+        {validationError && (
+          <Alert isInline variant="danger" title={ERROR_MESSAGES.VALIDATION_FAILED}>
+            {validationError.message}
+          </Alert>
+        )}
+        {isValidationSuccess && !isTokenLocked && (
+          <Alert isInline variant="success" title={SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL}>
+            {SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL_BODY}
+          </Alert>
+        )}
 
-      <ActionList>
-        {tokenValidationBtn}
-        {tokenClearBtn}
-      </ActionList>
+        <ActionList>
+          {tokenValidationBtn}
+          {tokenClearBtn}
+        </ActionList>
+      </Flex>
     </>
   );
 

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
@@ -17,13 +17,16 @@ import {
   Spinner,
   Button,
   AlertActionLink,
+  Icon,
 } from '@patternfly/react-core';
-import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, ExclamationTriangleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import {
   PAGE_TITLES,
   ERROR_MESSAGES,
   EMPTY_STATE_TEXT,
 } from '~/app/pages/modelCatalogSettings/constants';
+import { isPreviewModelGatedAccessDenied } from '~/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils';
+import { CatalogSourcePreviewModel } from '~/app/modelCatalogTypes';
 import { UseSourcePreviewResult } from '~/app/pages/modelCatalogSettings/useSourcePreview';
 import { CatalogSettingsPreviewTab } from '~/app/shared/catalogSettings/hooks/previewTypes';
 import PreviewButton from './PreviewButton';
@@ -54,6 +57,22 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
     handleTabChange(
       tabIndex === 0 ? CatalogSettingsPreviewTab.INCLUDED : CatalogSettingsPreviewTab.EXCLUDED,
     );
+  };
+
+  const renderModelIcon = (model: CatalogSourcePreviewModel) => {
+    if (isPreviewModelGatedAccessDenied(model)) {
+      return (
+        <Icon status="warning">
+          <ExclamationTriangleIcon aria-label="Gated access warning" />
+        </Icon>
+      );
+    }
+
+    if (model.included) {
+      return <CheckCircleIcon color="green" aria-label="Included model" />;
+    }
+
+    return <TimesCircleIcon color="red" aria-label="Excluded model" />;
   };
 
   const renderEmptyState = () => {
@@ -150,16 +169,7 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
               </strong>
               <List isPlain className="pf-v6-u-mt-md">
                 {items.map((model) => (
-                  <ListItem
-                    key={model.name}
-                    icon={
-                      model.included ? (
-                        <CheckCircleIcon color="green" />
-                      ) : (
-                        <TimesCircleIcon color="red" />
-                      )
-                    }
-                  >
+                  <ListItem key={model.name} icon={renderModelIcon(model)}>
                     {model.name}
                   </ListItem>
                 ))}

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils.ts
@@ -1,11 +1,16 @@
 import {
   CatalogSourceConfig,
   CatalogSourceConfigPayload,
+  CatalogSourcePreviewModel,
   CatalogSourceType,
 } from '~/app/modelCatalogTypes';
+import { isHfGatedAccessDeniedFromFields } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
 import { generateSourceIdFromName } from '~/app/shared/catalogSettings/utils/generateSourceIdFromName';
 import { parseCommaSeparatedList } from '~/app/shared/catalogSettings/utils/parseCommaSeparatedList';
+
+export const isPreviewModelGatedAccessDenied = (model: CatalogSourcePreviewModel): boolean =>
+  isHfGatedAccessDeniedFromFields(model.hfAccessType, model.hfGatedAccessGranted);
 
 export const catalogSourceConfigToFormData = (
   sourceConfig: CatalogSourceConfig,

--- a/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
+++ b/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
@@ -272,6 +272,8 @@ export const MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY = {
 export const MODEL_CATALOG_GATED_ACCESS_REQUIRED = {
   TITLE: 'Model access required',
   ...MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY,
+  DESCRIPTION_NON_ADMIN:
+    'You do not have access to this model, so it cannot be deployed or registered. To request access, contact your administrator.',
   REQUEST_ACCESS_LINK_TEXT: 'Request access on Hugging Face',
   REGISTER_BUTTON_TOOLTIP: 'Model access is required to deploy or register this model.',
 } as const;

--- a/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
+++ b/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
@@ -260,14 +260,20 @@ export enum ModelCatalogTensorType {
   MXFP4 = 'MXFP4',
 }
 
+export const MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY = {
+  INTRO: 'This model is gated on Hugging Face.',
+  USERNAME_PROMPT: 'Log in to the Hugging Face account',
+  USERNAME_ACTION: 'and request access.',
+  GENERIC_ACTION: 'Request access on Hugging Face.',
+  OUTRO:
+    'After access is granted on Hugging Face, it might take a few hours for this model to show as available in the catalog.',
+} as const;
+
 export const MODEL_CATALOG_GATED_ACCESS_REQUIRED = {
   TITLE: 'Model access required',
-  DESCRIPTION_ADMIN:
-    'You do not have access to this model, so it cannot be deployed or registered. Go to Hugging Face to request permission for this model.',
-  DESCRIPTION_NON_ADMIN:
-    'You do not have access to this model, so it cannot be deployed or registered. To request access, contact your administrator.',
+  ...MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY,
   REQUEST_ACCESS_LINK_TEXT: 'Request access on Hugging Face',
-  REQUEST_ACCESS_BUTTON_TOOLTIP: 'Model access is required to deploy or register this model.',
+  REGISTER_BUTTON_TOOLTIP: 'Model access is required to deploy or register this model.',
 } as const;
 
 export const HUGGING_FACE_BASE_URL = 'https://huggingface.co';


### PR DESCRIPTION
## Description

Sync to pull in changes from:
* https://github.com/kubeflow/model-registry/pull/3188
* https://github.com/kubeflow/model-registry/pull/3205
* https://github.com/kubeflow/model-registry/pull/3206

Downstream follow-ups on this sync branch:
* Restore ODH admin vs non-admin gated model details error states (non-admin: contact administrator; admin: upstream HF username guidance).
* Add `hfUsername` to `CatalogSource` type and fix react-hooks lint in `ModelDetailsTabs`.

### Conflicts Resolved

The following conflicts were resolved during this sync:

**[#3205 - Remove temp feature flag for Hugging Face token](https://github.com/kubeflow/model-registry/pull/3205)**
- `packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts`

*Nature of conflict:* Upstream removed temp dev feature flag usage; ODH uses route URL helpers (`catalogSettingsUrl`, `addSourceUrl`, `manageSourceUrl`) instead of hardcoded paths.

*Resolution:* Removed temp dev flag parameters while keeping ODH route helper imports and URLs.

**[#3206 - Add icon in preview section and update error state for the gated models](https://github.com/kubeflow/model-registry/pull/3206)**
- `packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts`
- `packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx`
- `packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsTabs.tsx`
- `packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx`
- `packages/model-registry/upstream/frontend/src/app/shared/types/catalogTypes.ts`
- `packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts`

*Nature of conflict:* Upstream added gated-model error states with `hfUsername` and preview warning icons; ODH had admin/non-admin messaging and type re-exports from `modelCatalogTypes`.

*Resolution:* Incorporated upstream gated access copy, preview warning icon behavior, and deploy/register tooltips; kept ODH catalog type re-exports and extensible deploy actions; restored admin/non-admin gated details states in a follow-up commit.

## How Has This Been Tested?

Tested by running the federated model-registry package locally, verifying existing behavior in the files this diff touches, and verifying the incoming changes.

Also ran available test scripts in `packages/model-registry/upstream/frontend`:
- `npm run test:lint` — pass
- `npm run test:type-check` — pass
- `npm run test:jest -- --testPathPattern=ModelGatedAccessRequiredView` — pass

## Test Impact

Upstream changes include their own tests. Added `ModelGatedAccessRequiredView.spec.tsx` for ODH admin/non-admin gated access states. Updated host cypress admin assertion in `packages/cypress/cypress/tests/mocked/modelCatalog/modelCatalogGatedAccess.cy.ts`.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Experience**
  - Updated the Hugging Face gated-access request message shown to administrators, providing revised guidance when access requires approval.

- **Maintenance**
  - Updated the model registry integration to incorporate the latest available changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->