### PR TITLE
adjust testCreateConnectionTypes.cy.ts name flaky test

### DIFF
--- a/packages/cypress/cypress/pages/connectionTypes.ts
+++ b/packages/cypress/cypress/pages/connectionTypes.ts
@@ -274,8 +274,12 @@ class ConnectionTypesPage {
   }
 
   getConnectionTypeRow(name: string) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return new ConnectionTypeRow(() =>
-      this.findTable().findAllByTestId(`table-row-title`).contains(name).parents('tr'),
+      this.findTable()
+        .findAllByTestId(`table-row-title`)
+        .contains(new RegExp(`^${escaped}$`))
+        .parents('tr'),
     );
   }
 

--- a/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts
@@ -17,6 +17,9 @@ import { deleteOpenShiftProject } from '../../../../utils/oc_commands/project';
 import { deleteConnectionTypeByName } from '../../../../utils/oc_commands/connectionTypes';
 import { modelServingWizard, modelServingGlobal } from '../../../../pages/modelServing';
 
+const toConnectionTypeConfigMapName = (displayName: string): string =>
+  `ct-${displayName.toLowerCase().replace(/[\s-]+/g, '-')}`;
+
 describe('Verify Connection Type Creation', () => {
   let testData: OOTBConnectionTypesData;
   let connectionTypeName: string;
@@ -43,7 +46,7 @@ describe('Verify Connection Type Creation', () => {
       projectName = `${testData.projectResourceName}-${uuid}`;
       connectionTypeName = `${testData.connectionTypeName}-${uuid}`;
       existingConnectionTypeName = `${testData.s3}`;
-      duplicateConnectionTypeName = `Copy of ${existingConnectionTypeName}`;
+      duplicateConnectionTypeName = `Copy of ${existingConnectionTypeName} - ${uuid}`;
       connectionTypeDescription = `${testData.connectionTypeDescription}`;
       connectionTypeCategory = testData.connectionTypeCategory;
       connectionTypeModelServingCompatibleType = testData.connectionTypeModelServingCompatibleType;
@@ -58,16 +61,19 @@ describe('Verify Connection Type Creation', () => {
         throw new Error('Project name is undefined or empty in the loaded fixture');
       }
       cy.log(`Loaded project name: ${projectName}`);
+      deleteConnectionTypeByName(toConnectionTypeConfigMapName(connectionTypeName));
+      deleteConnectionTypeByName(toConnectionTypeConfigMapName(duplicateConnectionTypeName));
+      deleteConnectionTypeByName(
+        toConnectionTypeConfigMapName(`Copy of ${existingConnectionTypeName}`),
+      );
       createCleanProject(projectName);
     }),
   );
 
   after(() => {
     // Delete createdconfigmaps in this e2e test
-    deleteConnectionTypeByName(`ct-${connectionTypeName.toLowerCase().replace(/[\s-]+/g, '-')}`);
-    deleteConnectionTypeByName(
-      `ct-${duplicateConnectionTypeName.toLowerCase().replace(/[\s-]+/g, '-')}`,
-    );
+    deleteConnectionTypeByName(toConnectionTypeConfigMapName(connectionTypeName));
+    deleteConnectionTypeByName(toConnectionTypeConfigMapName(duplicateConnectionTypeName));
     // Delete provisioned Project - wait for completion due to RHOAIENG-19969 to support test retries, 5 minute timeout
     // TODO: Review this timeout once RHOAIENG-19969 is resolved
     deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true, timeout: 300000 });
@@ -136,6 +142,7 @@ describe('Verify Connection Type Creation', () => {
 
       cy.step('Submit the form to create the connection type');
       createConnectionTypePage.findSubmitButton().click();
+      cy.findByTestId('connection-type-footer-error').should('not.exist');
 
       cy.step('Verify we are redirected to Connection Types list page');
       connectionTypesPage.shouldHaveConnectionTypes();
@@ -216,10 +223,9 @@ describe('Verify Connection Type Creation', () => {
       const exisitingRow = connectionTypesPage.getConnectionTypeRow(existingConnectionTypeName);
       exisitingRow.findKebab().click();
       connectionTypesPage.findDuplicateAction().click();
-      createConnectionTypePage
-        .findConnectionTypeName()
-        .should('have.value', duplicateConnectionTypeName);
+      createConnectionTypePage.findConnectionTypeName().clear().type(duplicateConnectionTypeName);
       createConnectionTypePage.findSubmitButton().should('be.enabled').click();
+      cy.findByTestId('connection-type-footer-error').should('not.exist');
 
       cy.step('Edit the Connection type');
       let duplicateRow = connectionTypesPage.getConnectionTypeRow(duplicateConnectionTypeName);
@@ -265,7 +271,14 @@ describe('Verify Connection Type Creation', () => {
       modelServingGlobal.selectSingleServingModelButtonIfExists();
       modelServingGlobal.findDeployModelButton().click();
       modelServingWizard.findModelLocationSelectOption(modelLocation).click();
-      modelServingWizard.findCustomModelLocationSelect().should('not.exist');
+      // Dropdown only renders when multiple S3-compatible types exist; after delete it may be gone.
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-testid="custom-type-select"]').length > 0) {
+          modelServingWizard
+            .findCustomModelLocationSelectOption(duplicateConnectionTypeName)
+            .should('not.exist');
+        }
+      });
     },
   );
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
For https://redhat.atlassian.net/browse/RHOAIENG-93964 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes flaky failures in `testCreateConnectionTypes.cy.ts` when the duplicate/edit/delete test runs alongside other S3 connection types or after a failed local run.

The spec was asserting that `custom-type-select` disappeared after delete, but that dropdown only means “multiple S3-compatible types exist,” not “this copy is gone.” It could also duplicate the wrong row when a leftover `Copy of S3…` name substring-matched the OOTB row.

Changes: 
- Use a unique duplicate name per run (`Copy of … - {uuid}`) and clean up stale configmaps in `before`/`after`
- Match connection type table rows by exact display name (not substring)
- After delete, assert the duplicate option is absent when the S3 dropdown exists; pass if the dropdown is gone (only OOTB S3 left)
- Default `deleteConnectionTypeByName` namespace to `redhat-ods-applications` when `APPLICATIONS_NAMESPACE` is unset

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- validated test using the  `npm run run:e2e -- --spec cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts`
- Also ran Jenkins test -
<img width="2312" height="422" alt="image" src="https://github.com/user-attachments/assets/d575e189-6870-4b3e-b768-679c13ec5203" />

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Adjusted `testCreateConnectionTypes.cy.ts` file
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Improved connection type test coverage for names containing special characters and exact name matching.
- Added validation that connection type creation and duplication complete without footer errors.
- Strengthened setup and cleanup handling for connection type resources.
- Updated deletion checks to account for cases where the custom-type dropdown is not displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->