### PR TITLE
feat(maas-consumer-portal): tailor navigation, remove MCP servers tab and provide governance access

### DIFF
--- a/distributions/maas-consumer-portal/README.md
+++ b/distributions/maas-consumer-portal/README.md
@@ -67,6 +67,7 @@ BFF targets use `https://` because on-cluster BFFs serve over TLS.
 | `distribution.yaml` | Feature flags, bundled packages, extension paths |
 | `src/bootstrap.tsx` | App entry — mounts providers via `createDistribution` |
 | `src/extensions.ts` | Distribution nav (`app.suppress` / `app.patch`), redirects, user dropdown |
-| `src/PortalContextProvider.tsx` | MaaS BFF context (mod-arch standalone) |
+| `src/PortalContextProvider.tsx` | Composes the standalone MaaS BFF and portal authorization providers |
+| `src/MaaSAuthzProvider.tsx` | Publishes `ADMIN_USER` from the MaaS authorization check; access failures deny governance visibility |
 | `config/rspack.dev.js` | Dual-mode proxy (cluster discovery or local BFF targets) |
 | `config/contextualTildeResolverPlugin.js` | Resolves `~/` imports per package |

--- a/distributions/maas-consumer-portal/src/MaaSAuthzProvider.tsx
+++ b/distributions/maas-consumer-portal/src/MaaSAuthzProvider.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { usePluginStore } from '@openshift/dynamic-plugin-sdk';
+
+const ADMIN_USER_FLAG = 'ADMIN_USER';
+const MAAS_ADMIN_ENDPOINT = `${process.env.BASE_PATH || ''}/maas/api/v1/is-maas-admin`;
+
+const isMaaSAdminResponse = (value: unknown): value is { data: { allowed: boolean } } =>
+  typeof value === 'object' &&
+  value !== null &&
+  'data' in value &&
+  typeof value.data === 'object' &&
+  value.data !== null &&
+  'allowed' in value.data &&
+  typeof value.data.allowed === 'boolean';
+
+const getMaaSAdminAccess = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(MAAS_ADMIN_ENDPOINT);
+    if (!response.ok) {
+      return false;
+    }
+
+    const responseBody: unknown = await response.json();
+    return isMaaSAdminResponse(responseBody) && responseBody.data.allowed;
+  } catch {
+    return false;
+  }
+};
+
+type MaaSAuthzProviderProps = {
+  children: React.ReactNode;
+};
+
+const MaaSAuthzProvider: React.FC<MaaSAuthzProviderProps> = ({ children }) => {
+  const pluginStore = usePluginStore();
+
+  React.useEffect(() => {
+    let isCurrent = true;
+    pluginStore.setFeatureFlags({ [ADMIN_USER_FLAG]: false });
+
+    void getMaaSAdminAccess().then((allowed) => {
+      if (isCurrent) {
+        pluginStore.setFeatureFlags({ [ADMIN_USER_FLAG]: allowed });
+      }
+    });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [pluginStore]);
+
+  return <>{children}</>;
+};
+
+export default MaaSAuthzProvider;

--- a/distributions/maas-consumer-portal/src/PortalContextProvider.tsx
+++ b/distributions/maas-consumer-portal/src/PortalContextProvider.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DeploymentMode, ModularArchContextProvider, type ModularArchConfig } from 'mod-arch-core';
+import MaaSAuthzProvider from './MaaSAuthzProvider';
 import PortalAreaContextProvider from './PortalAreaContextProvider';
 
 const modularArchConfig: ModularArchConfig = {
@@ -10,7 +11,9 @@ const modularArchConfig: ModularArchConfig = {
 
 const PortalContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <ModularArchContextProvider config={modularArchConfig}>
-    <PortalAreaContextProvider>{children}</PortalAreaContextProvider>
+    <MaaSAuthzProvider>
+      <PortalAreaContextProvider>{children}</PortalAreaContextProvider>
+    </MaaSAuthzProvider>
   </ModularArchContextProvider>
 );
 

--- a/distributions/maas-consumer-portal/src/__tests__/MaaSAuthzProvider.spec.tsx
+++ b/distributions/maas-consumer-portal/src/__tests__/MaaSAuthzProvider.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { usePluginStore } from '@openshift/dynamic-plugin-sdk';
+import MaaSAuthzProvider from '../MaaSAuthzProvider';
+
+jest.mock('@openshift/dynamic-plugin-sdk', () => ({
+  usePluginStore: jest.fn(),
+}));
+
+const mockUsePluginStore = jest.mocked(usePluginStore);
+const setFeatureFlags = jest.fn();
+
+describe('MaaSAuthzProvider', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    jest.clearAllMocks();
+    mockUsePluginStore.mockReturnValue({ setFeatureFlags } as unknown as ReturnType<
+      typeof usePluginStore
+    >);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const renderProvider = (): void => {
+    render(
+      <MaaSAuthzProvider>
+        <div />
+      </MaaSAuthzProvider>,
+    );
+  };
+
+  it('should enable ADMIN_USER only when the MaaS authorization endpoint allows access', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { allowed: true } }),
+    } as Response);
+
+    renderProvider();
+
+    expect(global.fetch).toHaveBeenCalledWith('/maas/api/v1/is-maas-admin');
+    expect(setFeatureFlags).toHaveBeenCalledWith({ ADMIN_USER: false });
+    await waitFor(() => expect(setFeatureFlags).toHaveBeenCalledTimes(2));
+    expect(setFeatureFlags).toHaveBeenLastCalledWith({ ADMIN_USER: true });
+  });
+
+  it('should keep ADMIN_USER disabled when the MaaS authorization endpoint denies access', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { allowed: false } }),
+    } as Response);
+
+    renderProvider();
+
+    await waitFor(() => expect(setFeatureFlags).toHaveBeenCalledTimes(2));
+    expect(setFeatureFlags).toHaveBeenLastCalledWith({ ADMIN_USER: false });
+  });
+
+  it('should keep ADMIN_USER disabled when the MaaS authorization check fails', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    renderProvider();
+
+    await waitFor(() => expect(setFeatureFlags).toHaveBeenCalledTimes(2));
+    expect(setFeatureFlags).toHaveBeenLastCalledWith({ ADMIN_USER: false });
+  });
+
+  it('should keep ADMIN_USER disabled when the MaaS authorization endpoint returns an error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false } as Response);
+
+    renderProvider();
+
+    await waitFor(() => expect(setFeatureFlags).toHaveBeenCalledTimes(2));
+    expect(setFeatureFlags).toHaveBeenLastCalledWith({ ADMIN_USER: false });
+  });
+});

--- a/distributions/maas-consumer-portal/src/__tests__/RootRedirect.spec.tsx
+++ b/distributions/maas-consumer-portal/src/__tests__/RootRedirect.spec.tsx
@@ -23,9 +23,9 @@ describe('RootRedirect', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByTestId('current-path').textContent).toBe('/maas/keys-and-subs');
+    expect(screen.getByTestId('current-path').textContent).toBe('/gen-ai-studio/assets');
     expect(screen.getByTestId('redirected-href').textContent).toBe(
-      '/maas-consumer-portal/maas/keys-and-subs',
+      '/maas-consumer-portal/gen-ai-studio/assets',
     );
   });
 });

--- a/distributions/maas-consumer-portal/src/__tests__/extensions.spec.ts
+++ b/distributions/maas-consumer-portal/src/__tests__/extensions.spec.ts
@@ -50,6 +50,42 @@ const mockGenAiExtensions: Extension[] = [
       component: jest.fn(),
     },
   },
+  {
+    type: 'gen-ai.ai-assets/tab',
+    flags: { required: ['plugin-gen-ai'] },
+    properties: {
+      id: 'models',
+      title: 'Models',
+      component: jest.fn(),
+    },
+  },
+  {
+    type: 'gen-ai.ai-assets/tab',
+    flags: { required: ['plugin-gen-ai'] },
+    properties: {
+      id: 'mcpservers',
+      title: 'MCP servers',
+      component: jest.fn(),
+    },
+  },
+  {
+    type: 'gen-ai.ai-assets/tab',
+    flags: { required: ['plugin-gen-ai', 'externalVectorStores'] },
+    properties: {
+      id: 'vectorstores',
+      title: 'Vector stores',
+      component: jest.fn(),
+    },
+  },
+  {
+    type: 'gen-ai.ai-assets/tab',
+    flags: { required: ['plugin-gen-ai', 'agentConfigManagement'] },
+    properties: {
+      id: 'agentprofile',
+      title: 'Agents',
+      component: jest.fn(),
+    },
+  },
 ];
 
 const mockMaasExtensions: Extension[] = [
@@ -64,7 +100,7 @@ const mockMaasExtensions: Extension[] = [
     type: 'app.navigation/href',
     flags: { required: ['modelAsService', 'ADMIN_USER'] },
     properties: {
-      id: 'maas-subscription-management-view',
+      id: 'maas-governance-view',
       title: 'MaaS governance',
       href: '/maas/maas-governance',
       section: 'settings',
@@ -110,6 +146,14 @@ const mockMaasExtensions: Extension[] = [
       component: jest.fn(),
     },
   },
+  {
+    type: 'app.route',
+    flags: { required: ['modelAsService', 'ADMIN_USER'] },
+    properties: {
+      path: '/maas/maas-governance/*',
+      component: jest.fn(),
+    },
+  },
 ];
 
 const buildCatalog = (): Record<string, Extension[]> => ({
@@ -136,8 +180,23 @@ describe('MaaS Consumer Portal extensions', () => {
       genAiStudio: true,
       'plugin-gen-ai': true,
       chatPlayground: true,
+      externalVectorStores: true,
+      agentConfigManagement: true,
     });
   };
+
+  it('should suppress only the MCP servers AI asset tab', () => {
+    const store = new PluginStore(buildCatalog());
+    enablePortalFlags(store);
+
+    const aiAssetTabs = store
+      .getExtensions()
+      .filter((e) => e.type === 'gen-ai.ai-assets/tab')
+      .map((e) => e.properties.id);
+
+    expect(aiAssetTabs).toEqual(['models', 'vectorstores', 'agentprofile']);
+    expect(aiAssetTabs).not.toContain('mcpservers');
+  });
 
   it('should produce no orphaned nav items under suppressed or absent sections', () => {
     const store = new PluginStore(buildCatalog());
@@ -157,7 +216,7 @@ describe('MaaS Consumer Portal extensions', () => {
     expect(orphaned).toHaveLength(0);
   });
 
-  it('should have chat-playground, ai-assets, and API keys at top level (no section)', () => {
+  it('should order AI asset endpoints, API keys, and Playground at top level', () => {
     const store = new PluginStore(buildCatalog());
     enablePortalFlags(store);
 
@@ -174,21 +233,60 @@ describe('MaaS Consumer Portal extensions', () => {
         e.type === 'app.navigation/href' && e.properties.id === 'maas-tokens-subscriptions-view',
     );
 
-    expect(playground).toBeDefined();
-    expect(playground?.properties.section).toBeUndefined();
-    expect(playground?.properties.group).toBe('2_playground');
-    expect(playground?.properties.label).toBeUndefined();
-    expect(playground?.properties.href).toBe('/gen-ai-studio/playground');
-
     expect(aiAssets).toBeDefined();
     expect(aiAssets?.properties.section).toBeUndefined();
-    expect(aiAssets?.properties.group).toBe('3_ai_assets');
+    expect(aiAssets?.properties.group).toBe('1_ai_assets');
     expect(aiAssets?.properties.label).toBeUndefined();
 
     expect(apiKeys).toBeDefined();
     expect(apiKeys?.properties.section).toBeUndefined();
-    expect(apiKeys?.properties.group).toBe('1_api_keys');
+    expect(apiKeys?.properties.group).toBe('2_api_keys');
     expect(apiKeys?.properties.title).toBe('API keys');
+
+    expect(playground).toBeDefined();
+    expect(playground?.properties.section).toBeUndefined();
+    expect(playground?.properties.group).toBe('3_playground');
+    expect(playground?.properties.label).toBeUndefined();
+    expect(playground?.properties.href).toBe('/gen-ai-studio/playground');
+
+    expect(
+      [aiAssets, apiKeys, playground]
+        .toSorted((a, b) => String(a?.properties.group).localeCompare(String(b?.properties.group)))
+        .map((extension) => extension?.properties.title),
+    ).toEqual(['AI asset endpoints', 'API keys', 'Playground']);
+  });
+
+  it('should show the MaaS governance navigation item and route only for MaaS admins', () => {
+    const store = new PluginStore(buildCatalog());
+    enablePortalFlags(store);
+    store.setFeatureFlags({ ADMIN_USER: true });
+
+    const governanceNavigation = store
+      .getExtensions()
+      .find((e) => e.type === 'app.navigation/href' && e.properties.id === 'maas-governance-view');
+    const governanceRoute = store
+      .getExtensions()
+      .find((e) => e.type === 'app.route' && e.properties.path === '/maas/maas-governance/*');
+
+    expect(governanceNavigation?.properties.section).toBeUndefined();
+    expect(governanceNavigation?.properties.group).toBe('4_maas_governance');
+    expect(governanceRoute).toBeDefined();
+  });
+
+  it('should hide the MaaS governance navigation item and route when MaaS admin access is absent', () => {
+    const store = new PluginStore(buildCatalog());
+    enablePortalFlags(store);
+    store.setFeatureFlags({ ADMIN_USER: false });
+
+    const governanceExtensions = store
+      .getExtensions()
+      .filter(
+        (e) =>
+          (e.type === 'app.navigation/href' && e.properties.id === 'maas-governance-view') ||
+          (e.type === 'app.route' && e.properties.path === '/maas/maas-governance/*'),
+      );
+
+    expect(governanceExtensions).toHaveLength(0);
   });
 
   it('should not contain the gen-ai-studio section', () => {

--- a/distributions/maas-consumer-portal/src/extensions.ts
+++ b/distributions/maas-consumer-portal/src/extensions.ts
@@ -46,13 +46,30 @@ const extensions: Extension[] = [
     },
   } satisfies SuppressExtension,
 
+  // Hide the MCP servers tab in the consumer portal.
+  {
+    type: 'app.suppress',
+    properties: {
+      targetType: 'gen-ai.ai-assets/tab',
+      targetId: 'mcpservers',
+    },
+  } satisfies SuppressExtension,
+
   // Patch package-owned nav items: clear section (flatten) and set top-level group order
   {
     type: 'app.patch',
     properties: {
       targetType: 'app.navigation/href',
+      targetId: 'ai-assets',
+      patch: { section: null, group: '1_ai_assets', label: null },
+    },
+  } satisfies PatchExtension<NavPatch>,
+  {
+    type: 'app.patch',
+    properties: {
+      targetType: 'app.navigation/href',
       targetId: 'maas-tokens-subscriptions-view',
-      patch: { section: null, group: '1_api_keys' },
+      patch: { section: null, group: '2_api_keys' },
     },
   } satisfies PatchExtension<NavPatch>,
   {
@@ -60,15 +77,15 @@ const extensions: Extension[] = [
     properties: {
       targetType: 'app.navigation/href',
       targetId: 'chat-playground',
-      patch: { section: null, group: '2_playground', label: null },
+      patch: { section: null, group: '3_playground', label: null },
     },
   } satisfies PatchExtension<NavPatch>,
   {
     type: 'app.patch',
     properties: {
       targetType: 'app.navigation/href',
-      targetId: 'ai-assets',
-      patch: { section: null, group: '3_ai_assets', label: null },
+      targetId: 'maas-governance-view',
+      patch: { section: null, group: '4_maas_governance' },
     },
   } satisfies PatchExtension<NavPatch>,
 ];

--- a/distributions/maas-consumer-portal/src/portalPaths.ts
+++ b/distributions/maas-consumer-portal/src/portalPaths.ts
@@ -5,4 +5,4 @@
 export const PORTAL_BASE_PATH = '/maas-consumer-portal';
 
 /** Internal route; React Router applies PORTAL_BASE_PATH as its basename. */
-export const PORTAL_ROOT_REDIRECT_PATH = '/maas/keys-and-subs';
+export const PORTAL_ROOT_REDIRECT_PATH = '/gen-ai-studio/assets';


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-94528
https://redhat.atlassian.net/browse/RHOAIENG-94529
https://redhat.atlassian.net/browse/RHOAIENG-94530

## Description

Tailors the MaaS Consumer Portal presentation and governance access without changing the main Dashboard or MaaS/GenAI backend capabilities.

- Hides only the GenAI AI asset `mcpservers` tab in the portal.
- Orders portal navigation as AI asset endpoints, API keys, Playground, and MaaS governance.
- Makes AI asset endpoints the portal landing page.
- Adds `MaaSAuthzProvider`, which calls the MaaS authorization endpoint and publishes its fail-closed result as the portal's dynamic `ADMIN_USER` flag. The existing MaaS governance navigation item and route remain gated by that flag, while backend authorization remains enforced by the MaaS BFF.
- Documents the portal authorization provider in the distribution README.

## How Has This Been Tested?

From `distributions/maas-consumer-portal`:

```bash
npm run test-unit
npm run type-check
npm run lint
```

The unit suite covers the portal extension catalog, root redirect, and MaaS authorization provider. For a real-cluster check, run the portal against the MaaS BFF as a MaaS-governance authorized user and as a user without that permission; restart the local portal server between users so its proxy picks up the active `oc` token.

<img width="1371" height="694" alt="Screenshot 2026-09-11 at 14 18 16" src="https://github.com/user-attachments/assets/a08f753e-deb7-463f-ae3c-1b20e6bd7455" />


## Test Impact

- Added coverage that the portal suppresses only the MCP Servers AI asset tab and retains other supported tabs.
- Added coverage for portal navigation ordering and the AI asset endpoints root redirect.
- Added authorized, denied, and failed MaaS authorization-check coverage for `ADMIN_USER`, plus governance navigation and route visibility coverage.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added administrator-aware access to MaaS governance navigation and routes.
  - Added conditional governance visibility based on the current user’s authorization.
  - Added Gen AI asset tabs for models, MCP servers, vector stores, and agent profiles.

- **Updates**
  - The portal root now opens the Gen AI Studio assets page.
  - Reorganized navigation groups and labels for assets, API keys, playground, and governance.
  - Hid the MCP servers asset tab from the portal.

- **Tests**
  - Added coverage for administrator access, authorization failures, asset visibility, navigation, and redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->